### PR TITLE
Harden redirect loop

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -27,6 +27,8 @@ open class WebViewController: UIViewController {
         static let hasOnlySecureContent = "hasOnlySecureContent"
     }
 
+    var failingUrls = Set<String>()
+    
     public weak var webEventsDelegate: WebEventsDelegate?
     
     @IBOutlet weak var progressBar: UIProgressView!
@@ -36,12 +38,15 @@ open class WebViewController: UIViewController {
 
     open private(set) var webView: WKWebView!
 
+    private var lastError: Error?
+    private var loadedURL: URL?
     private var shouldReloadOnError = false
+    
     private lazy var appUrls: AppUrls = AppUrls()
     private lazy var httpsUpgrade = HTTPSUpgrade()
 
     public var name: String? {
-        return webView.title    
+        return webView.title
     }
     
     public var url: URL? {
@@ -113,10 +118,12 @@ open class WebViewController: UIViewController {
     }
     
     public func load(url: URL) {
+        loadedURL = url
+        lastError = nil
         load(urlRequest: URLRequest(url: url))
     }
  
-    public func load(urlRequest: URLRequest) {
+    private func load(urlRequest: URLRequest) {
         loadViewIfNeeded()
         webView.stopLoading()
         webView.load(urlRequest)
@@ -240,6 +247,7 @@ extension WebViewController: WKNavigationDelegate {
 
 
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        lastError = nil
         shouldReloadOnError = false
         favicon = nil
         hideErrorMessage()
@@ -262,14 +270,16 @@ extension WebViewController: WKNavigationDelegate {
         webEventsDelegate?.webpageDidFailToLoad()
         checkForReloadOnError()
     }
-
+    
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        hideProgressIndicator()
-        showError(message: error.localizedDescription)
-        webEventsDelegate?.webpageDidFailToLoad()
-        checkForReloadOnError()
+        let nserror = error as NSError
+        lastError = error
+        if let url = loadedURL, let domain = url.host, nserror.code == 102 {
+            failingUrls.insert(domain)
+        }
+        showErrorLater()
     }
-
+    
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 
         guard let url = navigationAction.request.url else {
@@ -298,9 +308,9 @@ extension WebViewController: WKNavigationDelegate {
             return
         }
 
-        if navigationAction.isTargettingMainFrame(),
+        if !failingUrls.contains(url.host ?? ""),
+            navigationAction.isTargettingMainFrame(),
             let upgradeUrl = httpsUpgrade.upgrade(url: url) {
-            Logger.log(text: "upgrading \(url) to \(upgradeUrl)")
             load(url: upgradeUrl)
             decisionHandler(.cancel)
             return
@@ -315,6 +325,19 @@ extension WebViewController: WKNavigationDelegate {
 
     }
 
+    private func showErrorLater() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.showErrorNow()
+        }
+    }
+    
+    private func showErrorNow() {
+        guard let error = lastError else { return }
+        hideProgressIndicator()
+        showError(message: error.localizedDescription)
+        webEventsDelegate?.webpageDidFailToLoad()
+        checkForReloadOnError()
+    }
 
 }
 

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -26,6 +26,10 @@ open class WebViewController: UIViewController {
         static let estimatedProgress = "estimatedProgress"
         static let hasOnlySecureContent = "hasOnlySecureContent"
     }
+    
+    private struct webViewErrorCodes {
+        static let frameLoadInterrupted = 102
+    }
 
     var failingUrls = Set<String>()
     
@@ -272,9 +276,11 @@ extension WebViewController: WKNavigationDelegate {
     }
     
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        let nserror = error as NSError
         lastError = error
-        if let url = loadedURL, let domain = url.host, nserror.code == 102 {
+        let error = error as NSError
+        if let url = loadedURL,
+            let domain = url.host,
+            error.code == webViewErrorCodes.frameLoadInterrupted {
             failingUrls.insert(domain)
         }
         showErrorLater()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -146,15 +146,11 @@ class MainViewController: UIViewController {
     }
     
     func loadUrlInNewTab(_ url: URL) {
-        loadRequestInNewTab(URLRequest(url: url))
-    }
-    
-    func loadRequestInNewTab(_ request: URLRequest) {
         loadViewIfNeeded()
-        addTab(forUrlRequest: request)
+        addTab(url: url)
         refreshOmniBar()
     }
-
+    
     func launchNewSearch() {
         loadViewIfNeeded()
         attachHomeScreen()
@@ -173,8 +169,8 @@ class MainViewController: UIViewController {
         }
     }
     
-    private func addTab(forUrlRequest urlRequest: URLRequest) {
-        let tab = tabManager.add(request: urlRequest)
+    private func addTab(url: URL?) {
+        let tab = tabManager.add(url: url)
         omniBar.resignFirstResponder()
         addToView(tab: tab)
     }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -41,21 +41,18 @@ class TabManager {
     
     private func buildController(forTab tab: Tab) -> TabViewController {
         let url = tab.link?.url
-        let request = url == nil ? nil : URLRequest(url: url!)
-        return buildController(forTab: tab, request: request)
+        return buildController(forTab: tab, url: url)
     }
     
-    private func buildController(forTab tab: Tab, request: URLRequest?) -> TabViewController {
+    private func buildController(forTab tab: Tab, url: URL?) -> TabViewController {
         let contentBlocker = ContentBlockerConfigurationUserDefaults()
         let configuration =  WKWebViewConfiguration.persistent()
         let controller = TabViewController.loadFromStoryboard(model: tab, contentBlocker: contentBlocker)
         controller.attachWebView(configuration: configuration)
         controller.delegate = delegate
-        
-        if let request = request {
-            controller.load(urlRequest: request)
+        if let url = url {
+            controller.load(url: url)
         }
-        
         return controller
     }
     
@@ -97,16 +94,10 @@ class TabManager {
     }
     
     func add(url: URL?) -> TabViewController {
-        let request = url == nil ? nil : URLRequest(url: url!)
-        return add(request: request)
-    }
-    
-    func add(request: URLRequest?) -> TabViewController {
         current?.dismiss()
-        let url = request?.url
         let link = url == nil ? nil : Link(title: nil, url: url!)
         let tab = Tab(link: link)
-        let controller = buildController(forTab: tab, request: request)
+        let controller = buildController(forTab: tab, url: url)
         tabControllerCache.append(controller)
         model.add(tab: tab)
         save()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine or Mia
Asana:  https://app.asana.com/0/414235014887631/414510321511367
CC:

**Description**:

If we detect a site that needs to be upgraded to HTTPS but then it redirects back to HTTP we get stuck in a horrific looking loop.  This addresses that by checking for "frame load interrupted" errors on sites we've upgraded by storing them in a simple in-memory set of domains that we won't try to upgrade again.

**Steps to test this PR**:

1. Go to bbc.com
1. The site may redirect a few times (especially if redirect to a local version), but should ultimately settle on the site properly
