### PR TITLE
Lazily load tabs when launching and clear excess tabs on low memory

### DIFF
--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -1,0 +1,123 @@
+//
+//  WKWebViewConfigurationExtension.swift
+//  DuckDuckGo
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import WebKit
+
+extension WKWebViewConfiguration {
+    
+    public static func persistent() -> WKWebViewConfiguration {
+        return configuration(persistsData: true)
+    }
+    
+    public static func nonPersistent() -> WKWebViewConfiguration {
+        return configuration(persistsData: false)
+    }
+    
+    private static func configuration(persistsData: Bool) -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        if !persistsData {
+            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        }
+        if #available(iOSApplicationExtension 10.0, *) {
+            configuration.dataDetectorTypes = [.link, .phoneNumber]
+        }
+        configuration.loadScripts()
+        return configuration
+    }
+    
+    public func loadScripts() {
+        loadDocumentLevelScripts()
+        let contentBlocker = ContentBlockerConfigurationUserDefaults()
+        loadContentBlockerScripts(with: contentBlocker.domainWhitelist, and: contentBlocker.enabled)
+    }
+    
+    private func loadContentBlockerScripts(with whitelistedDomains: Set<String>, and blockingEnabled: Bool) {
+        loadContentBlockerDependencyScripts()
+        loadBlockerData(with: whitelistedDomains.toJsonLookupString(), and: blockingEnabled)
+        load(scripts: [ .disconnectme, .contentblocker ], forMainFrameOnly: false)
+    }
+    
+    private func loadContentBlockerDependencyScripts() {
+        load(scripts: [ .messaging, .apbfilter, .tlds ], forMainFrameOnly: false)
+    }
+    
+    private func loadDocumentLevelScripts() {
+        load(scripts: [ .document, .favicon ])
+    }
+    
+    private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool) {
+        
+        let javascriptLoader = JavascriptLoader()
+        
+        javascriptLoader.load(script: .blockerData, withReplacements: [
+            "${blocking_enabled}": "\(blockingEnabled)",
+            "${disconnectmeBanned}": DisconnectMeStore.shared.bannedTrackersJson,
+            "${disconnectmeAllowed}": DisconnectMeStore.shared.allowedTrackersJson,
+            "${whitelist}": whitelist ],
+                              andController:userContentController,
+                              forMainFrameOnly: false)
+        
+        let cache = ContentBlockerStringCache()
+        if let cachedEasylist = cache.get(named: EasylistStore.CacheNames.easylist), let cachedEasylistPrivacy = cache.get(named: EasylistStore.CacheNames.easylistPrivacy) {
+            
+            Logger.log(text: "using cached easylist")
+            
+            javascriptLoader.load(.bloom, withController: userContentController, forMainFrameOnly: false)
+            
+            javascriptLoader.load(script: .cachedEasylist, withReplacements: [
+                "${easylist_privacy_json}": cachedEasylistPrivacy,
+                "${easylist_general_json}": cachedEasylist ],
+                                  andController: userContentController,
+                                  forMainFrameOnly: false)
+            
+        } else {
+            
+            Logger.log(text: "parsing easylist")
+            
+            let easylistStore = EasylistStore()
+            
+            javascriptLoader.load(script: .easylistParsing, withReplacements: [
+                "${easylist_privacy}": easylistStore.easylistPrivacy,
+                "${easylist_general}": easylistStore.easylist ],
+                                  andController: userContentController,
+                                  forMainFrameOnly: false)
+            
+        }
+        
+    }
+    
+    private func load(scripts: [JavascriptLoader.Script], forMainFrameOnly: Bool = true) {
+        let javascriptLoader = JavascriptLoader()
+        for script in scripts {
+            javascriptLoader.load(script, withController: userContentController, forMainFrameOnly: forMainFrameOnly)
+        }
+    }
+}
+
+fileprivate extension Set where Element == String {
+    
+    func toJsonLookupString() -> String {
+        return reduce("{", { (result, next) -> String in
+            let separator = result != "{" ? ", " : ""
+            return "\(result)\(separator) \"\(next)\" : true"
+        }).appending("}")
+    }
+    
+}

