### PR TITLE
update controls when url changes

### DIFF
--- a/Core/WebEventsDelegate.swift
+++ b/Core/WebEventsDelegate.swift
@@ -33,6 +33,8 @@ public protocol WebEventsDelegate: class {
 
     func webView(_ webView: WKWebView, didUpdateHasOnlySecureContent hasOnlySecureContent: Bool)
 
+    func webView(_ webView: WKWebView, didChangeUrl url: URL?)
+
     func webpageDidStartLoading()
     
     func webpageDidFinishLoading()

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -25,6 +25,7 @@ open class WebViewController: UIViewController {
     private struct webViewKeyPaths {
         static let estimatedProgress = "estimatedProgress"
         static let hasOnlySecureContent = "hasOnlySecureContent"
+        static let url = "URL"
     }
 
     public weak var webEventsDelegate: WebEventsDelegate?
@@ -80,8 +81,11 @@ open class WebViewController: UIViewController {
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         attachLongPressHandler(webView: webView)
         webView.allowsBackForwardNavigationGestures = true
+
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+
         webView.navigationDelegate = self
         webView.uiDelegate = self
         webViewContainer.addSubview(webView)
@@ -134,6 +138,9 @@ open class WebViewController: UIViewController {
         case webViewKeyPaths.hasOnlySecureContent:
             webEventsDelegate?.webView(webView, didUpdateHasOnlySecureContent: webView.hasOnlySecureContent)
 
+        case webViewKeyPaths.url:
+            webEventsDelegate?.webView(webView, didChangeUrl: webView.url)
+            
         default:
             Logger.log(text: "Unhandled keyPath \(keyPath)")
         }
@@ -145,7 +152,6 @@ open class WebViewController: UIViewController {
             webEventsDelegate?.faviconWasUpdated(favicon, forUrl: url)
         }
     }
-
 
     private func checkForReloadOnError() {
         guard shouldReloadOnError else { return }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -152,10 +152,7 @@ open class WebViewController: UIViewController {
     }
     
     private func urlDidChange() {
-        guard navigation == nil else { return }
-        webEventsDelegate?.webpageDidStartLoading()
         webEventsDelegate?.webView(webView, didChangeUrl: webView.url)
-        webEventsDelegate?.webpageDidFinishLoading()
     }
     
     private func onFaviconLoaded(_ favicon: URL) {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -37,7 +37,6 @@ open class WebViewController: UIViewController {
 
     open private(set) var webView: WKWebView!
 
-    private var navigation: WKNavigation?
     private var shouldReloadOnError = false
     
     private lazy var appUrls: AppUrls = AppUrls()
@@ -255,7 +254,6 @@ extension WebViewController: WKNavigationDelegate {
 
 
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        self.navigation = navigation
         shouldReloadOnError = false
         favicon = nil
         hideErrorMessage()
@@ -264,7 +262,6 @@ extension WebViewController: WKNavigationDelegate {
     }
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        self.navigation = nil
         hideProgressIndicator()
         webView.getFavicon(completion: { [weak self] (favicon) in
             if let favicon = favicon {
@@ -275,14 +272,12 @@ extension WebViewController: WKNavigationDelegate {
     }
 
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        self.navigation = nil
         hideProgressIndicator()
         webEventsDelegate?.webpageDidFailToLoad()
         checkForReloadOnError()
     }
 
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        self.navigation = nil
         hideProgressIndicator()
         showError(message: error.localizedDescription)
         webEventsDelegate?.webpageDidFailToLoad()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -46,7 +46,7 @@ class MainViewController: UIViewController {
     private weak var launchTabObserver: LaunchTabNotification.Observer?
 
     fileprivate var currentTab: TabViewController? {
-        return tabManager.current
+        return tabManager?.current
     }
 
     override func viewDidLoad() {
@@ -433,7 +433,7 @@ extension MainViewController: TabDelegate {
         if currentTab == tab {
             refreshControls()
         }
-        tabManager.save()
+        tabManager?.save()
     }
 
     func tabDidRequestNewTab(_ tab: TabViewController) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -482,6 +482,10 @@ extension TabViewController: WebEventsDelegate {
         updateSiteRating()
     }
 
+    func webView(_ webView: WKWebView, didChangeUrl url: URL?) {
+        delegate?.tabLoadingStateDidChange(tab: self)
+    }
+
 }
 
 extension TabViewController: UIPopoverPresentationControllerDelegate {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -447,8 +447,10 @@ extension TabViewController: WebEventsDelegate {
         siteRating?.finishedLoading = true
         updateSiteRating()
         tabModel.link = link
-        delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.delegate?.tabLoadingStateDidChange(tab: self!)
+        }
     }
     
     func webpageDidFailToLoad() {
@@ -458,8 +460,10 @@ extension TabViewController: WebEventsDelegate {
         }
         siteRating?.finishedLoading = true
         updateSiteRating()
-        delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.delegate?.tabLoadingStateDidChange(tab: self!)
+        }
     }
     
     func faviconWasUpdated(_ favicon: URL, forUrl url: URL) {
@@ -483,7 +487,9 @@ extension TabViewController: WebEventsDelegate {
     }
 
     func webView(_ webView: WKWebView, didChangeUrl url: URL?) {
-        delegate?.tabLoadingStateDidChange(tab: self)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.delegate?.tabLoadingStateDidChange(tab: self!)
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Caine or Mia
Asana: https://app.asana.com/0/414235014887631/500748641649797
CC:

**Description**:

Some sites don't trigger the navigation events we use to update the controls on navigation when the user is browsing (e.g. Reddit and The Economist).

**Steps to test this PR**:

1. With a new tab visit https://reddit.com/r/duckduckgo and navigate around.  The controls should update correctly.
1. Likewise for https://economist.com 
