### PR TITLE
Merge live and model links

### DIFF
--- a/Core/Link.swift
+++ b/Core/Link.swift
@@ -59,4 +59,26 @@ public class Link: NSObject, NSCoding {
         guard let other = other as? Link else { return false }
         return title == other.title && url == other.url && favicon == other.favicon
     }
+    
+    /**
+     Where links share the same url, uses the seconday link to plug any missing data in the
+     primary link.
+     */
+    public static func mergeData(primary: Link?, secondary: Link?) -> Link? {
+        guard let primary = primary else {
+            return secondary
+        }
+        
+        guard let secondary = secondary else {
+            return primary
+        }
+        
+        if primary.url != secondary.url {
+            return primary
+        }
+    
+        let title = (primary.title == nil || primary.title!.isEmpty) ? secondary.title : primary.title
+        let favicon = primary.favicon ?? secondary.favicon
+        return Link(title: title, url: primary.url, favicon: favicon)
+    }
 }

--- a/Core/Link.swift
+++ b/Core/Link.swift
@@ -61,24 +61,16 @@ public class Link: NSObject, NSCoding {
     }
     
     /**
-     Where links share the same url, uses the seconday link to plug any missing data in the
-     primary link.
+     Provided links share the same url, uses other to plug any missing data.
      */