--- a/Core/WKWebViewExtension.swift
+++ b/Core/WKWebViewExtension.swift
@@ -22,12 +22,12 @@ import WebKit
 
 extension WKWebViewConfiguration {
     
-    public static func persistant() -> WKWebViewConfiguration {
+    public static func persistent() -> WKWebViewConfiguration {
         return configuration(persistsData: true)
     }
     
-    public static func nonPersistant() -> WKWebViewConfiguration {
-        return configuration(persistsData: true)
+    public static func nonPersistent() -> WKWebViewConfiguration {
+        return configuration(persistsData: false)
     }
     
     private static func configuration(persistsData: Bool) -> WKWebViewConfiguration {

--- a/Core/WKWebViewExtension.swift
+++ b/Core/WKWebViewExtension.swift
@@ -20,98 +20,6 @@
 
 import WebKit
 
-extension WKWebViewConfiguration {
-    
-    public static func persistent() -> WKWebViewConfiguration {
-        return configuration(persistsData: true)
-    }
-    
-    public static func nonPersistent() -> WKWebViewConfiguration {
-        return configuration(persistsData: false)
-    }
-    
-    private static func configuration(persistsData: Bool) -> WKWebViewConfiguration {
-        let configuration = WKWebViewConfiguration()
-        if !persistsData {
-            configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
-        }
-        if #available(iOSApplicationExtension 10.0, *) {
-            configuration.dataDetectorTypes = [.link, .phoneNumber]
-        }
-        configuration.loadScripts()
-        return configuration
-    }
-    
-    public func loadScripts() {
-        loadDocumentLevelScripts()
-        let contentBlocker = ContentBlockerConfigurationUserDefaults()
-        loadContentBlockerScripts(with: contentBlocker.domainWhitelist, and: contentBlocker.enabled)
-    }
-    
-    private func loadContentBlockerScripts(with whitelistedDomains: Set<String>, and blockingEnabled: Bool) {
-        loadContentBlockerDependencyScripts()
-        loadBlockerData(with: whitelistedDomains.toJsonLookupString(), and: blockingEnabled)
-        load(scripts: [ .disconnectme, .contentblocker ], forMainFrameOnly: false)
-    }
-    
-    private func loadContentBlockerDependencyScripts() {
-        load(scripts: [ .messaging, .apbfilter, .tlds ], forMainFrameOnly: false)
-    }
-    
-    private func loadDocumentLevelScripts() {
-        load(scripts: [ .document, .favicon ])
-    }
-    
-    private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool) {
-        
-        let javascriptLoader = JavascriptLoader()
-        
-        javascriptLoader.load(script: .blockerData, withReplacements: [
-            "${blocking_enabled}": "\(blockingEnabled)",
-            "${disconnectmeBanned}": DisconnectMeStore.shared.bannedTrackersJson,
-            "${disconnectmeAllowed}": DisconnectMeStore.shared.allowedTrackersJson,
-            "${whitelist}": whitelist ],
-             andController:userContentController,
-             forMainFrameOnly: false)
-        
-        let cache = ContentBlockerStringCache()
-        if let cachedEasylist = cache.get(named: EasylistStore.CacheNames.easylist), let cachedEasylistPrivacy = cache.get(named: EasylistStore.CacheNames.easylistPrivacy) {
-            
-            Logger.log(text: "using cached easylist")
-            
-            javascriptLoader.load(.bloom, withController: userContentController, forMainFrameOnly: false)
-            
-            javascriptLoader.load(script: .cachedEasylist, withReplacements: [
-                "${easylist_privacy_json}": cachedEasylistPrivacy,
-                "${easylist_general_json}": cachedEasylist ],
-                andController: userContentController,
-                forMainFrameOnly: false)
-            
-        } else {
-            
-            Logger.log(text: "parsing easylist")
-            
-            let easylistStore = EasylistStore()
-            
-            javascriptLoader.load(script: .easylistParsing, withReplacements: [
-                "${easylist_privacy}": easylistStore.easylistPrivacy,
-                "${easylist_general}": easylistStore.easylist ],
-                andController: userContentController,
-                forMainFrameOnly: false)
-            
-        }
-        
-    }
-    
-    private func load(scripts: [JavascriptLoader.Script], forMainFrameOnly: Bool = true) {
-        let javascriptLoader = JavascriptLoader()
-        for script in scripts {
-            javascriptLoader.load(script, withController: userContentController, forMainFrameOnly: forMainFrameOnly)
-        }
-    }
-    
-}
-
 extension WKWebView {
     
     public func getUrlAtPoint(x: Int, y: Int, completion: @escaping (URL?) -> Swift.Void) {
@@ -152,16 +60,4 @@ extension WKWebView {
         }
     }
 }
-
-fileprivate extension Set where Element == String {
-    
-    func toJsonLookupString() -> String {
-        return reduce("{", { (result, next) -> String in
-            let separator = result != "{" ? ", " : ""
-            return "\(result)\(separator) \"\(next)\" : true"
-        }).appending("}")
-    }
-    
-}
-
 

--- a/Core/WebEventsDelegate.swift
+++ b/Core/WebEventsDelegate.swift
@@ -25,6 +25,8 @@ public protocol WebEventsDelegate: class {
     
     func detached(webView: WKWebView)
 
+    func webViewDidTerminate(webView: WKWebView)
+    
     func webView(_ webView: WKWebView, shouldLoadUrl url: URL, forDocument documentUrl: URL) -> Bool
     
     func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point)

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -181,7 +181,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     }
 
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        Logger.log(text: "MEMORY: Webview did terminate")
+        webEventsDelegate?.webViewDidTerminate(webView: webView)
     }
     
     private func shouldReissueSearch(for url: URL) -> Bool {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -56,8 +56,9 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         return webView.canGoForward
     }
     
