### PR TITLE
shift logo up to avoid in-call status corruption

### DIFF
--- a/DuckDuckGo/Base.lproj/LaunchScreen.storyboard
+++ b/DuckDuckGo/Base.lproj/LaunchScreen.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9SF-AN-ir1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9SF-AN-ir1">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,30 +21,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="UHM-6q-8Cp">
-                                <rect key="frame" x="128" y="274" width="119" height="119"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="180" id="1pe-MT-Xab"/>
-                                    <constraint firstAttribute="width" constant="180" id="JS1-hH-rm4"/>
-                                </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="1pe-MT-Xab"/>
-                                        <exclude reference="JS1-hH-rm4"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="1pe-MT-Xab"/>
-                                        <include reference="JS1-hH-rm4"/>
-                                    </mask>
-                                </variation>
+                            <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="UHM-6q-8Cp">
+                                <rect key="frame" x="0.0" y="-110" width="375" height="667"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" red="0.1843137255" green="0.19215686269999999" blue="0.20784313730000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="centerY" secondItem="UHM-6q-8Cp" secondAttribute="centerY" id="650-xC-0jZ"/>
+                            <constraint firstAttribute="centerY" secondItem="UHM-6q-8Cp" secondAttribute="centerY" constant="110" id="650-xC-0jZ"/>
+                            <constraint firstItem="UHM-6q-8Cp" firstAttribute="height" secondItem="5uF-ws-lnA" secondAttribute="height" id="CFQ-Jf-rNT"/>
                             <constraint firstAttribute="centerX" secondItem="UHM-6q-8Cp" secondAttribute="centerX" id="Y2A-ko-GCq"/>
+                            <constraint firstItem="UHM-6q-8Cp" firstAttribute="width" secondItem="5uF-ws-lnA" secondAttribute="width" id="qvJ-cJ-gTg"/>
                         </constraints>
                     </view>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia or Caine
Asana: https://app.asana.com/0/414235014887631/489074728119349
CC:

**Description**:

When the In-Call status bar is showing, anything in the middle of the launch screen is strangely cropped.

Launch UI/UX make change later due to the emotional resonance project anyway.

**Steps to test this PR**:
1. On the simulator enable the in-call status bar
1. Launch the app
1. Observe the logo is uncorrupted


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)