-    public static func mergeData(primary: Link?, secondary: Link?) -> Link? {
-        guard let primary = primary else {
-            return secondary
-        }
+    public func fillMissingData(with other: Link) -> Link {
         
-        guard let secondary = secondary else {
-            return primary
-        }
-        
-        if primary.url != secondary.url {
-            return primary
+        if url != other.url {
+            return self
         }
     
-        let title = (primary.title == nil || primary.title!.isEmpty) ? secondary.title : primary.title
-        let favicon = primary.favicon ?? secondary.favicon
-        return Link(title: title, url: primary.url, favicon: favicon)
+        let mergeTitle = (title == nil || title!.isEmpty) ? other.title : title
+        let mergeFavicon = favicon ?? other.favicon
+        return Link(title: mergeTitle, url: url, favicon: mergeFavicon)
     }
 }

--- a/Core/Link.swift
+++ b/Core/Link.swift
@@ -63,7 +63,7 @@ public class Link: NSObject, NSCoding {
     /**
      Provided links share the same url, uses other to plug any missing data.
      */
-    public func fillMissingData(with other: Link) -> Link {
+    public func merge(with other: Link) -> Link {
         
         if url != other.url {
             return self

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -44,11 +44,6 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     
     public var favicon: URL?
     
-    public var link: Link? {
-        guard let url = url else { return nil }
-        return Link(title: name, url: url, favicon: favicon)
-    }
-    
     public var canGoBack: Bool {
         return webView.canGoBack
     }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -137,8 +137,7 @@ class TabManager {
     
     private func cachedController(forTab tab: Tab) -> TabViewController? {
         let controller = tabControllerCache.filter( { $0.tabModel === tab } ).first
-        if let link = controller?.link {
-            tab.link = link
+        if controller != nil {
             save()
         }
         return controller

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -137,7 +137,8 @@ class TabManager {
     
     private func cachedController(forTab tab: Tab) -> TabViewController? {
         let controller = tabControllerCache.filter( { $0.tabModel === tab } ).first
-        if controller != nil {
+        if let link = controller?.link {
+            tab.link = link
             save()
         }
         return controller

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -58,7 +58,7 @@ class TabViewController: WebViewController {
             return activeLink
         }
 
-        return activeLink.fillMissingData(with: storedLink)
+        return activeLink.merge(with: storedLink)
     }
     
     override func viewDidLoad() {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -53,8 +53,8 @@ class TabViewController: WebViewController {
             return Link.mergeData(primary: nil, secondary: tabModel.link)
         }
         
-        let current = Link(title: name, url: url, favicon: favicon)
-        return Link.mergeData(primary: current, secondary: tabModel.link)
+        let activeLink = Link(title: name, url: url, favicon: favicon)
+        return Link.mergeData(primary: activeLink, secondary: tabModel.link)
     }
     
     override func viewDidLoad() {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -346,7 +346,7 @@ extension TabViewController: WebEventsDelegate {
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
         resetSiteRating()
-        tabModel.link = link
+        tabModel.link = selectBestLink(modelLink: tabModel.link, activeLink: link)
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
     }
@@ -355,7 +355,7 @@ extension TabViewController: WebEventsDelegate {
         Logger.log(items: "webpageLoading finished:", Date().timeIntervalSince1970)
         siteRating?.finishedLoading = true
         updateSiteRating()
-        tabModel.link = link
+        tabModel.link = selectBestLink(modelLink: tabModel.link, activeLink: link)
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
     }
@@ -367,7 +367,7 @@ extension TabViewController: WebEventsDelegate {
     func faviconWasUpdated(_ favicon: URL, forUrl url: URL) {
         let bookmarks = BookmarkUserDefaults()
         bookmarks.updateFavicon(favicon, forBookmarksWithUrl: url)
-        tabModel.link = link
+        tabModel.link = selectBestLink(modelLink: tabModel.link, activeLink: link)
         delegate?.tabLoadingStateDidChange(tab: self)
     }
     
@@ -377,6 +377,22 @@ extension TabViewController: WebEventsDelegate {
     
     func webView(_ webView: WKWebView, didReceiveLongPressForUrl url: URL, atPoint point: Point) {
         launchLongPressMenu(atPoint: point, forUrl: url)
+    }
+    
+    private func selectBestLink(modelLink: Link?, activeLink: Link?) -> Link? {
+        guard let modelLink = modelLink else {
+            return activeLink
+        }
+        
+        guard let activeLink = activeLink else {
+            return nil
+        }
+        
+        if activeLink.url == modelLink.url, (activeLink.title == nil || activeLink.title!.isEmpty) {
+            return modelLink
+        }
+        
+        return activeLink
     }
 }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -367,7 +367,9 @@ extension TabViewController: WebEventsDelegate {
     func faviconWasUpdated(_ favicon: URL, forUrl url: URL) {
         let bookmarks = BookmarkUserDefaults()
         bookmarks.updateFavicon(favicon, forBookmarksWithUrl: url)
-        tabModel.link = selectBestLink(modelLink: tabModel.link, activeLink: link)
+        if let modelLink = tabModel.link {
+            tabModel.link = Link(title: modelLink.title, url: modelLink.url, favicon: favicon)
+        }
         delegate?.tabLoadingStateDidChange(tab: self)
     }
     
@@ -385,7 +387,7 @@ extension TabViewController: WebEventsDelegate {
         }
         
         guard let activeLink = activeLink else {
-            return nil
+            return modelLink
         }
         
         if activeLink.url == modelLink.url, (activeLink.title == nil || activeLink.title!.isEmpty) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -50,11 +50,15 @@ class TabViewController: WebViewController {
     
     public var link: Link? {
         guard let url = url else {
-            return Link.mergeData(primary: nil, secondary: tabModel.link)
+            return tabModel.link
         }
         
         let activeLink = Link(title: name, url: url, favicon: favicon)
-        return Link.mergeData(primary: activeLink, secondary: tabModel.link)
+        guard let storedLink = tabModel.link else {
+            return activeLink
+        }
+
+        return activeLink.fillMissingData(with: storedLink)
     }
     
     override func viewDidLoad() {

--- a/DuckDuckGoTests/LinkTests.swift
+++ b/DuckDuckGoTests/LinkTests.swift
@@ -66,4 +66,73 @@ class LinkTests: XCTestCase {
         let link = Link(title: Constants.title, url: Constants.url, favicon: Constants.favicon)
         XCTAssertFalse(link.isEqual(NSObject()))
     }
+    
+    func testWhenMergingAndBothLinksAreNilThenResultIsNil() {
+        XCTAssertNil(Link.mergeData(primary: nil, secondary: nil))
+    }
+    
+    func testWhenMergingAndPrimaryIsNilThenSecondaryIsUsed() {
+        let primay: Link? = nil
+        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result, secondary)
+    }
+
+    func testWhenMergingAndSecondaryIsNilThenPrimaryIsUsed() {
+        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
+        let secondary: Link? = nil
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result, primay)
+    }
+    
+    func testWhenMergingSAmeUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
+        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
+        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result?.title, "primary");
+    }
+    
+    func testWhenMergingSAmeUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
+        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
+        let secondary = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result?.title, "primary");
+    }
+    
+    func testWhenMergingSameUrlAndOnlySecondaryHasTitleThenSecondaryTitleIsUsed() {
+        let primay = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
+        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result?.title, "secondary");
+    }
+    
+    func testWhenMergingSameUrlAndBothHaveFaviconsThenPrimaryFaviconIsUsed() {
+        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
+        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result?.favicon, URL(string: "www.primaryfavicon.example.com")!);
+    }
+    
+    func testWhenMergingSameUrlAndOnlyPrimaryHasFaviconThenPrimaryFaviconIsUsed() {
+        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
+        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: nil)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result?.favicon, URL(string: "www.primaryfavicon.example.com")!);
+    }
+    
+    func testWhenMergingSameUlrAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
+        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: nil)
+        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertEqual(result?.favicon, URL(string: "www.secondaryfavicon.example.com")!);
+    }
+    
+    func testWhenMergingDifferentUrlsThenOnlySecondayDataIsIgnored() {
+        let primay = Link(title: nil, url: URL(string: "www.primary.example.com")!, favicon: nil)
+        let secondary = Link(title: "secondary", url: URL(string: "www.seconday.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
+        let result = Link.mergeData(primary: primay, secondary: secondary)
+        XCTAssertNotNil(result)
+        XCTAssertNil(result?.favicon);
+        XCTAssertNil(result?.title);
+    }
 }

--- a/DuckDuckGoTests/LinkTests.swift
+++ b/DuckDuckGoTests/LinkTests.swift
@@ -102,7 +102,7 @@ class LinkTests: XCTestCase {
         XCTAssertEqual(result.favicon, URL(string: "www.primaryfavicon.example.com")!);
     }
     
-    func testWhenMergingWithSameUrlSameUlrAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
+    func testWhenMergingWithSameUrlAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: nil)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
         let result = primay.merge(with: secondary)

--- a/DuckDuckGoTests/LinkTests.swift
+++ b/DuckDuckGoTests/LinkTests.swift
@@ -85,14 +85,14 @@ class LinkTests: XCTestCase {
         XCTAssertEqual(result, primay)
     }
     
-    func testWhenMergingSAmeUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
+    func testWhenMergingSameUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
         let result = Link.mergeData(primary: primay, secondary: secondary)
         XCTAssertEqual(result?.title, "primary");
     }
     
-    func testWhenMergingSAmeUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
+    func testWhenMergingSameUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
         let result = Link.mergeData(primary: primay, secondary: secondary)
@@ -127,7 +127,7 @@ class LinkTests: XCTestCase {
         XCTAssertEqual(result?.favicon, URL(string: "www.secondaryfavicon.example.com")!);
     }
     
-    func testWhenMergingDifferentUrlsThenOnlySecondayDataIsIgnored() {
+    func testWhenMergingDifferentUrlsThenSecondayDataIsIgnored() {
         let primay = Link(title: nil, url: URL(string: "www.primary.example.com")!, favicon: nil)
         let secondary = Link(title: "secondary", url: URL(string: "www.seconday.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
         let result = Link.mergeData(primary: primay, secondary: secondary)

--- a/DuckDuckGoTests/LinkTests.swift
+++ b/DuckDuckGoTests/LinkTests.swift
@@ -67,52 +67,52 @@ class LinkTests: XCTestCase {
         XCTAssertFalse(link.isEqual(NSObject()))
     }
     
-    func testWhenFillingMissingDataWithLinkWithSameUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
+    func testWhenMergingWithSameUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertEqual(result.title, "primary");
     }
     
-    func testWhenFillingMissingDataWithLinkWithSameUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
+    func testWhenMergingWithSameUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertEqual(result.title, "primary");
     }
     
-    func testWhenFillingMissingDataWithLinkWithSameUrlAndOnlySecondaryHasTitleThenSecondaryTitleIsUsed() {
+    func testWhenMergingWithSameUrlAndOnlySecondaryHasTitleThenSecondaryTitleIsUsed() {
         let primay = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertEqual(result.title, "secondary");
     }
     
-    func testWhenFillingMissingDataWithLinkWithSameUrlAndBothHaveFaviconsThenPrimaryFaviconIsUsed() {
+    func testWhenMergingWithSameUrlAndBothHaveFaviconsThenPrimaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertEqual(result.favicon, URL(string: "www.primaryfavicon.example.com")!);
     }
     
-    func testWhenFillingMissingDataWithLinkWithSameUrlAndOnlyPrimaryHasFaviconThenPrimaryFaviconIsUsed() {
+    func testWhenMergingWithSameUrlAndOnlyPrimaryHasFaviconThenPrimaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: nil)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertEqual(result.favicon, URL(string: "www.primaryfavicon.example.com")!);
     }
     
-    func testWhenFillingMissingDataWithLinkWithSameUrlSameUlrAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
+    func testWhenMergingWithSameUrlSameUlrAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: nil)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertEqual(result.favicon, URL(string: "www.secondaryfavicon.example.com")!);
     }
     
     func testWhenMergingDifferentUrlsThenSecondaryDataIsIgnored() {
         let primay = Link(title: nil, url: URL(string: "www.primary.example.com")!, favicon: nil)
         let secondary = Link(title: "secondary", url: URL(string: "www.seconday.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = primay.fillMissingData(with: secondary)
+        let result = primay.merge(with: secondary)
         XCTAssertNil(result.favicon);
         XCTAssertNil(result.title);
     }

--- a/DuckDuckGoTests/LinkTests.swift
+++ b/DuckDuckGoTests/LinkTests.swift
@@ -67,72 +67,53 @@ class LinkTests: XCTestCase {
         XCTAssertFalse(link.isEqual(NSObject()))
     }
     
-    func testWhenMergingAndBothLinksAreNilThenResultIsNil() {
-        XCTAssertNil(Link.mergeData(primary: nil, secondary: nil))
-    }
-    
-    func testWhenMergingAndPrimaryIsNilThenSecondaryIsUsed() {
-        let primay: Link? = nil
-        let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result, secondary)
-    }
-
-    func testWhenMergingAndSecondaryIsNilThenPrimaryIsUsed() {
-        let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
-        let secondary: Link? = nil
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result, primay)
-    }
-    
-    func testWhenMergingSameUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
+    func testWhenFillingMissingDataWithLinkWithSameUrlAndBothHaveTitlesThenPrimaryTitleIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result?.title, "primary");
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertEqual(result.title, "primary");
     }
     
