### PR TITLE
Make AppDeepLinks quick link detection methods not case sensitive.

### DIFF
--- a/Core/AppDeepLinks.swift
+++ b/Core/AppDeepLinks.swift
@@ -26,7 +26,7 @@ public struct AppDeepLinks {
     
     public static let quickLink = "ddgQuickLink://"
     
-    public static let aboutLink = URL(string: "\(AppDeepLinks.quickLink)https://duckduckgo.com/about")!
+    public static let aboutLink = URL(string: "\(AppDeepLinks.quickLink)duckduckgo.com/about")!
     
     public static func isLaunch(url: URL) -> Bool {
         if let scheme = url.scheme {

--- a/Core/AppDeepLinks.swift
+++ b/Core/AppDeepLinks.swift
@@ -37,12 +37,15 @@ public struct AppDeepLinks {
     
     public static func isQuickLink(url: URL) -> Bool {
         if let scheme = url.scheme {
-            return AppDeepLinks.quickLink.contains(scheme)
+            return AppDeepLinks.quickLink.lowercased().contains(scheme.lowercased())
         }
         return false
     }
     
     public static func query(fromQuickLink url: URL) -> String {
-        return url.absoluteString.replacingOccurrences(of: quickLink, with: "")
+        let components = NSURLComponents.init(url: url, resolvingAgainstBaseURL: true)!
+        components.scheme = nil // remove scheme
+        let string = String(components.url!.absoluteString.dropFirst(2)) // strip off '//' prefix
+        return string
     }
 }

--- a/Core/AppDeepLinks.swift
+++ b/Core/AppDeepLinks.swift
@@ -43,7 +43,7 @@ public struct AppDeepLinks {
     }
     
     public static func query(fromQuickLink url: URL) -> String {
-        let components = NSURLComponents.init(url: url, resolvingAgainstBaseURL: true)!
+        let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true)!
         components.scheme = nil // remove scheme
         let string = String(components.url!.absoluteString.dropFirst(2)) // strip off '//' prefix
         return string

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */; };
 		830381C01F850AAF00863075 /* WKWebViewConfigurationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */; };
 		830C375C1F6C06BF00E317A7 /* TermsOfService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C375B1F6C06BF00E317A7 /* TermsOfService.swift */; };
 		830C375E1F6C3A3B00E317A7 /* TermsOfServiceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C375D1F6C3A3B00E317A7 /* TermsOfServiceStore.swift */; };
@@ -328,6 +329,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeepLinksTests.swift; sourceTree = "<group>"; };
 		830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WKWebViewConfigurationExtension.swift; sourceTree = "<group>"; };
 		830C375B1F6C06BF00E317A7 /* TermsOfService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfService.swift; sourceTree = "<group>"; };
 		830C375D1F6C3A3B00E317A7 /* TermsOfServiceStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceStore.swift; sourceTree = "<group>"; };
@@ -1459,6 +1461,7 @@
 		F17D722C1E8B3563003E8B0E /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */,
 				F17D72381E8B35C6003E8B0E /* AppUrlsTests.swift */,
 				F143C2CB1E4A4B9100CFDE3A /* AppVersionTests.swift */,
 				F189AEE31F18FDAF001EBAE1 /* LinkTests.swift */,
@@ -2252,6 +2255,7 @@
 				F198D7981E3A45D90088DA8A /* WKWebViewExtensionTests.swift in Sources */,
 				8364F7131F961E5E00562989 /* DisconnectMeStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,
+				22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */,
 				830C37671F6C4A6200E317A7 /* TermsOfServiceParserTests.swift in Sources */,
 				F1134ED21F40EF3A00B73467 /* JsonTestDataLoader.swift in Sources */,
 				85F591251FD1BFAA00746C77 /* DisconnectMeTrackerTests.swift in Sources */,

--- a/DuckDuckGoTests/AppDeepLinksTests.swift
+++ b/DuckDuckGoTests/AppDeepLinksTests.swift
@@ -1,9 +1,20 @@
 //
 //  AppDeepLinksTests.swift
-//  UnitTests
+//  DuckDuckGo
 //
-//  Created by Tim Johnsen on 2/20/18.
-//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import XCTest

--- a/DuckDuckGoTests/AppDeepLinksTests.swift
+++ b/DuckDuckGoTests/AppDeepLinksTests.swift
@@ -1,0 +1,42 @@
+//
+//  AppDeepLinksTests.swift
+//  UnitTests
+//
+//  Created by Tim Johnsen on 2/20/18.
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+
+import XCTest
+@testable import Core
+
+class AppDeepLinksTests: XCTestCase {
+    
+    func testLowercaseQuickLinkIsDetected() {
+        XCTAssert(AppDeepLinks.isQuickLink(url: URL(string: "ddgquicklink://foo.bar")!))
+    }
+    
+    func testUppercaseQuickLinkIsDetected() {
+        XCTAssert(AppDeepLinks.isQuickLink(url: URL(string: "DDGQUICKLINK://foo.bar")!))
+    }
+    
+    func testCamelCaseQuickLinkIsDetected() {
+        XCTAssert(AppDeepLinks.isQuickLink(url: URL(string: "ddgQuickLink://foo.bar")!))
+    }
+    
+    func testLowercaseQuickLinkQueryIsExtracted() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar")!), "foo.bar")
+    }
+    
+    func testLowercaseQuickLinkQueryIsExtractedURLPathPreserved() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123")!), "foo.bar/baz/123")
+    }
+    
+    func testLowercaseQuickLinkQueryIsExtractedURLQueryPreserved() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123?A=b&c=D")!), "foo.bar/baz/123?A=b&c=D")
+    }
+    
+    func testLowercaseQuickLinkQueryIsExtractedURLFragmentPreserved() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123#hello-world?A=b&c=D")!), "foo.bar/baz/123#hello-world?A=b&c=D")
+    }
+    
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer:
Asana:
CC:

**Description**:
This pull request resolves an issue I found when trying to integrate DuckDuckGo into my app [Opener](http://www.opener.link/), which relies on URL schemes to work with other apps. I was pleased to find DuckDuckGo was open source so I could diagnose and resolve the issue 😊.

Here's a video of what I was seeing (also demos the testing steps) https://db.tt/ISduGbXZOv

**Steps to test this PR**:
1. Install and launch DuckDuckGo.
2. Launch Safari.
3. Enter the URL `ddgQuickLink://apple.com` and press the 'Go' key.
4. See that DuckDuckGo launches and navigates to apple.com.

Prior to this PR the iOS normalization of URL schemes to lowercase caused this link detection to not work, so the app would launch but not navigate to the correct URL.

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)