### PR TITLE
explicitly launch itunes protocol links

### DIFF
--- a/Core/SupportedExternalURLScheme.swift
+++ b/Core/SupportedExternalURLScheme.swift
@@ -26,9 +26,11 @@ public enum SupportedExternalURLScheme: String {
     case mailto
     case maps
     case sms
+    case itunesapps = "itms-appss"
     
     public static func isSupported(url: URL) -> Bool {
         guard let scheme = url.scheme else { return false }
         return SupportedExternalURLScheme(rawValue: scheme) != nil
     }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: 
CC:

**Description**:

Launch iTunes links explicitly.

**Steps to test this PR**:

On a device (will just get error page on simulator)

1. Search for 
> cnet best iOS apps
1. Tap on the CNET Best iPhone Apps of 2017 link
1. Tap on an iOS app link
1. The App Store app will launch

