### PR TITLE
use equality and an index when fetching domains for https upgrade

### DIFF
--- a/Core/HTTPSUpgrade.xcdatamodeld/HTTPSUpgrade.xcdatamodel/contents
+++ b/Core/HTTPSUpgrade.xcdatamodeld/HTTPSUpgrade.xcdatamodel/contents
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13533" systemVersion="17B1003" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="HTTPSUpgradeSimpleDomain" representedClassName=".HTTPSUpgradeSimpleDomain" syncable="YES" codeGenerationType="class">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13772" systemVersion="17C88" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="HTTPSUpgradeSimpleDomain" representedClassName=".HTTPSUpgradeSimpleDomain" versionHashModifier="added domain index" syncable="YES" codeGenerationType="class">
         <attribute name="domain" optional="YES" attributeType="String" syncable="YES"/>
+        <fetchIndex name="domainIndex">
+            <fetchIndexElement property="domain" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
-    <entity name="HTTPSUpgradeWildcardDomain" representedClassName="HTTPSUpgradeWildcardDomain" syncable="YES" codeGenerationType="class">
+    <entity name="HTTPSUpgradeWildcardDomain" representedClassName="HTTPSUpgradeWildcardDomain" versionHashModifier="added domain index" syncable="YES" codeGenerationType="class">
         <attribute name="domain" optional="YES" attributeType="String" syncable="YES"/>
+        <fetchIndex name="domainIndex">
+            <fetchIndexElement property="domain" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <elements>
         <element name="HTTPSUpgradeSimpleDomain" positionX="-63" positionY="-18" width="128" height="60"/>

--- a/Core/HTTPSUpgradePersistence.swift
+++ b/Core/HTTPSUpgradePersistence.swift
@@ -43,7 +43,7 @@ public class CoreDataHTTPSUpgradePersistence: HTTPSUpgradePersistence {
             let entityName = String(describing: HTTPSUpgradeSimpleDomain.self)
             let context = container.managedObjectContext
             let storedDomain = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context) as! HTTPSUpgradeSimpleDomain
-            storedDomain.domain = simpleDomain
+            storedDomain.domain = simpleDomain.lowercased()
         }
 
         for wildcardDomain in wildcardDomains {
@@ -51,14 +51,14 @@ public class CoreDataHTTPSUpgradePersistence: HTTPSUpgradePersistence {
             let entityName = String(describing: HTTPSUpgradeWildcardDomain.self)
             let context = container.managedObjectContext
             let storedDomain = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context) as! HTTPSUpgradeWildcardDomain
-            storedDomain.domain = domain
+            storedDomain.domain = domain.lowercased()
         }
 
         _ = container.save()
     }
 
     public func hasWildcardDomain(_ domain: String) -> Bool {
-        let domains = buildDomainList(domain)
+        let domains = buildDomainList(domain.lowercased())
         let request:NSFetchRequest<HTTPSUpgradeWildcardDomain> = HTTPSUpgradeWildcardDomain.fetchRequest()
         request.predicate = NSPredicate(format: "domain in %@", domains)
         guard let count = try? container.managedObjectContext.count(for: request) else { return false }
@@ -67,7 +67,7 @@ public class CoreDataHTTPSUpgradePersistence: HTTPSUpgradePersistence {
 
     public func hasSimpleDomain(_ domain: String) -> Bool {
         let request:NSFetchRequest<HTTPSUpgradeSimpleDomain> = HTTPSUpgradeSimpleDomain.fetchRequest()
-        request.predicate = NSPredicate(format: "domain like %@", domain)
+        request.predicate = NSPredicate(format: "domain = %@", domain.lowercased())
         guard let count = try? container.managedObjectContext.count(for: request) else { return false }
         return count > 0
     }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -218,6 +218,7 @@ open class WebViewController: UIViewController {
         guard let webView = webView else { return }
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
         webView.removeFromSuperview()
         webEventsDelegate?.detached(webView: webView)
     }

--- a/DuckDuckGoTests/CoreDataHTTPSUpgradePersistenceTests.swift
+++ b/DuckDuckGoTests/CoreDataHTTPSUpgradePersistenceTests.swift
@@ -28,6 +28,12 @@ class CoreDataHTTPSUpgradePersistenceTests: XCTestCase {
         testee = CoreDataHTTPSUpgradePersistence()
         testee.reset()
     }
+    
+    func testWhenDomainIsMixedCaseDomainIsStillFound() {
+        testee.persist(domains: [ "www.bbc.co.uk", "apple.com" ], wildcardDomains: [ "*.example.com", "*.cnn.com" ])
+        XCTAssertTrue(testee.hasDomain("APPLE.com"))
+        XCTAssertTrue(testee.hasDomain("EDITION.cnn.com"))
+    }
 
     func testWhenSimpleAndWildcardDomainsPersistedDomainsAreFound() {
         testee.persist(domains: [ "www.bbc.co.uk", "apple.com" ], wildcardDomains: [ "*.example.com", "*.cnn.com" ])


### PR DESCRIPTION

Reviewer: Caine or Mia
Asana: https://app.asana.com/0/488551667048375/514330959360383
CC:

**Description**:

Adds an index to the database and uses equality to look up domains (instead of like).  Note that the smaller list is still in use at this point until the other PR iOS merged.

Also fixes a crash bug (I think on iOS or slower devices, only observed on iPhone 5s running iOS 10).

**Steps to test this PR**:
1. Browse about - performance appear normal especially when accessing
1. Use the fire button - shouldn't crash.
