### PR TITLE
Fix issue where navigating back displays an error page

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -131,11 +131,14 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     }
     
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        handle(error: error)
+        hideProgressIndicator()
+        webEventsDelegate?.webpageDidFailToLoad()
     }
     
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        handle(error: error)
+        hideProgressIndicator()
+        webEventsDelegate?.webpageDidFailToLoad()
+        showError(message: error.localizedDescription)
     }
     
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
@@ -191,12 +194,6 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     fileprivate func touchesYOffset() -> CGFloat {
         guard navigationController != nil else { return 0 }
         return decorHeight
-    }
-    
-    private func handle(error: Error) {
-        hideProgressIndicator()
-        webEventsDelegate?.webpageDidFailToLoad()
-        showError(message: error.localizedDescription)
     }
     
     private func showError(message: String) {


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/361428290920652/405530593816400

**Description**:
The error page is being displayed in a number of situations where browsing had previously succeeded. This is being caused by navigation errors that are thrown by some pages when navigating back.

As the error page was initially introduced to capture connection / loading failures I have removed it from the navigation errors flow. The errors we want to capture should still work as expected.

**Steps to test this PR**:
TEST 1:
1. Go to the www.theguardian.com
2. Tap on an article
3. Tap the back button / swipe back
4. The previous page should display without an error

TEST 2:
1. Navigate to a url which does not exist
2. An error page should be presented

TEST 3:
1. Turn all networking off and attempt to navigate to a page
2. An error page should be presented

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)