### PR TITLE
Fix crash caused by incorrect index selection after deletion

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -55,8 +55,9 @@ class MainViewController: UIViewController {
     }
     
     private func loadInitialView() {
-        if let index = tabManager.currentIndex {
-            select(tabAt: index)
+        if let tab = currentTab {
+            addToView(tab: tab)
+            refreshControls()
         } else {
             attachHomeScreen(active: false)
         }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -81,7 +81,7 @@ struct TabManager {
     
     mutating func select(tabAt index: Int) -> TabViewController {
         current?.dismiss()
-        model.currentIndex = index
+        model.select(tabAt: index)
         save()
         return current!
     }

--- a/DuckDuckGoTests/TabsModelTests.swift
+++ b/DuckDuckGoTests/TabsModelTests.swift
@@ -100,27 +100,35 @@ class TabsModelTests: XCTestCase {
     
     func testWhenPreviousItemRemovedThenCurrentIndexDecrements() {
         let testee = filledModel
-        testee.currentIndex = 2
+        testee.select(tabAt: 2)
         testee.remove(at: 0)
         XCTAssertEqual(testee.currentIndex, 1)
     }
-    
-    func testWhenCurrentItemRemovedAndCurrentIsNotLastThenCurrentIndexStaysTheSame() {
+
+    func testWhenLaterItemRemovedThenCurrentIndexStaysTheSame() {
         let testee = filledModel
-        testee.currentIndex = 1
-        testee.remove(at: 1)
-        XCTAssertEqual(testee.currentIndex, 1)
-    }
-    
-    func testWhenCurrentItemRemovedAndCurrentIsLastThenCurrentIndexDecrements() {
-        let testee = filledModel
-        testee.currentIndex = 2
+        testee.select(tabAt: 0)
         testee.remove(at: 2)
-        XCTAssertEqual(testee.currentIndex, 1)
+        XCTAssertEqual(testee.currentIndex, 0)
+    }
+
+    func testWhenCurrentIsFirstItemAndItIsRemovedThenCurrentIsZero() {
+        let testee = filledModel
+        testee.select(tabAt: 0)
+        testee.remove(at: 0)
+        XCTAssertEqual(testee.currentIndex, 0)
     }
     
-    func testWhenFinalItemRemovedThenCurrentIsNil() {
+    func testWhenCurrentIsOnlyItemAndItIsRemovedThenCurrentIsNil() {
         let testee = singleModel
+        testee.select(tabAt: 0)
+        testee.remove(at: 0)
+        XCTAssertNil(testee.currentIndex)
+    }
+    
+    func testWhenNoSelectionAndFinalItemRemovedThenCurrentIsNil() {
+        let testee = singleModel
+        testee.clearSelection()
         testee.remove(at: 0)
         XCTAssertNil(testee.currentIndex)
     }


### PR DESCRIPTION
Reviewer: Chris or Caine
Asana: https://app.asana.com/0/361428290920652/394872926116306

**Description**:
Fixed crash caused by incorrect index selection after deletion. Also add check so any users who has an incorrectly persisted index will now recover.

**Steps to test this PR**:
On develop:
1. Open 2 tabs
2. Go to the tab manager and SELECT the FIRST one
3. Go back to the tab manager and DELETE the SECOND one.
4. Note the horrible crash

On this branch:
1. Repeat the above steps. The app should no longer crash

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)