### PR TITLE
Fixes issue where a url load can overwrite text a user is currently editing

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -312,13 +312,13 @@ extension MainViewController: AutocompleteViewControllerDelegate {
 extension MainViewController: HomeControllerDelegate {
     
     func homeDidActivateOmniBar(home: HomeViewController) {
+        omniBar.clear()
         omniBar.becomeFirstResponder()
     }
     
     func homeDidDeactivateOmniBar(home: HomeViewController) {
         dismissAutcompleteSuggestions()
         omniBar.resignFirstResponder()
-        omniBar.clear()
     }
     
     func homeDidRequestForgetAll(home: HomeViewController) {

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -99,7 +99,6 @@ class OmniBar: UIView {
     }
     
     func stopBrowsing() {
-        clear()
         refreshState(state.onBrowsingStoppedState)
     }
     
@@ -165,6 +164,11 @@ class OmniBar: UIView {
     }
     
     func refreshText(forUrl url: URL?) {
+        
+        if textField.isEditing {
+            return
+        }
+        
         guard let url = url else {
             textField.text = nil
             return


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/361428290920652/363362847447799

**Description**:
Fixes issue where a url load can overwrite text a user is currently editing. The omnibar no longer refreshes its text while the user is editing.

**Steps to test this PR**:
1. Visit a page that loads slowly
2. While it is loading start entering a new query in the omnibar
3. The text should NOT be overwritten with the url when the page finishes loading
4. Press the omnibar arrow to stop editing and dismiss the keyboard. The omnibar should now update with the latest url.

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)