### PR TITLE
only share url

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -273,7 +273,7 @@ class TabViewController: WebViewController {
     private func shareAction(forLink link: Link) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] action in
             guard let menu = self?.chromeDelegate?.omniBar.menuButton else { return }
-            self?.presentShareSheet(withItems: [ link.title ?? "", link.url, link ], fromView: menu)
+            self?.presentShareSheet(withItems: [ link.url, link ], fromView: menu)
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia or Craig
Asana: https://app.asana.com/0/414235014887631/487161033888839
CC:

**Description**:

Only share the URL and Link object, not the title.

**Steps to test this PR**:

Test 1
1. Navigate to a page
1. From the menu select Share...
1. Share in to a message (or select "Copy" and paste it somewhere)
1. Only the URL appears

Test 2

1. Navigate to a page
1. From the menu select Share...
1. Choose DuckDuckGo Bookmarks
1. The dialog is populated with the URL and title

