### PR TITLE
implement correct first party lookup in app

### DIFF
--- a/Core/MajorTrackerNetwork.swift
+++ b/Core/MajorTrackerNetwork.swift
@@ -49,7 +49,7 @@ public class InMemoryMajorNetworkStore: MajorTrackerNetworkStore {
 
     public func network(forDomain domain: String) -> MajorTrackerNetwork? {
         let lowercased = domain.lowercased()
-        return networks.first(where: { lowercased.hasSuffix($0.domain) })
+        return networks.first(where: { lowercased == $0.domain || lowercased.hasSuffix(".\($0.domain)") })
     }
 
     public func network(forName name: String) -> MajorTrackerNetwork? {

--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -120,7 +120,7 @@ public extension SiteRating {
     }
 
     public func networkNameAndCategory(forDomain domain: String) -> ( networkName: String?, category: String? ) {
-        if let tracker = disconnectMeTrackers.first(where: { domain.hasSuffix($0.key) } )?.value {
+        if let tracker = disconnectMeTrackers.first(where: { domain == $0.key || domain.hasSuffix(".\($0.key)") } )?.value {
             return ( tracker.networkName, tracker.category?.rawValue )
         }
         

--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -120,11 +120,12 @@ public extension SiteRating {
     }
 
     public func networkNameAndCategory(forDomain domain: String) -> ( networkName: String?, category: String? ) {
-        if let tracker = disconnectMeTrackers.first(where: { domain == $0.key || domain.hasSuffix(".\($0.key)") } )?.value {
+        let lowercasedDomain = domain.lowercased()
+        if let tracker = disconnectMeTrackers.first(where: { lowercasedDomain == $0.key || lowercasedDomain.hasSuffix(".\($0.key)") } )?.value {
             return ( tracker.networkName, tracker.category?.rawValue )
         }
         
-        if let majorNetwork = majorTrackerNetworkStore.network(forDomain: domain) {
+        if let majorNetwork = majorTrackerNetworkStore.network(forDomain: lowercasedDomain) {
             return ( majorNetwork.name, nil )
         }
         

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -62,7 +62,15 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual("Major", nameAndCategory.networkName)
         XCTAssertNil(nameAndCategory.category)
     }
-    
+
+    func testWhenNetworkNameAndCategoryExistsForUppercasedDomainTheyAreReturned() {
+        let disconnectMeTrackers = ["sometracker.com": DisconnectMeTracker(url: Url.http.absoluteString, networkName: "TrickyAds", category: .social ) ]
+        let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS)
+        let nameAndCategory = testee.networkNameAndCategory(forDomain: "SOMETRACKER.com")
+        XCTAssertEqual("TrickyAds", nameAndCategory.networkName)
+        XCTAssertEqual("Social", nameAndCategory.category)
+    }
+
     func testWhenNetworkNameAndCategoryExistsForDomainTheyAreReturned() {
         let disconnectMeTrackers = ["sometracker.com": DisconnectMeTracker(url: Url.http.absoluteString, networkName: "TrickyAds", category: .social ) ]
         let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine or Mia
Asana: https://app.asana.com/0/414235014887631/414510321511365
CC:

**Description**:

Some trackers were being categories as Amazon just because their domain name ended with amazon.com, e.g. images-na.ssl-images-amazon.com yet were still blocked by our JavaScript.  This meant we appeared to be blocking Amazon on their site.

Even though they probably are Amazon trackers, to make the above domain appear as an Amazon tracker (and not be blocked on Amazon) the correct thing to do would be to upgrade our related URL lookup source (ie Disconnect), once confirmed it really is related.

This PR ensures consistency between JavaScript and iOS.

**Steps to test this PR**:
1. Visit Amazon.com
1. Note that items not in Disconnect appear in the list of trackers


  