### PR TITLE
only show the major network tracker score if the site is one

### DIFF
--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -1507,13 +1507,13 @@ with a website is protected.</string>
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="38"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site Is Not Major Tracker Network" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0ax-Nd-tDU">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site is Major Tracker Network" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0ax-Nd-tDU">
                                                     <rect key="frame" x="20" y="11" width="303" height="16"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Icon Result Success" translatesAutoresizingMaskIntoConstraints="NO" id="ovR-q9-grK">
+                                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Icon Result Fail" translatesAutoresizingMaskIntoConstraints="NO" id="ovR-q9-grK">
                                                     <rect key="frame" x="333" y="8" width="22" height="22"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="22" id="iG2-k6-XjS"/>

--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -51,6 +51,11 @@ class PrivacyProtectionScoreCardController: UITableViewController {
         navigationController?.popViewController(animated: true)
     }
 
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let cell = super.tableView(tableView, cellForRowAt: indexPath)
+        return cell.isHidden ? 0 : super.tableView(tableView, heightForRowAt:indexPath)
+    }
+
     private func update() {
         guard isViewLoaded else { return }
 
@@ -60,11 +65,11 @@ class PrivacyProtectionScoreCardController: UITableViewController {
         updateIsMajorNetworkCell()
         updatePrivacyPractices()
         updatePrivacyGradeCells()
+        tableView.reloadData()
     }
 
     private func updateIsMajorNetworkCell() {
-        let success = !siteRating.isMajorTrackerNetwork
-        isMajorNetworkCell.update(message: siteRating.isMajorNetworkText(), image: success ? #imageLiteral(resourceName: "PP Icon Result Success") : #imageLiteral(resourceName: "PP Icon Result Fail"))
+        isMajorNetworkCell.isHidden = !siteRating.isMajorTrackerNetwork
     }
 
     private func updateConnectionCell() {

--- a/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
+++ b/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
@@ -38,12 +38,6 @@ extension SiteRating {
         .poor: UserText.privacyProtectionTOSPoor
     ]
 
-    func isMajorNetworkText() -> String {
-        return isMajorTrackerNetwork ?
-            UserText.privacyProtectionIsMajorTrackerNetwork :
-            UserText.privacyProtectionIsNotMajorTrackerNetwork
-    }
-
     func encryptedConnectionText() -> String {
         if !https {
             return UserText.privacyProtectionEncryptionBadConnection

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -74,8 +74,6 @@ public struct UserText {
     public static let privacyProtectionTrackersFound = NSLocalizedString("privacy.protection.trackers.found", comment: "Trackers found")
     public static let privacyProtectionMajorTrackersBlocked = NSLocalizedString("privacy.protection.major.trackers.blocked", comment: "Major trackers blocked")
     public static let privacyProtectionMajorTrackersFound = NSLocalizedString("privacy.protection.major.trackers.found", comment: "Major trackers found")
-    public static let privacyProtectionIsMajorTrackerNetwork = NSLocalizedString("privacy.protection.is.major.network", comment: "Is major network")
-    public static let privacyProtectionIsNotMajorTrackerNetwork = NSLocalizedString("privacy.protection.is.not.major.network", comment: "Is not major network")
 
     public static let privacyProtectionTOSUnknown = NSLocalizedString("privacy.protection.tos.unknown", comment: "Unknown Privacy Practices")
     public static let privacyProtectionTOSGood = NSLocalizedString("privacy.protection.tos.good", comment: "Good Privacy Practices")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -76,8 +76,6 @@
 "privacy.protection.tos.good" = "Good Privacy Practices";
 "privacy.protection.tos.mixed" = "Mixed Privacy Practices";
 "privacy.protection.tos.poor" = "Poor Privacy Practices";
-"privacy.protection.is.major.network" = "Site is Major Tracker Network";
-"privacy.protection.is.not.major.network" = "Site is not Major Tracker Network";
 
 "privacy.protection.encryption.cert.error" = "Error extracting certificate";
 "privacy.protection.encryption.subject.name" = "Subject Name";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine or Mia
Asana: https://app.asana.com/0/414235014887631/497272658411132
CC:

**Description**:

Only show the "is major network tracker" if the site one, leave it off otherwise.

**Steps to test this PR**:
1. Visit facebook.com and view the score card - the "is major network tracker..." message and red-x is visible
1. Visit duckduckgo.com and view the score card - the "is major network tracker..." message and red-x is not in the list at all

