### PR TITLE
Installs the licensed fonts from a standard location

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1351,11 +1351,12 @@
 			buildPhases = (
 				84E3418E1E2F7EFB00BDBA6F /* Sources */,
 				84E3418F1E2F7EFB00BDBA6F /* Frameworks */,
+				85F4D03A1F44A7BE0018BFD5 /* Install Fonts */,
 				84E341901E2F7EFB00BDBA6F /* Resources */,
 				F17669C31E421847003D3222 /* Embed App Extensions */,
 				F143C2F01E4A4CD400CFDE3A /* Embed Frameworks */,
 				F10307651E7D5B2C0059FEC7 /* Copy Frameworks */,
-				F17BA4411F1CD9D300460FFA /* ShellScript */,
+				F17BA4411F1CD9D300460FFA /* Cathage Copy Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1618,6 +1619,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		85F4D03A1F44A7BE0018BFD5 /* Install Fonts */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Install Fonts";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\n[ -z \"$TRAVIS\" ]\n\nif env | grep -q ^TRAVIS=\nthen\n    echo Skipping fonts on TRAVIS build\nelse\n    echo Installing fonts from standard location\n    cp ~/DuckDuckGo/Fonts/proximanova/*.otf $SRCROOT/fonts/licensed\nfi\n";
+		};
 		F17843E61F361B3C00390DCD /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1633,7 +1648,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
-		F17BA4411F1CD9D300460FFA /* ShellScript */ = {
+		F17BA4411F1CD9D300460FFA /* Cathage Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1646,6 +1661,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftRichString.framework",
 			);
+			name = "Cathage Copy Frameworks";
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Device.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)//Kingfisher.framework",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We use Carthage for dependency management. If you don't have Carthage installed 
 Run `carthage bootstrap --platform iOS` before opening the project in XCode
 
 ### Fonts
-We use Proxima Nova fonts which are proprietary and cannot be committed to source control, see [fonts](https://github.com/duckduckgo/iOS/tree/develop/fonts/licensed). If you own the Proxima Nova fonts you can add them to the fonts directory. If not, you can still run this project however the fonts may look a little distorted.
+We use Proxima Nova fonts which are proprietary and cannot be committed to source control, see [fonts](https://github.com/duckduckgo/iOS/tree/develop/fonts/licensed). 
 
 ## Discuss
 

--- a/fonts/licensed/readme.txt
+++ b/fonts/licensed/readme.txt
@@ -1,3 +1,9 @@
 This folder contains empty placeholder fonts which are replaced with licensed versions by Jenkins during a release.
 
 Developers: you may replace the placeholder font files with their licensed counterparts locally however you must not commit these to source control. You can run `git update-index --assume-unchanged *.otf` to stop git tracking changes you make to these files.
+
+The build will now fail if you do not have the fonts in a standard location, which is:
+
+~/DuckDuckGo/Fonts/proximanova
+
+You can copy the fonts from this project in to that folder in order to build and run locally.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana:
CC:

**Description**:

To ensure the correct fonts are used during testing and releases, this change adds a script to the build phase to copy the licensed font files from a standard location.  

The standard location for the fonts is:
~/DuckDuckGo/Fonts/proximanova

To prevent an error on Travis, the script checks for the TRAVIS env var and if it is present it does not attempt to copy the fonts.


**Steps to test this PR**:
1. Try a build without the fonts in the standard location.  There should be an error.
2. Put the fonts in to the standard location and rebuild.
3. Run the app - it should now include the correct fonts.
4. Travis should pass successfully, check the Travis log for a message which says `Skipping fonts on TRAVIS build`


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)