### PR TITLE
speed improvements for older devices

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -4,7 +4,7 @@ github "subsymbolic/SwiftyJSON" "4a62eb3a37e1e694a7f83d50093e803f966055ba"
 
 github "subsymbolic/Kingfisher" ~> 3.10.3
 
-github "subsymbolic/Device.swift" ~> 0.5.0
+github "duckduckgo/Device.swift" ~> 1.1 
 
 github "subsymbolic/Toast-Swift" ~> 2.0.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
+github "duckduckgo/Device.swift" "1.1"
 github "subsymbolic/Alamofire" "4.5.0"
-github "subsymbolic/Device.swift" "0.5"
 github "subsymbolic/Kingfisher" "3.10.3"
 github "subsymbolic/OHHTTPStubs" "6.0.0"
 github "subsymbolic/SimulatorStatusMagic" "tags/1.9.5"

--- a/Core/ContentBlockerStringCache.swift
+++ b/Core/ContentBlockerStringCache.swift
@@ -23,7 +23,7 @@ public class ContentBlockerStringCache {
 
     struct Constants {
         // bump the cache version if you know the cache should be invalidated on the next release
-        static let cacheVersion = 1
+        static let cacheVersion = 2
         static let cacheVersionKey = "com.duckduckgo.contentblockerstringcache.version"
     }
 

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -48,6 +48,8 @@ extension WKWebViewConfiguration {
 
 fileprivate class Loader {
     
+    let javascriptLoader = JavascriptLoader()
+    
     let id: String
     let userContentController: WKUserContentController
     let restrictedDevice: Bool
@@ -86,7 +88,6 @@ fileprivate class Loader {
     
     private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool, with id: String) {
         let disconnectMeStore = DisconnectMeStore()
-        let javascriptLoader = JavascriptLoader()
         
         javascriptLoader.load(script: .blockerData, withReplacements: [
             "${protectionId}": id,
@@ -97,11 +98,11 @@ fileprivate class Loader {
                               andController:userContentController,
                               forMainFrameOnly: false)
         
-        loadEasylist(javascriptLoader)
+        loadEasylist()
     
     }
     
-    fileprivate func injectCompiledEasylist(_ javascriptLoader: JavascriptLoader, _ cachedEasylistPrivacy: String, _ cachedEasylist: String, _ cachedEasylistWhitelist: String) {
+    fileprivate func injectCompiledEasylist(_ cachedEasylistPrivacy: String, _ cachedEasylist: String, _ cachedEasylistWhitelist: String) {
         Logger.log(text: "using cached easylist")
         
         if #available(iOS 10, *) {
@@ -118,7 +119,7 @@ fileprivate class Loader {
                               forMainFrameOnly: false)
     }
     
-    fileprivate func injectRawEasylist(_ javascriptLoader: JavascriptLoader, _ easylistPrivacy: String, _ easylist: String, _ easylistWhitelist: String) {
+    fileprivate func injectRawEasylist(_ easylistPrivacy: String, _ easylist: String, _ easylistWhitelist: String) {
         Logger.log(text: "parsing easylist")
         
         javascriptLoader.load(script: .easylistParsing, withReplacements: [
@@ -130,7 +131,7 @@ fileprivate class Loader {
         
     }
     
-    private func loadEasylist(_ javascriptLoader: JavascriptLoader) {
+    private func loadEasylist() {
         let easylistStore = EasylistStore()
         let cache = ContentBlockerStringCache()
         
@@ -138,19 +139,18 @@ fileprivate class Loader {
             let cachedEasylistPrivacy = cache.get(named: EasylistStore.CacheNames.easylistPrivacy),
             let cachedEasylistWhitelist = cache.get(named: EasylistStore.CacheNames.easylistWhitelist) {
             
-            injectCompiledEasylist(javascriptLoader, cachedEasylistPrivacy, cachedEasylist, cachedEasylistWhitelist)
+            injectCompiledEasylist(cachedEasylistPrivacy, cachedEasylist, cachedEasylistWhitelist)
             
         } else if let easylist = easylistStore.easylist,
             let easylistPrivacy = easylistStore.easylistPrivacy,
             let easylistWhitelist = easylistStore.easylistWhitelist {
             
-            injectRawEasylist(javascriptLoader, easylistPrivacy, easylist, easylistWhitelist)
+            injectRawEasylist(easylistPrivacy, easylist, easylistWhitelist)
             
         }
     }
     
     private func load(scripts: [JavascriptLoader.Script], forMainFrameOnly: Bool = true) {
-        let javascriptLoader = JavascriptLoader()
         for script in scripts {
             javascriptLoader.load(script, withController: userContentController, forMainFrameOnly: forMainFrameOnly)
         }

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -68,7 +68,6 @@ extension WKWebViewConfiguration {
     }
     
     private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool, with id: String) {
-        let easylistStore = EasylistStore()
         let disconnectMeStore = DisconnectMeStore()
         let javascriptLoader = JavascriptLoader()
         
@@ -81,13 +80,18 @@ extension WKWebViewConfiguration {
                               andController:userContentController,
                               forMainFrameOnly: false)
         
+//        loadEasylist(javascriptLoader)
+    }
+    
+    private func loadEasylist(_ javascriptLoader: JavascriptLoader) {
+        let easylistStore = EasylistStore()
         let cache = ContentBlockerStringCache()
         if let cachedEasylist = cache.get(named: EasylistStore.CacheNames.easylist),
             let cachedEasylistPrivacy = cache.get(named: EasylistStore.CacheNames.easylistPrivacy),
             let cachedEasylistWhitelist = cache.get(named: EasylistStore.CacheNames.easylistWhitelist) {
             
             Logger.log(text: "using cached easylist")
-
+            
             if #available(iOS 10, *) {
                 javascriptLoader.load(.bloom, withController: userContentController, forMainFrameOnly: false)
             } else {
@@ -106,7 +110,7 @@ extension WKWebViewConfiguration {
             let easylistWhitelist = easylistStore.easylistWhitelist {
             
             Logger.log(text: "parsing easylist")
-
+            
             javascriptLoader.load(script: .easylistParsing, withReplacements: [
                 "${easylist_privacy}": easylistPrivacy,
                 "${easylist_general}": easylist,
@@ -115,7 +119,6 @@ extension WKWebViewConfiguration {
                                   forMainFrameOnly: false)
             
         }
-        
     }
     
     private func load(scripts: [JavascriptLoader.Script], forMainFrameOnly: Bool = true) {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -235,9 +235,9 @@ open class WebViewController: UIViewController {
         webView.isHidden = false
     }
 
-    open func reloadScripts(with protectionId: String) {
+    open func reloadScripts(with protectionId: String, restrictedDevice: Bool) {
         webView.configuration.userContentController.removeAllUserScripts()
-        webView.configuration.loadScripts(with: protectionId)
+        webView.configuration.loadScripts(with: protectionId, restrictedDevice: restrictedDevice)
     }
 
 }

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -225,7 +225,8 @@ var duckduckgoContentBlocking = function() {
 				return false
 			}
 
-			disconnectMeMatch(event) || easylistPrivacyMatch(event) || easylistMatch(event)
+			disconnectMeMatch(event) 
+			// || easylistPrivacyMatch(event) || easylistMatch(event)
 		}, true)
 	}
 

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -183,6 +183,8 @@ var duckduckgoContentBlocking = function() {
 	}
 
 	function checkEasylist(event, easylist, name) {
+		if (Object.keys(easylist).length == 0) { return }
+
 		var config = {
 			domain: document.location.hostname,
 			elementTypeMaskMap: ABPFilterParser.elementTypeMaskMap
@@ -221,12 +223,11 @@ var duckduckgoContentBlocking = function() {
 		parentEntityUrl = getParentEntityUrl()
 
 		document.addEventListener("beforeload", function(event) {
-//            if (trackerWhitelisted(event)) {
-//                return false
-//            }
+            if (trackerWhitelisted(event)) {
+                return false
+            }
 
-			disconnectMeMatch(event) 
-			// || easylistPrivacyMatch(event) || easylistMatch(event)
+			disconnectMeMatch(event)|| easylistPrivacyMatch(event) || easylistMatch(event)
 		}, true)
 	}
 

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -79,6 +79,8 @@ var duckduckgoContentBlocking = function() {
 	}
 
 	function trackerWhitelisted(event) {
+        if (Object.keys(duckduckgoBlockerData.easylistWhitelist).length == 0) { return }
+        
 		var config = {
 			domain: document.location.hostname,
 			elementTypeMaskMap: ABPFilterParser.elementTypeMaskMap

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -229,7 +229,7 @@ var duckduckgoContentBlocking = function() {
                 return false
             }
 
-			disconnectMeMatch(event)|| easylistPrivacyMatch(event) || easylistMatch(event)
+			disconnectMeMatch(event) || easylistPrivacyMatch(event) || easylistMatch(event)
 		}, true)
 	}
 

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -221,9 +221,9 @@ var duckduckgoContentBlocking = function() {
 		parentEntityUrl = getParentEntityUrl()
 
 		document.addEventListener("beforeload", function(event) {
-			if (trackerWhitelisted(event)) {
-				return false
-			}
+//            if (trackerWhitelisted(event)) {
+//                return false
+//            }
 
 			disconnectMeMatch(event) 
 			// || easylistPrivacyMatch(event) || easylistMatch(event)

--- a/Core/easylist-cached.js
+++ b/Core/easylist-cached.js
@@ -26,6 +26,14 @@ function duckduckgoEasylistRepair(parserData) {
 	parserData.exceptionBloomFilter = new BloomFilterModule.BloomFilter(parserData.exceptionFilter)
 }
 
-duckduckgoEasylistRepair(duckduckgoBlockerData.easylist)
-duckduckgoEasylistRepair(duckduckgoBlockerData.easylistPrivacy)
-duckduckgoEasylistRepair(duckduckgoBlockerData.easylistWhitelist)
+if (Object.keys(duckduckgoBlockerData.easylist).length > 0) {
+	duckduckgoEasylistRepair(duckduckgoBlockerData.easylist)	
+}
+
+if (Object.keys(duckduckgoBlockerData.easylistPrivacy).length > 0) {
+	duckduckgoEasylistRepair(duckduckgoBlockerData.easylistPrivacy)
+}
+
+if (Object.keys(duckduckgoBlockerData.easylistWhitelist).length > 0) {
+	duckduckgoEasylistRepair(duckduckgoBlockerData.easylistWhitelist)
+}

--- a/Core/easylist-cached.js
+++ b/Core/easylist-cached.js
@@ -17,23 +17,27 @@
 //  limitations under the License.
 //
 
-duckduckgoBlockerData.easylist = ${easylist_general_json}
-duckduckgoBlockerData.easylistPrivacy = ${easylist_privacy_json}
-duckduckgoBlockerData.easylistWhitelist = ${easylist_whitelist_json}
+(function() {
 
-function duckduckgoEasylistRepair(parserData) {
-	parserData.bloomFilter = new BloomFilterModule.BloomFilter(parserData.bloomFilter)
-	parserData.exceptionBloomFilter = new BloomFilterModule.BloomFilter(parserData.exceptionFilter)
-}
+    duckduckgoBlockerData.easylist = ${easylist_general_json}
+    duckduckgoBlockerData.easylistPrivacy = ${easylist_privacy_json}
+    duckduckgoBlockerData.easylistWhitelist = ${easylist_whitelist_json}
 
-if (Object.keys(duckduckgoBlockerData.easylist).length > 0) {
-	duckduckgoEasylistRepair(duckduckgoBlockerData.easylist)	
-}
+    function duckduckgoEasylistRepair(parserData) {
+        parserData.bloomFilter = new BloomFilterModule.BloomFilter(parserData.bloomFilter)
+        parserData.exceptionBloomFilter = new BloomFilterModule.BloomFilter(parserData.exceptionFilter)
+    }
 
-if (Object.keys(duckduckgoBlockerData.easylistPrivacy).length > 0) {
-	duckduckgoEasylistRepair(duckduckgoBlockerData.easylistPrivacy)
-}
+    if (Object.keys(duckduckgoBlockerData.easylist).length > 0) {
+        duckduckgoEasylistRepair(duckduckgoBlockerData.easylist)
+    }
 
-if (Object.keys(duckduckgoBlockerData.easylistWhitelist).length > 0) {
-	duckduckgoEasylistRepair(duckduckgoBlockerData.easylistWhitelist)
-}
+    if (Object.keys(duckduckgoBlockerData.easylistPrivacy).length > 0) {
+        duckduckgoEasylistRepair(duckduckgoBlockerData.easylistPrivacy)
+    }
+
+    if (Object.keys(duckduckgoBlockerData.easylistWhitelist).length > 0) {
+        duckduckgoEasylistRepair(duckduckgoBlockerData.easylistWhitelist)
+    }
+
+})()

--- a/Core/easylist-parsing.js
+++ b/Core/easylist-parsing.js
@@ -17,27 +17,32 @@
 //  limitations under the License.
 //
 
-try {
+(function (){
 
-    var easylistPrivacy = `${easylist_privacy}`
-    var easylistGeneral = `${easylist_general}`
-    var easylistWhitelist = `${easylist_whitelist}`
-    
-    if (easylistPrivacy != "") {
-	    ABPFilterParser.parse(easylistPrivacy, duckduckgoBlockerData.easylistPrivacy)
-	}
-    duckduckgoMessaging.cache("easylist-privacy", JSON.stringify(duckduckgoBlockerData.easylistPrivacy))
+    try {
 
-	if (easylistGeneral != "") {
-	    ABPFilterParser.parse(easylistGeneral, duckduckgoBlockerData.easylist)
-	}
-    duckduckgoMessaging.cache("easylist", JSON.stringify(duckduckgoBlockerData.easylist))
-	
-	if (easylistWhitelist != "") {
-	    ABPFilterParser.parse(easylistWhitelist, duckduckgoBlockerData.easylistWhitelist)
-	}
-    duckduckgoMessaging.cache("easylist-whitelist", JSON.stringify(duckduckgoBlockerData.easylistWhitelist))
+        var easylistPrivacy = `${easylist_privacy}`
+        var easylistGeneral = `${easylist_general}`
+        var easylistWhitelist = `${easylist_whitelist}`
+        
+        if (easylistPrivacy != "") {
+            ABPFilterParser.parse(easylistPrivacy, duckduckgoBlockerData.easylistPrivacy)
+        }
+        duckduckgoMessaging.cache("easylist-privacy", JSON.stringify(duckduckgoBlockerData.easylistPrivacy))
 
-} catch (error) {
-    // no-op
-}
+        if (easylistGeneral != "") {
+            ABPFilterParser.parse(easylistGeneral, duckduckgoBlockerData.easylist)
+        }
+        duckduckgoMessaging.cache("easylist", JSON.stringify(duckduckgoBlockerData.easylist))
+        
+        if (easylistWhitelist != "") {
+            ABPFilterParser.parse(easylistWhitelist, duckduckgoBlockerData.easylistWhitelist)
+        }
+        duckduckgoMessaging.cache("easylist-whitelist", JSON.stringify(duckduckgoBlockerData.easylistWhitelist))
+
+    } catch (error) {
+        // no-op
+    }
+
+})()
+

--- a/Core/easylist-parsing.js
+++ b/Core/easylist-parsing.js
@@ -19,13 +19,23 @@
 
 try {
 
-    ABPFilterParser.parse(`${easylist_privacy}`, duckduckgoBlockerData.easylistPrivacy)
+    var easylistPrivacy = `${easylist_privacy}`
+    var easylistGeneral = `${easylist_general}`
+    var easylistWhitelist = `${easylist_whitelist}`
+    
+    if (easylistPrivacy != "") {
+	    ABPFilterParser.parse(easylistPrivacy, duckduckgoBlockerData.easylistPrivacy)
+	}
     duckduckgoMessaging.cache("easylist-privacy", JSON.stringify(duckduckgoBlockerData.easylistPrivacy))
 
-    ABPFilterParser.parse(`${easylist_general}`, duckduckgoBlockerData.easylist)
+	if (easylistGeneral != "") {
+	    ABPFilterParser.parse(easylistGeneral, duckduckgoBlockerData.easylist)
+	}
     duckduckgoMessaging.cache("easylist", JSON.stringify(duckduckgoBlockerData.easylist))
-
-    ABPFilterParser.parse(`${easylist_whitelist}`, duckduckgoBlockerData.easylistWhitelist)
+	
+	if (easylistWhitelist != "") {
+	    ABPFilterParser.parse(easylistWhitelist, duckduckgoBlockerData.easylistWhitelist)
+	}
     duckduckgoMessaging.cache("easylist-whitelist", JSON.stringify(duckduckgoBlockerData.easylistWhitelist))
 
 } catch (error) {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -38,6 +38,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        
+        print("***", UIDevice.current.deviceType.displayName)
+        
         appIsLaunching = true
         return true
     }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -38,9 +38,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        
-        print("***", UIDevice.current.deviceType.displayName)
-        
         appIsLaunching = true
         return true
     }

--- a/README.md
+++ b/README.md
@@ -8,10 +8,17 @@ If you are trying to contribute in other ways, that happens over at [DuckDuckHac
 
 ## Building
 
+### Submodules
+We only have one submodule at the moment, but because of that you will need to bring it in to the project in order to build and run it:
+
+Run `git submodule update --init --recursive`
+
 ### Dependencies
 We use Carthage for dependency management. If you don't have Carthage installed refer to [Installing Carthage](https://github.com/Carthage/Carthage#installing-carthage).
 
 Run `carthage bootstrap --platform iOS` before opening the project in XCode
+
+You can also run the unit tests to do the above and ensure everythig seems in order: `./run_tests.sh`
 
 ### Fonts
 We use Proxima Nova fonts which are proprietary and cannot be committed to source control, see [fonts](https://github.com/duckduckgo/iOS/tree/develop/fonts/licensed). 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: Mia (for iPhone 6 plus + simulator), optionally Caine (on iPhone X and/or simulator)
Asana:  https://app.asana.com/0/414235014887631/534828681523247
CC:

**Description**:

* Update Device.swift to be forked on DDG's Github and brought up to date for the device detect
* Don't use easylist or easyprivacy on restricted/older devices
* Updated README to help people trying to build the app
* Refactored the JS loading in to a file private class to help avoiding having to pass too many variables around

**Steps to test this PR**:

Older device:

1. Go to cnn.com 
1. Trackers should still be blocked
1. Check console to see only disconnect blocking
1. Observe speed improvement in page loading speed

Newer device (or simulator):

1. Go to cnn.com
1. Trackers should be blocked
1. Check console see easylist, easyprivacy and disconnect blocking


