### PR TITLE
show navbars on navigation

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -41,27 +41,25 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
 
     var hidden = false
     var lastYOffset: CGFloat = 0
+    var cumulative: CGFloat = 0
 
     init(delegate: BrowserChromeDelegate) {
         self.delegate = delegate
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-
-        let yDiff = scrollView.contentOffset.y - lastYOffset
-        print("*** yDiff", yDiff)
-
-        if abs(yDiff) > Constants.threshold {
-            updateBars(yDiff > 0)
+        let y = scrollView.contentOffset.y
+        let diff = y - lastYOffset
+        cumulative += diff
+        
+        if abs(cumulative) > Constants.threshold {
+            updateBars(cumulative > 0)
+            cumulative = 0
         }
-
+        
+        lastYOffset = y
     }
-
-    func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
-        lastYOffset = scrollView.contentOffset.y
-        print("***", #function, lastYOffset)
-    }
-
+    
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
         if hidden {
             updateBars(false)
@@ -72,13 +70,11 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     }
 
     func reset() {
-        print("***", #function)
         lastYOffset = 0
         hidden = false
     }
 
     private func updateBars(_ shouldHide: Bool) {
-        print("***", #function, shouldHide, hidden)
         guard shouldHide != hidden else { return }
         hidden = shouldHide
         delegate.setBarsHidden(shouldHide, animated: true)

--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -39,44 +39,27 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
 
     let delegate: BrowserChromeDelegate
 
-    var dragging = false
     var hidden = false
-    var lastOffset: CGPoint?
-    var cumulative: CGFloat = 0
+    var lastYOffset: CGFloat = 0
 
     init(delegate: BrowserChromeDelegate) {
         self.delegate = delegate
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard dragging else { return }
 
-        if let lastOffset = lastOffset {
+        let yDiff = scrollView.contentOffset.y - lastYOffset
+        print("*** yDiff", yDiff)
 
-            let ydiff = lastOffset.y - scrollView.contentOffset.y
-
-            if ydiff == 0 || (cumulative < 0 && ydiff > 0) || (cumulative > 0 && ydiff < 0) {
-                cumulative = 0
-            }
-
-            cumulative += ydiff
-
-            if abs(cumulative) > Constants.threshold {
-                updateBars(ydiff < 0)
-            }
-
+        if abs(yDiff) > Constants.threshold {
+            updateBars(yDiff > 0)
         }
 
-        lastOffset = scrollView.contentOffset
     }
 
-    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        dragging = true
-    }
-
-    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        dragging = false
-        cumulative = 0
+    func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
+        lastYOffset = scrollView.contentOffset.y
+        print("***", #function, lastYOffset)
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
@@ -88,7 +71,14 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
         return true
     }
 
+    func reset() {
+        print("***", #function)
+        lastYOffset = 0
+        hidden = false
+    }
+
     private func updateBars(_ shouldHide: Bool) {
+        print("***", #function, shouldHide, hidden)
         guard shouldHide != hidden else { return }
         hidden = shouldHide
         delegate.setBarsHidden(shouldHide, animated: true)

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -309,7 +309,8 @@ extension MainViewController: BrowserChromeDelegate {
     }
 
     func setBarsHidden(_ hidden: Bool, animated: Bool) {
-
+        chromeManager.hidden = hidden
+        
         updateToolbarConstant(hidden)
         updateNavBarConstant(hidden)
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -413,6 +413,8 @@ extension TabViewController: WebEventsDelegate {
     
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
+        showBars(animated: true)
+
         resetSiteRating()
         if let siteRating = siteRating {
             reloadScripts(with: siteRating.protectionId)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine
Asana: https://app.asana.com/0/414235014887631/482056236481739
CC:

**Description**:

Show navbars when navigating (fixes the show/hide bug and behaves more like safari)

**Steps to test this PR**:
1. Open a page
1. Scroll to hide the bars
1. Tap a link to navigate
1. Observe bars are displayed
1. Confirm tap bottom of screen to show bars still works
1. Confirm tap top of screen to show bars and then again to scroll to top still works

