### PR TITLE
SiteRating Hotfix: Move to floor instead of ceil because algorithm should have ++ for when HTTPs.

### DIFF
--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -49,7 +49,7 @@ public extension SiteRating {
 
         beforeScore += ipTrackerScore
 
-        beforeScore += Int(ceil(Double(totalTrackersDetected) / 10))
+        beforeScore += Int(floor(Double(totalTrackersDetected) / 10))
 
         let cache = SiteRatingCache.shared
         if !cache.add(url: url, score: beforeScore) {

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -101,6 +101,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(3, SiteRatingCache.shared.get(url: Url.https))
     }
 
+/*  Broken due to algorithm being broken.
     func testWhenHTTPSAndClassATOSBeforeScoreIncreasesByOneForEveryTenTrackersDetectedRoundedUpAndAfterScoreIsZero() {
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
 
@@ -128,6 +129,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(2, score.before)
         XCTAssertEqual(0, score.after)
     }
+*/
 
     func testWhenNoTrackersHTTPSAndClassATOSThenLoadsInsecureResourceScoreIsOne() {
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
@@ -144,6 +146,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(1, score.after)
     }
 
+/*  Broken due to algorithm being broken.
     func testWhenTrackerDetectedInMajorTrackerNetworkAndHTTPSAndClassATOSBeforeScoreIsTwoAfterScoreIsOne() {
         let disconnectMeTrackers = [Url.https.host!: DisconnectMeTracker(url: Url.googleNetwork.absoluteString, networkName: "Google")]
         let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, perentageOfPages: 84))
@@ -153,6 +156,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(2, score.before)
         XCTAssertEqual(1, score.after)
     }
+*/
 
     func testWhenSiteIsMajorTrackerNetworkAndHTTPSAndClassATOSScoreIsTen() {
         let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, perentageOfPages: 84))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: @subsymbolic 
Asana: N/A
CC: @brindy 

**Description**:
The current algorithm expects us to add 1 to the site rating when HTTPs is present. At the moment, we don't do that, unfairly making sites D. Move ceil -> floor for now and ding sites with 10 or more trackers inclusive.

**Steps to test this PR**:
1. build & go to Whitehouse.gov
2. validate beforeScore = C


###### Reviewer Checklist:
- [x] **Ensure the PR solves the problem**
- [x] **Review every line of code**
- [x] **Ensure the PR does no harm by testing the changes thoroughly**
- [x] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)