### PR TITLE
Fix failing tap touch handler

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -75,7 +75,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     }
     
     private func attachLongPressHandler(webView: WKWebView) {
-        let handler = UILongPressGestureRecognizer(target: self, action: #selector(onLongPress(sender:)))
+        let handler = WebLongPressGestureRecognizer(target: self, action: #selector(onLongPress(sender:)))
         handler.delegate = self
         webView.scrollView.addGestureRecognizer(handler)
     }
@@ -200,6 +200,10 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
 extension WebViewController: UIGestureRecognizerDelegate {
     
     open func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer is WebLongPressGestureRecognizer else {
+            return false
+        }
+        
         let yOffset = touchesYOffset()
         let x = Int(gestureRecognizer.location(in: webView).x)
         let y = Int(gestureRecognizer.location(in: webView).y-yOffset)
@@ -208,6 +212,8 @@ extension WebViewController: UIGestureRecognizerDelegate {
     }
     
     open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        return gestureRecognizer is WebLongPressGestureRecognizer
     }
 }
+
+fileprivate class WebLongPressGestureRecognizer: UILongPressGestureRecognizer {}

--- a/DuckDuckGo/WebTabViewController.swift
+++ b/DuckDuckGo/WebTabViewController.swift
@@ -254,7 +254,7 @@ extension WebTabViewController: UIPopoverPresentationControllerDelegate {
 }
 
 extension WebTabViewController {
-    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if isShowBarsTap(gestureRecognizer) {
             return true
         }
@@ -270,6 +270,13 @@ extension WebTabViewController {
     
     private func isBottom(yPosition y: CGFloat) -> Bool {
         return y > (view.frame.size.height - InterfaceMeasurement.defaultToolbarHeight)
+    }
+    
+    override func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer == showBarsTapGestureRecogniser {
+            return true
+        }
+        return super.gestureRecognizer(gestureRecognizer, shouldBeRequiredToFailBy: otherGestureRecognizer)
     }
 }
 


### PR DESCRIPTION
Reviewer: Caine

**Description**:
Made gesture recogniser delegate logic fussier about which gesture recogniser it responds to. Fixes issue in develop (master is fine) where tapping a link does not open it.

**Steps to test this PR**:
• Run app
• Navigate to a webpage
• Ensure that tapping a link opens it (previously only long press worked)

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)