### PR TITLE
Add new fire confirmation and always on tab switcher text

### DIFF
--- a/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
+++ b/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
@@ -27,7 +27,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tabs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cy7-Lb-veV">
-                                <rect key="frame" x="170" y="38" width="33.5" height="16"/>
+                                <rect key="frame" x="170" y="36.5" width="33.5" height="19"/>
                                 <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -45,7 +45,7 @@
                                 </connections>
                             </button>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="XZT-ek-lrC">
-                                <rect key="frame" x="0.0" y="72" width="375" height="551"/>
+                                <rect key="frame" x="0.0" y="73.5" width="375" height="549.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="0.0" id="bWt-k2-BEm">
                                     <size key="itemSize" width="327" height="70"/>
@@ -140,8 +140,8 @@
                                     <rect key="frame" x="0.0" y="90" width="375" height="50"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cf1-NJ-M9S">
-                                            <rect key="frame" x="8" y="25" width="359" height="0.0"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap 🔥 to forget everything" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cf1-NJ-M9S">
+                                            <rect key="frame" x="8" y="16.5" width="359" height="17.5"/>
                                             <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="15"/>
                                             <color key="textColor" red="0.46666666666666667" green="0.46666666666666667" blue="0.46666666666666667" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -152,9 +152,6 @@
                                         <constraint firstItem="cf1-NJ-M9S" firstAttribute="leading" secondItem="nEk-BZ-E8i" secondAttribute="leadingMargin" id="MaO-sV-XAc"/>
                                         <constraint firstItem="cf1-NJ-M9S" firstAttribute="centerY" secondItem="nEk-BZ-E8i" secondAttribute="centerY" id="xbI-6m-SFt"/>
                                     </constraints>
-                                    <connections>
-                                        <outlet property="quantityLabel" destination="cf1-NJ-M9S" id="OFp-U8-E5F"/>
-                                    </connections>
                                 </collectionReusableView>
                                 <connections>
                                     <outlet property="dataSource" destination="G9p-Sf-e96" id="gcb-SK-xXr"/>
@@ -213,6 +210,7 @@
                     </view>
                     <connections>
                         <outlet property="collectionView" destination="XZT-ek-lrC" id="iNF-Uj-4dl"/>
+                        <outlet property="fireButton" destination="mVy-93-3fh" id="Ma5-fW-CuJ"/>
                         <outlet property="titleView" destination="Cy7-Lb-veV" id="p6U-i5-pwf"/>
                         <outlet property="toolbar" destination="PrD-ff-flI" id="IUz-6K-N0F"/>
                     </connections>

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -23,10 +23,11 @@ import Core
 import WebKit
 
 class TabSwitcherViewController: UIViewController {
-
-    @IBOutlet weak var toolbar: UIToolbar!
+    
     @IBOutlet weak var titleView: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var toolbar: UIToolbar!
+    @IBOutlet weak var fireButton: UIButton!
     
     weak var delegate: TabSwitcherDelegate!
     weak var tabsModel: TabsModel!
@@ -76,7 +77,16 @@ class TabSwitcherViewController: UIViewController {
     }
     
     @IBAction func onForgetAllPressed(_ sender: UIButton) {
-         FireAnimation.animate() {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] action in
+            self?.forgetAll()
+        })
+        alert.addAction(UIAlertAction(title: UserText.actionCancel, style: .cancel))
+        present(controller: alert, fromView: fireButton)
+    }
+    
+    private func forgetAll() {
+        FireAnimation.animate() {
             self.delegate.tabSwitcherDidRequestForgetAll(tabSwitcher: self)
             self.collectionView.reloadData()
             self.refreshTitle()
@@ -119,16 +129,7 @@ extension TabSwitcherViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let reuseIdentifier = TabsFooter.reuseIdentifier
-        let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath) as! TabsFooter
-
-        if !hasSeenFooter {
-            footer.refreshLabel()
-            hasSeenFooter = true
-        } else {
-            footer.clearLabel()
-        }
-
-        return footer
+        return collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: reuseIdentifier, for: indexPath) as! TabsFooter
     }
     
     func onRemoveTapped(sender: UIView) {

--- a/DuckDuckGo/TabsFooter.swift
+++ b/DuckDuckGo/TabsFooter.swift
@@ -26,23 +26,4 @@ class TabsFooter: UICollectionReusableView {
 
     static let reuseIdentifier = "Footer"
 
-    @IBOutlet weak var quantityLabel: UILabel!
-
-    public func refreshLabel() {
-        WebCacheManager.summary { [weak self] summary in
-            self?.refreshLabel(withCacheSummary: summary)
-        }
-    }
-    
-    public func refreshLabel(withCacheSummary summary: WebCacheSummary) {
-        if summary.count != 0 {
-            quantityLabel.text = String(format: UserText.tabSwitcherData, summary.count)
-        } else {
-            clearLabel()
-        }
-    }
-    
-    public func clearLabel() {
-        quantityLabel.text = ""
-    }
 }

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -34,8 +34,7 @@ public struct UserText {
     
     public static let tabSwitcherTitleHasTabs = NSLocalizedString("tabswitcher.title.tabs", comment: "Private Tabs title")
     public static let tabSwitcherTitleNoTabs = NSLocalizedString("tabswitcher.title.notabs", comment: "No Tabs title")
-    public static let tabSwitcherData = NSLocalizedString("tabswitcher.data", comment: "Tap fire to forget instructions")
-    
+
     public static let onboardingRealPrivacyTitle = NSLocalizedString("onboarding.realprivacy.title", comment: "Onboarding real privacy title")
     public static let onboardingRealPrivacyDescription = NSLocalizedString("onboarding.realprivacy.description", comment: "Onboarding real privacy description")
     public static let onboardingContentBlockingTitle = NSLocalizedString("onboarding.contentblocking.title", comment: "Onboarding content blocking title")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -27,7 +27,6 @@
 
 "tabswitcher.title.tabs" = "Private Tabs";
 "tabswitcher.title.notabs" = "No Tabs";
-"tabswitcher.data" = "Tap 'Fire' to erase your tabs and data";
 
 "action.title.pasteAndGo" = "Paste & Go";
 "action.title.save" = "Save";


### PR DESCRIPTION
Reviewer: Caine or Chris

**Description**:
Added a confirmation to the tab switcher fire button and updated tab switcher text. Tab switcher text is now also always there.

**Steps to test this PR**:
Go to the Tab Switcher and not the new text and menu option

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)