### PR TITLE
show correct plurality of detected/blocked network(s)

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		85047B861F6887D2002A95D8 /* BlockerListsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85047B851F6887D2002A95D8 /* BlockerListsLoader.swift */; };
 		85047B881F6966ED002A95D8 /* disconnectme.js in Resources */ = {isa = PBXBuildFile; fileRef = 85047B871F6966ED002A95D8 /* disconnectme.js */; };
 		85047B8A1F69692C002A95D8 /* contentblocker.js in Resources */ = {isa = PBXBuildFile; fileRef = 85047B891F69692C002A95D8 /* contentblocker.js */; };
+		85081A031FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85081A021FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift */; };
 		85200F911FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85200F901FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift */; };
 		85200F931FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85200F921FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift */; };
 		85200F951FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 85200F941FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard */; };
@@ -376,6 +377,7 @@
 		85047B851F6887D2002A95D8 /* BlockerListsLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockerListsLoader.swift; sourceTree = "<group>"; };
 		85047B871F6966ED002A95D8 /* disconnectme.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = disconnectme.js; sourceTree = "<group>"; };
 		85047B891F69692C002A95D8 /* contentblocker.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = contentblocker.js; sourceTree = "<group>"; };
+		85081A021FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteRatingPrivacyProtectionExtensionTests.swift; sourceTree = "<group>"; };
 		85200F901FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionScoreCardController.swift; sourceTree = "<group>"; };
 		85200F921FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionHeaderController.swift; sourceTree = "<group>"; };
 		85200F941FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PrivacyProtectionHeader.storyboard; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				85F1E9B61FB7C81C00A75AC1 /* NativeDisplayableCertificateBuilderDriverTests.swift */,
 				85200F981FBBBFD6001AF290 /* NetworkLeaderboardTests.swift */,
 				85923C3F1FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift */,
+				85081A021FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift */,
 			);
 			name = PrivacyProtection;
 			sourceTree = "<group>";
@@ -2273,6 +2276,7 @@
 				8565A34D1FC8DFE400239327 /* LaunchTabNotificationTests.swift in Sources */,
 				F1134EC41F40E25800B73467 /* AppVersionExtensionTests.swift in Sources */,
 				F16BB6621F56498B00B47A42 /* UseDuckDuckGoInSafariViewControllerTests.swift in Sources */,
+				85081A031FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift in Sources */,
 				85C271E41FD04ACD007216B4 /* HTTPSUpgradeStoreTests.swift in Sources */,
 				F1B88A141F3BB445000263D6 /* SiteGradeTests.swift in Sources */,
 				85ECA7F11F2A83190018EBEB /* MigrationTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		85047B881F6966ED002A95D8 /* disconnectme.js in Resources */ = {isa = PBXBuildFile; fileRef = 85047B871F6966ED002A95D8 /* disconnectme.js */; };
 		85047B8A1F69692C002A95D8 /* contentblocker.js in Resources */ = {isa = PBXBuildFile; fileRef = 85047B891F69692C002A95D8 /* contentblocker.js */; };
 		85081A031FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85081A021FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift */; };
+		85081A051FE05D40006561FD /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 85081A041FE05D40006561FD /* Localizable.stringsdict */; };
 		85200F911FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85200F901FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift */; };
 		85200F931FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85200F921FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift */; };
 		85200F951FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 85200F941FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard */; };
@@ -378,6 +379,7 @@
 		85047B871F6966ED002A95D8 /* disconnectme.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = disconnectme.js; sourceTree = "<group>"; };
 		85047B891F69692C002A95D8 /* contentblocker.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = contentblocker.js; sourceTree = "<group>"; };
 		85081A021FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteRatingPrivacyProtectionExtensionTests.swift; sourceTree = "<group>"; };
+		85081A041FE05D40006561FD /* Localizable.stringsdict */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; path = Localizable.stringsdict; sourceTree = "<group>"; };
 		85200F901FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionScoreCardController.swift; sourceTree = "<group>"; };
 		85200F921FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionHeaderController.swift; sourceTree = "<group>"; };
 		85200F941FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PrivacyProtectionHeader.storyboard; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				F18641FF1E949E1900B2A911 /* Fonts */,
 				84E3419E1E2F7EFB00BDBA6F /* LaunchScreen.storyboard */,
 				F1F533861F26ABAC00D80D4F /* Localizable.strings */,
