### PR TITLE
Show cached items count in tab switcher

### DIFF
--- a/Core/CacheSummary.swift
+++ b/Core/CacheSummary.swift
@@ -1,0 +1,30 @@
+//
+//  CacheSummary.swift
+//  DuckDuckGo
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+
+public struct CacheSummary {
+    
+    public let count: Int
+    
+    public init(count: Int) {
+        self.count = count
+    }
+}

--- a/Core/UserText.swift
+++ b/Core/UserText.swift
@@ -35,6 +35,7 @@ public struct UserText {
 
     public static let tabSwitcherTitleHasTabs = forKey("tabswitcher.title.tabs")
     public static let tabSwitcherTitleNoTabs = forKey("tabswitcher.title.notabs")
+    public static let tabSwitcherData = forKey("tabswitcher.data")
     
     public static let onboardingRealPrivacyTitle = forKey("onboarding.realprivacy.title")
     public static let onboardingRealPrivacyDescription = forKey( "onboarding.realprivacy.description")

--- a/Core/WKWebViewExtension.swift
+++ b/Core/WKWebViewExtension.swift
@@ -40,12 +40,26 @@ extension WKWebView {
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         return webView
     }
+  
+    public static func cacheSummary(completionHandler: @escaping (_ summary: CacheSummary) -> Swift.Void) {
+        let allData = WKWebsiteDataStore.allWebsiteDataTypes()
+        let dataStore = WKWebsiteDataStore.default()
+        
+        dataStore.fetchDataRecords(ofTypes: allData, completionHandler: { records in
+            let count = records.reduce(0, { $0 + $1.dataTypes.count })
+            let cacheSummary = CacheSummary(count: count)
+            completionHandler(cacheSummary)
+        })
+    }
     
     public static func clearCache(completionHandler: @escaping () -> Swift.Void) {
         let allData = WKWebsiteDataStore.allWebsiteDataTypes()
-        let distantPast = Date.distantPast
         let dataStore = WKWebsiteDataStore.default()
-        dataStore.removeData(ofTypes: allData, modifiedSince: distantPast, completionHandler: completionHandler)
+        dataStore.fetchDataRecords(ofTypes: allData) { records in
+            dataStore.removeData(ofTypes: allData, for: records) {
+                completionHandler()
+            }
+        }
     }
     
     public func loadScripts() {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14E491E1E391CE900DC037C /* URLExtensionTests.swift */; };
 		F14E6EE81E773BA9001A184E /* InterfaceMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14E6EE71E773BA9001A184E /* InterfaceMeasurement.swift */; };
 		F152F55C1EFC002400A911B5 /* ContentBlockerMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F152F55B1EFC002400A911B5 /* ContentBlockerMonitor.swift */; };
+		F159BDA71F0C073D00B4A01D /* CacheSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159BDA61F0C073D00B4A01D /* CacheSummary.swift */; };
+		F159BDB51F0C0D0D00B4A01D /* TabsFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159BDB41F0C0D0D00B4A01D /* TabsFooter.swift */; };
 		F15A8B771E43A428008B8C6F /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15A8B761E43A428008B8C6F /* ShareViewController.swift */; };
 		F15A8B7A1E43A428008B8C6F /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F15A8B781E43A428008B8C6F /* MainInterface.storyboard */; };
 		F15A8B7E1E43A428008B8C6F /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F15A8B741E43A428008B8C6F /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -412,6 +414,8 @@
 		F14E491E1E391CE900DC037C /* URLExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLExtensionTests.swift; sourceTree = "<group>"; };
 		F14E6EE71E773BA9001A184E /* InterfaceMeasurement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceMeasurement.swift; sourceTree = "<group>"; };
 		F152F55B1EFC002400A911B5 /* ContentBlockerMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerMonitor.swift; sourceTree = "<group>"; };
+		F159BDA61F0C073D00B4A01D /* CacheSummary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheSummary.swift; sourceTree = "<group>"; };
+		F159BDB41F0C0D0D00B4A01D /* TabsFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsFooter.swift; sourceTree = "<group>"; };
 		F15A8B741E43A428008B8C6F /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F15A8B761E43A428008B8C6F /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		F15A8B791E43A428008B8C6F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -782,6 +786,7 @@
 				F1617C181E573EA800DEDCAF /* TabSwitcherDelegate.swift */,
 				F1617C121E572E0300DEDCAF /* TabSwitcherViewController.swift */,
 				F1DE78571E5CAE350058895A /* TabViewCell.swift */,
+				F159BDB41F0C0D0D00B4A01D /* TabsFooter.swift */,
 			);
 			name = TabSwitcher;
 			sourceTree = "<group>";
@@ -855,6 +860,7 @@
 				F143C3381E4A9A9200CFDE3A /* WebEventsDelegate.swift */,
 				F143C33A1E4A9A9200CFDE3A /* WKWebViewExtension.swift */,
 				F18326861E60542100240060 /* JavascriptLoader.swift */,
+				F159BDA61F0C073D00B4A01D /* CacheSummary.swift */,
 			);
 			name = Web;
 			sourceTree = "<group>";
@@ -1723,6 +1729,7 @@
 				F1668BCE1E798081008CBA04 /* BookmarksViewController.swift in Sources */,
 				F1CA3C371F045878005FADB3 /* PrivacyStore.swift in Sources */,
 				F1DE78581E5CAE350058895A /* TabViewCell.swift in Sources */,
+				F159BDB51F0C0D0D00B4A01D /* TabsFooter.swift in Sources */,
 				F17922D71E717AF0006E3D97 /* AutocompleteParser.swift in Sources */,
 				F13508031E8C303F00B7ECC4 /* DateFilterSelectionDelegate.swift in Sources */,
 				F1E249501EF207D4008C947A /* ContentBlockerPopover.swift in Sources */,
