### PR TITLE
Feature/use unchanged tracker lists

### DIFF
--- a/Core/APIRequest.swift
+++ b/Core/APIRequest.swift
@@ -57,7 +57,7 @@ public class APIRequest {
 
                 Logger.log(text: "Request for \(self.url) completed with response code: \(String(describing: response.response?.statusCode)) and headers \(String(describing: response.response?.allHeaderFields))")
 
-                guard nil == etag, etag != response.response?.headerValue(for: HeaderNames.etag) else {
+                if etag != nil && etag == response.response?.headerValue(for: HeaderNames.etag) {
                     Logger.log(text: "Using cached version of \(self.url) with etag: \(String(describing: etag))")
                     _ = completion(nil, nil)
                     return
@@ -86,7 +86,7 @@ class UserDefaultsETagStorage: APIRequestETagStorage {
 
     func etag(for url: URL) -> String? {
         let etag = defaults?.string(forKey: url.absoluteString)
-        print("*** etag for ", url, etag)
+        Logger.log(items: "stored etag for ", url, etag as Any)
         return etag
     }
 

--- a/Core/BlockerListRequest.swift
+++ b/Core/BlockerListRequest.swift
@@ -1,0 +1,103 @@
+//
+//  BlockerListRequest.swift
+//  DuckDuckGo
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+class BlockerListRequest {
+
+    enum List: String {
+
+        case disconnectMe = "disconnectme"
+        case easylist = "easylist"
+        case easylistPrivacy = "easyprivacy"
+
+    }
+
+    let etagStorage: BlockerListETagStorage
+
+    init(etagStorage: BlockerListETagStorage = UserDefaultsETagStorage()) {
+        self.etagStorage = etagStorage
+    }
+
+    func request(_ list: List, completion:@escaping (Data?) -> Void) {
+        APIRequest.request(url: url(for: list)) { (response, error) in
+
+            guard error == nil else {
+                completion(nil)
+                return
+            }
+
+            guard let response = response else {
+                completion(nil)
+                return
+            }
+
+            guard let data = response.data else {
+                completion(nil)
+                return
+            }
+
+            let etag = self.etagStorage.etag(for: list)
+
+            if etag == nil || etag != response.etag {
+                self.etagStorage.set(etag: response.etag, for: list)
+                completion(data)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
+    private func url(for list: List) -> URL {
+        let appUrls = AppUrls()
+
+        switch(list) {
+            case .disconnectMe: return appUrls.disconnectMeBlockList
+            case .easylist: return appUrls.easylistBlockList
+            case .easylistPrivacy: return appUrls.easylistPrivacyBlockList
+        }
+
+    }
+
+}
+
+
+protocol BlockerListETagStorage {
+
+    func set(etag: String?, for list: BlockerListRequest.List)
+
+    func etag(for list: BlockerListRequest.List) -> String?
+
+}
+
+class UserDefaultsETagStorage: BlockerListETagStorage {
+
+    lazy var defaults = UserDefaults(suiteName: "com.duckduckgo.blocker-list.etags")
+
+    func etag(for list: BlockerListRequest.List) -> String? {
+        let etag = defaults?.string(forKey: list.rawValue)
+        Logger.log(items: "stored etag for ", list.rawValue, etag as Any)
+        return etag
+    }
+
+    func set(etag: String?, for list: BlockerListRequest.List) {
+        defaults?.set(etag, forKey: list.rawValue)
+    }
+    
+}

--- a/Core/BlockerListsLoader.swift
+++ b/Core/BlockerListsLoader.swift
@@ -75,7 +75,7 @@ public class BlockerListsLoader {
 
         }
 
-        return 1
+        return 3
     }
 
     private class func handleResponseAndSignalCompletion(data: Data?, error: Error?, semaphore: DispatchSemaphore, dataHandler: (Data) -> Void) -> APIRequestCompleteionResult {

--- a/Core/EasylistStore.swift
+++ b/Core/EasylistStore.swift
@@ -34,7 +34,11 @@ class EasylistStore {
 
     }
 
-    var hasData = false
+    var hasData: Bool {
+        get {
+            return exists(type: .easylist) && exists(type: .easylistPrivacy)
+        }
+    }
 
     var easylistPrivacy: String? {
         get {
@@ -46,13 +50,6 @@ class EasylistStore {
         get {
             return load(.easylist)
         }
-    }
-
-    public init() {
-        let cache = ContentBlockerStringCache()
-
-        hasData = nil != cache.get(named: CacheNames.easylist) &&
-            nil != cache.get(named: CacheNames.easylistPrivacy)
     }
 
     func load(_ type: Easylist) -> String? {
@@ -68,6 +65,10 @@ class EasylistStore {
 
     func persistEasylistPrivacy(data: Data) {
         persistAndPrepareForInjection(data: data, as: .easylistPrivacy, withCacheName: CacheNames.easylistPrivacy)
+    }
+
+    private func exists(type: Easylist) -> Bool {
+        return (try? persistenceLocation(type: type).checkResourceIsReachable()) ?? false
     }
 
     private func persistAndPrepareForInjection(data: Data, as type: Easylist, withCacheName cacheName: String) {

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -63,7 +63,8 @@ extension WKWebViewConfiguration {
     }
     
     private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool) {
-        
+        let easylistStore = EasylistStore()
+
         let javascriptLoader = JavascriptLoader()
         
         javascriptLoader.load(script: .blockerData, withReplacements: [
@@ -87,15 +88,14 @@ extension WKWebViewConfiguration {
                                   andController: userContentController,
                                   forMainFrameOnly: false)
             
-        } else {
+        } else if let easylist = easylistStore.easylist,
+            let easylistPrivacy = easylistStore.easylistPrivacy {
             
             Logger.log(text: "parsing easylist")
-            
-            let easylistStore = EasylistStore()
-            
+
             javascriptLoader.load(script: .easylistParsing, withReplacements: [
-                "${easylist_privacy}": easylistStore.easylistPrivacy,
-                "${easylist_general}": easylistStore.easylist ],
+                "${easylist_privacy}": easylistPrivacy,
+                "${easylist_general}": easylist ],
                                   andController: userContentController,
                                   forMainFrameOnly: false)
             

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		85F1C3CA1F7A4E8000161346 /* ContentBlockerStringCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F1C3C91F7A4E8000161346 /* ContentBlockerStringCache.swift */; };
 		85F1C3CD1F7A76EF00161346 /* ContentBlockerStringCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F1C3CB1F7A76B900161346 /* ContentBlockerStringCache.swift */; };
 		85F1C3D11F7BF30B00161346 /* EasylistStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F1C3D01F7BF30B00161346 /* EasylistStoreTests.swift */; };
+		85F45B2A1F875DFF00DB1978 /* BlockerListRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F45B291F875DFF00DB1978 /* BlockerListRequest.swift */; };
+		85F45B2C1F87672000DB1978 /* BlockerListRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F45B2B1F87672000DB1978 /* BlockerListRequestTests.swift */; };
 		85FC52641F6BD86700933A70 /* abp-filter-parser-packed-es2015.js in Resources */ = {isa = PBXBuildFile; fileRef = 85FC52631F6BD86700933A70 /* abp-filter-parser-packed-es2015.js */; };
 		F10307391E7C5E310059FEC7 /* NoBookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10307381E7C5E310059FEC7 /* NoBookmarksCell.swift */; };
 		F103073B1E7C91330059FEC7 /* BookmarksDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */; };
@@ -362,6 +364,8 @@
 		85F1C3C91F7A4E8000161346 /* ContentBlockerStringCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerStringCache.swift; sourceTree = "<group>"; };
 		85F1C3CB1F7A76B900161346 /* ContentBlockerStringCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerStringCache.swift; sourceTree = "<group>"; };
 		85F1C3D01F7BF30B00161346 /* EasylistStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EasylistStoreTests.swift; sourceTree = "<group>"; };
+		85F45B291F875DFF00DB1978 /* BlockerListRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockerListRequest.swift; sourceTree = "<group>"; };
+		85F45B2B1F87672000DB1978 /* BlockerListRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockerListRequestTests.swift; sourceTree = "<group>"; };
 		85FC52631F6BD86700933A70 /* abp-filter-parser-packed-es2015.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "abp-filter-parser-packed-es2015.js"; sourceTree = "<group>"; };
 		F10307381E7C5E310059FEC7 /* NoBookmarksCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoBookmarksCell.swift; sourceTree = "<group>"; };
 		F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksDataSource.swift; sourceTree = "<group>"; };
@@ -1213,8 +1217,9 @@
 		F17FB1701F349B7B005B1CB6 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				85047B851F6887D2002A95D8 /* BlockerListsLoader.swift */,
 				8570656F1F6ABFA40044DCB1 /* APIRequest.swift */,
+				85047B851F6887D2002A95D8 /* BlockerListsLoader.swift */,
+				85F45B291F875DFF00DB1978 /* BlockerListRequest.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -1496,6 +1501,7 @@
 			isa = PBXGroup;
 			children = (
 				F1FCF3B11F354F7200C23128 /* APIRequestTests.swift */,
+				85F45B2B1F87672000DB1978 /* BlockerListRequestTests.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -1983,6 +1989,7 @@
 				F13B4BF91F18CA0600814661 /* TabsModelTests.swift in Sources */,
 				F165B8FD1EBBF055004496FC /* OnboaridingViewControllerTests.swift in Sources */,
 				833B46FF1F6CB7D4001ECFEC /* TermsOfServiceTests.swift in Sources */,
+				85F45B2C1F87672000DB1978 /* BlockerListRequestTests.swift in Sources */,
 				F1134ECE1F40EA9C00B73467 /* CohortParserTests.swift in Sources */,
 				F189AEE41F18FDAF001EBAE1 /* LinkTests.swift in Sources */,
 				F12790EA1EBBDE75001D3AEC /* InterfaceMeasurementTests.swift in Sources */,
@@ -2078,6 +2085,7 @@
 				F16956421ECCA3D4009C35C9 /* ContentBlockerConfigurationUserDefaults.swift in Sources */,
 				F1722BC91E8BE2AB0058AAA5 /* BookmarkStore.swift in Sources */,
 				830C37631F6C482E00E317A7 /* TermsOfServiceListParser.swift in Sources */,
+				85F45B2A1F875DFF00DB1978 /* BlockerListRequest.swift in Sources */,
 				F1D477CB1F2149C40031ED49 /* Type.swift in Sources */,
 				F1134EC61F40E3B400B73467 /* AppVersion.swift in Sources */,
 				F143C33C1E4A9A9200CFDE3A /* WebViewController.swift in Sources */,

--- a/DuckDuckGoTests/BlockerListRequestTests.swift
+++ b/DuckDuckGoTests/BlockerListRequestTests.swift
@@ -1,0 +1,144 @@
+//
+//  BlockerListRequestTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import OHHTTPStubs
+@testable import Core
+
+class BlockerListRequestTests: XCTestCase {
+
+    let host = AppUrls().disconnectMeBlockList.host!
+    let url = AppUrls().disconnectMeBlockList
+
+    var testee: BlockerListRequest!
+    fileprivate var mockEtagStorage: MockEtagStorage!
+
+    override func setUp() {
+        super.setUp()
+        mockEtagStorage = MockEtagStorage()
+        testee = BlockerListRequest(etagStorage: mockEtagStorage)
+    }
+
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+
+    func testWhenErrorThenCompletesWithNoData() {
+
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 404, headers: nil )
+        }
+
+        let expect = expectation(description: "testWhenMisMatchingEtagCompletesWithData")
+        testee.request(.disconnectMe) { (data) in
+            XCTAssertNil(data)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func testWhenMisMatchingEtagThenCompletesWithDataAndEtagSet() {
+
+        let etag = UUID().uuidString
+        mockEtagStorage.etagToReturn = etag
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 200, headers: [ "ETag": "different" ] )
+        }
+
+        let expect = expectation(description: "testWhenMisMatchingEtagCompletesWithDataAndEtagSet")
+        testee.request(.disconnectMe) { (data) in
+            XCTAssertEqual("different", self.mockEtagStorage.lastEtagSet)
+            XCTAssertNotNil(data)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func testWhenEtagAndNoEtagStoredThenCompletesWithDataAndEtagSet() {
+
+        let etag = UUID().uuidString
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 200, headers: [ "ETag": etag ] )
+        }
+
+        let expect = expectation(description: "testWhenMisMatchingEtagCompletesWithDataAndEtagSet")
+        testee.request(.disconnectMe) { (data) in
+            XCTAssertEqual(etag, self.mockEtagStorage.lastEtagSet)
+            XCTAssertNotNil(data)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func testWhenMatchingEtagThenCompletesWithNoData() {
+
+        let etag = UUID().uuidString
+        mockEtagStorage.etagToReturn = etag
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 200, headers: [ "ETag": etag ] )
+        }
+
+        let expect = expectation(description: "testWhenMatchingEtagCompletesWithNoData")
+        testee.request(.disconnectMe) { (data) in
+            XCTAssertNil(data)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0, handler: nil)
+    }
+
+    func testWhenNoEtagAndNoEtagStoredThenCompletesWithData() {
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 200, headers: nil )
+        }
+
+        let expect = expectation(description: "testWhenNoEtagAndNoEtagStoredCompletesWithData")
+        testee.request(.disconnectMe) { (data) in
+            XCTAssertNotNil(data)
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1.0, handler: nil)
+
+    }
+
+    func validJson() -> String {
+        return OHPathForFile("MockJson/disconnect.json", type(of: self))!
+    }
+
+}
+
+fileprivate class MockEtagStorage: BlockerListETagStorage {
+
+    var lastEtagSet: String?
+    var etagToReturn: String?
+
+    func set(etag: String?, for list: BlockerListRequest.List) {
+        lastEtagSet = etag
+    }
+
+    func etag(for list: BlockerListRequest.List) -> String? {
+        return etagToReturn
+    }
+
+}
+


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: https://app.asana.com/0/414235014887631/442414558181571
CC:

**Description**:

Tracks etags returned by the server and if it matches, doesn't pass the data to be persisted (and subsequently invalidating any caches, etc).

Alamofire caches via URLSession so returns 200 even if the response from the server is a 304 (confirmed with Charles).  

There's a setting to disable this when creating a URLRequest, but then you have to manage more of the caching yourself (expiries, etc). Comparing etags directly regardless of (positive response code) does the job.

**Steps to test this PR**:
1. Clean install - run the app
2. Visit a tracker heavy site and observe blocking for easylist and disconnect me
3. Kill the app
4. Launch the app - observe that etags have been matched when the downloader runs
5. Visit a tracker heavy site, observe blocking 


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)