+				85081A041FE05D40006561FD /* Localizable.stringsdict */,
 			);
 			name = UserInterfaceResources;
 			sourceTree = "<group>";
@@ -2033,6 +2036,7 @@
 				85200F951FBA5D6E001AF290 /* PrivacyProtectionHeader.storyboard in Resources */,
 				8563A0351F8E369400F04442 /* Home.storyboard in Resources */,
 				F143C2B21E49D78C00CFDE3A /* Assets.xcassets in Resources */,
+				85081A051FE05D40006561FD /* Localizable.stringsdict in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DuckDuckGo/Localizable.stringsdict
+++ b/DuckDuckGo/Localizable.stringsdict
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>privacy.protection.major.trackers.found</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@networks@</string>
+		<key>networks</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Major Tracker Network Found</string>
+			<key>other</key>
+			<string>%d Major Tracker Networks Found</string>
+		</dict>
+	</dict>
+
+	<key>privacy.protection.major.trackers.blocked</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@networks@</string>
+		<key>networks</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Major Tracker Network Blocked</string>
+			<key>other</key>
+			<string>%d Major Tracker Networks Blocked</string>
+		</dict>
+	</dict>
+
+	<key>privacy.protection.trackers.found</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@networks@</string>
+		<key>networks</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Tracker Network Found</string>
+			<key>other</key>
+			<string>%d Tracker Networks Found</string>
+		</dict>
+	</dict>
+
+	<key>privacy.protection.trackers.blocked</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@networks@</string>
+		<key>networks</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Major Tracker Network Blocked</string>
+			<key>other</key>
+			<string>%d Major Tracker Networks Blocked</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
+++ b/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
@@ -61,11 +61,19 @@ extension SiteRating {
     }
 
     func majorNetworksBlockedText() -> String {
-        return String(format: UserText.privacyProtectionMajorTrackersBlocked, uniqueMajorTrackerNetworksBlocked)
+        if 1 == uniqueMajorTrackerNetworksBlocked {
+            return UserText.privacyProtectionMajorTrackerBlocked
+        } else {
+            return String(format: UserText.privacyProtectionMajorTrackersBlocked, uniqueMajorTrackerNetworksBlocked)
+        }
     }
 
     func majorNetworksDetectedText() -> String {
-        return String(format: UserText.privacyProtectionMajorTrackersFound, uniqueMajorTrackerNetworksDetected)
+        if 1 == uniqueMajorTrackerNetworksDetected {
+            return UserText.privacyProtectionMajorTrackerFound
+        } else {
+            return String(format: UserText.privacyProtectionMajorTrackersFound, uniqueMajorTrackerNetworksDetected)
+        }
     }
 
     func networksText(contentBlocker: ContentBlockerConfigurationStore) -> String {
@@ -77,11 +85,19 @@ extension SiteRating {
     }
 
     func networksBlockedText() -> String {
-        return String(format: UserText.privacyProtectionTrackersBlocked, uniqueTrackerNetworksBlocked)
+        if 1 == uniqueTrackerNetworksBlocked {
+            return  UserText.privacyProtectionTrackerBlocked
+        } else {
+            return String(format: UserText.privacyProtectionTrackersBlocked, uniqueTrackerNetworksBlocked)
+        }
     }
 
     func networksDetectedText() -> String {
-        return String(format: UserText.privacyProtectionTrackersFound, uniqueTrackerNetworksDetected)
+        if 1 == uniqueTrackerNetworksDetected {
+            return UserText.privacyProtectionTrackerFound
+        } else {
+            return String(format: UserText.privacyProtectionTrackersFound, uniqueTrackerNetworksDetected)
+        }
     }
 
     func protecting(_ contentBlocker: ContentBlockerConfigurationStore) -> Bool {

--- a/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
+++ b/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
@@ -61,19 +61,11 @@ extension SiteRating {
     }
 
     func majorNetworksBlockedText() -> String {
-        if uniqueMajorTrackerNetworksBlocked == 1 {
-            return UserText.privacyProtectionMajorTrackerBlocked
-        } else {
-            return String(format: UserText.privacyProtectionMajorTrackersBlocked, uniqueMajorTrackerNetworksBlocked)
-        }
+        return String(format: UserText.privacyProtectionMajorTrackersBlocked, uniqueMajorTrackerNetworksBlocked)
     }
 
     func majorNetworksDetectedText() -> String {
-        if uniqueMajorTrackerNetworksDetected == 1 {
-            return UserText.privacyProtectionMajorTrackerFound
-        } else {
-            return String(format: UserText.privacyProtectionMajorTrackersFound, uniqueMajorTrackerNetworksDetected)
-        }
+        return String(format: UserText.privacyProtectionMajorTrackersFound, uniqueMajorTrackerNetworksDetected)
     }
 
     func networksText(contentBlocker: ContentBlockerConfigurationStore) -> String {
@@ -85,19 +77,11 @@ extension SiteRating {
     }
 
     func networksBlockedText() -> String {
-        if uniqueTrackerNetworksBlocked == 1 {
-            return  UserText.privacyProtectionTrackerBlocked
-        } else {
-            return String(format: UserText.privacyProtectionTrackersBlocked, uniqueTrackerNetworksBlocked)
-        }
+        return String(format: UserText.privacyProtectionTrackersBlocked, uniqueTrackerNetworksBlocked)
     }
 
     func networksDetectedText() -> String {
-        if uniqueTrackerNetworksDetected == 1 {
-            return UserText.privacyProtectionTrackerFound
-        } else {
-            return String(format: UserText.privacyProtectionTrackersFound, uniqueTrackerNetworksDetected)
-        }
+        return String(format: UserText.privacyProtectionTrackersFound, uniqueTrackerNetworksDetected)
     }
 
     func protecting(_ contentBlocker: ContentBlockerConfigurationStore) -> Bool {

--- a/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
+++ b/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
@@ -61,7 +61,7 @@ extension SiteRating {
     }
 
     func majorNetworksBlockedText() -> String {
-        if 1 == uniqueMajorTrackerNetworksBlocked {
+        if uniqueMajorTrackerNetworksBlocked == 1 {
             return UserText.privacyProtectionMajorTrackerBlocked
         } else {
             return String(format: UserText.privacyProtectionMajorTrackersBlocked, uniqueMajorTrackerNetworksBlocked)
@@ -69,7 +69,7 @@ extension SiteRating {
     }
 
     func majorNetworksDetectedText() -> String {
-        if 1 == uniqueMajorTrackerNetworksDetected {
+        if uniqueMajorTrackerNetworksDetected == 1 {
             return UserText.privacyProtectionMajorTrackerFound
         } else {
             return String(format: UserText.privacyProtectionMajorTrackersFound, uniqueMajorTrackerNetworksDetected)
@@ -85,7 +85,7 @@ extension SiteRating {
     }
 
     func networksBlockedText() -> String {
-        if 1 == uniqueTrackerNetworksBlocked {
+        if uniqueTrackerNetworksBlocked == 1 {
             return  UserText.privacyProtectionTrackerBlocked
         } else {
             return String(format: UserText.privacyProtectionTrackersBlocked, uniqueTrackerNetworksBlocked)
@@ -93,7 +93,7 @@ extension SiteRating {
     }
 
     func networksDetectedText() -> String {
-        if 1 == uniqueTrackerNetworksDetected {
+        if uniqueTrackerNetworksDetected == 1 {
             return UserText.privacyProtectionTrackerFound
         } else {
             return String(format: UserText.privacyProtectionTrackersFound, uniqueTrackerNetworksDetected)

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -71,7 +71,6 @@ public struct UserText {
     public static let privacyProtectionEncryptionBadConnection = NSLocalizedString("privacy.protection.encryption.bad.connection", comment: "Unencrypted conection")
     public static let privacyProtectionEncryptionMixedConnection = NSLocalizedString("privacy.protection.encryption.mixed.connection", comment: "Mixed encryption conection")
 
-    // Plurals
     public static let privacyProtectionTrackersBlocked = NSLocalizedString("privacy.protection.trackers.blocked", comment: "Trackers blocked")
     public static let privacyProtectionTrackersFound = NSLocalizedString("privacy.protection.trackers.found", comment: "Trackers found")
     public static let privacyProtectionMajorTrackersBlocked = NSLocalizedString("privacy.protection.major.trackers.blocked", comment: "Major trackers blocked")

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -70,10 +70,18 @@ public struct UserText {
     public static let privacyProtectionEncryptionGoodConnection = NSLocalizedString("privacy.protection.encryption.good.connection", comment: "Encrypted conection")
     public static let privacyProtectionEncryptionBadConnection = NSLocalizedString("privacy.protection.encryption.bad.connection", comment: "Unencrypted conection")
     public static let privacyProtectionEncryptionMixedConnection = NSLocalizedString("privacy.protection.encryption.mixed.connection", comment: "Mixed encryption conection")
+
+    // Plurals
     public static let privacyProtectionTrackersBlocked = NSLocalizedString("privacy.protection.trackers.blocked", comment: "Trackers blocked")
     public static let privacyProtectionTrackersFound = NSLocalizedString("privacy.protection.trackers.found", comment: "Trackers found")
     public static let privacyProtectionMajorTrackersBlocked = NSLocalizedString("privacy.protection.major.trackers.blocked", comment: "Major trackers blocked")
     public static let privacyProtectionMajorTrackersFound = NSLocalizedString("privacy.protection.major.trackers.found", comment: "Major trackers found")
+
+    // Singular
+    public static let privacyProtectionTrackerBlocked = NSLocalizedString("privacy.protection.tracker.blocked", comment: "Tracker blocked")
+    public static let privacyProtectionTrackerFound = NSLocalizedString("privacy.protection.tracker.found", comment: "Tracker found")
+    public static let privacyProtectionMajorTrackerBlocked = NSLocalizedString("privacy.protection.major.tracker.blocked", comment: "Major tracker blocked")
+    public static let privacyProtectionMajorTrackerFound = NSLocalizedString("privacy.protection.major.tracker.found", comment: "Major tracker found")
 
     public static let privacyProtectionTOSUnknown = NSLocalizedString("privacy.protection.tos.unknown", comment: "Unknown Privacy Practices")
     public static let privacyProtectionTOSGood = NSLocalizedString("privacy.protection.tos.good", comment: "Good Privacy Practices")

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -77,12 +77,6 @@ public struct UserText {
     public static let privacyProtectionMajorTrackersBlocked = NSLocalizedString("privacy.protection.major.trackers.blocked", comment: "Major trackers blocked")
     public static let privacyProtectionMajorTrackersFound = NSLocalizedString("privacy.protection.major.trackers.found", comment: "Major trackers found")
 
-    // Singular
-    public static let privacyProtectionTrackerBlocked = NSLocalizedString("privacy.protection.tracker.blocked", comment: "Tracker blocked")
-    public static let privacyProtectionTrackerFound = NSLocalizedString("privacy.protection.tracker.found", comment: "Tracker found")
-    public static let privacyProtectionMajorTrackerBlocked = NSLocalizedString("privacy.protection.major.tracker.blocked", comment: "Major tracker blocked")
-    public static let privacyProtectionMajorTrackerFound = NSLocalizedString("privacy.protection.major.tracker.found", comment: "Major tracker found")
-
     public static let privacyProtectionTOSUnknown = NSLocalizedString("privacy.protection.tos.unknown", comment: "Unknown Privacy Practices")
     public static let privacyProtectionTOSGood = NSLocalizedString("privacy.protection.tos.good", comment: "Good Privacy Practices")
     public static let privacyProtectionTOSMixed = NSLocalizedString("privacy.protection.tos.mixed", comment: "Mixed Privacy Practices")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -68,10 +68,19 @@
 "privacy.protection.encryption.good.connection" = "Encrypted Connection";
 "privacy.protection.encryption.bad.connection" = "Unencrypted Connection";
 "privacy.protection.encryption.mixed.connection" = "Mixed Encryption";
+
+// Plurals
 "privacy.protection.trackers.blocked" = "%d Tracker Networks Blocked";
 "privacy.protection.trackers.found" = "%d Tracker Networks Found";
 "privacy.protection.major.trackers.blocked" = "%d Major Tracker Networks Blocked";
 "privacy.protection.major.trackers.found" = "%d Major Tracker Networks Found";
+
+// Singular
+"privacy.protection.tracker.blocked" = "1 Tracker Network Blocked";
+"privacy.protection.tracker.found" = "1 Tracker Network Found";
+"privacy.protection.major.tracker.blocked" = "1 Major Tracker Network Blocked";
+"privacy.protection.major.tracker.found" = "1 Major Tracker Network Found";
+
 "privacy.protection.tos.unknown" = "Unknown Privacy Practices";
 "privacy.protection.tos.good" = "Good Privacy Practices";
 "privacy.protection.tos.mixed" = "Mixed Privacy Practices";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -69,18 +69,6 @@
 "privacy.protection.encryption.bad.connection" = "Unencrypted Connection";
 "privacy.protection.encryption.mixed.connection" = "Mixed Encryption";
 
-// Plurals
-"privacy.protection.trackers.blocked" = "%d Tracker Networks Blocked";
-"privacy.protection.trackers.found" = "%d Tracker Networks Found";
-"privacy.protection.major.trackers.blocked" = "%d Major Tracker Networks Blocked";
-"privacy.protection.major.trackers.found" = "%d Major Tracker Networks Found";
-
-// Singular
-"privacy.protection.tracker.blocked" = "1 Tracker Network Blocked";
-"privacy.protection.tracker.found" = "1 Tracker Network Found";
-"privacy.protection.major.tracker.blocked" = "1 Major Tracker Network Blocked";
-"privacy.protection.major.tracker.found" = "1 Major Tracker Network Found";
-
 "privacy.protection.tos.unknown" = "Unknown Privacy Practices";
 "privacy.protection.tos.good" = "Good Privacy Practices";
 "privacy.protection.tos.mixed" = "Mixed Privacy Practices";

--- a/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
@@ -36,52 +36,52 @@ class SiteRatingPrivacyProtectionExtensionTests: XCTestCase {
         let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major1", category: nil, blocked: true))
         rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "major2", category: nil, blocked: true))
-        XCTAssertEqual(rating.majorNetworksBlockedText(), String(format: DuckDuckGo.UserText.privacyProtectionMajorTrackersBlocked, 2))
+        XCTAssertTrue(rating.majorNetworksBlockedText().contains("Networks Blocked"))
     }
 
     func testMultipleMajorNetworksDetectedReturnsPluralText() {
         let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major1", category: nil, blocked: false))
         rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "major2", category: nil, blocked: false))
-        XCTAssertEqual(rating.majorNetworksDetectedText(), String(format: DuckDuckGo.UserText.privacyProtectionMajorTrackersFound, 2))
+        XCTAssertTrue(rating.majorNetworksDetectedText().contains("Networks Found"))
     }
 
     func testMultipleNetworksBlockedReturnsPluralText() {
         let rating = SiteRating(url: Constants.pageURL)
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor1", category: nil, blocked: true))
         rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "minor2", category: nil, blocked: true))
-        XCTAssertEqual(rating.networksBlockedText(), String(format: DuckDuckGo.UserText.privacyProtectionTrackersBlocked, 2))
+        XCTAssertTrue(rating.networksBlockedText().contains("Networks Blocked"))
     }
 
     func testMultipleNetworksDetectedReturnsPluralText() {
         let rating = SiteRating(url: Constants.pageURL)
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor1", category: nil, blocked: false))
         rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "minor2", category: nil, blocked: false))
-        XCTAssertEqual(rating.networksDetectedText(), String(format: DuckDuckGo.UserText.privacyProtectionTrackersFound, 2))
+        XCTAssertTrue(rating.networksDetectedText().contains("Networks Found"))
     }
 
     func testSingleMajorNetworkBlockedReturnsSinglularText() {
         let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major", category: nil, blocked: true))
-        XCTAssertEqual(rating.majorNetworksBlockedText(), DuckDuckGo.UserText.privacyProtectionMajorTrackerBlocked)
+        XCTAssertTrue(rating.majorNetworksBlockedText().contains("Network Blocked"))
     }
 
     func testSingleMajorNetworkDetectedReturnsSinglularText() {
         let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major", category: nil, blocked: false))
-        XCTAssertEqual(rating.majorNetworksDetectedText(), DuckDuckGo.UserText.privacyProtectionMajorTrackerFound)
+        XCTAssertTrue(rating.majorNetworksDetectedText().contains("Network Found"))
     }
 
     func testSingleNetworkBlockedReturnsSinglularText() {
         let rating = SiteRating(url: Constants.pageURL)
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor", category: nil, blocked: true))
-        XCTAssertEqual(rating.networksBlockedText(), DuckDuckGo.UserText.privacyProtectionTrackerBlocked)
+        XCTAssertTrue(rating.networksBlockedText().contains("Network Blocked"))
     }
 
     func testSingleNetworkDetectedReturnsSinglularText() {
         let rating = SiteRating(url: Constants.pageURL)
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor", category: nil, blocked: false))
-        XCTAssertEqual(rating.networksDetectedText(), DuckDuckGo.UserText.privacyProtectionTrackerFound)
+        XCTAssertTrue(rating.networksDetectedText().contains("Network Found"))
     }
 
 }

--- a/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
@@ -1,0 +1,61 @@
+//
+//  PrivacyProtectionTrackerNetworksTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+import XCTest
+
+@testable import Core
+@testable import DuckDuckGo
+
+class SiteRatingPrivacyProtectionExtensionTests: XCTestCase {
+
+    struct Constants {
+
+        static let pageURL = URL(string: "https://example.com")!
+
+    }
+
+    func testMultipleNetworkBlockedReturnsPluralText() {
+        let rating = SiteRating(url: Constants.pageURL)
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor1", category: nil, blocked: true))
+        rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "minor2", category: nil, blocked: true))
+        XCTAssertEqual(rating.networksBlockedText(), String(format: DuckDuckGo.UserText.privacyProtectionTrackersBlocked, 2))
+    }
+
+    func testMultipleNetworkDetectedReturnsPluralText() {
+        let rating = SiteRating(url: Constants.pageURL)
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor1", category: nil, blocked: false))
+        rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "minor2", category: nil, blocked: false))
+        XCTAssertEqual(rating.networksDetectedText(), String(format: DuckDuckGo.UserText.privacyProtectionTrackersFound, 2))
+    }
+
+    func testSingleNetworkBlockedReturnsSinglularText() {
+        let rating = SiteRating(url: Constants.pageURL)
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor", category: nil, blocked: true))
+        XCTAssertEqual(rating.networksBlockedText(), DuckDuckGo.UserText.privacyProtectionTrackerBlocked)
+    }
+
+    func testSingleNetworkDetectedReturnsSinglularText() {
+        let rating = SiteRating(url: Constants.pageURL)
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor", category: nil, blocked: false))
+        XCTAssertEqual(rating.networksDetectedText(), DuckDuckGo.UserText.privacyProtectionTrackerFound)
+    }
+
+}

--- a/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
@@ -32,18 +32,44 @@ class SiteRatingPrivacyProtectionExtensionTests: XCTestCase {
 
     }
 
-    func testMultipleNetworkBlockedReturnsPluralText() {
+    func testMultipleMajorNetworksBlockedReturnsPluralText() {
+        let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major1", category: nil, blocked: true))
+        rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "major2", category: nil, blocked: true))
+        XCTAssertEqual(rating.majorNetworksBlockedText(), String(format: DuckDuckGo.UserText.privacyProtectionMajorTrackersBlocked, 2))
+    }
+
+    func testMultipleMajorNetworksDetectedReturnsPluralText() {
+        let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major1", category: nil, blocked: false))
+        rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "major2", category: nil, blocked: false))
+        XCTAssertEqual(rating.majorNetworksDetectedText(), String(format: DuckDuckGo.UserText.privacyProtectionMajorTrackersFound, 2))
+    }
+
+    func testMultipleNetworksBlockedReturnsPluralText() {
         let rating = SiteRating(url: Constants.pageURL)
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor1", category: nil, blocked: true))
         rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "minor2", category: nil, blocked: true))
         XCTAssertEqual(rating.networksBlockedText(), String(format: DuckDuckGo.UserText.privacyProtectionTrackersBlocked, 2))
     }
 
-    func testMultipleNetworkDetectedReturnsPluralText() {
+    func testMultipleNetworksDetectedReturnsPluralText() {
         let rating = SiteRating(url: Constants.pageURL)
         rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "minor1", category: nil, blocked: false))
         rating.trackerDetected(DetectedTracker(url: "otherurl", networkName: "minor2", category: nil, blocked: false))
         XCTAssertEqual(rating.networksDetectedText(), String(format: DuckDuckGo.UserText.privacyProtectionTrackersFound, 2))
+    }
+
+    func testSingleMajorNetworkBlockedReturnsSinglularText() {
+        let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major", category: nil, blocked: true))
+        XCTAssertEqual(rating.majorNetworksBlockedText(), DuckDuckGo.UserText.privacyProtectionMajorTrackerBlocked)
+    }
+
+    func testSingleMajorNetworkDetectedReturnsSinglularText() {
+        let rating = SiteRating(url: Constants.pageURL, disconnectMeTrackers: [: ], termsOfServiceStore: MockTermsOfServiceStore(), majorTrackerNetworkStore: MockMajorTrackerNetworkStore())
+        rating.trackerDetected(DetectedTracker(url: "someurl", networkName: "major", category: nil, blocked: false))
+        XCTAssertEqual(rating.majorNetworksDetectedText(), DuckDuckGo.UserText.privacyProtectionMajorTrackerFound)
     }
 
     func testSingleNetworkBlockedReturnsSinglularText() {
@@ -59,3 +85,20 @@ class SiteRatingPrivacyProtectionExtensionTests: XCTestCase {
     }
 
 }
+
+fileprivate class MockMajorTrackerNetworkStore: MajorTrackerNetworkStore {
+    func network(forName name: String) -> MajorTrackerNetwork? {
+        return MajorTrackerNetwork(name: name, domain: name, perentageOfPages: 50)
+    }
+
+    func network(forDomain domain: String) -> MajorTrackerNetwork? {
+        return nil
+    }
+}
+
+fileprivate class MockTermsOfServiceStore: TermsOfServiceStore {
+
+    var terms = [String : TermsOfService]()
+
+}
+


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer:
Asana:
CC:

**Description**:

Show the correct plurality for the networks.  

The correct way to do this is to use a strings dictionary rather than branching logic and using the localised strings file, but that is overkill at this stage.  Will need to revisit when we localise for multiple languages.

**Steps to test this PR**:
1. Visit a site and open the privacy dashboard immediately
1. Observe the text update for blocked network(s)
1. Turn off protection 
1. Observe the text update for detected network(s)

Note, nytimes.com is good for observing the singular.  cnn.com is good for the plural.
