### PR TITLE
Add ceiling of B to privacy grades for sites without a ToS;DR classification of A

### DIFF
--- a/Core/SiteRatingScoreExtension.swift
+++ b/Core/SiteRatingScoreExtension.swift
@@ -50,6 +50,14 @@ public extension SiteRating {
         beforeScore += ipTrackerScore
 
         beforeScore += Int(floor(Double(totalTrackersDetected) / 10))
+        
+        if afterScore == 0 && termsOfService?.classification != .a {
+            afterScore = 1
+        }
+        
+        if beforeScore == 0 && termsOfService?.classification != .a {
+            beforeScore = 1
+        }
 
         let cache = SiteRatingCache.shared
         if !cache.add(url: url, score: beforeScore) {

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -173,12 +173,21 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(2, score.after)
     }
 
-    // TODO check with extension team - the JS logic leaves after unchanged if the normalized score is negative
-    func testWhenNoTrackersAndHTTPSAndNegativeTOSScoreIsZero() {
+    func testWhenTOSIsNegativeThenScoreGreaterThanOneIsDecremented() {
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: nil, score: -10))
+        for _ in 1...10 {
+            testee.trackerDetected(DetectedTracker(url: "https://tracky.com/tracker.js", networkName: nil, category: nil, blocked: false))
+        }
+        let score = testee.siteScore()
+        XCTAssertEqual(1, score.before)
+        XCTAssertEqual(1, score.after)
+    }
+    
+    func testWhenTOSIsNegativeThenScoreOfOneIsUnchanged() {
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: nil, score: -10))
         let score = testee.siteScore()
-        XCTAssertEqual(0, score.before)
-        XCTAssertEqual(0, score.after)
+        XCTAssertEqual(1, score.before)
+        XCTAssertEqual(1, score.after)
     }
 
     func testWhenNoTrackersAndHTTPSAndClassETOSScoreIsThree() {


### PR DESCRIPTION
Reviewer: Caine
Asana: https://app.asana.com/0/318512979878271/530377544792268

**Description**:
Add ceiling of B to privacy grades without a ToS;DR classification of A

**Steps to test this PR**:
1. Visit netflix.com with content blocking on
1. Note that result is a "B" now not an "A"

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)