### PR TITLE
Suppress links with a blank target from automatically launching in new tab

### DIFF
--- a/Core/WebEventsDelegate.swift
+++ b/Core/WebEventsDelegate.swift
@@ -27,8 +27,6 @@ public protocol WebEventsDelegate: class {
     
     func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point)
     
-    func webView(_ webView: WKWebView, didRequestNewTabForRequest urlRequest: URLRequest)
-    
     func webpageDidStartLoading()
     
     func webpageDidFinishLoading()

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -158,7 +158,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     }
     
     public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        webEventsDelegate?.webView(webView, didRequestNewTabForRequest: navigationAction.request)
+        webView.load(navigationAction.request)
         return nil
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -352,11 +352,7 @@ extension MainViewController: TabDelegate {
     func tab(_ tab: TabViewController, didRequestNewTabForUrl url: URL) {
         loadUrlInNewTab(url)
     }
-    
-    func tab(_ tab: TabViewController, didRequestNewTabForRequest urlRequest: URLRequest) {
-        loadRequestInNewTab(urlRequest)
-    }
-    
+
     func tab(_ tab: TabViewController, didChangeSiteRating siteRating: SiteRating?) {
         omniBar.updateSiteRating(siteRating)
     }

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -26,8 +26,6 @@ protocol TabDelegate: class {
     func tabDidRequestNewTab(_ tab: TabViewController)
     
     func tab(_ tab: TabViewController, didRequestNewTabForUrl url: URL)
-    
-    func tab(_ tab: TabViewController, didRequestNewTabForRequest urlRequest: URLRequest)
 
     func tabLoadingStateDidChange(tab: TabViewController)
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -273,10 +273,6 @@ extension TabViewController: WebEventsDelegate {
         return shouldLoad(url: url, forDocument: documentUrl)
     }
     
-    func webView(_ webView: WKWebView, didRequestNewTabForRequest urlRequest: URLRequest) {
-        delegate?.tab(self, didRequestNewTabForRequest: urlRequest)
-    }
-    
     func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point) {
         launchLongPressMenu(atPoint: point, forUrl: url)
     }

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -133,10 +133,6 @@ extension ShareViewController: WebEventsDelegate {
     func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point) {
         webView.load(URLRequest(url: url))
     }
-
-    func webView(_ webView: WKWebView, didRequestNewTabForRequest urlRequest: URLRequest) {
-        webView.load(urlRequest)
-    }
     
     func webpageDidStartLoading() {
     }


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/361428290920652/401736099036640

**Description**:
Links now always load in the current tab, unless the user explicitly long presses and selects "open in new tab"

**Steps to test this PR**:
1. Navigate to http://verk.space/
2. Tap "Membership Options"
3. Check that this has launched in the current tab, rather than a new one

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)