### PR TITLE
Fix to prevent two URLs opening (the URL and the favicon) when using …

### DIFF
--- a/DuckDuckGo/SaveBookmarkActivity.swift
+++ b/DuckDuckGo/SaveBookmarkActivity.swift
@@ -40,20 +40,20 @@ class SaveBookmarkActivity: UIActivity {
     
     override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
         for item in activityItems {
-            if item is URL {
+            if item is Link {
                 return true
             }
         }
         return false
     }
     
-    override func prepare(withActivityItems items: [Any]) {
-        var favicon: URL? = nil
-        guard items.count >= 2, let title = items[0] as? String, let url = items[1] as? URL else { return }
-        if items.count == 3, let icon = items[2] as? URL {
-            favicon = icon
+    override func prepare(withActivityItems activityItems: [Any]) {
+        for item in activityItems {
+            if let link = item as? Link {
+                bookmark = link
+                return
+            }
         }
-        bookmark = Link(title: title, url: url, favicon: favicon)
     }
     
     override var activityViewController: UIViewController? {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -221,11 +221,7 @@ class TabViewController: WebViewController {
     private func shareAction(forLink link: Link) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] action in
             guard let webView = self?.webView else { return }
-            var items = [link.title ?? "", link.url] as [Any]
-            if let favicon = link.favicon {
-                items.append(favicon)
-            }
-            self?.presentShareSheet(withItems: items, fromView: webView)
+            self?.presentShareSheet(withItems: [ link.title ?? "", link.url, link ], fromView: webView)
         }
     }
     


### PR DESCRIPTION
…AirDrop.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer:
Asana:
CC:

**Description**:
When sharing via Airdrop two URLs would open - the webpage and its favicon.  The code did this to be able to reconstruct the Link object when adding to bookmarks via the Share sheet.  However, passing both the Link object and the URL will be handled correctly if the SaveBookmarkActivity expects a Link object.

**Steps to test this PR**:
1. Open a web page with a favicon and a title
2. Share it
3. Select an AirDrop target
4. The receiver no longer opens two URLs
5. Share it again
6. Select Add to Bookmarks
7. The bookmark is added correctly, with favicon
8. Share it again
9. Select iMessage
10. The URL with title are added to a new message ready to send


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)