### PR TITLE
Fix addressbar overlap issue on iOS 11

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -44,8 +44,8 @@ class TabViewController: WebViewController {
         webEventsDelegate = self
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         resetNavigationBar()
     }
     


### PR DESCRIPTION
Reviewer: Chris (if you've updated to iOS11 otherwise Caine)
Asana: https://app.asana.com/0/414235014887631/388973137827611

**Description**:
Fixes an ios 11 issue where the address bar overlapped the web content

**Steps to test this PR**:
1. Launch the app on an iOS 11 device (must be built using XCode 8.3.3)
2. Clear all tabs and data
3. Submit a new search e.g "test"
4. Ensure that the address bar does not overlap the webview

###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)