### PR TITLE
Fix score reporting

### DIFF
--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -126,10 +126,10 @@ public class SiteRatingCache {
     }
     
     private func cacheKey(forUrl url: URL) -> String {
-        let scheme = url.scheme ?? URL.URLProtocol.http.rawValue
         guard let domain = url.host else {
             return url.absoluteString
         }
+        let scheme = url.scheme ?? URL.URLProtocol.http.rawValue
         return "\(scheme)_\(domain)"
     }
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -198,6 +198,7 @@ class MainViewController: UIViewController {
             return
         }
         omniBar.refreshText(forUrl: tab.link?.url)
+        omniBar.updateSiteRating(tab.siteRating)
         omniBar.startBrowsing()
     }
     
@@ -363,7 +364,9 @@ extension MainViewController: TabDelegate {
     }
 
     func tab(_ tab: TabViewController, didChangeSiteRating siteRating: SiteRating?) {
-        omniBar.updateSiteRating(siteRating)
+        if currentTab == tab {
+            omniBar.updateSiteRating(siteRating)
+        }
     }
     
     func tabDidRequestSettings(tab: TabViewController) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -31,7 +31,7 @@ class TabViewController: WebViewController {
     private lazy var appUrls: AppUrls = AppUrls()
     private(set) var contentBlocker: ContentBlockerConfigurationStore!
     private weak var contentBlockerPopover: ContentBlockerPopover?
-    fileprivate var siteRating: SiteRating?
+    private(set) var siteRating: SiteRating?
     
     static func loadFromStoryboard(contentBlocker: ContentBlockerConfigurationStore) -> TabViewController {
         let controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "TabViewController") as! TabViewController

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -116,7 +116,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     }
     
     func testWhenNewRatingIsLowerThanCachedRatingThenCachedRatingIsUsed() {
-        _ = SiteRatingCache.shared.add(domain: Url.http.host!, score: 100)
+        _ = SiteRatingCache.shared.add(url: Url.http, score: 100)
         let testee = SiteRating(url: Url.http)!
         XCTAssertEqual(100, testee.siteScore)
     }


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/414709148257752/420099613930289

**Description**:
This PR updates the cache to only match if the schemes are the same (as we score https better than http) and ensures the site rating is only updated for the current tab

**Steps to test this PR**:
TEST 1:
1. Visit http://duckduckgo.com
2. Note the url becomes https://duckduckgo.com
3. Ensure the site rating is still an A

TEST 2:
1. Open two tabs with very different ratings e.g http://duckduckgo.com which is an A and http://www.dailymail.co.uk/ which is a D
2. While the "D" rating is still loading, switch back to the "A" rated one
3. Ensure the rating stays an "A" during loading
4. When all loading is done flip between the tabs and ensure the rating is updated appropriately

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)