### PR TITLE
Add a simple in-memory cache to maintain site score during navigation

### DIFF
--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -39,7 +39,7 @@ public struct SiteRating {
         score += httpsScore
         score += trackerCountScore
         score += majorTrackerNetworkScore
-        return score
+        return SiteRatingCache.shared.register(domain: domain, score: score)
     }
     
     public var https: Bool {
@@ -70,4 +70,31 @@ public struct SiteRating {
     public var siteGrade: SiteGrade {
         return SiteGrade.grade(fromScore: siteScore)
     }
+}
+
+
+public class SiteRatingCache {
+    
+    public static let shared = SiteRatingCache()
+    
+    private var cachedScores = [String: Int]()
+
+    
+    /**
+     Registers a site score for in-memory caching. Only updates the score
+     in the cache if the new score is higher.
+     - returns: The score maintaned in the cache
+     */
+    func register(domain: String, score current: Int) -> Int {
+        if let previous = cachedScores[domain], previous > current {
+            return previous
+        }
+        cachedScores[domain] = current
+        return current
+    }
+    
+    func reset() {
+        cachedScores =  [String: Int]()
+    }
+
 }

--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -39,7 +39,10 @@ public struct SiteRating {
         score += httpsScore
         score += trackerCountScore
         score += majorTrackerNetworkScore
-        return SiteRatingCache.shared.register(domain: domain, score: score)
+        
+        let cache =  SiteRatingCache.shared
+        cache.register(domain: domain, score: score)
+        return cache.score(forDomain: domain)!
     }
     
     public var https: Bool {
@@ -78,19 +81,20 @@ public class SiteRatingCache {
     public static let shared = SiteRatingCache()
     
     private var cachedScores = [String: Int]()
-
     
     /**
      Registers a site score for in-memory caching. Only updates the score
      in the cache if the new score is higher.
-     - returns: The score maintaned in the cache
      */
-    func register(domain: String, score current: Int) -> Int {
+    func register(domain: String, score current: Int) {
         if let previous = cachedScores[domain], previous > current {
-            return previous
+            return
         }
         cachedScores[domain] = current
-        return current
+    }
+    
+    func score(forDomain domain: String) -> Int? {
+        return cachedScores[domain]
     }
     
     func reset() {

--- a/DuckDuckGoTests/SiteRatingTests.swift
+++ b/DuckDuckGoTests/SiteRatingTests.swift
@@ -84,7 +84,7 @@ class SiteRatingTests: XCTestCase {
     }
     
     func testWhenNewRatingIsLowerThanCachedRatingThenCachedRatingIsUsed() {
-        SiteRatingCache.shared.register(domain: httpUrl.host!, score: 100)
+        _ = SiteRatingCache.shared.add(domain: httpUrl.host!, score: 100)
         let testee = SiteRating(url: httpUrl)!
         XCTAssertEqual(100, testee.siteScore)
     }

--- a/DuckDuckGoTests/SiteRatingTests.swift
+++ b/DuckDuckGoTests/SiteRatingTests.swift
@@ -84,7 +84,7 @@ class SiteRatingTests: XCTestCase {
     }
     
     func testWhenNewRatingIsLowerThanCachedRatingThenCachedRatingIsUsed() {
-        let _ = SiteRatingCache.shared.register(domain: httpUrl.host!, score: 100)
+        SiteRatingCache.shared.register(domain: httpUrl.host!, score: 100)
         let testee = SiteRating(url: httpUrl)!
         XCTAssertEqual(100, testee.siteScore)
     }

--- a/DuckDuckGoTests/SiteRatingTests.swift
+++ b/DuckDuckGoTests/SiteRatingTests.swift
@@ -23,6 +23,10 @@ import XCTest
 
 class SiteRatingTests: XCTestCase {
 
+    override func setUp() {
+        SiteRatingCache.shared.reset()
+    }
+    
     func testWhenUrlContainHostThenInitSucceeds() {
         let testee = SiteRating(url: urlWithHost)
         XCTAssertNotNil(testee)
@@ -77,6 +81,12 @@ class SiteRatingTests: XCTestCase {
         var testee = SiteRating(url: httpUrl)!
         testee.trackers = trackers(qty: 6, majorQty: 5)
         XCTAssertEqual(4, testee.siteScore)
+    }
+    
+    func testWhenNewRatingIsLowerThanCachedRatingThenCachedRatingIsUsed() {
+        let _ = SiteRatingCache.shared.register(domain: httpUrl.host!, score: 100)
+        let testee = SiteRating(url: httpUrl)!
+        XCTAssertEqual(100, testee.siteScore)
     }
     
     func trackers(qty: Int, majorQty: Int = 0) -> [Tracker: Int] {


### PR DESCRIPTION
Reviewer: Chris ot Caine

**Description**:
When the user is navigating backwards and forwards a full page load may not occur meaning that the site score may be artificially low. The cache allows us to return a better score

**Steps to test this PR**:
1. Browse to a page with bad site score e.g the daily mail
2. Browse to a another page with a better rating e.g duckduckgo
3. Navigate back (by swiping or with the back button). Ensure the site score stays the same

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation

###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)