### PR TITLE
handle blocker list download error

### DIFF
--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -353,44 +353,68 @@
                                 </connections>
                             </containerView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Grade Null" translatesAutoresizingMaskIntoConstraints="NO" id="Eym-g2-2W7">
-                                <rect key="frame" x="119" y="82" width="137" height="111"/>
+                                <rect key="frame" x="119" y="80" width="137" height="111"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Uh-oh, that didn’t work." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wwJ-gu-wkh">
-                                <rect key="frame" x="20" y="205.5" width="335" height="20"/>
+                                <rect key="frame" x="20" y="203.5" width="335" height="20"/>
                                 <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="20"/>
                                 <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Check your internet connection and try again." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d5L-XE-U9e">
-                                <rect key="frame" x="38" y="236.5" width="299" height="32"/>
+                                <rect key="frame" x="38" y="234.5" width="299" height="32"/>
                                 <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                 <color key="textColor" red="0.55294117647058827" green="0.55294117647058827" blue="0.55294117647058827" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PN6-XD-NaV">
+                                <rect key="frame" x="27" y="436" width="322" height="46"/>
+                                <color key="backgroundColor" red="0.37254901959999998" green="0.3803921569" blue="0.40784313729999999" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="46" id="OTf-p5-pnz"/>
+                                </constraints>
+                                <state key="normal" title="Try Again">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="onTapTryAgain" destination="X3g-za-d5S" eventType="touchUpInside" id="fwj-nb-6kK"/>
+                                </connections>
+                            </button>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="n2A-BJ-cmy">
+                                <rect key="frame" x="178" y="449" width="20" height="20"/>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" red="0.94117647058823528" green="0.94117647058823528" blue="0.94117647058823528" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="Eym-g2-2W7" firstAttribute="top" secondItem="OCb-9B-JB1" secondAttribute="top" constant="62" id="1KR-A6-oT4"/>
+                            <constraint firstItem="Eym-g2-2W7" firstAttribute="top" secondItem="OCb-9B-JB1" secondAttribute="top" priority="250" constant="60" id="1KR-A6-oT4"/>
+                            <constraint firstItem="PN6-XD-NaV" firstAttribute="centerX" secondItem="OCb-9B-JB1" secondAttribute="centerX" id="AO9-Jo-wbZ"/>
                             <constraint firstItem="wwJ-gu-wkh" firstAttribute="centerX" secondItem="OCb-9B-JB1" secondAttribute="centerX" id="Bk6-U0-Svl"/>
                             <constraint firstItem="wwJ-gu-wkh" firstAttribute="width" secondItem="hph-V2-QWe" secondAttribute="width" constant="-40" id="Gre-MQ-5rB"/>
                             <constraint firstItem="Eym-g2-2W7" firstAttribute="centerX" secondItem="OCb-9B-JB1" secondAttribute="centerX" id="JCE-Dk-6Ph"/>
                             <constraint firstItem="2tj-Oo-RA1" firstAttribute="width" secondItem="hph-V2-QWe" secondAttribute="width" id="M1j-sU-ac4"/>
                             <constraint firstItem="wwJ-gu-wkh" firstAttribute="top" secondItem="Eym-g2-2W7" secondAttribute="bottom" constant="12.699999999999999" id="NWQ-ry-GzZ"/>
+                            <constraint firstItem="n2A-BJ-cmy" firstAttribute="centerX" secondItem="OCb-9B-JB1" secondAttribute="centerX" id="OpK-oL-8B3"/>
                             <constraint firstItem="d5L-XE-U9e" firstAttribute="width" secondItem="hph-V2-QWe" secondAttribute="width" constant="-76" id="Wgs-Zo-LaY"/>
                             <constraint firstItem="d5L-XE-U9e" firstAttribute="centerX" secondItem="OCb-9B-JB1" secondAttribute="centerX" id="Yly-Ys-GVM"/>
+                            <constraint firstItem="2tj-Oo-RA1" firstAttribute="top" secondItem="PN6-XD-NaV" secondAttribute="bottom" constant="21" id="eIs-yc-XcU"/>
+                            <constraint firstItem="PN6-XD-NaV" firstAttribute="width" secondItem="hph-V2-QWe" secondAttribute="width" constant="-53" id="fzy-Yw-SoA"/>
                             <constraint firstItem="OCb-9B-JB1" firstAttribute="bottom" secondItem="2tj-Oo-RA1" secondAttribute="bottom" id="hpH-xp-DNQ"/>