-    public func attachWebView(persistsData: Bool) {
-        webView = WKWebView.createWebView(frame: view.bounds, persistsData: persistsData)
+    open func attachWebView(configuration: WKWebViewConfiguration) {
+        webView = WKWebView(frame: view.bounds, configuration: configuration)
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         attachLongPressHandler(webView: webView)
         webView.allowsBackForwardNavigationGestures = true
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
@@ -67,7 +68,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         view.insertSubview(webView, at: 0)
         view.addEqualSizeConstraints(subView: webView)
         webEventsDelegate?.attached(webView: webView)
-        reloadScripts()
+        
         if let url = url {
             load(url: url)
         }
@@ -241,7 +242,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
 
     open func reloadScripts() {
         webView.configuration.userContentController.removeAllUserScripts()
-        webView.loadScripts(contentBlocker: ContentBlockerConfigurationUserDefaults())
+        webView.configuration.loadScripts()
     }
 
 }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -180,6 +180,10 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         return nil
     }
 
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Logger.log(text: "MEMORY: Webview did terminate")
+    }
+    
     private func shouldReissueSearch(for url: URL) -> Bool {
         return appUrls.isDuckDuckGoSearch(url: url) && !appUrls.hasCorrectMobileStatsParams(url: url)
     }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		830381C01F850AAF00863075 /* WKWebViewConfigurationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */; };
 		830C375C1F6C06BF00E317A7 /* TermsOfService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C375B1F6C06BF00E317A7 /* TermsOfService.swift */; };
 		830C375E1F6C3A3B00E317A7 /* TermsOfServiceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C375D1F6C3A3B00E317A7 /* TermsOfServiceStore.swift */; };
 		830C37631F6C482E00E317A7 /* TermsOfServiceListParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C37621F6C482E00E317A7 /* TermsOfServiceListParser.swift */; };
@@ -332,6 +333,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WKWebViewConfigurationExtension.swift; sourceTree = "<group>"; };
 		830C375B1F6C06BF00E317A7 /* TermsOfService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfService.swift; sourceTree = "<group>"; };
 		830C375D1F6C3A3B00E317A7 /* TermsOfServiceStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceStore.swift; sourceTree = "<group>"; };
 		830C37621F6C482E00E317A7 /* TermsOfServiceListParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceListParser.swift; sourceTree = "<group>"; };
@@ -1118,6 +1120,7 @@
 				F143C3391E4A9A9200CFDE3A /* WebViewController.swift */,
 				F143C3381E4A9A9200CFDE3A /* WebEventsDelegate.swift */,
 				F143C33A1E4A9A9200CFDE3A /* WKWebViewExtension.swift */,
