### PR TITLE
Fix issue where closing a tab does not free memory

### DIFF
--- a/Core/WebEventsDelegate.swift
+++ b/Core/WebEventsDelegate.swift
@@ -22,6 +22,8 @@ import WebKit
 public protocol WebEventsDelegate: class {
 
     func attached(webView: WKWebView)
+    
+    func detached(webView: WKWebView)
 
     func webView(_ webView: WKWebView, shouldLoadUrl url: URL, forDocument documentUrl: URL) -> Bool
     

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -214,6 +214,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         guard let webView = webView else { return }
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
         webView.removeFromSuperview()
+        webEventsDelegate?.detached(webView: webView)
     }
     
     fileprivate func touchesYOffset() -> CGFloat {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -261,11 +261,19 @@ extension TabViewController: WKScriptMessageHandler {
 }
 
 extension TabViewController: WebEventsDelegate {
-    
+
+    struct Constants {
+        static let trackerDetectedMessage = "trackerDetectedMessage"
+    }
+
     func attached(webView: WKWebView) {
         webView.loadScripts()
         webView.scrollView.delegate = self
-        webView.configuration.userContentController.add(self, name: "trackerDetectedMessage")
+        webView.configuration.userContentController.add(self, name: Constants.trackerDetectedMessage)
+    }
+    
+    func detached(webView: WKWebView) {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: Constants.trackerDetectedMessage)
     }
 
     func webpageDidStartLoading() {

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -124,6 +124,9 @@ extension ShareViewController: WebEventsDelegate {
         webView.loadScripts()
     }
     
+    func detached(webView: WKWebView) {
+    }
+    
     func webView(_ webView: WKWebView, shouldLoadUrl url: URL, forDocument documentUrl: URL) -> Bool {
         return true
     }


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/414235014887631/431340016793883

**Description**:
TabViewControllers still consume memory even after a tab is closed.

**Steps to test this PR**:
1. Open the profiler
2. Select leaks and start profiling
3. In "Instrument Detail" enter TabViewController
4. Open 6 tabs and note that there are now 6 persistent TabViewControllers
5. Close all 6 tabs and note that they all disappear (this did not previously happen)

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)