### PR TITLE
suppress blank nav

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -154,6 +154,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
 
         guard let delegate = webEventsDelegate,
             let documentUrl = navigationAction.request.mainDocumentURL else {
+            decisionHandler(.allow)
             return
         }
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: https://app.asana.com/0/0/402612726718857/f
CC:

**Description**:

After some investigation, there appears to be no official way to detect apps being launched as a result of universal links.

I've worked around this by observing a policy decision request (which still comes through for the destination URL).  If the app is backgrounded before any of the delegate methods are called (i.e. the web view has not processed the URL), then it assumes an app has been launched as a result of a universal link and tells the view to 'go back' to the previous page.

**Steps to test this PR**:

Test 1 - launch app via universal link
1.  Install twitter
2. Open the DuckDuckGo app and search for something that will give you a twitter links
3. Tap on a twitter link
4. Twitter will launch (unless you've previously suppressed this!)
5. When you return to the app it is on a blank page

Test 2 - standard browsing
1. Search for something that will not open in Twitter
2. Tap on a link
3. Observe the page loading in the app
4. Navigate to another app via pressing the home button
5. Return to the DuckDuckGo app and observe the same page is still displayed


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)