### PR TITLE
fix networks not shown when site is whitelisted

### DIFF
--- a/Core/DetectedTracker.swift
+++ b/Core/DetectedTracker.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 
+// Populated with relevant info at the point of detection.  If networkName or category are nil, they are genuinely not known.
 public struct DetectedTracker {
 
     public let url: String

--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -118,8 +118,15 @@ public extension SiteRating {
     }
 
     public func networkNameAndCategory(forDomain domain: String) -> ( networkName: String?, category: String? ) {
-        let tracker = disconnectMeTrackers.first(where: { domain.hasSuffix($0.key) } )?.value
-        return ( tracker?.networkName, tracker?.category?.rawValue )
+        if let tracker = disconnectMeTrackers.first(where: { domain.hasSuffix($0.key) } )?.value {
+            return ( tracker.networkName, tracker.category?.rawValue )
+        }
+        
+        if let majorNetwork = majorTrackerNetworkStore.network(forDomain: domain) {
+            return ( majorNetwork.name, nil )
+        }
+        
+        return ( nil, nil )
     }
 
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		85782E261F33E24900313000 /* UserText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85782E251F33E24900313000 /* UserText.swift */; };
 		859151E91F543C7500F5FB53 /* SimulatorStatusMagiciOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 859151E81F543C7500F5FB53 /* SimulatorStatusMagiciOS.framework */; };
 		859151EB1F543F5600F5FB53 /* SimulatorStatusMagiciOS.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 859151E81F543C7500F5FB53 /* SimulatorStatusMagiciOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		85923C401FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85923C3F1FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift */; };
 		859872241F5743D800041CB8 /* FireAnimation.xib in Resources */ = {isa = PBXBuildFile; fileRef = 859872231F5743D800041CB8 /* FireAnimation.xib */; };
 		85AB24A81FA7449D00896A5F /* PrivacyProtection.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 85AB24A71FA7449D00896A5F /* PrivacyProtection.storyboard */; };
 		85B718F51FD071E50031A14F /* HTTPSUpgrade.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 85B718F31FD071E50031A14F /* HTTPSUpgrade.xcdatamodeld */; };
@@ -413,6 +414,7 @@
 		857A07A81F3AE3800035EFF4 /* SwiftRichString.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftRichString.framework; path = Carthage/Build/iOS/SwiftRichString.framework; sourceTree = "<group>"; };
 		857AEF7F1F4F2AE9003B84A1 /* AppScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		859151E81F543C7500F5FB53 /* SimulatorStatusMagiciOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SimulatorStatusMagiciOS.framework; path = Carthage/Build/iOS/SimulatorStatusMagiciOS.framework; sourceTree = "<group>"; };
+		85923C3F1FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionTrackerNetworksTests.swift; sourceTree = "<group>"; };
 		859872231F5743D800041CB8 /* FireAnimation.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FireAnimation.xib; sourceTree = "<group>"; };
 		85AB24A71FA7449D00896A5F /* PrivacyProtection.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PrivacyProtection.storyboard; sourceTree = "<group>"; };
 		85B718F41FD071E50031A14F /* HTTPSUpgrade.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = HTTPSUpgrade.xcdatamodel; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				85F1E9B21FB7C59C00A75AC1 /* DisplayableCertificateExtensionTests.swift */,
 				85F1E9B61FB7C81C00A75AC1 /* NativeDisplayableCertificateBuilderDriverTests.swift */,
 				85200F981FBBBFD6001AF290 /* NetworkLeaderboardTests.swift */,
+				85923C3F1FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift */,
 			);
 			name = PrivacyProtection;
 			sourceTree = "<group>";
@@ -2254,6 +2257,7 @@
 				85F1C3CD1F7A76EF00161346 /* ContentBlockerStringCache.swift in Sources */,
 				8570656E1F6AAE270044DCB1 /* DetectedTrackerTests.swift in Sources */,
 				83EDCC411F86B89C005CDFCD /* StatisticsLoaderTests.swift in Sources */,
+				85923C401FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift in Sources */,
 				F1FCF3B31F3550BD00C23128 /* APIRequestTests.swift in Sources */,
 				85BA58581F34F72F00C6E8CA /* AppUserDefaultsTests.swift in Sources */,
 				F1134EBC1F40D45700B73467 /* MockStatisticsStore.swift in Sources */,

--- a/DuckDuckGoTests/MockContentBlockerConfigurationStore.swift
+++ b/DuckDuckGoTests/MockContentBlockerConfigurationStore.swift
@@ -17,33 +17,24 @@
 //  limitations under the License.
 //
 