@@ -1842,6 +1849,7 @@
 				F1DA2F701EBCEA8B00313F51 /* SupportedExternalURLScheme.swift in Sources */,
 				F11044FD1ECFD57100C5E3D3 /* AppleContentBlockerParser.swift in Sources */,
 				F197EA3C1E6885F20029BDC1 /* TextFieldWithInsets.swift in Sources */,
+				F159BDA71F0C073D00B4A01D /* CacheSummary.swift in Sources */,
 				F16394051ECDFFE500DDD653 /* ContentBlockerEntry.swift in Sources */,
 				F1126DEA1EA5C43C0016A6C7 /* AppEmails.swift in Sources */,
 				F143C3181E4A99D200CFDE3A /* Link.swift in Sources */,

--- a/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
+++ b/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
@@ -38,7 +38,7 @@
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="0.0" id="bWt-k2-BEm">
                                     <size key="itemSize" width="327" height="70"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="50" height="50"/>
                                     <inset key="sectionInset" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
                                 </collectionViewFlowLayout>
                                 <cells>
@@ -123,6 +123,26 @@
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
+                                <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Footer" id="nEk-BZ-E8i" customClass="TabsFooter" customModule="DuckDuckGo" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="90" width="375" height="50"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 items cached" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cf1-NJ-M9S">
+                                            <rect key="frame" x="8" y="18" width="359" height="15"/>
+                                            <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="15"/>
+                                            <color key="textColor" red="0.46666666666666667" green="0.46666666666666667" blue="0.46666666666666667" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailingMargin" secondItem="cf1-NJ-M9S" secondAttribute="trailing" id="Bmb-6e-nRh"/>
+                                        <constraint firstItem="cf1-NJ-M9S" firstAttribute="leading" secondItem="nEk-BZ-E8i" secondAttribute="leadingMargin" id="MaO-sV-XAc"/>
+                                        <constraint firstItem="cf1-NJ-M9S" firstAttribute="centerY" secondItem="nEk-BZ-E8i" secondAttribute="centerY" id="xbI-6m-SFt"/>
+                                    </constraints>
+                                    <connections>
+                                        <outlet property="quantityLabel" destination="cf1-NJ-M9S" id="OFp-U8-E5F"/>
+                                    </connections>
+                                </collectionReusableView>
                                 <connections>
                                     <outlet property="dataSource" destination="G9p-Sf-e96" id="gcb-SK-xXr"/>
                                     <outlet property="delegate" destination="G9p-Sf-e96" id="GK9-W4-6gs"/>
@@ -174,7 +194,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="0.40000000600000002" green="0.40000000600000002" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="RLs-RI-FXc" firstAttribute="top" secondItem="PrD-ff-flI" secondAttribute="bottom" id="0oA-Ll-zZd"/>
                             <constraint firstItem="XZT-ek-lrC" firstAttribute="leading" secondItem="WJ0-lP-E4v" secondAttribute="leading" id="2c3-VD-tFG"/>

--- a/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
+++ b/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
@@ -127,8 +127,8 @@
                                     <rect key="frame" x="0.0" y="90" width="375" height="50"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 items cached" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cf1-NJ-M9S">
-                                            <rect key="frame" x="8" y="18" width="359" height="15"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cf1-NJ-M9S">
+                                            <rect key="frame" x="8" y="25" width="359" height="0.0"/>
                                             <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="15"/>
                                             <color key="textColor" red="0.46666666666666667" green="0.46666666666666667" blue="0.46666666666666667" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>

--- a/DuckDuckGo/Localizable.strings
+++ b/DuckDuckGo/Localizable.strings
@@ -29,6 +29,7 @@
 
 "tabswitcher.title.tabs" = "Private Tabs";
 "tabswitcher.title.notabs" = "No Tabs";
+"tabswitcher.data" = "%d items cached";
 
 "action.title.pasteAndGo" = "Paste & Go";
 "action.title.save" = "Save";

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -141,6 +141,13 @@ extension TabSwitcherViewController: UICollectionViewDataSource {
         return cell
     }
     
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        let reuseIdentifier = TabsFooter.reuseIdentifier
+        let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath) as! TabsFooter
+        footer.refreshLabel()
+        return footer
+    }
+    
     func onRemoveTapped(sender: UIView) {
         let index = sender.tag
         onDeleted(tabAt: index)
@@ -152,7 +159,6 @@ extension TabSwitcherViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         onSelected(tabAt: indexPath.row)
     }
-
 }
 
 extension TabSwitcherViewController: UICollectionViewDelegateFlowLayout {

--- a/DuckDuckGo/TabsFooter.swift
+++ b/DuckDuckGo/TabsFooter.swift
@@ -1,0 +1,36 @@
+//
+//  TabsFooter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import UIKit
+import Core
+import WebKit
+
+class TabsFooter: UICollectionReusableView {
+
+    static let reuseIdentifier = "Footer"
+
+    @IBOutlet weak var quantityLabel: UILabel!
+
+    public func refreshLabel() {
+        WKWebView.cacheSummary { [weak self] summary in
+            self?.quantityLabel.text = String(format: UserText.tabSwitcherData, summary.count)
+        }
+    }
+}


### PR DESCRIPTION
Reviewer: Caine
Asana: https://app.asana.com/0/361428290920652/367390337372578

**Description**:
Displays summary of cached items in tab switcher.
NOTE: Feel free to send this back to me when reviewed as I would like to squash rather than merge

**Steps to test this PR**:
1. Open app and browse a few webpages
3. Go to the tab manager and note the cached items count
4. Press the fire button and see the cached items count is now zero

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)