### PR TITLE
Autoselect omnibar text when activated

### DIFF
--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -155,6 +155,9 @@ extension OmniBar: UITextFieldDelegate {
         dismissButton.isHidden = false
         menuButton.isHidden = true
         contentBlockerButton.isHidden = true
+        DispatchQueue.main.async {
+            textField.selectAll(nil)
+        }
     }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {


### PR DESCRIPTION
Reviewer: Caine or Francesco (whoever has time)
Asana: https://app.asana.com/0/361428290920652/366951898545941

**Description**:
Another small tweak. Updates the omnibar so it automatically selects text when activated. Makes it easier to "just start typing" a new query

**Steps to test this PR**:
- Launch the app
- Navigate to a website
- Tap the omnibar and note that the contents are selected and that typing immediately overwrites selection

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)