+                            <constraint firstItem="PN6-XD-NaV" firstAttribute="top" relation="greaterThanOrEqual" secondItem="d5L-XE-U9e" secondAttribute="bottom" constant="20" id="jOV-Ba-0UK"/>
                             <constraint firstItem="d5L-XE-U9e" firstAttribute="top" secondItem="wwJ-gu-wkh" secondAttribute="bottom" constant="11" id="mdl-JZ-hwq"/>
                             <constraint firstItem="2tj-Oo-RA1" firstAttribute="centerX" secondItem="OCb-9B-JB1" secondAttribute="centerX" id="scc-f5-hHb"/>
+                            <constraint firstItem="2tj-Oo-RA1" firstAttribute="top" secondItem="n2A-BJ-cmy" secondAttribute="bottom" constant="34" id="xly-LV-FBu"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="OCb-9B-JB1"/>
                     </view>
                     <connections>
+                        <outlet property="activity" destination="n2A-BJ-cmy" id="pYQ-Hp-amT"/>
+                        <outlet property="button" destination="PN6-XD-NaV" id="f3A-en-WRn"/>
                         <outlet property="errorLabel" destination="d5L-XE-U9e" id="JHu-NF-C63"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4V6-xu-lqI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2399" y="-365"/>
+            <point key="canvasLocation" x="2397.5999999999999" y="-365.66716641679164"/>
         </scene>
         <!--PrivacyProtectionFooter-->
         <scene sceneID="hHO-R7-6mI">