-
 @testable import Core
 
 class MockContentBlockerConfigurationStore: ContentBlockerConfigurationStore {
 
-    var domainWhitelist: Set<String> {
-        get {
-            return Set<String>()
-        }
-    }
-
+    var domainWhitelist = Set<String>()
     var protecting = true
     var enabled = true
     
-    // A very sophisticated stub, it supports a single whitelisted item ;-)
-    private var lastWhiteListedItem: String?
-    
     func whitelisted(domain: String) -> Bool {
-        return domain == lastWhiteListedItem
+        return domainWhitelist.contains(domain)
     }
     
     func addToWhitelist(domain: String) {
-        lastWhiteListedItem = domain
+        domainWhitelist.insert(domain)
     }
     
     func removeFromWhitelist(domain: String) {
-        lastWhiteListedItem = nil
+        domainWhitelist.remove(domain)
     }
 
     func protecting(domain: String?) -> Bool {

--- a/DuckDuckGoTests/PrivacyProtectionTrackerNetworksTests.swift
+++ b/DuckDuckGoTests/PrivacyProtectionTrackerNetworksTests.swift
@@ -1,9 +1,20 @@
 //
 //  PrivacyProtectionTrackerNetworksTests.swift
-//  UnitTests
+//  DuckDuckGo
 //
-//  Created by Christopher Brind on 02/12/2017.
 //  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/DuckDuckGoTests/PrivacyProtectionTrackerNetworksTests.swift
+++ b/DuckDuckGoTests/PrivacyProtectionTrackerNetworksTests.swift
@@ -1,0 +1,118 @@
+//
+//  PrivacyProtectionTrackerNetworksTests.swift
+//  UnitTests
+//
+//  Created by Christopher Brind on 02/12/2017.
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+
+import Foundation
+
+import Foundation
+import XCTest
+@testable import DuckDuckGo
+@testable import Core
+
+class PrivacyProtectionTrackerNetworksTests: XCTestCase {
+
+    func testWhenNetworkNotKnownSingleSectionWithSingleRowOfSameDomainBuilt() {
+        let mockContentBlocker = MockContentBlockerConfigurationStore()
+        mockContentBlocker.addToWhitelist(domain: "edition.cnn.com")
+        
+        let siteRating = SiteRating(url: URL(string: "https://edition.cnn.com")!)
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker1.com", networkName: nil, category: nil, blocked: false))
+        
+        let sections = SiteRatingTrackerNetworkSectionBuilder(siteRating: siteRating, contentBlocker: mockContentBlocker, majorNetworksOnly: false).build()
+        
+        XCTAssertEqual(1, sections.count)
+        XCTAssertEqual("tracker1.com", sections[0].name)
+        XCTAssertEqual(1, sections[0].rows.count)
+        XCTAssertEqual("tracker1.com", sections[0].rows[0].name)
+    }
+    
+    func testWhenDomainWhitelistedSectionsBuiltForNetworksDetected() {
+        let mockContentBlocker = MockContentBlockerConfigurationStore()
+        mockContentBlocker.addToWhitelist(domain: "edition.cnn.com")
+        
+        let siteRating = SiteRating(url: URL(string: "https://edition.cnn.com")!)
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker1.com", networkName: "Network 1", category: nil, blocked: false))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Network 1", category: nil, blocked: false))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker3.com", networkName: "Network 2", category: nil, blocked: false))
+        
+        let sections = SiteRatingTrackerNetworkSectionBuilder(siteRating: siteRating, contentBlocker: mockContentBlocker, majorNetworksOnly: false).build()
+        
+        XCTAssertEqual(2, sections.count)
+        XCTAssertEqual(2, sections[0].rows.count)
+        XCTAssertEqual(1, sections[1].rows.count)
+    }
+    
+    func testWhenDomainNotWhitelistedSectionsBuiltForNetworksBlocked() {
+        let mockContentBlocker = MockContentBlockerConfigurationStore()
+        
+        let siteRating = SiteRating(url: URL(string: "https://edition.cnn.com")!)
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker1.com", networkName: "Network 1", category: nil, blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Network 1", category: nil, blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker3.com", networkName: "Network 2", category: nil, blocked: false))
+        
+        let sections = SiteRatingTrackerNetworkSectionBuilder(siteRating: siteRating, contentBlocker: mockContentBlocker, majorNetworksOnly: false).build()
+        
+        XCTAssertEqual(1, sections.count)
+        XCTAssertEqual(2, sections[0].rows.count)
+    }
+
+    func testWhenMajorNetworkDetectedSectionBuiltWithRowPerUniqueMajorTracker() {
+        let mockContentBlocker = MockContentBlockerConfigurationStore()
+        
+        let siteRating = SiteRating(url: URL(string: "https://edition.cnn.com")!, majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker1.com", networkName: "Major", category: "Category 1", blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Major", category: "Category 2", blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Major", category: "Category 3", blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker3.com", networkName: "Minor", category: "Category 4", blocked: true))
+
+        let sections = SiteRatingTrackerNetworkSectionBuilder(siteRating: siteRating, contentBlocker: mockContentBlocker, majorNetworksOnly: true).build()
+        
+        XCTAssertEqual(1, sections.count)
+        XCTAssertEqual("Major", sections[0].name)
+        XCTAssertEqual(2, sections[0].rows.count)
+        XCTAssertEqual("tracker1.com", sections[0].rows[0].name)
+        XCTAssertEqual("tracker2.com", sections[0].rows[1].name)
+    }
+
+    func testWhenNetworkDetectedSectionBuiltWithRowPerUniqueTracker() {
+
+        let mockContentBlocker = MockContentBlockerConfigurationStore()
+        
+        let siteRating = SiteRating(url: URL(string: "https://edition.cnn.com")!)
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker1.com", networkName: "Network 1", category: "Category 1", blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Network 1", category: "Category 2", blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Network 1", category: "Category 2", blocked: true))
+        siteRating.trackerDetected(DetectedTracker(url: "http://tracker2.com", networkName: "Network 1", category: "Category 2", blocked: true))
+
+        let sections = SiteRatingTrackerNetworkSectionBuilder(siteRating: siteRating, contentBlocker: mockContentBlocker, majorNetworksOnly: false).build()
+        
+        XCTAssertEqual(1, sections.count)
+        XCTAssertEqual("Network 1", sections[0].name)
+        XCTAssertEqual(2, sections[0].rows.count)
+        XCTAssertEqual("tracker1.com", sections[0].rows[0].name)
+        XCTAssertEqual("Category 1", sections[0].rows[0].value)
+        XCTAssertEqual("tracker2.com", sections[0].rows[1].name)
+        XCTAssertEqual("Category 2", sections[0].rows[1].value)
+    }
+    
+}
+
+fileprivate class MockMajorTrackerNetworkStore: MajorTrackerNetworkStore {
+    
+    let majorTrackerNetwork = MajorTrackerNetwork(name: "Major", domain: "major.com", perentageOfPages: 20)
+    
+    func network(forName name: String) -> MajorTrackerNetwork? {
+        if "Major" == name { return majorTrackerNetwork }
+        return nil
+    }
+    
+    func network(forDomain domain: String) -> MajorTrackerNetwork? {
+        if "major.com" == domain { return majorTrackerNetwork }
+        return nil
+    }
+
+}

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -53,7 +53,24 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     override func setUp() {
         SiteRatingCache.shared.reset()
     }
