### PR TITLE
Replace SwiftyJSON with Codable (2/3)

### DIFF
--- a/Core/Atb.swift
+++ b/Core/Atb.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-public struct Atb {
+public struct Atb: Decodable {
     
     public static let variant = "mi"
 

--- a/Core/AtbParser.swift
+++ b/Core/AtbParser.swift
@@ -19,20 +19,17 @@
 
 
 import Foundation
-import SwiftyJSON
 
 
 public struct AtbParser {
-
-    public init() {}
-    
     func convert(fromJsonData data: Data) throws -> Atb {
-        guard let json = try? JSON(data: data) else {
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(Atb.self, from: data)
+        } catch DecodingError.dataCorrupted {
             throw JsonError.invalidJson
-        }
-        guard let version = json["version"].string else {
+        } catch {
             throw JsonError.typeMismatch
         }
-        return Atb(version: version)
     }
 }

--- a/Core/TermsOfServiceListParser.swift
+++ b/Core/TermsOfServiceListParser.swift
@@ -18,38 +18,18 @@
 //
 
 import Foundation
-import SwiftyJSON
 
+public typealias TermsOfServiceList = [String: TermsOfService]
 
 public class TermsOfServiceListParser {
-    
-    public init() {}
-    
-    func convert(fromJsonData data: Data) throws -> [String: TermsOfService] {
-        guard let json = try? JSON(data: data) else {
+    func convert(fromJsonData data: Data) throws -> TermsOfServiceList {
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(TermsOfServiceList.self, from: data)
+        } catch DecodingError.dataCorrupted {
             throw JsonError.invalidJson
+        } catch {
+            throw JsonError.typeMismatch
         }
-        return try convertList(fromJson: json)
     }
-
-    private func convertList(fromJson json: JSON) throws -> [String: TermsOfService] {
-        var dict = [String: TermsOfService]()
-        for (key, termsJson) in json {
-            let terms = try convertTerms(fromJson: termsJson)
-            dict[key] = terms
-        }
-        return dict
-    }
-    
-    private func convertTerms(fromJson json: JSON) throws -> TermsOfService {
-        var classification: TermsOfService.Classification? = nil
-        if let classificationString = json["class"].string?.lowercased() {
-            classification = TermsOfService.Classification(rawValue: classificationString)
-        }
-        guard let score = json["score"].int else { throw JsonError.typeMismatch }
-        let goodReasons = json["match"]["good"].arrayObject as? [String] ?? []
-        let badReasons = json["match"]["bad"].arrayObject as? [String] ?? []
-        return TermsOfService(classification: classification, score: score, goodReasons: goodReasons, badReasons: badReasons)
-    }
-
 }


### PR DESCRIPTION
Partially adopted Codable. (#257)
Left out `DisconnectMeTrackersParser` because it seemed a little complex.

With Codable there's no need for the `*Parser` structs. If you still want to throw your own errors I recommend writing an extension on `Decodable` like this:

```swift
extension Decodable {
    init(fromJsonData data: Data) throws {
        do {
            let decoder = JSONDecoder()
            self = try decoder.decode(Self.self, from: data)
        } catch DecodingError.dataCorrupted {
            throw JsonError.invalidJson
        } catch {
            throw JsonError.typeMismatch
        }
    }
}
```