### PR TITLE
Update long press popover so it is displayed at location pressed

### DIFF
--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Core
 
 extension UIViewController {
     
@@ -33,6 +34,14 @@ extension UIViewController {
         if let popover = controller.popoverPresentationController {
             popover.sourceView = sourceView
             popover.sourceRect = sourceView.bounds
+        }
+        present(controller, animated: true, completion: nil)
+    }
+    
+    public func present(controller: UIViewController, fromView sourceView: UIView, atPoint point: Point) {
+        if let popover = controller.popoverPresentationController {
+            popover.sourceView = sourceView
+            popover.sourceRect = CGRect(x: point.x, y: point.y, width: 0, height: 0)
         }
         present(controller, animated: true, completion: nil)
     }

--- a/Core/WebEventsDelegate.swift
+++ b/Core/WebEventsDelegate.swift
@@ -14,7 +14,7 @@ public protocol WebEventsDelegate: class {
 
     func webView(_ webView: WKWebView, shouldLoadUrl url: URL) -> Bool
     
-    func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL)
+    func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point)
     
     func webView(_ webView: WKWebView, didRequestNewTabForRequest urlRequest: URLRequest)
     

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -82,21 +82,22 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     }
     
     private func attachLongPressHandler(webView: WKWebView) {
-        let longPressRecogniser = UILongPressGestureRecognizer(target: self, action: #selector(onLongPress(sender:)))
-        longPressRecogniser.delegate = self
-        webView.scrollView.addGestureRecognizer(longPressRecogniser)
+        let handler = UILongPressGestureRecognizer(target: self, action: #selector(onLongPress(sender:)))
+        handler.delegate = self
+        webView.scrollView.addGestureRecognizer(handler)
     }
     
     func onLongPress(sender: UILongPressGestureRecognizer) {
-        if sender.state != .began {
-            return
-        }
+        guard sender.state == .began else { return }
+        
         let x = Int(sender.location(in: webView).x)
-        let y = Int(sender.location(in: webView).y-touchesYOffset())
-        webView.getUrlAtPoint(x: x, y: y)  { [weak self] (url) in
-            if let webView = self?.webView, let url = url {
-                self?.webEventsDelegate?.webView(webView, didReceiveLongPressForUrl: url)
-            }
+        let y = Int(sender.location(in: webView).y)
+        let offsetY = y - Int(touchesYOffset())
+        
+        webView.getUrlAtPoint(x: x, y: offsetY)  { [weak self] (url) in
+            guard let webView = self?.webView, let url = url else { return }
+            let point = Point(x: x, y: y)
+            self?.webEventsDelegate?.webView(webView, didReceiveLongPressForUrl: url, atPoint: point)
         }
     }
     

--- a/DuckDuckGo/WebTabViewController.swift
+++ b/DuckDuckGo/WebTabViewController.swift
@@ -62,7 +62,7 @@ class WebTabViewController: WebViewController, Tab {
         settings.hasSeenFireTutorial = true
     }
     
-    func launchActionSheet(forUrl url: URL) {
+    func launchActionSheet(atPoint point: Point, forUrl url: URL) {
         let alert = UIAlertController(title: nil, message: url.absoluteString, preferredStyle: .actionSheet)
         alert.addAction(newTabAction(forUrl: url))
         alert.addAction(openAction(forUrl: url))
@@ -70,7 +70,7 @@ class WebTabViewController: WebViewController, Tab {
         alert.addAction(copyAction(forURL: url))
         alert.addAction(shareAction(forURL: url))
         alert.addAction(UIAlertAction(title: UserText.actionCancel, style: .cancel))
-        present(controller: alert, fromView: webView)
+        present(controller: alert, fromView: webView, atPoint: point)
     }
     
     func newTabAction(forUrl url: URL) -> UIAlertAction {
@@ -154,7 +154,7 @@ extension WebTabViewController: WebEventsDelegate {
         tabDelegate?.webTab(self, didRequestNewTabForRequest: urlRequest)
     }
     
-    func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL) {
-        launchActionSheet(forUrl: url)
+    func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point) {
+        launchActionSheet(atPoint: point, forUrl: url)
     }
 }

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -119,7 +119,7 @@ extension ShareViewController: WebEventsDelegate {
         return true
     }
     
-    func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL) {
+    func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point) {
         webView.load(URLRequest(url: url))
     }
 


### PR DESCRIPTION
Reviewer: Caine

**Description**:
Adds support for long pressing a link on tablet and showing the popover beside it. The popover was previously unpositioned so appeared at odd locations on the screen.

**Steps to test this PR**:
From a tablet, long press a link and note that the popover is displayed at the location which was long pressed (see image).
<img width="512" alt="screen shot 2017-05-24 at 16 25 25" src="https://cloud.githubusercontent.com/assets/1652407/26411353/9fda44e8-409d-11e7-9afc-8ea9bbf1ae2c.png">

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)