### PR TITLE
reset the site rating on back navigation

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -259,7 +259,7 @@ open class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelega
         webView.reload()
     }
     
-    public func goBack() {
+    open func goBack() {
         if isError {
             hideErrorMessage()
             webEventsDelegate?.webpageDidStartLoading()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -92,6 +92,11 @@ class TabViewController: WebViewController {
 
     }
 
+    override func goBack() {
+        resetSiteRating()
+        super.goBack()
+    }
+
     private func addContentBlockerConfigurationObserver() {
         NotificationCenter.default.addObserver(self, selector: #selector(onContentBlockerConfigurationChanged), name: ContentBlockerConfigurationChangedNotification.name, object: nil)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine 
Asana: https://app.asana.com/0/inbox/392891325557408/497272658411136/492792371095421
CC:

**Description**:

Reset the site rating on back navigation to prevent pages ahead from influencing the "upgrade from" message.

**Steps to test this PR**:
1. Visit news.ycombinator.com - observe B grade 
1. Click on a link that results in a C or D grade 
1. Navigate back and the B should remain in a not upgraded state

