### PR TITLE
Add missing statistics to ddg searches

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -95,8 +95,6 @@ public struct AppUrls {
      app version and cohort (atb) https://duck.co/help/privacy/atb
      */
     public func searchUrl(text: String) -> URL {
-        let appVersion = "\(ParamValue.appVersion)_\(version.versionNumber)_\(version.buildNumber)"
-        
         let searchUrl = home
             .addParam(name: Param.search, value: text)
             .addParam(name: Param.source, value: ParamValue.source)
@@ -104,6 +102,10 @@ public struct AppUrls {
         
         guard let cohortVersion = statisticsStore.cohortVersion else { return searchUrl }
         return searchUrl.addParam(name: Param.cohort, value: cohortVersion)
+    }
+    
+    private var appVersion: String {
+        return "\(ParamValue.appVersion)_\(version.versionNumber)_\(version.buildNumber)"
     }
     
     public func autocompleteUrl(forText text: String) -> URL {
@@ -116,8 +118,10 @@ public struct AppUrls {
         return true
     }
 
-    public func hasMobileStatsParams(url: URL) -> Bool {
+    public func hasCorrectMobileStatsParams(url: URL) -> Bool {
         guard let cohort = url.getParam(name: Param.cohort), cohort == statisticsStore.cohortVersion else { return false }
+        guard let source = url.getParam(name: Param.source), source == ParamValue.source  else { return false }
+        guard let version = url.getParam(name: Param.appVersion), version == appVersion else { return false }
         return true
     }
 

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -180,7 +180,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     }
 
     private func shouldReissueSearch(for url: URL) -> Bool {
-        return appUrls.isDuckDuckGoSearch(url: url) && !appUrls.hasMobileStatsParams(url: url)
+        return appUrls.isDuckDuckGoSearch(url: url) && !appUrls.hasCorrectMobileStatsParams(url: url)
     }
 
     private func reissueSearchWithStatsParams(for url: URL) {


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/414235014887631/413609835171504

**Description**:
We recently updated the project to attach params to ddg searches that happen outside the omnibar. This PR adds additional logic to ensure none are missed.

**Steps to test this PR**:
1. Perform a search
2. Turn safe search on
3. Ensure that the atb, tappv and t params are all still there

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)