-    func testWhenMergingSameUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
+    func testWhenFillingMissingDataWithLinkWithSameUrlAndOnlyPrimaryHasTitleThenPrimaryTitleIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result?.title, "primary");
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertEqual(result.title, "primary");
     }
     
-    func testWhenMergingSameUrlAndOnlySecondaryHasTitleThenSecondaryTitleIsUsed() {
+    func testWhenFillingMissingDataWithLinkWithSameUrlAndOnlySecondaryHasTitleThenSecondaryTitleIsUsed() {
         let primay = Link(title: nil, url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result?.title, "secondary");
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertEqual(result.title, "secondary");
     }
     
-    func testWhenMergingSameUrlAndBothHaveFaviconsThenPrimaryFaviconIsUsed() {
+    func testWhenFillingMissingDataWithLinkWithSameUrlAndBothHaveFaviconsThenPrimaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result?.favicon, URL(string: "www.primaryfavicon.example.com")!);
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertEqual(result.favicon, URL(string: "www.primaryfavicon.example.com")!);
     }
     
-    func testWhenMergingSameUrlAndOnlyPrimaryHasFaviconThenPrimaryFaviconIsUsed() {
+    func testWhenFillingMissingDataWithLinkWithSameUrlAndOnlyPrimaryHasFaviconThenPrimaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.primaryfavicon.example.com")!)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: nil)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result?.favicon, URL(string: "www.primaryfavicon.example.com")!);
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertEqual(result.favicon, URL(string: "www.primaryfavicon.example.com")!);
     }
     
-    func testWhenMergingSameUlrAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
+    func testWhenFillingMissingDataWithLinkWithSameUrlSameUlrAndOnlySecondaryHasFaviconThenSecondaryFaviconIsUsed() {
         let primay = Link(title: "primary", url: URL(string: "www.example.com")!, favicon: nil)
         let secondary = Link(title: "secondary", url: URL(string: "www.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertEqual(result?.favicon, URL(string: "www.secondaryfavicon.example.com")!);
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertEqual(result.favicon, URL(string: "www.secondaryfavicon.example.com")!);
     }
     
-    func testWhenMergingDifferentUrlsThenSecondayDataIsIgnored() {
+    func testWhenMergingDifferentUrlsThenSecondaryDataIsIgnored() {
         let primay = Link(title: nil, url: URL(string: "www.primary.example.com")!, favicon: nil)
         let secondary = Link(title: "secondary", url: URL(string: "www.seconday.example.com")!, favicon: URL(string: "www.secondaryfavicon.example.com")!)
-        let result = Link.mergeData(primary: primay, secondary: secondary)
-        XCTAssertNotNil(result)
-        XCTAssertNil(result?.favicon);
-        XCTAssertNil(result?.title);
+        let result = primay.fillMissingData(with: secondary)
+        XCTAssertNil(result.favicon);
+        XCTAssertNil(result.title);
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine and Chris
Asana: https://app.asana.com/0/414235014887631/469637695297538

**Description**:
Stop TabViewController from updating the model with blank fields in cases where the model has better data.

It is possible for the model to have a title from a previously persisted session and for the TabViewController's title to be blank while it is loading - so even though the TabViewController is most up-to-date we still want to fallback on the model data at times.

**Steps to test this PR**:
1. Open the app, launch a few tabs
2. Ensure they are fully loaded (check that all details are populated in the tab switcher)
3. Kill and open the app again
4. Open the tab switcher and ensure that all title data etc is populated.
5. Kill some tabs and ensure that the tab switcher data is maintained as items are reloaded from the cache.

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)