### PR TITLE
ensure we only upgrade urls targetting the main frame

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -210,7 +210,9 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
             return
         }
 
-        if let upgradeUrl = httpsUpgrade.upgrade(url: url) {
+        if let targetMainFrame = navigationAction.targetFrame?.isMainFrame,
+            targetMainFrame == true,
+            let upgradeUrl = httpsUpgrade.upgrade(url: url) {
             Logger.log(text: "upgrading \(url) to \(upgradeUrl)")
             load(url: upgradeUrl)
             decisionHandler(.cancel)

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -210,8 +210,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
             return
         }
 
-        if let targetMainFrame = navigationAction.targetFrame?.isMainFrame,
-            targetMainFrame == true,
+        if navigationAction.isTargettingMainFrame(),
             let upgradeUrl = httpsUpgrade.upgrade(url: url) {
             Logger.log(text: "upgrading \(url) to \(upgradeUrl)")
             load(url: upgradeUrl)
@@ -236,7 +235,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         webEventsDelegate?.contentProcessDidTerminate(webView: webView)
     }
-    
+
     private func shouldReissueSearch(for url: URL) -> Bool {
         return appUrls.isDuckDuckGoSearch(url: url) && !appUrls.hasCorrectMobileStatsParams(url: url)
     }
@@ -326,3 +325,11 @@ extension WebViewController: UIGestureRecognizerDelegate {
 }
 
 fileprivate class WebLongPressGestureRecognizer: UILongPressGestureRecognizer {}
+
+fileprivate extension WKNavigationAction {
+
+    func isTargettingMainFrame() -> Bool {
+        return targetFrame?.isMainFrame ?? false
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine
Asana: https://app.asana.com/0/414235014887631/493597308631724
CC:

**Description**:

Only upgrade URLs targeting the main frame, otherwise we end up loading frame content in to the main frame.

**Steps to test this PR**:
1. Visit retirejapan.info and check page loads correctly (with embedded YouTube video)
1. Visit booking.com and check site is redirected to https
