### PR TITLE
Fix iOS9 scrollview delegate memory bug

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -90,11 +90,6 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         }
     }
     
-    private func detachWebView(webView: WKWebView) {
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
-        webView.removeFromSuperview()
-    }
-    
     public func load(url: URL) {
         load(urlRequest: URLRequest(url: url))
     }
@@ -184,7 +179,8 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     
     public func tearDown() {
         guard let webView = webView else { return }
-        detachWebView(webView: webView)
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
+        webView.removeFromSuperview()
     }
     
     fileprivate func touchesYOffset() -> CGFloat {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -95,7 +95,6 @@ class MainViewController: UIViewController {
     
     func loadRequestInNewTab(_ request: URLRequest) {
         loadViewIfNeeded()
-        currentTab?.dismiss()
         attachTab(forUrlRequest: request)
         refreshControls()
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -193,6 +193,7 @@ class TabViewController: WebViewController {
     }
     
     func dismiss() {
+        webView.scrollView.delegate = nil
         removeFromParentViewController()
         view.removeFromSuperview()
     }


### PR DESCRIPTION
Reviewer: Caine

**Description**:
Fix iOS9 scrollview delegate memory bug by setting scroll delegate to nil. Looks like Apple has fixed this on iOS10. Also some minor code tidying.

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)