### PR TITLE
improved privacy grade accuracy after navigation

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -210,7 +210,7 @@ open class WebViewController: UIViewController {
         }
     }
     
-    public func goForward() {
+    open func goForward() {
         webView.goForward()
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -103,8 +103,13 @@ class TabViewController: WebViewController {
     }
 
     override func goBack() {
-        resetSiteRating()
+        siteRating = nil
         super.goBack()
+    }
+    
+    override func goForward() {
+        siteRating = nil
+        super.goForward()
     }
 
     private func addContentBlockerConfigurationObserver() {
@@ -147,10 +152,6 @@ class TabViewController: WebViewController {
     
     fileprivate func updateSiteRating() {
         if isError {
-            siteRating = nil
-        } else if let url = url {
-            siteRating?.url = url
-        } else {
             siteRating = nil
         }
         onSiteRatingChanged()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -125,6 +125,14 @@ class TabViewController: WebViewController {
         }
     }
     
+    func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+        guard let url = webView.url else { return }
+        
+        siteRating = SiteRating(url: url)
+        reloadScripts(with: siteRating!.protectionId)
+        updateSiteRating()
+    }
+    
     private func resetNavigationBar() {
         chromeDelegate?.setBarsHidden(false, animated: false)
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -483,6 +483,7 @@ extension TabViewController: WebEventsDelegate {
     }
 
     func webView(_ webView: WKWebView, didUpdateHasOnlySecureContent hasOnlySecureContent: Bool) {
+        guard webView.url?.host == siteRating?.url.host else { return }        
         siteRating?.hasOnlySecureContent = hasOnlySecureContent
         updateSiteRating()
     }


### PR DESCRIPTION
Reviewer: Caine or Mia
Asana: 

* https://app.asana.com/0/414235014887631/523426024528729

CC:

**Description**:

Fixes a couple of bugs with the site grade showing incorrectly because of back/forward button and swipe navigation.

Also enhances privacy grade caching so that the privacy dashboard is more accurate when performing back and forward navigation without a page reload

**Steps to test this PR**:

***Test 1***:

1. Clean launch of the app
1. Go directly to huffingtonpost.com
1. Perform a search: DDG Grade should be A

Repeat with privacy protection off

***Test 2***:

1. Clear data
1. Search for cnn
1. Navigate to cnn.com 
1. Swipe back to DDG
1. DDG should remain an A

(repeat a few times to be sure)

***Test 3***

1. Go to cnn.com directly
1. Go to ddg.gg directly 
1. Redirects to DuckDuckGo.com which has an A grade

