### PR TITLE
Refresh when content blocker is toggled in settings

### DIFF
--- a/Core/ContentBlockerConfigurationStore.swift
+++ b/Core/ContentBlockerConfigurationStore.swift
@@ -20,11 +20,13 @@
 
 import Foundation
 
-public protocol ContentBlockerConfigurationStore {
+public struct ContentBlockerConfigurationChangedNotification {
+    public static let name = Notification.Name(rawValue: "com.duckduckgo.contentblocker.storeChanged")
+}
 
-    var domainWhitelist: Set<String> {
-        get
-    }
+public protocol ContentBlockerConfigurationStore {
+    
+    var domainWhitelist: Set<String> { get }
 
     var enabled: Bool { get set }
     

--- a/Core/ContentBlockerConfigurationUserDefaults.swift
+++ b/Core/ContentBlockerConfigurationUserDefaults.swift
@@ -47,6 +47,7 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
         set(newValue) {
             userDefaults?.set(newValue, forKey: Keys.enabled)
             SFContentBlockerManager.reloadContentBlocker()
+            onStoreChanged()
         }
     }
     
@@ -59,7 +60,7 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
         set(newWhitelistedDomain) {
             let data = NSKeyedArchiver.archivedData(withRootObject: newWhitelistedDomain)
             userDefaults?.set(data, forKey: Keys.whitelistedDomains)
-            SFContentBlockerManager.reloadContentBlocker()
+            onStoreChanged()
         }
     }
     
@@ -71,13 +72,17 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
         var whitelist = domainWhitelist
         whitelist.insert(domain)
         domainWhitelist = whitelist
-        SFContentBlockerManager.reloadContentBlocker()
+        onStoreChanged()
     }
     
     public func removeFromWhitelist(domain: String) {
         var whitelist = domainWhitelist
         whitelist.remove(domain)
         domainWhitelist = whitelist
-        SFContentBlockerManager.reloadContentBlocker()
+        onStoreChanged()
+    }
+    
+    private func onStoreChanged() {
+        NotificationCenter.default.post(name: ContentBlockerConfigurationChangedNotification.name , object: nil)
     }
 }

--- a/Core/ContentBlockerConfigurationUserDefaults.swift
+++ b/Core/ContentBlockerConfigurationUserDefaults.swift
@@ -72,14 +72,12 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
         var whitelist = domainWhitelist
         whitelist.insert(domain)
         domainWhitelist = whitelist
-        onStoreChanged()
     }
     
     public func removeFromWhitelist(domain: String) {
         var whitelist = domainWhitelist
         whitelist.remove(domain)
         domainWhitelist = whitelist
-        onStoreChanged()
     }
     
     private func onStoreChanged() {

--- a/DuckDuckGo/SiteRatingView.swift
+++ b/DuckDuckGo/SiteRatingView.swift
@@ -38,27 +38,19 @@ public class SiteRatingView: UIView {
         let view = Bundle.main.loadNibNamed("SiteRatingView", owner: self, options: nil)![0] as! UIView
         self.addSubview(view)
         view.frame = self.bounds
-        addUserDefaultsObserver()
-    }
-    
-    deinit {
-        removeUserDefaultsObserver()
+        addContentBlockerConfigurationObserver()
     }
     
     public override func layoutSubviews() {
         super.layoutSubviews()
         refresh()
     }
-    
-    private func addUserDefaultsObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(onUserDefaultsChanged), name: UserDefaults.didChangeNotification, object: nil)
+
+    private func addContentBlockerConfigurationObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(onContentBlockerConfigurationChanged), name: ContentBlockerConfigurationChangedNotification.name, object: nil)
     }
     
-    private func removeUserDefaultsObserver() {
-        NotificationCenter.default.removeObserver(self, name: UserDefaults.didChangeNotification, object: nil)
-    }
-    
-    func onUserDefaultsChanged(notification: NSNotification) {
+    func onContentBlockerConfigurationChanged() {
         refresh()
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -43,10 +43,23 @@ class TabViewController: WebViewController {
         super.init(coder: aDecoder)
         webEventsDelegate = self
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addContentBlockerConfigurationObserver()
+    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         resetNavigationBar()
+    }
+    
+    private func addContentBlockerConfigurationObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(onContentBlockerConfigurationChanged), name: ContentBlockerConfigurationChangedNotification.name, object: nil)
+    }
+
+    func onContentBlockerConfigurationChanged() {
+        webView?.reload()
     }
     
     private func resetNavigationBar() {


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/414709148257752/433776422524752

**Description**:
Update the site rating and tab to refresh when the content blocker toggle changes

**Steps to test this PR**:
TEST 1:
1. Navigate to a page
2. Go to settings, toggle the content blocker option off
3. Ensure that the page is refreshed and the site rating and content blocker views are updated to indicate that the content blocker is off

TEST 2:
1. Navigate to a page
2. Go to settings, toggle the content blocker option on
3. Ensure that the page is refreshed and the site rating and content blocker views are updated to indicate that the content blocker is on

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)