### PR TITLE
Remove historic logic which cleared the cache when all tabs where closed

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -102,9 +102,6 @@ class TabSwitcherViewController: UIViewController {
         delegate.tabSwitcher(self, didRemoveTabAt: index)
         collectionView.reloadData()
         refreshTitle()
-        if tabsModel.isEmpty {
-            delegate.tabSwitcherDidRequestForgetAll(tabSwitcher: self)
-        }
     }
     
     fileprivate func dismiss() {


### PR DESCRIPTION
Reviewer: Chris

**Description**:
In the past we cleared the cache when all tabs were closed. We now only do this explicitly when the user presses the fire button

**Steps to test this PR**:
1. Log into a service e.g facebook or twitter
2. Close all tabs
3. Open previous page again, you should still be logged in

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)