### PR TITLE
Home: Remove Use in Safari from Home. Distracting if we want users to use DDG all the time.

### DIFF
--- a/DuckDuckGo/Home.storyboard
+++ b/DuckDuckGo/Home.storyboard
@@ -4,8 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -112,28 +111,10 @@
                                             <segue destination="Dad-qS-z4K" kind="presentation" modalPresentationStyle="currentContext" id="MtS-xn-LUm"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="aty-ep-OLn">
-                                        <rect key="frame" x="93" y="540" width="191" height="63"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Safari" translatesAutoresizingMaskIntoConstraints="NO" id="qBn-dZ-gMp">
-                                                <rect key="frame" x="80.5" y="0.0" width="30" height="30"/>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use DuckDuckGo in Safari" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="toq-tJ-EUD">
-                                                <rect key="frame" x="0.0" y="44" width="191" height="19"/>
-                                                <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
-                                                <color key="textColor" red="0.65098039220000004" green="0.66666666669999997" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <connections>
-                                            <outletCollection property="gestureRecognizers" destination="htY-lm-6Gm" appends="YES" id="zca-do-EkO"/>
-                                        </connections>
-                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="pwM-bh-TMk" secondAttribute="trailing" constant="20" id="HIA-K1-pE2"/>
                                     <constraint firstItem="pwM-bh-TMk" firstAttribute="leading" secondItem="eYX-Xc-kri" secondAttribute="leading" constant="20" id="e5Y-W7-YCP"/>
-                                    <constraint firstItem="aty-ep-OLn" firstAttribute="centerX" secondItem="eYX-Xc-kri" secondAttribute="centerX" id="eyj-OW-Mel"/>
                                     <constraint firstItem="pwM-bh-TMk" firstAttribute="centerY" secondItem="eYX-Xc-kri" secondAttribute="centerY" constant="-34" id="jR5-0V-F2Q"/>
                                     <constraint firstItem="Fku-9C-PCe" firstAttribute="top" secondItem="eYX-Xc-kri" secondAttribute="top" constant="24" id="rcD-aS-v4Z"/>
                                     <constraint firstAttribute="trailing" secondItem="Fku-9C-PCe" secondAttribute="trailing" constant="24" id="uvr-yJ-gs3"/>
@@ -146,7 +127,6 @@
                             <constraint firstItem="eYX-Xc-kri" firstAttribute="height" secondItem="klK-ZJ-wmA" secondAttribute="height" id="ZiJ-EY-KxH"/>
                             <constraint firstItem="eYX-Xc-kri" firstAttribute="width" secondItem="klK-ZJ-wmA" secondAttribute="width" id="bsB-cI-R2F"/>
                             <constraint firstItem="eYX-Xc-kri" firstAttribute="centerX" secondItem="ijV-Vn-w9w" secondAttribute="centerX" id="lDz-Gu-MVs"/>
-                            <constraint firstItem="ijV-Vn-w9w" firstAttribute="bottom" secondItem="aty-ep-OLn" secondAttribute="bottom" constant="54" id="pBX-x6-Mea"/>
                             <constraint firstItem="eYX-Xc-kri" firstAttribute="centerY" secondItem="ijV-Vn-w9w" secondAttribute="centerY" id="y9x-PP-Zad"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ijV-Vn-w9w"/>
@@ -162,7 +142,6 @@
                         <outlet property="searchBarContent" destination="sH7-xn-wYA" id="zsQ-ly-5LA"/>
                         <outlet property="searchImage" destination="GHd-JT-J5r" id="FK0-Oe-eR3"/>
                         <outlet property="searchText" destination="HWx-8c-7xM" id="aVn-da-jBf"/>
-                        <outlet property="useSafariContainer" destination="aty-ep-OLn" id="JHn-2h-Pt4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Vtg-6j-Bq6" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -203,7 +182,6 @@
     </scenes>
     <resources>
         <image name="LogoWithText" width="201" height="160"/>
-        <image name="Safari" width="30" height="30"/>
         <image name="SearchLoupe" width="22" height="22"/>
         <image name="Settings" width="23" height="22"/>
     </resources>

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -33,7 +33,6 @@ class HomeViewController: UIViewController {
     @IBOutlet weak var searchBarContent: UIView!
     @IBOutlet weak var searchImage: UIImageView!
     @IBOutlet weak var searchText: UILabel!
-    @IBOutlet weak var useSafariContainer: UIView!
     
     weak var delegate: HomeControllerDelegate?
     weak var chromeDelegate: BrowserChromeDelegate?
@@ -59,7 +58,6 @@ class HomeViewController: UIViewController {
     }
     
     private func enterActiveModeAnimated() {
-        hideSafariButton()
         UIView.animate(withDuration: Constants.animationDuration, animations: {
             self.moveSearchBarUp()
         }, completion: { _ in
@@ -89,13 +87,11 @@ class HomeViewController: UIViewController {
     
     private func enterPassiveMode() {
         chromeDelegate?.setNavigationBarHidden(true)
-        adjustSafariButtonVisibility()
         passiveContent.isHidden = false
         delegate?.homeDidDeactivateOmniBar(home: self)
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        adjustSafariButtonVisibility(forHeight: size.height)
     }
     
     private func moveSearchBarUp() {
@@ -122,14 +118,6 @@ class HomeViewController: UIViewController {
         searchBarContent.transform = CGAffineTransform.identity
         searchText.transform = CGAffineTransform.identity
         searchImage.alpha = 1
-    }
-    
-    private func adjustSafariButtonVisibility(forHeight height: CGFloat = UIScreen.main.bounds.size.height) {
-        useSafariContainer.isHidden = height < Constants.minHeightForSafariButton
-    }
-    
-    private func hideSafariButton() {
-        useSafariContainer.isHidden = true
     }
     
     func load(url: URL) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: @brindy 
Asana: N/A
CC: @subsymbolic 

**Description**:
I think this is a distraction for users, especially ones that are deeply invested in the app. At first we talked about this, and there was push back -- which was warranted. I look at this a lot -- and it's just clutter IMO. Just a thought, not a demand 😄.

**Steps to test this PR**:
1. launch the app
2. realize the use duckduckgo in safari screen is gone.


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)