### PR TITLE
give some feedback when delete tab is pressed

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -90,7 +90,7 @@ class TabSwitcherViewController: UIViewController {
     
     func onDeleted(tabAt index: Int) {
         delegate.tabSwitcher(self, didRemoveTabAt: index)
-        collectionView.reloadData()
+        collectionView.deleteItems(at: [ IndexPath(row: index, section: 0) ])
         refreshTitle()
     }
     
@@ -121,7 +121,12 @@ extension TabSwitcherViewController: UICollectionViewDataSource {
     
     @objc func onRemoveTapped(sender: UIView) {
         let index = sender.tag
-        onDeleted(tabAt: index)
+        UIView.animate(withDuration: 0.3, animations: {
+            guard let superview = sender.superview else { return }
+            superview.transform.tx = -superview.frame.width * 1.5
+        }, completion: { completed in
+            self.onDeleted(tabAt: index)
+        })
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine
Asana: https://app.asana.com/0/414235014887631/491536455516320
CC:

**Description**:

Minor fix to give some feedback when delete tab is pressed. Stop-gap until we revisit tabs later.

**Steps to test this PR**:
1. Create and delete tabs. 
1. Ensure animations are shown.
1. Ensure correct tabs are deleted.

