### PR TITLE
reload page after loading blocker lists from error popover

### DIFF
--- a/DuckDuckGo/ContentBlockerPopover.swift
+++ b/DuckDuckGo/ContentBlockerPopover.swift
@@ -94,6 +94,7 @@ extension ContentBlockerPopover: ContentBlockerErrorDelegate {
     func errorWasResolved(errorController: ContentBlockerErrorViewController) {
         dismiss(viewController: errorController)
         attachContentBlockerViewController()
+        contentBlockerSettingsDidChange()
     }
 }
 

--- a/DuckDuckGo/SiteRatingView.swift
+++ b/DuckDuckGo/SiteRatingView.swift
@@ -61,7 +61,7 @@ public class SiteRatingView: UIView {
     
     public func refresh() {
         
-        guard contentBlockerConfiguration.enabled else {
+        guard contentBlockerConfiguration.enabled, BlockerListsLoader().hasData else {
             circleIndicator.tintColor = UIColor.monitoringNegativeTint
             gradeLabel.text = "!"
             return

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -402,6 +402,6 @@ extension TabViewController: UIScrollViewDelegate {
 
 extension TabViewController: ContentBlockerSettingsChangeDelegate {
     func contentBlockerSettingsDidChange() {
-        webView.reload()
+        onContentBlockerConfigurationChanged()
     }
 }


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer:  Mia
Asana:
CC:

**Description**:

Forces the page and scripts to reload when loading blocker lists from the error popover.  Also shows red ! when there's no data.

**Steps to test this PR**:

1. Airplane mode
1. Clean install 
1. Perform search -> error page and red "!" should be visible
1. Turn on network
1. Perform search again
1. Visit tracker heavy site
1. Tap site rating
1. Hit reload -> page should reload and site rating should update to reflect trackers detected


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)