### PR TITLE
Dismiss keyboard when bookmark is loaded

### DIFF
--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -123,8 +123,8 @@ class BookmarksViewController: UIViewController {
     }
     
     fileprivate func selectBookmark(_ bookmark: Link) {
-        delegate?.bookmarksDidSelect(link:  bookmark)
         dismiss()
+        delegate?.bookmarksDidSelect(link:  bookmark)
     }
     
     private func dismiss() {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -160,11 +160,7 @@ class MainViewController: UIViewController {
         omniBar.updateContentBlockerMonitor(monitor: tab.contentBlockerMonitor)
         omniBar.startBrowsing()
     }
-    
-    fileprivate func updateOmniBar(withQuery updatedQuery: String) {
-        displayAutocompleteSuggestions(forQuery: updatedQuery)
-    }
-    
+
     fileprivate func dismissOmniBar() {
         omniBar.resignFirstResponder()
         dismissAutcompleteSuggestions()
@@ -172,7 +168,7 @@ class MainViewController: UIViewController {
         homeController?.omniBarWasDismissed()
     }
     
-    private func displayAutocompleteSuggestions(forQuery query: String) {
+    fileprivate func displayAutocompleteSuggestions(forQuery query: String) {
         if autocompleteController == nil {
             let controller = AutocompleteViewController.loadFromStoryboard()
             controller.delegate = self
@@ -216,7 +212,7 @@ class MainViewController: UIViewController {
 extension MainViewController: OmniBarDelegate {
     
     func onOmniQueryUpdated(_ updatedQuery: String) {
-        updateOmniBar(withQuery: updatedQuery)
+        displayAutocompleteSuggestions(forQuery: updatedQuery)
     }
     
     func onOmniQuerySubmitted(_ query: String) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -347,6 +347,7 @@ extension MainViewController: TabSwitcherDelegate {
 
 extension MainViewController: BookmarksDelegate {
     func bookmarksDidSelect(link: Link) {
+        omniBar.resignFirstResponder()
         loadUrl(link.url)
     }
 }


### PR DESCRIPTION
Reviewer: Caine or Chris

**Description**:
Dismisses the keyboard when a bookmark is loaded.
Also includes a small (no effect) refactor to remove an unneeded method.

**Steps to test this PR**:
1. Go to the home screen
2. Tap on the search bar, the keyboard will come up & a bookmark icon will appear in the omnibar
3. Tap the bookmark button & select a bookmark
4. Note that the bookmark loads and the keyboard is dismissed

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)