### PR TITLE
fix site grade when redirecting

### DIFF
--- a/Core/ContentBlockerConfigurationStore.swift
+++ b/Core/ContentBlockerConfigurationStore.swift
@@ -36,6 +36,6 @@ public protocol ContentBlockerConfigurationStore: class {
     
     func removeFromWhitelist(domain: String)
 
-    func protecting(domain: String) -> Bool
+    func protecting(domain: String?) -> Bool
 
 }

--- a/Core/ContentBlockerConfigurationUserDefaults.swift
+++ b/Core/ContentBlockerConfigurationUserDefaults.swift
@@ -79,7 +79,8 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
         domainWhitelist = whitelist
     }
 
-    public func protecting(domain: String) -> Bool {
+    public func protecting(domain: String?) -> Bool {
+        guard let domain = domain else { return enabled }
         return enabled && !whitelisted(domain: domain)
     }
     

--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -24,8 +24,8 @@ public class SiteRating {
     
     public var url: URL
     public var hasOnlySecureContent: Bool
-    public var domain: String {
-        return url.host ?? ""
+    public var domain: String? {
+        return url.host
     }
     public var finishedLoading = false
     private var trackersDetected = [Tracker: Int]()
@@ -72,6 +72,7 @@ public class SiteRating {
     }
     
     public var termsOfService: TermsOfService? {
+        let domain = self.domain ?? ""
         return termsOfServiceStore.terms.filter( { domain.hasSuffix($0.0) } ).first?.value
     }
 

--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -24,7 +24,9 @@ public class SiteRating {
     
     public var url: URL
     public var hasOnlySecureContent: Bool
-    public let domain: String
+    public var domain: String {
+        return url.host ?? ""
+    }
     public var finishedLoading = false
     private var trackersDetected = [Tracker: Int]()
     private var trackersBlocked = [Tracker: Int]()
@@ -34,11 +36,7 @@ public class SiteRating {
     let majorTrackerNetworkStore: MajorTrackerNetworkStore
     
     public init?(url: URL, disconnectMeTrackers: [String: Tracker] = DisconnectMeStore().trackers, termsOfServiceStore: TermsOfServiceStore = EmbeddedTermsOfServiceStore(), majorTrackerNetworkStore: MajorTrackerNetworkStore = EmbeddedMajorTrackerNetworkStore()) {
-        guard let domain = url.host else {
-            return nil
-        }
         self.url = url
-        self.domain = domain
         self.disconnectMeTrackers = disconnectMeTrackers
         self.termsOfServiceStore = termsOfServiceStore
         self.majorTrackerNetworkStore = majorTrackerNetworkStore

--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -35,7 +35,7 @@ public class SiteRating {
     let disconnectMeTrackers: [String: Tracker]
     let majorTrackerNetworkStore: MajorTrackerNetworkStore
     
-    public init?(url: URL, disconnectMeTrackers: [String: Tracker] = DisconnectMeStore().trackers, termsOfServiceStore: TermsOfServiceStore = EmbeddedTermsOfServiceStore(), majorTrackerNetworkStore: MajorTrackerNetworkStore = EmbeddedMajorTrackerNetworkStore()) {
+    public init(url: URL, disconnectMeTrackers: [String: Tracker] = DisconnectMeStore().trackers, termsOfServiceStore: TermsOfServiceStore = EmbeddedTermsOfServiceStore(), majorTrackerNetworkStore: MajorTrackerNetworkStore = EmbeddedMajorTrackerNetworkStore()) {
         self.url = url
         self.disconnectMeTrackers = disconnectMeTrackers
         self.termsOfServiceStore = termsOfServiceStore

--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -69,11 +69,13 @@ public extension SiteRating {
     }
 
     private var inMajorTrackerScore: Int {
+        guard let domain = domain else { return 0 }
         guard let associatedDomain = disconnectMeTrackers.filter( { domain.hasSuffix($0.key) } ).first?.value.networkName else { return 0 }
         return majorTrackerNetworkStore.network(forName: associatedDomain) == nil ? 0 : 1
     }
 
     private var isMajorTrackerScore: Int {
+        guard let domain = domain else { return 0 }
         guard let network = majorTrackerNetworkStore.network(forName: domain) else { return 0 }
         return network.score
     }
@@ -94,7 +96,7 @@ public extension SiteRating {
         let grade = siteGrade()
         return [
             "score": [
-                "domain": domain,
+                "domain": domain ?? "unknown",
                 "hasHttps": https,
                 "isAMajorTrackingNetwork": isMajorTrackerScore,
                 "containsMajorTrackingNetwork": containsMajorTracker,

--- a/DuckDuckGo/PrivacyProtectionHeaderController.swift
+++ b/DuckDuckGo/PrivacyProtectionHeaderController.swift
@@ -65,7 +65,7 @@ class PrivacyProtectionHeaderController: UIViewController {
 
         if !contentBlocker.enabled {
             protectionDisabledLabel.isHidden = false
-        } else if contentBlocker.domainWhitelist.contains(siteRating.domain) {
+        } else if contentBlocker.domainWhitelist.contains(siteRating.domain ?? "") {
             protectionPausedLabel.isHidden = false
         } else {
             protectionUpgraded.isHidden = false

--- a/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
+++ b/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
@@ -91,6 +91,7 @@ extension SiteRating {
     }
 
     func protecting(_ contentBlocker: ContentBlockerConfigurationStore) -> Bool {
+        guard let domain = domain else { return contentBlocker.enabled }
         return contentBlocker.enabled && !contentBlocker.domainWhitelist.contains(domain)
     }
 

--- a/DuckDuckGo/SiteRatingView.swift
+++ b/DuckDuckGo/SiteRatingView.swift
@@ -62,16 +62,17 @@ public class SiteRatingView: UIView {
     public func refresh() {
         circleIndicator.tintColor = UIColor.monitoringInactiveTint
 
-        guard let siteRating = siteRating else {
+        guard let siteRating = siteRating,
+            let domain = siteRating.domain else {
             gradeLabel.text = "-"
             return
         }
         
         let grades = siteRating.siteGrade()
-        gradeLabel.text = UserText.forSiteGrade(contentBlockerConfiguration.protecting(domain: siteRating.domain) ? grades.after : grades.before)
+        gradeLabel.text = UserText.forSiteGrade(contentBlockerConfiguration.protecting(domain: domain) ? grades.after : grades.before)
     }
 
     private func protecting() -> Bool {
-        return contentBlockerConfiguration.protecting(domain: siteRating!.domain)
+        return contentBlockerConfiguration.protecting(domain: siteRating?.domain)
     }
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -378,8 +378,8 @@ extension TabViewController: WebEventsDelegate {
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
 
-        if let siteRating = siteRating {
-            NetworkLeaderboard.shared.visited(domain: siteRating.domain)
+        if let domain = siteRating?.domain {
+            NetworkLeaderboard.shared.visited(domain: domain)
         }
     }
     

--- a/DuckDuckGoTests/MockContentBlockerConfigurationStore.swift
+++ b/DuckDuckGoTests/MockContentBlockerConfigurationStore.swift
@@ -46,7 +46,7 @@ class MockContentBlockerConfigurationStore: ContentBlockerConfigurationStore {
         lastWhiteListedItem = nil
     }
 
-    func protecting(domain: String) -> Bool {
+    func protecting(domain: String?) -> Bool {
         return protecting
     }
 

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -46,7 +46,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
 
     func testWhenHighScoreCachedResultIsGradeD() {
         _ = SiteRatingCache.shared.add(url: Url.https, score: 10)
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())
         let before = testee.siteGrade().before
         XCTAssertEqual(SiteGrade.d, before)
     }
@@ -54,20 +54,20 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     func testWhenWorseScoreIsCachedForBeforeScoreItIsUsed() {
         _ = SiteRatingCache.shared.add(url: Url.https, score: 10)
 
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())
         let score = testee.siteScore()
         XCTAssertEqual(10, score.before)
         XCTAssertEqual(1, score.after)
     }
 
     func testBeforeScoreIsCached() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .e, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .e, score: 0))
         XCTAssertNotNil(testee.siteScore())
         XCTAssertEqual(3, SiteRatingCache.shared.get(url: Url.https))
     }
 
     func testWhenHTTPSAndClassATOSBeforeScoreIncreasesByOneForEveryTenTrackersDetectedRoundedUpAndAfterScoreIsZero() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
 
         for _ in 0 ..< 11 {
             testee.trackerDetected(MockTracker.standard, blocked: false)
@@ -79,7 +79,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     }
 
     func testWhenSingleTrackerDetectedAndHTTPSAndClassATOSBeforeScoreIsOneAfterScoreIsZero() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
         testee.trackerDetected(MockTracker.standard, blocked: false)
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
@@ -87,7 +87,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     }
 
     func testWhenObsecureTrackerDetectedAndHTTPSAndClassATOSBeforeScoreIsTwoAfterScoreIsZero() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
         testee.trackerDetected(MockTracker.ipTracker, blocked: true)
         let score = testee.siteScore()
         XCTAssertEqual(2, score.before)
@@ -95,7 +95,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     }
 
     func testWhenNoTrackersHTTPSAndClassATOSThenLoadsInsecureResourceScoreIsOne() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
         testee.hasOnlySecureContent = false
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
@@ -103,7 +103,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     }
 
     func testWhenNoTrackersAndHTTPAndClassATOSScoreIsOne() {
-        let testee = SiteRating(url: Url.http, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))!
+        let testee = SiteRating(url: Url.http, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
         XCTAssertEqual(1, score.after)
@@ -112,7 +112,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     func testWhenSiteInMajorTrackerNetworkAndHTTPSAndClassATOSBeforeScoreIsOneAfterScoreIsZero() {
         let disconnectMeTrackers = [Url.https.host!: MockTracker.google]
         let networkStore = MockMajorTrackerNetworkStore().add(network: MajorTrackerNetwork(name: Url.googleNetwork.host!, perentageOfPages: 84))
-        let testee = SiteRating(url: Url.https, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)!
+        let testee = SiteRating(url: Url.https, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
         XCTAssertEqual(0, score.after)
@@ -120,14 +120,14 @@ class SiteRatingScoreExtensionTests: XCTestCase {
 
     func testWhenSiteIsMajorTrackerNetworkAndHTTPSAndClassATOSScoreIsTen() {
         let networkStore = MockMajorTrackerNetworkStore().add(network: MajorTrackerNetwork(name: Url.googleNetwork.host!, perentageOfPages: 84))
-        let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)!
+        let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)
         let score = testee.siteScore()
         XCTAssertEqual(10, score.before)
         XCTAssertEqual(10, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndPositiveTOSScoreIsTwo() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: nil, score: 10))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: nil, score: 10))
         let score = testee.siteScore()
         XCTAssertEqual(2, score.before)
         XCTAssertEqual(2, score.after)
@@ -135,49 +135,49 @@ class SiteRatingScoreExtensionTests: XCTestCase {
 
     // TODO check with extension team - the JS logic leaves after unchanged if the normalized score is negative
     func testWhenNoTrackersAndHTTPSAndNegativeTOSScoreIsZero() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: nil, score: -10))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: nil, score: -10))
         let score = testee.siteScore()
         XCTAssertEqual(0, score.before)
         XCTAssertEqual(0, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndClassETOSScoreIsThree() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .e, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .e, score: 0))
         let score = testee.siteScore()
         XCTAssertEqual(3, score.before)
         XCTAssertEqual(3, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndClassDTOSScoreIsTwo() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .d, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .d, score: 0))
         let score = testee.siteScore()
         XCTAssertEqual(2, score.before)
         XCTAssertEqual(2, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndClassCTOSScoreIsOne() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .c, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .c, score: 0))
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
         XCTAssertEqual(1, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndClassBTOSScoreIsOne() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .b, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .b, score: 0))
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
         XCTAssertEqual(1, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndClassATOSScoreIsZero() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
         let score = testee.siteScore()
         XCTAssertEqual(0, score.before)
         XCTAssertEqual(0, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndNoTOSScoreIsOne() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())!
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())
         let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
         XCTAssertEqual(1, score.after)

--- a/DuckDuckGoTests/SiteRatingTests.swift
+++ b/DuckDuckGoTests/SiteRatingTests.swift
@@ -44,23 +44,18 @@ class SiteRatingTests: XCTestCase {
         XCTAssertNotNil(testee)
     }
     
-    func testWhenUrlDoesNotContainHostThenInitFails() {
-        let testee = SiteRating(url: Url.noHost)
-        XCTAssertNil(testee)
-    }
-    
     func testWhenHttpThenHttpsIsFalse() {
-        let testee = SiteRating(url: Url.http)!
+        let testee = SiteRating(url: Url.http)
         XCTAssertFalse(testee.https)
     }
     
     func testWhenHttpsThenHttpsIsTrue() {
-        let testee = SiteRating(url: Url.https)!
+        let testee = SiteRating(url: Url.https)
         XCTAssertTrue(testee.https)
     }
     
     func testCountsAreInitiallyZero() {
-        let testee = SiteRating(url: Url.https)!
+        let testee = SiteRating(url: Url.https)
         XCTAssertEqual(testee.totalTrackersDetected, 0)
         XCTAssertEqual(testee.uniqueTrackersDetected, 0)
         XCTAssertEqual(testee.totalTrackersBlocked, 0)
@@ -68,7 +63,7 @@ class SiteRatingTests: XCTestCase {
     }
     
     func testWhenUniqueTrackersAreBlockedThenAllDetectionAndBlockCountsIncremenet() {
-        let testee = SiteRating(url: Url.https)!
+        let testee = SiteRating(url: Url.https)
         testee.trackerDetected(TrackerMock.tracker, blocked: true)
         testee.trackerDetected(TrackerMock.differentTracker, blocked: true)
         XCTAssertEqual(testee.totalTrackersDetected, 2)
@@ -78,7 +73,7 @@ class SiteRatingTests: XCTestCase {
     }
     
     func testWhenRepeatTrackersAreBlockedThenUniqueCountsOnlyIncrementOnce() {
-        let testee = SiteRating(url: Url.https)!
+        let testee = SiteRating(url: Url.https)
         testee.trackerDetected(TrackerMock.tracker, blocked: true)
         testee.trackerDetected(TrackerMock.tracker, blocked: true)
         XCTAssertEqual(testee.totalTrackersDetected, 2)
@@ -88,7 +83,7 @@ class SiteRatingTests: XCTestCase {
     }
     
     func testWhenNotBlockerThenDetectedCountsIncrementButBlockCountsDoNot() {
-        let testee = SiteRating(url: Url.https)!
+        let testee = SiteRating(url: Url.https)
         testee.trackerDetected(TrackerMock.tracker, blocked: false)
         XCTAssertEqual(testee.totalTrackersDetected, 1)
         XCTAssertEqual(testee.uniqueTrackersDetected, 1)
@@ -97,18 +92,18 @@ class SiteRatingTests: XCTestCase {
     }
     
     func testWhenUrlHasTosThenTosReturned() {
-        let testee = SiteRating(url: Url.google)!
+        let testee = SiteRating(url: Url.google)
         XCTAssertNotNil(testee.termsOfService)
     }
     
     func testWhenUrlDoeNotHaveTosThenTosIsNil() {
-        let testee = SiteRating(url: Url.http)!
+        let testee = SiteRating(url: Url.http)
         XCTAssertNil(testee.termsOfService)
     }
     
     func testUniqueMajorTrackersDetected() {
         let tracker = Tracker(url: "googlemail.com", networkName: "Google")
-        let testee = SiteRating(url: Url.googlemail, disconnectMeTrackers: [tracker.url: tracker])!
+        let testee = SiteRating(url: Url.googlemail, disconnectMeTrackers: [tracker.url: tracker])
         testee.trackerDetected(tracker, blocked: false)
         XCTAssertEqual(1, testee.uniqueMajorTrackerNetworksDetected)
         XCTAssertEqual(0, testee.uniqueMajorTrackerNetworksBlocked)
@@ -116,7 +111,7 @@ class SiteRatingTests: XCTestCase {
 
     func testUniqueMajorTrackersBlocked() {
         let tracker = Tracker(url: "googlemail.com", networkName: "Google")
-        let testee = SiteRating(url: Url.googlemail, disconnectMeTrackers: [tracker.url: tracker])!
+        let testee = SiteRating(url: Url.googlemail, disconnectMeTrackers: [tracker.url: tracker])
         testee.trackerDetected(tracker, blocked: true)
         XCTAssertEqual(1, testee.uniqueMajorTrackerNetworksBlocked)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia or Caine
Asana: https://app.asana.com/0/413877547933097/395487348379600/f
CC:

**Description**:

Site grade should reflect currently URL, not the one at the beginning of request which might redirect.

**Steps to test this PR**:
1. Visit ddg.gg
1. When redirected to DuckDuckGo.com check site grade is A


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)