### PR TITLE
load blocker lists on app launch and set up background fetch

### DIFF
--- a/Core/BlockerListsLoader.swift
+++ b/Core/BlockerListsLoader.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-public typealias BlockerListsLoaderCompletion = () -> Void
+public typealias BlockerListsLoaderCompletion = (Bool) -> Void
 
 public class BlockerListsLoader {
 
@@ -30,6 +30,8 @@ public class BlockerListsLoader {
             return DisconnectMeStore.shared.hasData && easylistStore.hasData
         }
     }
+
+    private var newDataItems = 0
 
     public init() { }
 
@@ -43,8 +45,8 @@ public class BlockerListsLoader {
                 semaphore.wait()
             }
 
-            Logger.log(items: "BlockerListsLoader", "completed")
-            completion?()
+            Logger.log(items: "BlockerListsLoader", "completed", self.newDataItems)
+            completion?(self.newDataItems > 0)
         }
 
     }
@@ -55,6 +57,7 @@ public class BlockerListsLoader {
 
         blockerListRequest.request(.disconnectMe) { (data) in
             if let data = data {
+                self.newDataItems += 1
                 try? DisconnectMeStore.shared.persist(data: data)
             }
             semaphore.signal()
@@ -62,6 +65,7 @@ public class BlockerListsLoader {
 
         blockerListRequest.request(.easylist) { (data) in
             if let data = data {
+                self.newDataItems += 1
                 self.easylistStore.persistEasylist(data: data)
             }
             semaphore.signal()
@@ -69,6 +73,7 @@ public class BlockerListsLoader {
 
         blockerListRequest.request(.easylistPrivacy) { (data) in
             if let data = data {
+                self.newDataItems += 1
                 self.easylistStore.persistEasylistPrivacy(data: data)
             }
             semaphore.signal()

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1659,6 +1659,9 @@
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
 							};
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
 						};
 					};
 					84E341A51E2F7EFB00BDBA6F = {

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo (Background).xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo (Background).xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+               BuildableName = "DuckDuckGo.app"
+               BlueprintName = "DuckDuckGo"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "1">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DuckDuckGo/ContentBlockerErrorViewController.swift
+++ b/DuckDuckGo/ContentBlockerErrorViewController.swift
@@ -41,7 +41,9 @@ class ContentBlockerErrorViewController: UIViewController {
         startSpinner()
 
         let loader = BlockerListsLoader()
-        loader.start() { [weak self] in
+        loader.start() { [weak self]
+            newData in
+
             DispatchQueue.main.async {
                 self?.stopSpinner()
                 if loader.hasData {

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -73,6 +73,10 @@
 			<string>com.duckduckgo.mobile.ios.clipboard</string>
 		</dict>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer:
Asana:
CC:

**Description**:

Kicks off the blocker lists download only when the app is launching and sets up a regular download of the blocker lists as a background fetch every 24 hours.

As such, fixes an edge case bug where the UI thinks there's no blocker list data and if the user accesses the control panel (e.g. to turn on airplane mode) it would kickoff the blocker list download but the UI wouldn't be notified.

**Steps to test this PR**:

Test 1: 

1. Airplane mode
1. Clean install
1. Perform search -> error page and red "!" should be visible
1. Turn on network using control panel!
1. Perform search again
1. Visit tracker heavy site
1. Tap site rating
1. Hit reload -> page should reload and site rating should update to reflect trackers detected

Test 2: 

1. Using Xcode and NO network connection launch app in simulator
1. Perform a search
1. Connect network
1. Switch to the DuckDuckGo (background) scheme and launch
1. Switch to the DuckDuckGo scheme and launch
1. Perform a search and confirm blocking is active


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [x] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)