+				830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */,
 				F1A886771F29394E0096251E /* WebCacheManager.swift */,
 				F159BDA61F0C073D00B4A01D /* WebCacheSummary.swift */,
 				F18326861E60542100240060 /* JavascriptLoader.swift */,
@@ -2216,6 +2219,7 @@
 				F11E22F61ED31CB600523BC9 /* JsonError.swift in Sources */,
 				F1134EB51F40AEEA00B73467 /* StatisticsLoader.swift in Sources */,
 				F143C3281E4A9A0E00CFDE3A /* StringExtension.swift in Sources */,
+				830381C01F850AAF00863075 /* WKWebViewConfigurationExtension.swift in Sources */,
 				F1B88A101F3BA176000263D6 /* SiteGrade.swift in Sources */,
 				F1A886781F29394E0096251E /* WebCacheManager.swift in Sources */,
 				F1DA2F701EBCEA8B00313F51 /* SupportedExternalURLScheme.swift in Sources */,

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -40,7 +40,7 @@ class MainViewController: UIViewController {
     fileprivate lazy var appSettings: AppSettings = AppUserDefaults()
 
     fileprivate var currentTab: TabViewController? {
-        return tabManager.current
+        return tabManager.current()
     }
     
     override func viewDidLoad() {
@@ -153,8 +153,12 @@ class MainViewController: UIViewController {
     }
     
     fileprivate func select(tabAt index: Int) {
-        let selectedTab = tabManager.select(tabAt: index)
-        addToView(tab: selectedTab)
+        let tab = tabManager.select(tabAt: index)
+        select(tab: tab)
+    }
+    
+    fileprivate func select(tab: TabViewController) {
+        addToView(tab: tab)
         refreshControls()
     }
     
@@ -173,8 +177,8 @@ class MainViewController: UIViewController {
 
     fileprivate func remove(tabAt index: Int) {
         tabManager.remove(at: index)
-        if let index = tabManager.currentIndex {
-            select(tabAt: index)
+        if let currentTab = currentTab {
+            select(tab: currentTab)
         } else {
             attachHomeScreen(active: false)
         }
@@ -261,10 +265,7 @@ class MainViewController: UIViewController {
     }
     
     fileprivate func launchTabSwitcher() {
-        if let currentTab = currentTab {
-            tabManager.updateModelFromTab(tab: currentTab)
-        }
-        let controller = TabSwitcherViewController.loadFromStoryboard(delegate: self, tabsModel: tabManager.model)
+            let controller = TabSwitcherViewController.loadFromStoryboard(delegate: self, tabsModel: tabManager.model)
         controller.transitioningDelegate = self
         controller.modalPresentationStyle = .overCurrentContext
         present(controller, animated: true, completion: nil)
@@ -280,6 +281,10 @@ class MainViewController: UIViewController {
         let controller = SettingsViewController.loadFromStoryboard()
         controller.modalPresentationStyle = .overCurrentContext
         present(controller, animated: true, completion: nil)
+    }
+    
+    override func didReceiveMemoryWarning() {
+        Logger.log(text: "MEMORY: Warning received")
     }
 }
 
@@ -356,7 +361,7 @@ extension MainViewController: TabDelegate {
     
     func tabLoadingStateDidChange(tab: TabViewController) {
         refreshControls()
-        tabManager.updateModelFromTab(tab: tab)
+        tabManager.save()
     }
 
     func tabDidRequestNewTab(_ tab: TabViewController) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -40,7 +40,7 @@ class MainViewController: UIViewController {
     fileprivate lazy var appSettings: AppSettings = AppUserDefaults()
 
     fileprivate var currentTab: TabViewController? {
-        return tabManager.current()
+        return tabManager.current
     }
     
     override func viewDidLoad() {
@@ -188,7 +188,7 @@ class MainViewController: UIViewController {
         WebCacheManager.clear() {}
         FireAnimation.animate() {
             completion()
-            self.tabManager.clearAll()
+            self.tabManager.removeAll()
             self.attachHomeScreen(active: false)
         }
         let window = UIApplication.shared.keyWindow
@@ -284,7 +284,9 @@ class MainViewController: UIViewController {
     }
     
     override func didReceiveMemoryWarning() {
-        Logger.log(text: "MEMORY: Warning received")
+        Logger.log(text: "Memory warning received, reducing memory")
+        super.didReceiveMemoryWarning()
+        tabManager.reduceMemory()
     }
 }
 
@@ -380,6 +382,11 @@ extension MainViewController: TabDelegate {
     
     func tabDidRequestSettings(tab: TabViewController) {
         launchSettings()
+    }
+    
+    func tabDidRequestMemoryReduction(tab: TabViewController) {
+        Logger.log(text: "Memory reduction requested, reducing memory")
+        tabManager.reduceMemory()
     }
 }
 

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -32,4 +32,6 @@ protocol TabDelegate: class {
     func tab(_ tab: TabViewController, didChangeSiteRating siteRating: SiteRating?)
 
     func tabDidRequestSettings(tab: TabViewController)
+    
+    func tabDidRequestMemoryReduction(tab: TabViewController)
 }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -46,7 +46,7 @@ class TabManager {
     
     private func buildController(forTab tab: Tab, request: URLRequest?) -> TabViewController {
         let contentBlocker = ContentBlockerConfigurationUserDefaults()
-        let configuration =  WKWebViewConfiguration.persistant()
+        let configuration =  WKWebViewConfiguration.persistent()
         let controller = TabViewController.loadFromStoryboard(model: tab, contentBlocker: contentBlocker)
         controller.attachWebView(configuration: configuration)
         controller.delegate = delegate

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -19,11 +19,11 @@
 
 
 import Core
+import WebKit
 
 class TabManager {
     
     private(set) var model: TabsModel
-    
     private var tabControllerCache = [TabViewController]()
     
     private weak var delegate: TabDelegate?
@@ -46,8 +46,9 @@ class TabManager {
     
     private func buildController(forTab tab: Tab, request: URLRequest?) -> TabViewController {
         let contentBlocker = ContentBlockerConfigurationUserDefaults()
+        let configuration =  WKWebViewConfiguration.persistant()
         let controller = TabViewController.loadFromStoryboard(model: tab, contentBlocker: contentBlocker)
-        controller.attachWebView(persistsData: true)
+        controller.attachWebView(configuration: configuration)
         controller.delegate = delegate
         
         if let request = request {
@@ -148,7 +149,11 @@ class TabManager {
     
     func reduceMemory() {
         
-        let itemsToClear = 2
+        if tabControllerCache.count < 3 {
+            return
+        }
+        
+        let itemsToClear = tabControllerCache.count / 2
         var itemsCleared = 0
         
         for controller in tabControllerCache {

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -68,6 +68,7 @@ class TabManager {
             tabControllerCache.append(controller)
             return controller
         } else {
+            Logger.log(text: "Tab not in cache, creating")
             let controller = buildController(forTab: tab)
             tabControllerCache.append(controller)
             return controller

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -316,6 +316,10 @@ extension TabViewController: WebEventsDelegate {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: MessageHandlerNames.trackerDetected)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: MessageHandlerNames.cache)
     }
+    
+    func webViewDidTerminate(webView: WKWebView) {
+        delegate?.tabDidRequestMemoryReduction(tab: self)
+    }
 
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -32,14 +32,17 @@ class TabViewController: WebViewController {
     private(set) var contentBlocker: ContentBlockerConfigurationStore!
     private weak var contentBlockerPopover: ContentBlockerPopover?
     private(set) var siteRating: SiteRating?
+    private(set) var tabModel: Tab
     
-    static func loadFromStoryboard(contentBlocker: ContentBlockerConfigurationStore) -> TabViewController {
+    static func loadFromStoryboard(model: Tab, contentBlocker: ContentBlockerConfigurationStore) -> TabViewController {
         let controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "TabViewController") as! TabViewController
         controller.contentBlocker = contentBlocker
+        controller.tabModel = model
         return controller
     }
     
     required init?(coder aDecoder: NSCoder) {
+        tabModel = Tab(link: nil)
         super.init(coder: aDecoder)
         webEventsDelegate = self
     }
@@ -317,6 +320,7 @@ extension TabViewController: WebEventsDelegate {
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
         resetSiteRating()
+        tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
     }
@@ -325,6 +329,7 @@ extension TabViewController: WebEventsDelegate {
         Logger.log(items: "webpageLoading finished:", Date().timeIntervalSince1970)
         siteRating?.finishedLoading = true
         updateSiteRating()
+        tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
     }
@@ -336,6 +341,7 @@ extension TabViewController: WebEventsDelegate {
     func faviconWasUpdated(_ favicon: URL, forUrl url: URL) {
         let bookmarks = BookmarkUserDefaults()
         bookmarks.updateFavicon(favicon, forBookmarksWithUrl: url)
+        tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
     }
     

--- a/DuckDuckGoTests/WKWebViewExtensionTests.swift
+++ b/DuckDuckGoTests/WKWebViewExtensionTests.swift
@@ -24,12 +24,14 @@ import WebKit
 class WKWebViewExtensionTests: XCTestCase {
     
     func testWhenWebViewCreatedWithNonPersistenceThenDataStoreIsNonPersistent() {
-        let webView = WKWebView.createWebView(frame: CGRect(), persistsData: false)
+        let configuration = WKWebViewConfiguration.nonPersistant()
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertFalse(webView.configuration.websiteDataStore.isPersistent)
     }
 
     func testWhenWebViewCreatedWithPersistenceThenDataStoreIsPersistent() {
-        let webView = WKWebView.createWebView(frame: CGRect(), persistsData: true)
+        let configuration = WKWebViewConfiguration.persistant()
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertTrue(webView.configuration.websiteDataStore.isPersistent)
     }
     

--- a/DuckDuckGoTests/WKWebViewExtensionTests.swift
+++ b/DuckDuckGoTests/WKWebViewExtensionTests.swift
@@ -24,13 +24,13 @@ import WebKit
 class WKWebViewExtensionTests: XCTestCase {
     
     func testWhenWebViewCreatedWithNonPersistenceThenDataStoreIsNonPersistent() {
-        let configuration = WKWebViewConfiguration.nonPersistant()
+        let configuration = WKWebViewConfiguration.nonPersistent()
         let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertFalse(webView.configuration.websiteDataStore.isPersistent)
     }
 
     func testWhenWebViewCreatedWithPersistenceThenDataStoreIsPersistent() {
-        let configuration = WKWebViewConfiguration.persistant()
+        let configuration = WKWebViewConfiguration.persistent()
         let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertTrue(webView.configuration.websiteDataStore.isPersistent)
     }

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -125,6 +125,10 @@ extension ShareViewController: WebEventsDelegate {
     
     func detached(webView: WKWebView) {
     }
+
+    func webViewDidTerminate(webView: WKWebView) {
+        webView.reload()
+    }
     
     func webView(_ webView: WKWebView, shouldLoadUrl url: URL, forDocument documentUrl: URL) -> Bool {
         return true

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -36,7 +36,7 @@ class ShareViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        webController?.attachWebView(persistsData: false)
+        webController?.attachWebView(configuration: WKWebViewConfiguration.nonPersistant())
         refreshNavigationButtons()
     }
     

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -36,7 +36,7 @@ class ShareViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        webController?.attachWebView(configuration: WKWebViewConfiguration.nonPersistant())
+        webController?.attachWebView(configuration: WKWebViewConfiguration.nonPersistent())
         refreshNavigationButtons()
     }
     


### PR DESCRIPTION
Reviewer: Chris
Asana: https://app.asana.com/0/414235014887631/442414558181570

**Description**:
This PR lazily loads persisted tabs on launch. It also clears loaded tabs when memory gets low.

**Steps to test this PR**:
1. In a simulator open 4 tabs
2. Background the app and kill it
3. Relaunch
4. Go to the tab switcher and select all the non-active tabs. They will each be created from the cache on demand printing a "Tab not in memory, creating" log as they are selected.
5. Switch between them, now that they are in memory there should be no new creation logs
6. Trigger a low memory warning. Half the tabs (the two OLDEST) will be removed from the cache. Selecting these will again cause the "Tab not in cache, creating" log to be displayed

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation

###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)