### PR TITLE
Add platform suffix to cohort statistics

### DIFF
--- a/Core/CohortParser.swift
+++ b/Core/CohortParser.swift
@@ -24,6 +24,8 @@ import SwiftyJSON
 
 public struct CohortParser {
     
+    public static let versionPlatformSuffix = "mi"
+    
     public init() {}
     
     func convert(fromJsonData data: Data) throws -> Cohort {
@@ -33,6 +35,6 @@ public struct CohortParser {
         guard let version = json["version"].string else {
             throw JsonError.typeMismatch
         }
-        return Cohort(version: version)
+        return Cohort(version: version + CohortParser.versionPlatformSuffix)
     }
 }

--- a/Core/StatisticsUserDefaults.swift
+++ b/Core/StatisticsUserDefaults.swift
@@ -25,7 +25,7 @@ public class StatisticsUserDefaults: StatisticsStore {
     private let groupName: String
     
     private struct Keys {
-        static let cohortVersion = "com.duckduckgo.statistics.cohortVersion.key"
+        static let cohortVersion = "com.duckduckgo.statistics.cohortVersion.v2.key"
     }
     
     private var userDefaults: UserDefaults? {

--- a/DuckDuckGoTests/CohortParserTests.swift
+++ b/DuckDuckGoTests/CohortParserTests.swift
@@ -50,10 +50,10 @@ class CohortParserTests: XCTestCase {
     }
     
     
-    func testWhenJsonValidThenResultContainsCohort() {
+    func testWhenJsonValidThenResultContainsCohortWithPlatformSuffix() {
         let validJson = data.fromJsonFile("MockResponse/cohort_atb")
         let result = try! testee.convert(fromJsonData: validJson)
-        XCTAssertEqual(result.version, "v77-5")
+        XCTAssertEqual(result.version, "v77-5mi")
     }
     
 }

--- a/DuckDuckGoTests/CohortRequestTests.swift
+++ b/DuckDuckGoTests/CohortRequestTests.swift
@@ -31,7 +31,7 @@ class CohortRequestTests: XCTestCase {
         super.tearDown()
     }
     
-    func testWhenStatus200AndValidJsonThenRequestCompletestWithCohort() {
+    func testWhenStatus200AndValidJsonThenRequestCompletestWithCohortWithPlatformSuffix() {
         
         stub(condition: isHost(host)) { _ in
             return fixture(filePath: self.validJson(), status: 200, headers: nil)
@@ -40,7 +40,7 @@ class CohortRequestTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Valid json")
         testee.execute { (result, error) in
             XCTAssertNotNil(result)
-            XCTAssertEqual(result?.version, "v77-5")
+            XCTAssertEqual(result?.version, "v77-5mi")
             XCTAssertNil(error)
             expectation.fulfill()
         }


### PR DESCRIPTION
Reviewer: Chris & Caine
Asana: https://app.asana.com/0/414709148257752/414274279387349

**Description**:
Add the "mi" variant to the atb parameter

**Steps to test this PR**:
1. Perform a search
2. Watch traffic and ensure the "mi" suffix appears on the atb parameter e.g
`https://duckduckgo.com/?q=example&t=ddg_ios&tappv=ios_7_863&atb=v79-6mi`


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)