### PR TITLE
Fix issues where SERP search shows pluses instead of spaces

### DIFF
--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -57,10 +57,13 @@ extension URL {
     
     public func removeParam(name: String) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
+        guard let encodedQuery = components.percentEncodedQuery else { return self }
+        components.percentEncodedQuery = switchWebSpacesToSystemEncoding(text: encodedQuery)
         guard var query = components.queryItems else { return self }
         for (index, param) in query.enumerated() {
             if param.name == name {
                 query.remove(at: index)
+                break
             }
         }
         components.queryItems = query

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -140,6 +140,13 @@ class URLExtensionTests: XCTestCase {
         XCTAssertEqual(actual, url)
     }
     
+    func testWhenRemovingAParamThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
+        let expected = URL(string: "http://test.com?secondParam=45%20+%205")
+        let actual = url?.removeParam(name: "firstParam")
+        XCTAssertEqual(actual, expected)
+    }
+    
     func testWhenNoParamsThenAddingAppendsQuery() {
         let url = URL(string: "http://test.com")
         let expected = URL(string: "http://test.com?aParam=aValue")


### PR DESCRIPTION
Reviewer: Chris and/or Caine
Asana: https://app.asana.com/0/414709148257752/418906758184617

**Description**:
Fix issue where plus symbol web spaces were being treated as legitimate plus characters when mutating a url.

**Steps to test this PR**:
TEST ONE
1. Search for 45 + 50 in the omnibar
2. Ensure the query appears in the serp correctly and the the calculator is shown

TEST TWO
1. Search for 45 + 50 from ddg's web search bar
2. Ensure the query appears correctly and the the calculator is shown

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)