### PR TITLE
Add url detection for urls with complex / encoded params

### DIFF
--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension URL {
     
-    private static let webUrlRegex = "^(https?:\\/\\/)?([\\da-z\\.-]+\\.[a-z\\.]{2,6}|(([\\d]+[.]){3}[\\d]+))([\\/:?=&#]{1}[\\da-z\\.-]+)*[\\/\\?]?$"
+    private static let webUrlRegex = "^(https?:\\/\\/)?([\\da-z\\.-]+\\.[a-z\\.]{2,6}|(([\\d]+[.]){3}[\\d]+))([\\/]?[\\/:?=&#]{1}[\\%\\da-zA-Z_\\.-]+)*[\\/\\?]?$"
     
     public func getParam(name: String) -> String? {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -50,6 +50,7 @@ class URLExtensionTests: XCTestCase {
         XCTAssertTrue(URL.isWebUrl(text: "http://121.33.2.11?s=dafas&d=342"))
         XCTAssertTrue(URL.isWebUrl(text: "test.com?s=dafas&d=342"))
         XCTAssertTrue(URL.isWebUrl(text: "121.33.2.11?s=dafas&d=342"))
+        XCTAssertTrue(URL.isWebUrl(text: "https://m.facebook.com/?refsrc=https%3A%2F%2Fwww.facebook.com%2F&_rdr"))
     }
     
     func testWhenParamsAreInvalidThenIsWebUrlIsFalse() {


### PR DESCRIPTION
Reviewer: Fracesco

**Description**:
Fix issue where https://m.facebook.com/?refsrc=https%3A%2F%2Fwww.facebook.com%2F&_rdr is loaded as a search query

**Steps to test this PR**:
Go to https://m.facebook.com/?refsrc=https%3A%2F%2Fwww.facebook.com%2F&_rdr. Ensure it is detected as a url rather than a search query.

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)