-
+    
+    func testWhenNetworkExistsForMajorDomainNotInDisconnectItIsReturned() {
+        let disconnectMeTrackers = ["sometracker.com": DisconnectMeTracker(url: Url.http.absoluteString, networkName: "TrickyAds", category: .social ) ]
+        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Major", domain: "major.com", perentageOfPages: 5))
+        let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)
+        let nameAndCategory = testee.networkNameAndCategory(forDomain: "major.com")
+        XCTAssertEqual("Major", nameAndCategory.networkName)
+        XCTAssertNil(nameAndCategory.category)
+    }
+    
+    func testWhenNetworkNameAndCategoryExistsForDomainTheyAreReturned() {
+        let disconnectMeTrackers = ["sometracker.com": DisconnectMeTracker(url: Url.http.absoluteString, networkName: "TrickyAds", category: .social ) ]
+        let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS)
+        let nameAndCategory = testee.networkNameAndCategory(forDomain: "sometracker.com")
+        XCTAssertEqual("TrickyAds", nameAndCategory.networkName)
+        XCTAssertEqual("Social", nameAndCategory.category)
+    }
+    
     func testWhenHighScoreCachedResultIsGradeD() {
         _ = SiteRatingCache.shared.add(url: Url.https, score: 10)
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: https://app.asana.com/0/414235014887631/493467473776905
CC:

**Description**:

Fixes networks not being shown when a domain is whitelisted and also checks major network store for the domain when searching for the network and category (right now maxcdn.com is not in the disconnect list so would never be picked up as a network, never mind a major one)

**Steps to test this PR**:
1. Visit cnn.com
1. Observe large number of networks on overview screen
1. Open networks detail and observe networks listed
1. Add cnn.com to whitelist
1. Observe large number of networks on overview screen
1. Open networks detail and observe networks listed
