### PR TITLE
Fix issue where tapping outside omnibar could dismiss and leave empty

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -289,7 +289,7 @@ extension MainViewController: OmniBarDelegate {
         launchBookmarks()
     }
     
-    func onDismissButtonPressed() {
+    func onDismissed() {
         dismissOmniBar()
     }
 }

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -152,7 +152,7 @@ class OmniBar: UIView {
     
     @IBAction func onDismissButtonPressed() {
         resignFirstResponder()
-        omniDelegate?.onDismissButtonPressed()
+        omniDelegate?.onDismissed()
     }
     
     @IBAction func onTextEntered(_ sender: Any) {
@@ -210,6 +210,9 @@ extension OmniBar: UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
+        if let text = textField.text, text.isEmpty {
+            omniDelegate?.onDismissed()
+        }
         refreshState(state.onEditingStoppedState)
     }
 }

--- a/DuckDuckGo/OmniBarDelegate.swift
+++ b/DuckDuckGo/OmniBarDelegate.swift
@@ -26,7 +26,7 @@ protocol OmniBarDelegate: class {
 
     func onOmniQuerySubmitted(_ query: String)
             
-    func onDismissButtonPressed()
+    func onDismissed()
     
     func onSiteRatingPressed()
 


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/414235014887631/408022749446951

**Description**:
If the user had activated the omnibar and cleared it, then tapped outside, it could be left empty

**Steps to test this PR**:
1. Tap in the omnibar
2. Press the clear "x" button
3. Tap outside the omnibar
4. The omnibar should be dismissed and the text box should be repopulated with previous content


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)