--- a/DuckDuckGo/PrivacyProtectionController.swift
+++ b/DuckDuckGo/PrivacyProtectionController.swift
@@ -77,8 +77,8 @@ class PrivacyProtectionController: UIViewController {
     private func showLoadBlockerListTryAgain(_ controller: PrivacyProtectionErrorController) {
         controller.onTryAgain {
             let blockerListLoader = BlockerListsLoader()
-            blockerListLoader.start { newData in
-                self.handleLoadBlockerListResult(controller, blockerListLoader.hasData)
+            blockerListLoader.start { [weak self] newData in
+                self?.handleLoadBlockerListResult(controller, blockerListLoader.hasData)
             }
         }
     }

--- a/DuckDuckGo/PrivacyProtectionController.swift
+++ b/DuckDuckGo/PrivacyProtectionController.swift
@@ -69,7 +69,7 @@ class PrivacyProtectionController: UIViewController {
 
     private func showBlockerListError() {
         guard let controller = storyboard?.instantiateViewController(withIdentifier: "Error") as? PrivacyProtectionErrorController else { return }
-        controller.errorText = "This can be caused by a loss of internet connection when loading the content blocking rules."
+        controller.errorText = UserText.privacyProtectionReloadBlockerLists
         embeddedController.pushViewController(controller, animated: true)
         showLoadBlockerListTryAgain(controller)
     }

--- a/DuckDuckGo/PrivacyProtectionErrorController.swift
+++ b/DuckDuckGo/PrivacyProtectionErrorController.swift
@@ -23,11 +23,33 @@ import UIKit
 class PrivacyProtectionErrorController: UIViewController {
 
     @IBOutlet weak var errorLabel: UILabel!
+    @IBOutlet weak var button: UIButton!
+    @IBOutlet weak var activity: UIActivityIndicatorView!
 
     var errorText: String?
 
+    private var tryAgain: (() -> Void)?
+
     override func viewDidLoad() {
+        button.layer.cornerRadius = 5
         errorLabel.text = errorText
+        configureTryAgain()
+    }
+
+    private func configureTryAgain() {
+        button?.isHidden = tryAgain == nil
+        activity?.isHidden = true
+    }
+
+    func onTryAgain(_ tryAgain: @escaping () -> Void) {
+        self.tryAgain = tryAgain
+        configureTryAgain()
+    }
+
+    @IBAction func onTapTryAgain() {
+        activity.isHidden = false
+        button.isHidden = true
+        tryAgain?()
     }
 
 }

--- a/DuckDuckGo/PrivacyProtectionErrorController.swift
+++ b/DuckDuckGo/PrivacyProtectionErrorController.swift
@@ -20,6 +20,14 @@
 import Foundation
 import UIKit
 
+protocol PrivacyProtectionErrorDelegate: class {
+
+    func canTryAgain(controller: PrivacyProtectionErrorController) -> Bool
+
+    func tryAgain(controller: PrivacyProtectionErrorController)
+
+}
+
 class PrivacyProtectionErrorController: UIViewController {
 
     @IBOutlet weak var errorLabel: UILabel!
@@ -28,28 +36,23 @@ class PrivacyProtectionErrorController: UIViewController {
 
     var errorText: String?
 
-    private var tryAgain: (() -> Void)?
+    weak var delegate: PrivacyProtectionErrorDelegate?
 
     override func viewDidLoad() {
         button.layer.cornerRadius = 5
         errorLabel.text = errorText
-        configureTryAgain()
+        resetTryAgain()
     }
 
-    private func configureTryAgain() {
-        button?.isHidden = tryAgain == nil
+    func resetTryAgain() {
+        button?.isHidden = !(delegate?.canTryAgain(controller: self) ?? false)
         activity?.isHidden = true
-    }
-
-    func onTryAgain(_ tryAgain: @escaping () -> Void) {
-        self.tryAgain = tryAgain
-        configureTryAgain()
     }
 
     @IBAction func onTapTryAgain() {
         activity.isHidden = false
         button.isHidden = true
-        tryAgain?()
+        delegate?.tryAgain(controller: self)
     }
 
 }

--- a/DuckDuckGo/PrivacyProtectionOverviewController.swift
+++ b/DuckDuckGo/PrivacyProtectionOverviewController.swift
@@ -36,7 +36,7 @@ class PrivacyProtectionOverviewController: UITableViewController {
     @IBOutlet weak var majorTrackersCell: SummaryCell!
     @IBOutlet weak var privacyPracticesCell: SummaryCell!
 
-    fileprivate var popRecognizer: InteractivePopRecognizer!
+    fileprivate weak var popRecognizer: InteractivePopRecognizer!
 
     private weak var siteRating: SiteRating!
     private weak var contentBlocker: ContentBlockerConfigurationStore!

--- a/DuckDuckGo/SiteRatingView.swift
+++ b/DuckDuckGo/SiteRatingView.swift
@@ -68,6 +68,7 @@ public class SiteRatingView: UIView {
     public func refresh() {
         circleIndicator.image = #imageLiteral(resourceName: "PP Indicator Unknown")
 
+        guard BlockerListsLoader().hasData else { return }
         guard let siteRating = siteRating else { return }
         
         let grades = siteRating.siteGrade()

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -81,6 +81,8 @@ public struct UserText {
     public static let privacyProtectionTOSMixed = NSLocalizedString("privacy.protection.tos.mixed", comment: "Mixed Privacy Practices")
     public static let privacyProtectionTOSPoor = NSLocalizedString("privacy.protection.tos.poor", comment: "Poor Privacy Practices")
 
+    public static let privacyProtectionReloadBlockerLists = NSLocalizedString("privacy.protection.reload.blocker.lists", comment: "This can be caused by a loss of internet connection when loading the content blocking rules.")
+
     public static let ppEncryptionCertError = NSLocalizedString("privacy.protection.encryption.cert.error", comment: "Error extracting certificate")
     public static let ppEncryptionSubjectName = NSLocalizedString("privacy.protection.encryption.subject.name", comment:  "Subject Name")
     public static let ppEncryptionPublicKey = NSLocalizedString("privacy.protection.encryption.public.key", comment:  "Public Key")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -74,6 +74,8 @@
 "privacy.protection.tos.mixed" = "Mixed Privacy Practices";
 "privacy.protection.tos.poor" = "Poor Privacy Practices";
 
+"privacy.protection.reload.blocker.lists" = "This can be caused by a loss of internet connection when loading the content blocking rules.";
+
 "privacy.protection.encryption.cert.error" = "Error extracting certificate";
 "privacy.protection.encryption.subject.name" = "Subject Name";
 "privacy.protection.encryption.public.key" = "Public Key";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia
Asana: https://app.asana.com/0/414235014887631/470949914705548
CC:

**Description**:

Show an error in privacy protection when there's no blocker lists data and allow user to try and reload

**Steps to test this PR**:
1. Clean install of app then quickly break the network connection (breakpoint in start func of `BlockerListsLoader` class if using simulator, turn off network, then resume)
1. Tap site rating view
1. Error message about content blocker lists with retry button should appear
1. Tap retry - activity indicator will appear and button will disappear
1. Shortly the button will reappear and the activity indicator will disappear
1. Turn on network
1. Tap retry - activity indicator will appear, button will disappear
1. Privacy protection will close and web page will reload
1. Open privacy protection to see site grade

