### PR TITLE
use entire disconnect list to look up associated sites

### DIFF
--- a/Core/DisconnectMeContentBlockerParser.swift
+++ b/Core/DisconnectMeContentBlockerParser.swift
@@ -25,15 +25,16 @@ import SwiftyJSON
 public struct DisconnectMeTrackersParser {
     
    enum Category: String {
-        case advertising = "Advertising"
         case analytics = "Analytics"
-        case disconnect = "Disconnect"
+        case advertising = "Advertising"
         case social = "Social"
+        case disconnect = "Disconnect"
         case content = "Content"
     }
     
     static let bannedCategoryFilter: [Category] = [.analytics, .advertising, .social]
-    
+    static let allowedCategoryFilter: [Category] = [ .disconnect, .content ]
+
     func convert(fromJsonData data: Data, categoryFilter: [Category]?) throws -> [String: String] {
         guard let json = try? JSON(data: data) else {
             throw JsonError.invalidJson

--- a/Core/WKWebViewExtension.swift
+++ b/Core/WKWebViewExtension.swift
@@ -60,7 +60,8 @@ extension WKWebView {
 
         javascriptLoader.load(script: .blockerData, withReplacements: [
             "${blocking_enabled}": "\(blockingEnabled)",
-            "${disconnectme}": DisconnectMeStore.shared.bannedTrackersJson,
+            "${disconnectmeBanned}": DisconnectMeStore.shared.bannedTrackersJson,
+            "${disconnectmeAllowed}": DisconnectMeStore.shared.allowedTrackersJson,
             "${whitelist}": whitelist ],
              andController:configuration.userContentController,
              forMainFrameOnly: false)

--- a/Core/blockerdata.js
+++ b/Core/blockerdata.js
@@ -20,7 +20,8 @@
 var duckduckgoBlockerData = {
 
     blockingEnabled: ${blocking_enabled},
-	disconnectme: ${disconnectme},
+	disconnectmeBanned: ${disconnectmeBanned},
+    disconnectmeAllowed: ${disconnectmeAllowed},
     whitelist: ${whitelist},
     easylist: {},
     easylistPrivacy: {}

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -132,7 +132,7 @@ var duckduckgoContentBlocking = function() {
 		}
 
 		var result = DisconnectMe.parentTracker(urlToCheck)
-		if (result && domainsMatch(result.parent, topLevelUrl)) {
+		if (result && domainsMatch(new URL(topLevelUrl.protocol + result.parent), topLevelUrl)) {
 			return true
 		}
 

--- a/Core/disconnectme.js
+++ b/Core/disconnectme.js
@@ -19,38 +19,18 @@
 
 var DisconnectMe = function() {
 
-	// private
-	function isCurrentDomain(parentDomain, currentDomain) {
-
-		if (parentDomain == currentDomain) {
-			return true
-		}
-
-		if (currentDomain.endsWith("." + parentDomain)) {
-			return true
-		}
-
-		return false
-	}
-
 	// public
-	function parentTracker(urlToCheck, topLevelUrl) {
-		var domainToCheck = urlToCheck.hostname
-		var currentDomain = topLevelUrl.hostname		
+	function parentTracker(url) {
+		var domain = duckduckgoTLDParser.extractDomain(url)
+		
+		var parentBlocked = duckduckgoBlockerData.disconnectmeBanned[domain]
+		if (parentBlocked) {
+			return { parent: parentBlocked, banned: true }
+		}
 
-		var domainNameParts = domainToCheck.split(".")
-		var max = domainNameParts.length;
-
-		for (var i = max - 2; i >= 0; i--) {
-			var hostname = domainNameParts.slice(i, max).join(".");
-			var parent = duckduckgoBlockerData.disconnectme[hostname]
-
-			if (parent) {
- 				if (isCurrentDomain(parent, currentDomain)) {
- 					return false
- 				}
-				return parent
-			}		
+		var parentAllowed = duckduckgoBlockerData.disconnectmeAllowed[domain]
+		if (parentAllowed) {
+			return { parent: parentAllowed, banned: false }
 		}
 
 		return null


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: https://app.asana.com/0/414235014887631/438261419283368
CC:

**Description**:

Passes two structures to the Javascript - trackers that are banned and trackers that are allowed.  If a url is in the banned structure, it will be blocked, unless it is an associated first party url.  The logic for first party url checking checks both structures to give complete coverage of associated domains.

**Steps to test this PR**:
1. Visit a tracker heavy site and confirm that tracking is still working
2. Visit a site like criteo.com and ensure that first party URLs are still working


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)