### PR TITLE
Refresh site rating url after page load

### DIFF
--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -22,7 +22,7 @@ import Foundation
 
 public class SiteRating {
     
-    public let url: URL
+    public var url: URL
     public let domain: String
     private var trackersDetected = [Tracker: Int]()
     private var trackersBlocked = [Tracker: Int]()

--- a/DuckDuckGo/ContentBlockerPopover.swift
+++ b/DuckDuckGo/ContentBlockerPopover.swift
@@ -56,10 +56,6 @@ class ContentBlockerPopover: UIViewController {
     func updateSiteRating(siteRating: SiteRating) {
         contentBlockerViewController?.updateSiteRating(siteRating: siteRating)
     }
-    
-    func refresh() {
-        contentBlockerViewController?.refresh()
-    }
 
     fileprivate func attachErrorViewController() {
         let controller = ContentBlockerErrorViewController.loadFromStoryboard(delegate: self)

--- a/DuckDuckGo/ContentBlockerViewController.swift
+++ b/DuckDuckGo/ContentBlockerViewController.swift
@@ -56,7 +56,7 @@ class ContentBlockerViewController: UITableViewController {
         refresh()
     }
 
-    public func refresh() {
+    private func refresh() {
         siteRatingView.refresh()
         refreshHttps()
         blockThisDomainToggle.isOn = contentBlocker.enabled(forDomain: siteRating.domain)
@@ -64,7 +64,7 @@ class ContentBlockerViewController: UITableViewController {
         blockCountCircle.tintColor = blockCountCircleTint()
     }
     
-    public func refreshHttps() {
+    private func refreshHttps() {
         if siteRating.https {
             httpsBackground.tintColor = UIColor.monitoringPositiveTint
             httpsLabel.text = UserText.secureConnection

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -73,21 +73,28 @@ class TabViewController: WebViewController {
         present(controller: controller, fromView: button)
         contentBlockerPopover = controller
     }
-
-    fileprivate func onNewPageLoad() {
+    
+    fileprivate func resetSiteRating() {
         if let url = url {
             siteRating = SiteRating(url: url)
-            contentBlockerPopover?.updateSiteRating(siteRating: siteRating!)
         } else {
-            contentBlockerPopover?.dismiss(animated: false, completion: nil)
             siteRating = nil
         }
-        delegate?.tab(self, didChangeSiteRating: siteRating)
+        onSiteRatingChanged()
+    }
+    
+    fileprivate func updateSiteRating() {
+        if let url = url {
+            siteRating?.url = url
+        } else {
+            siteRating = nil
+        }
+        onSiteRatingChanged()
     }
     
     fileprivate func onSiteRatingChanged() {
         delegate?.tab(self, didChangeSiteRating: siteRating)
-        contentBlockerPopover?.refresh()
+        contentBlockerPopover?.updateSiteRating(siteRating: siteRating!)
     }
 
     func launchBrowsingMenu() {
@@ -244,12 +251,13 @@ extension TabViewController: WebEventsDelegate {
     }
     
     func webpageDidStartLoading() {
-        onNewPageLoad()
+        resetSiteRating()
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
     }
     
     func webpageDidFinishLoading() {
+        updateSiteRating()
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
     }


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/inbox/361428290920650/411040950249187/311459485241785

**Description**:
Refresh site rating url after page load to ensure https redirects are accounted for

**Steps to test this PR**:
1. Navigate to a http page which gets updated e.g http://bbc.co.uk
2. Open the content blocker popover and ensure it shows "Secure connection"

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)