### PR TITLE
show bars on navigation

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -93,5 +93,11 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
         hidden = shouldHide
         delegate.setBarsHidden(shouldHide, animated: true)
     }
+    
+    func reset() {
+        updateBars(false)
+        cumulative = 0
+        lastOffset = nil
+    }
 
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -457,6 +457,11 @@ extension MainViewController: TabDelegate {
     func tabContentProcessDidTerminate(tab: TabViewController) {
         tabManager.invalidateCache(forController: tab)
     }
+    
+    func showBars() {
+        chromeManager.reset()
+    }
+    
 }
 
 extension MainViewController: TabSwitcherDelegate {

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -34,4 +34,7 @@ protocol TabDelegate: class {
     func tabDidRequestSettings(tab: TabViewController)
     
     func tabContentProcessDidTerminate(tab: TabViewController)
+    
+    func showBars()
+    
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -413,6 +413,7 @@ extension TabViewController: WebEventsDelegate {
     
     func webpageDidStartLoading() {
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
+        delegate?.showBars()
         resetSiteRating()
         if let siteRating = siteRating {
             reloadScripts(with: siteRating.protectionId)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine
Asana: https://app.asana.com/0/414235014887631/482056236481739
CC:

**Description**:

Show navbars when navigating (fixes the show/hide bug and behaves more like safari)

**Steps to test this PR**:
1. Open a page
1. Scroll to hide the bars
1. Tap a link to navigate
1. Observe bars are displayed
1. Confirm tap bottom of screen to show bars still works
1. Confirm tap top of screen to show bars and then again to scroll to top still works
