### PR TITLE
fix site grade being carried over

### DIFF
--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -21,7 +21,7 @@
 import Foundation
 
 public class SiteRating {
-    
+    public let protectionId: String
     public var url: URL
     public var hasOnlySecureContent: Bool
     public var domain: String? {
@@ -36,6 +36,7 @@ public class SiteRating {
     let majorTrackerNetworkStore: MajorTrackerNetworkStore
     
     public init(url: URL, disconnectMeTrackers: [String: Tracker] = DisconnectMeStore().trackers, termsOfServiceStore: TermsOfServiceStore = EmbeddedTermsOfServiceStore(), majorTrackerNetworkStore: MajorTrackerNetworkStore = EmbeddedMajorTrackerNetworkStore()) {
+        self.protectionId = UUID.init().uuidString
         self.url = url
         self.disconnectMeTrackers = disconnectMeTrackers
         self.termsOfServiceStore = termsOfServiceStore

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -38,27 +38,26 @@ extension WKWebViewConfiguration {
         if #available(iOSApplicationExtension 10.0, *) {
             configuration.dataDetectorTypes = [.link, .phoneNumber]
         }
-        configuration.loadScripts()
         return configuration
     }
     
-    public func loadScripts() {
+    public func loadScripts(with id: String) {
         loadDocumentLevelScripts()
-        loadSiteMonitoringScripts()
+        loadSiteMonitoringScripts(with: id)
     }
     
     private func loadDocumentLevelScripts() {
         load(scripts: [ .document, .favicon ] )
     }
     
-    private func loadSiteMonitoringScripts() {
+    private func loadSiteMonitoringScripts(with id: String) {
         let configuration = ContentBlockerConfigurationUserDefaults()
         let whitelist = configuration.domainWhitelist.toJsonLookupString()
         loadContentBlockerDependencyScripts()
-        loadBlockerData(with: whitelist, and:  configuration.enabled)
+        loadBlockerData(with: whitelist, and:  configuration.enabled, with: id)
         load(scripts: [ .disconnectme, .contentblocker ], forMainFrameOnly: false)
     }
-    
+
     private func loadContentBlockerDependencyScripts() {
 
         if #available(iOS 10, *) {
@@ -68,12 +67,13 @@ extension WKWebViewConfiguration {
         }
     }
     
-    private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool) {
+    private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool, with id: String) {
         let easylistStore = EasylistStore()
         let disconnectMeStore = DisconnectMeStore()
         let javascriptLoader = JavascriptLoader()
         
         javascriptLoader.load(script: .blockerData, withReplacements: [
+            "${protectionId}": id,
             "${blocking_enabled}": "\(blockingEnabled)",
             "${disconnectmeBanned}": disconnectMeStore.bannedTrackersJson,
             "${disconnectmeAllowed}": disconnectMeStore.allowedTrackersJson,

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -269,9 +269,9 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         webView.alpha = 1
     }
 
-    open func reloadScripts() {
+    open func reloadScripts(with protectionId: String) {
         webView.configuration.userContentController.removeAllUserScripts()
-        webView.configuration.loadScripts()
+        webView.configuration.loadScripts(with: protectionId)
     }
 
     public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -107,6 +107,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
  
     public func load(urlRequest: URLRequest) {
         loadViewIfNeeded()
+        webView.stopLoading()
         webView.load(urlRequest)
     }
     

--- a/Core/blockerdata.js
+++ b/Core/blockerdata.js
@@ -19,6 +19,7 @@
 
 var duckduckgoBlockerData = {
 
+	protectionId: "${protectionId}",
     blockingEnabled: ${blocking_enabled},
 	disconnectmeBanned: ${disconnectmeBanned},
     disconnectmeAllowed: ${disconnectmeAllowed},

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -26,6 +26,7 @@ var duckduckgoContentBlocking = function() {
 	function handleDetection(event, parent, detectionMethod) {
 		var blocked = block(event)
         duckduckgoMessaging.trackerDetected({
+        	pageUrl: location.href,
 	        url: event.url,
 	        networkName: parent,
 	        blocked: blocked,

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -26,7 +26,7 @@ var duckduckgoContentBlocking = function() {
 	function handleDetection(event, parent, detectionMethod) {
 		var blocked = block(event)
         duckduckgoMessaging.trackerDetected({
-        	pageUrl: location.href,
+        	protectionId: duckduckgoBlockerData.protectionId,
 	        url: event.url,
 	        networkName: parent,
 	        blocked: blocked,

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -349,8 +349,8 @@ extension MainViewController: OmniBarDelegate {
     }
     
     func onOmniQuerySubmitted(_ query: String) {
-        dismissOmniBar()
         loadQuery(query)
+        dismissAutcompleteSuggestions()
     }
     
     func onSiteRatingPressed() {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -332,6 +332,7 @@ extension TabViewController: WKScriptMessageHandler {
     }
     
     struct TrackerDetectedKey {
+        static let pageUrl = "pageUrl"
         static let blocked = "blocked"
         static let networkName = "networkName"
         static let url = "url"
@@ -342,7 +343,11 @@ extension TabViewController: WKScriptMessageHandler {
         guard let dict = message.body as? Dictionary<String, Any> else { return }
         guard let blocked = dict[TrackerDetectedKey.blocked] as? Bool else { return }
         guard let url = dict[TrackerDetectedKey.url] as? String else { return }
+        guard let pageUrl = dict[TrackerDetectedKey.pageUrl] as? String else { return }
         let parent = dict[TrackerDetectedKey.networkName] as? String
+
+        guard pageUrl == self.url?.absoluteString else { return }
+
         let tracker = Tracker(url: url, networkName: parent)
         siteRating?.trackerDetected(tracker, blocked: blocked)
         onSiteRatingChanged()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -412,6 +412,7 @@ extension TabViewController: WebEventsDelegate {
     }
 
     func webView(_ webView: WKWebView, didUpdateHasOnlySecureContent hasOnlySecureContent: Bool) {
+        guard webView.url == siteRating?.url else { return }
         siteRating?.hasOnlySecureContent = hasOnlySecureContent
         updateSiteRating()
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -385,8 +385,9 @@ extension TabViewController: WebEventsDelegate {
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
         resetSiteRating()
-        reloadScripts(with: siteRating!.protectionId)
-
+        if let siteRating = siteRating {
+            reloadScripts(with: siteRating.protectionId)
+        }
         tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -89,7 +89,8 @@ class TabViewController: WebViewController {
     @objc func onContentBlockerConfigurationChanged() {
         // defer it for 0.2s so that the privacy protection UI can update instantly, otherwise this causes a visible delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            self.reloadScripts()
+            guard let siteRating = self.siteRating else { return }
+            self.reloadScripts(with: siteRating.protectionId)
             self.webView?.reload()
         }
     }
@@ -109,7 +110,7 @@ class TabViewController: WebViewController {
     func showPrivacyProtection() {
         performSegue(withIdentifier: "PrivacyProtection", sender: self)
     }
-    
+
     fileprivate func resetSiteRating() {
         if let url = url {
             siteRating = SiteRating(url: url)
@@ -328,11 +329,13 @@ extension TabViewController: WKScriptMessageHandler {
         guard let name = dict["name"] as? String else { return }
         guard let data = dict["data"] as? String else { return }
         ContentBlockerStringCache().put(name: name, value: data)
-        reloadScripts()
+
+        guard let siteRating = siteRating else { return }
+        reloadScripts(with: siteRating.protectionId)
     }
     
     struct TrackerDetectedKey {
-        static let pageUrl = "pageUrl"
+        static let protectionId = "protectionId"
         static let blocked = "blocked"
         static let networkName = "networkName"
         static let url = "url"
@@ -343,10 +346,13 @@ extension TabViewController: WKScriptMessageHandler {
         guard let dict = message.body as? Dictionary<String, Any> else { return }
         guard let blocked = dict[TrackerDetectedKey.blocked] as? Bool else { return }
         guard let url = dict[TrackerDetectedKey.url] as? String else { return }
-        guard let pageUrl = dict[TrackerDetectedKey.pageUrl] as? String else { return }
+        guard let protectionId = dict[TrackerDetectedKey.protectionId] as? String else { return }
         let parent = dict[TrackerDetectedKey.networkName] as? String
 
-        guard pageUrl == self.url?.absoluteString else { return }
+        guard protectionId == siteRating?.protectionId else {
+            Logger.log(text: "id check failed \(protectionId) != \(self.siteRating?.protectionId ?? "<none>")")
+            return
+        }
 
         let tracker = Tracker(url: url, networkName: parent)
         siteRating?.trackerDetected(tracker, blocked: blocked)
@@ -379,6 +385,8 @@ extension TabViewController: WebEventsDelegate {
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
         resetSiteRating()
+        reloadScripts(with: siteRating!.protectionId)
+
         tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: https://app.asana.com/0/413877547933097/483017302281705/f
CC: Caine

**Description**:

Sites appeared to be carrying over the grade.

Additionally, entering search query or a url would be temporarily overwritten by the current site's url after submitting until the load had made progress.

**Steps to test this PR**:

Test 1
1. Bookmark DuckDuckGo.com
1. Visit cnn.com - observe D rating
1. Without giving CNN too much time to load, select DDG from the bookmarks - observe A rating
1. Repeat on a few sites
1. Observe text in omni reflects what is submitted until the page load begins and makes progress.


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)