### PR TITLE
minor speed improvements

### DIFF
--- a/Core/JavascriptLoader.swift
+++ b/Core/JavascriptLoader.swift
@@ -56,7 +56,7 @@ public class JavascriptLoader {
 
         var js = try! String(contentsOfFile: JavascriptLoader.path(for: script.rawValue))
         for (key, value) in replacements {
-            js = js.replacingOccurrences(of: key, with: value)
+            js = js.replacingOccurrences(of: key, with: value, options: .literal)
         }
         load(js: js, into: controller, forMainFrameOnly: forMainFrameOnly, injectionTime: injectionTime)
     }

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -44,8 +44,8 @@ extension WKWebViewConfiguration {
         return configuration
     }
     
-    public func loadScripts(with id: String, restrictedDevice: Bool) {
-        Loader(id, userContentController, restrictedDevice).load()
+    public func loadScripts(with id: String, restrictedDevice: Bool, contentBlocking: Bool) {
+        Loader(id, userContentController, restrictedDevice, contentBlocking).load()
     }
     
 }
@@ -66,24 +66,29 @@ fileprivate class Loader {
     let id: String
     let userContentController: WKUserContentController
     let restrictedDevice: Bool
+    let contentBlocking: Bool
 
-    init(_ id: String, _ userContentController: WKUserContentController, _ restrictedDevice: Bool) {
+    init(_ id: String, _ userContentController: WKUserContentController, _ restrictedDevice: Bool, _ contentBlocking: Bool) {
         self.id = id
         self.userContentController = userContentController
         self.restrictedDevice = restrictedDevice
+        self.contentBlocking = contentBlocking
     }
     
     func load() {
         Logger.log(text: "Loading scripts")
         loadDocumentLevelScripts()
-        loadSiteMonitoringScripts()
+        
+        if contentBlocking {
+            loadContentBlockingScripts()
+        }
     }
     
     private func loadDocumentLevelScripts() {
         load(scripts: [ .document, .favicon ] )
     }
     
-    private func loadSiteMonitoringScripts() {
+    private func loadContentBlockingScripts() {
         let configuration = ContentBlockerConfigurationUserDefaults()
         let whitelist = configuration.domainWhitelist.toJsonLookupString()
         loadContentBlockerDependencyScripts()

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -74,6 +74,7 @@ fileprivate class Loader {
     }
     
     func load() {
+        Logger.log(text: "Loading scripts")
         loadDocumentLevelScripts()
         loadSiteMonitoringScripts()
     }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		8531A08E1F9950E6000484F0 /* WhitelistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8531A08D1F9950E6000484F0 /* WhitelistViewController.swift */; };
 		85325A8D2024BB7C003EB195 /* detection.js in Resources */ = {isa = PBXBuildFile; fileRef = 85325A8C2024BB7C003EB195 /* detection.js */; };
 		8533133F1F98EA7900E061A5 /* WhitelistManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8533133C1F98E9DB00E061A5 /* WhitelistManager.swift */; };
+		85393121203C5F1F009C0B12 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85393120203C5F1F009C0B12 /* main.swift */; };
 		8539D9F71FA756AD00BE8746 /* PrivacyProtectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8539D9F61FA756AD00BE8746 /* PrivacyProtectionController.swift */; };
 		85436C3F1FA74BC300F4EEE1 /* PrivacyProtection.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85436C3E1FA74BC300F4EEE1 /* PrivacyProtection.xcassets */; };
 		8563A0311F8E1EE300F04442 /* FireButton.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8563A0301F8E1EE300F04442 /* FireButton.xib */; };
@@ -91,6 +92,8 @@
 		85C271E41FD04ACD007216B4 /* HTTPSUpgradeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C271E31FD04ACD007216B4 /* HTTPSUpgradeStoreTests.swift */; };
 		85C271E61FD065D8007216B4 /* CoreDataHTTPSUpgradePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C271E51FD065D8007216B4 /* CoreDataHTTPSUpgradePersistenceTests.swift */; };
 		85C37D861FA8BE7100CDE257 /* PrivacyProtectionOverviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C37D851FA8BE7100CDE257 /* PrivacyProtectionOverviewController.swift */; };
+		85CC936E203C402C00690089 /* SpeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CC936D203C402C00690089 /* SpeedTests.swift */; };
+		85CC9376203C42A500690089 /* speed_test_sites.json in Resources */ = {isa = PBXBuildFile; fileRef = 85CC9375203C42A500690089 /* speed_test_sites.json */; };
 		85CEC0771F2FD5CD0092C0C3 /* Stories.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 85CEC0731F2FD5CD0092C0C3 /* Stories.xcdatamodeld */; };
 		85ECA7EE1F2A82C20018EBEB /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ECA7ED1F2A82C20018EBEB /* Migration.swift */; };
 		85ECA7F11F2A83190018EBEB /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ECA7F01F2A83190018EBEB /* MigrationTests.swift */; };
@@ -294,6 +297,13 @@
 			remoteGlobalIDString = 84E341911E2F7EFB00BDBA6F;
 			remoteInfo = DuckDuckGo;
 		};
+		85CC9370203C402C00690089 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84E3418A1E2F7EFB00BDBA6F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 84E341911E2F7EFB00BDBA6F;
+			remoteInfo = DuckDuckGo;
+		};
 		F143C2E91E4A4CD400CFDE3A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 84E3418A1E2F7EFB00BDBA6F /* Project object */;
@@ -379,6 +389,7 @@
 		8531A08D1F9950E6000484F0 /* WhitelistViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhitelistViewController.swift; sourceTree = "<group>"; };
 		85325A8C2024BB7C003EB195 /* detection.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = detection.js; sourceTree = "<group>"; };
 		8533133C1F98E9DB00E061A5 /* WhitelistManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WhitelistManager.swift; path = ../DuckDuckGo/WhitelistManager.swift; sourceTree = "<group>"; };
+		85393120203C5F1F009C0B12 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8539D9F61FA756AD00BE8746 /* PrivacyProtectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionController.swift; sourceTree = "<group>"; };
 		85436C3E1FA74BC300F4EEE1 /* PrivacyProtection.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PrivacyProtection.xcassets; sourceTree = "<group>"; };
 		8563A0301F8E1EE300F04442 /* FireButton.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FireButton.xib; sourceTree = "<group>"; };
@@ -426,6 +437,10 @@
 		85C271E31FD04ACD007216B4 /* HTTPSUpgradeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPSUpgradeStoreTests.swift; sourceTree = "<group>"; };
 		85C271E51FD065D8007216B4 /* CoreDataHTTPSUpgradePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataHTTPSUpgradePersistenceTests.swift; sourceTree = "<group>"; };
 		85C37D851FA8BE7100CDE257 /* PrivacyProtectionOverviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionOverviewController.swift; sourceTree = "<group>"; };
+		85CC936B203C402C00690089 /* SpeedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpeedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		85CC936D203C402C00690089 /* SpeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTests.swift; sourceTree = "<group>"; };
+		85CC936F203C402C00690089 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		85CC9375203C42A500690089 /* speed_test_sites.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = speed_test_sites.json; sourceTree = "<group>"; };
 		85CEC0741F2FD5CD0092C0C3 /* Stories v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Stories v2.xcdatamodel"; sourceTree = "<group>"; };
 		85CEC0751F2FD5CD0092C0C3 /* Stories v3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Stories v3.xcdatamodel"; sourceTree = "<group>"; };
 		85CEC0761F2FD5CD0092C0C3 /* Stories.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Stories.xcdatamodel; sourceTree = "<group>"; };
@@ -651,6 +666,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		85CC9368203C402C00690089 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F143C2E01E4A4CD400CFDE3A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -806,6 +828,7 @@
 				84E341A91E2F7EFB00BDBA6F /* UnitTests */,
 				836B6B681F67F11E0061ECFB /* IntegrationTests */,
 				83DBCA791F7BBB5000DFD170 /* TopSitesReport */,
+				85CC936C203C402C00690089 /* SpeedTests */,
 				F1AA545F1E48D90700223211 /* Frameworks */,
 				84E341931E2F7EFB00BDBA6F /* Products */,
 				83ED3B8D1FA8E63700B47556 /* README.md */,
@@ -823,6 +846,7 @@
 				F143C2E41E4A4CD400CFDE3A /* Core.framework */,
 				836B6B671F67F11E0061ECFB /* IntegrationTests.xctest */,
 				83DBCA781F7BBB5000DFD170 /* TopSitesReport.xctest */,
+				85CC936B203C402C00690089 /* SpeedTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -999,6 +1023,17 @@
 				85C271E51FD065D8007216B4 /* CoreDataHTTPSUpgradePersistenceTests.swift */,
 			);
 			name = HTTPSUpgrade;
+			sourceTree = "<group>";
+		};
+		85CC936C203C402C00690089 /* SpeedTests */ = {
+			isa = PBXGroup;
+			children = (
+				85CC936D203C402C00690089 /* SpeedTests.swift */,
+				85CC936F203C402C00690089 /* Info.plist */,
+				85CC9375203C42A500690089 /* speed_test_sites.json */,
+				85393120203C5F1F009C0B12 /* main.swift */,
+			);
+			path = SpeedTests;
 			sourceTree = "<group>";
 		};
 		85ECA7EA1F2A825C0018EBEB /* Migration */ = {
@@ -1824,6 +1859,24 @@
 			productReference = 84E341A61E2F7EFB00BDBA6F /* UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		85CC936A203C402C00690089 /* SpeedTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 85CC9372203C402C00690089 /* Build configuration list for PBXNativeTarget "SpeedTests" */;
+			buildPhases = (
+				85CC9367203C402C00690089 /* Sources */,
+				85CC9368203C402C00690089 /* Frameworks */,
+				85CC9369203C402C00690089 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				85CC9371203C402C00690089 /* PBXTargetDependency */,
+			);
+			name = SpeedTests;
+			productName = SpeedTests;
+			productReference = 85CC936B203C402C00690089 /* SpeedTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		F143C2E31E4A4CD400CFDE3A /* Core */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F143C2ED1E4A4CD400CFDE3A /* Build configuration list for PBXNativeTarget "Core" */;
@@ -1865,7 +1918,7 @@
 		84E3418A1E2F7EFB00BDBA6F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0830;
+				LastSwiftUpdateCheck = 0920;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = DuckDuckGo;
 				TargetAttributes = {
@@ -1901,6 +1954,12 @@
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = HKE973VLUW;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 84E341911E2F7EFB00BDBA6F;
+					};
+					85CC936A203C402C00690089 = {
+						CreatedOnToolsVersion = 9.2;
+						DevelopmentTeam = HKE973VLUW;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 84E341911E2F7EFB00BDBA6F;
 					};
@@ -1940,6 +1999,7 @@
 				F143C2E31E4A4CD400CFDE3A /* Core */,
 				84E341A51E2F7EFB00BDBA6F /* UnitTests */,
 				836B6B661F67F11E0061ECFB /* IntegrationTests */,
+				85CC936A203C402C00690089 /* SpeedTests */,
 				83DBCA771F7BBB5000DFD170 /* TopSitesReport */,
 				F1AA545D1E48D90700223211 /* TodayExtension */,
 			);
@@ -2007,6 +2067,14 @@
 				85F1E9BB1FB7D06300A75AC1 /* ddgcert.der in Resources */,
 				85F1E9B91FB7CB7100A75AC1 /* testcert.der in Resources */,
 				F17843E91F36226700390DCD /* MockFiles in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		85CC9369203C402C00690089 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				85CC9376203C42A500690089 /* speed_test_sites.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2261,6 +2329,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		85CC9367203C402C00690089 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				85393121203C5F1F009C0B12 /* main.swift in Sources */,
+				85CC936E203C402C00690089 /* SpeedTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F143C2DF1E4A4CD400CFDE3A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2360,6 +2437,11 @@
 			isa = PBXTargetDependency;
 			target = 84E341911E2F7EFB00BDBA6F /* DuckDuckGo */;
 			targetProxy = 84E341A71E2F7EFB00BDBA6F /* PBXContainerItemProxy */;
+		};
+		85CC9371203C402C00690089 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 84E341911E2F7EFB00BDBA6F /* DuckDuckGo */;
+			targetProxy = 85CC9370203C402C00690089 /* PBXContainerItemProxy */;
 		};
 		F143C2EA1E4A4CD400CFDE3A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2685,6 +2767,50 @@
 			};
 			name = Release;
 		};
+		85CC9373203C402C00690089 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HKE973VLUW;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = SpeedTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.mobile.ios.SpeedTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DuckDuckGo.app/DuckDuckGo";
+			};
+			name = Debug;
+		};
+		85CC9374203C402C00690089 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HKE973VLUW;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = SpeedTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.mobile.ios.SpeedTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DuckDuckGo.app/DuckDuckGo";
+			};
+			name = Release;
+		};
 		F143C2EE1E4A4CD400CFDE3A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2826,6 +2952,15 @@
 			buildConfigurations = (
 				84E341BE1E2F7EFC00BDBA6F /* Debug */,
 				84E341BF1E2F7EFC00BDBA6F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		85CC9372203C402C00690089 /* Build configuration list for PBXNativeTarget "SpeedTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				85CC9373203C402C00690089 /* Debug */,
+				85CC9374203C402C00690089 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -50,6 +50,16 @@
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "85CC936A203C402C00690089"
+               BuildableName = "SpeedTests.xctest"
+               BlueprintName = "SpeedTests"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/SpeedTests.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/SpeedTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
-   version = "1.7">
+   LastUpgradeVersion = "0920"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -28,9 +28,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "836B6B661F67F11E0061ECFB"
-               BuildableName = "IntegrationTests.xctest"
-               BlueprintName = "IntegrationTests"
+               BlueprintIdentifier = "85CC936A203C402C00690089"
+               BuildableName = "SpeedTests.xctest"
+               BlueprintName = "SpeedTests"
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -41,54 +41,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "cd $SRCROOT/IntegrationTests/TrackerPageMocks&#10;python -m SimpleHTTPServer 8000 &amp;&#10;SERVER_PID=$!&#10;echo $SERVER_PID &gt; $BUILD_DIR/serverpid.txt">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "836B6B661F67F11E0061ECFB"
-                     BuildableName = "IntegrationTests.xctest"
-                     BlueprintName = "IntegrationTests"
-                     ReferencedContainer = "container:DuckDuckGo.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
-      <PostActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "kill `cat $BUILD_DIR/serverpid.txt`">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "836B6B661F67F11E0061ECFB"
-                     BuildableName = "IntegrationTests.xctest"
-                     BlueprintName = "IntegrationTests"
-                     ReferencedContainer = "container:DuckDuckGo.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PostActions>
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "836B6B661F67F11E0061ECFB"
-               BuildableName = "IntegrationTests.xctest"
-               BlueprintName = "IntegrationTests"
-               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference
@@ -109,6 +63,12 @@
             ReferencedContainer = "container:DuckDuckGo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "testing"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/TodayExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/TodayExtension.xcscheme
@@ -54,6 +54,16 @@
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "85CC936A203C402C00690089"
+               BuildableName = "SpeedTests.xctest"
+               BlueprintName = "SpeedTests"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -433,12 +433,17 @@ extension TabViewController: WebEventsDelegate {
     }
     
     func webpageDidStartLoading() {
-        Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
+        Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970, siteRating?.url.host, url?.host)
         delegate?.showBars()
-        resetSiteRating()
-        if let siteRating = siteRating {
-            reloadScripts(with: siteRating.protectionId, restrictedDevice: UIDevice.current.isSlow())
+
+        // if host is the same use same protection id and don't inject scripts, otherwise, reset and reload
+        if let siteRating = siteRating, siteRating.url.host == url?.host {
+            self.siteRating = SiteRating(url: siteRating.url, protectionId: siteRating.protectionId)
+        } else {
+            resetSiteRating()
+            reloadScripts(with: siteRating!.protectionId, restrictedDevice: UIDevice.current.isSlow())
         }
+        
         tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -433,7 +433,7 @@ extension TabViewController: WebEventsDelegate {
     }
     
     func webpageDidStartLoading() {
-        Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970, siteRating?.url.host, url?.host)
+        Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
         delegate?.showBars()
 
         // if host is the same use same protection id and don't inject scripts, otherwise, reset and reload

--- a/SpeedTests/Info.plist
+++ b/SpeedTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/SpeedTests/SpeedTests.swift
+++ b/SpeedTests/SpeedTests.swift
@@ -1,0 +1,127 @@
+//
+//  SpeedTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import XCTest
+
+@testable import DuckDuckGo
+@testable import Core
+
+class SpeedTests: XCTestCase {
+    
+    private var results = [Any]()
+    private var mainController: MainViewController!
+    
+    struct Filename {
+        static let sites = "speed_test_sites.json"
+        static let report = "speed_test_results_\(SpeedTests.dateString()).json"
+    }
+    
+    struct Timeout {
+        static let pageLoad = 20.0
+    }
+    
+    override func setUp() {
+        loadBlockingLists()
+        TabsModel.clear()
+        loadStoryboard()
+    }
+    
+    override func tearDown() {
+        saveResults()
+        TabsModel.clear()
+    }
+    
+    func loadBlockingLists() {
+        let blocker = DispatchSemaphore(value: 0)
+        BlockerListsLoader().start { newData in
+            blocker.signal()
+        }
+        blocker.wait()
+    }
+    
+    func test() {
+        let data = try! FileLoader().load(fileName: Filename.sites, fromBundle: Bundle(for: SpeedTests.self))
+        let sites = try! JSONSerialization.jsonObject(with: data, options: .mutableContainers) as! [[String: String]]
+        
+        for site in sites {
+            guard let url = site["url"] else {
+                XCTFail("site has no url \(site)")
+                return
+            }
+            
+            let time = evalulate(url)
+            results.append([
+                "url": url,
+                "time": time,
+                "trackers": mainController.siteRating?.totalTrackersDetected ?? -1
+                ])
+            waitFor(seconds: 2)
+        }
+    }
+    
+    func waitFor(seconds: TimeInterval) {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
+    }
+    
+    func evalulate(_ url: String) -> TimeInterval {
+        if let siteRating = mainController.siteRating {
+            siteRating.finishedLoading = false
+        }
+        
+        mainController.loadUrl(URL(string: url)!)
+        let start = Date()
+        waitForPageLoad()
+        return Date().timeIntervalSince(start)
+    }
+    
+    func waitForPageLoad() {
+        let pageTimeout = Date(timeIntervalSinceNow: Timeout.pageLoad)
+        while (mainController.siteRating == nil || !mainController.siteRating!.finishedLoading) && Date() < pageTimeout {
+            waitFor(seconds: 0.001)
+        }
+    }
+    
+    func loadStoryboard() {
+        let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
+        mainController = storyboard.instantiateInitialViewController() as! MainViewController
+        UIApplication.shared.keyWindow!.rootViewController = mainController
+        XCTAssertNotNil(mainController.view)
+    }
+    
+    func saveResults() {
+        let fileName = Filename.report
+        let fileUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last!.appendingPathComponent(fileName)
+        let jsonResults = try! JSONSerialization.data(withJSONObject: results, options: [ .prettyPrinted, .sortedKeys ])
+        var stringResults = String(data: jsonResults, encoding: .utf8)!
+        stringResults = stringResults.replacingOccurrences(of: "\\/", with: "/")
+        try! stringResults.write(to: fileUrl, atomically: true, encoding: .utf8)
+        print("Saving results to \(fileUrl)")
+        print("You can access this file directly if runnning in the simulator.")
+        print("If you run on a device you must enable file sharing for the app target and then use iTunes to extract the file.")
+        print("Hint: add UIFileSharing = YES to Info.plist")
+    }
+    
+    static func dateString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmm"
+        return formatter.string(from: Date())
+    }
+    
+}

--- a/SpeedTests/main.swift
+++ b/SpeedTests/main.swift
@@ -1,0 +1,82 @@
+#!/usr/bin/swift
+
+import Foundation
+
+// TYPES
+
+enum Errors: Error {
+    
+    case fileNotFound
+    case invalidJson
+    case reportLengthsAreDifferent
+    case jsonEncodingFailed
+    case stringFromDataFailed
+    
+}
+
+struct URLTime: Codable {
+    
+    let url: String
+    let time: TimeInterval
+    let trackers: Int
+    
+}
+
+// FUNCTIONS
+
+func loadJson(fromFile file: String) throws -> [URLTime] {
+    guard let data = try? Data(contentsOf: URL(string: "file://\(file)")!) else {
+        throw Errors.fileNotFound
+    }
+    
+    let decoder = JSONDecoder()
+    guard let results = try? decoder.decode([URLTime].self, from: data) else {
+        throw Errors.invalidJson
+    }
+
+    return results
+}
+
+func usage() {
+    print("usage: \(#function) base.json comparison.json")
+    print()
+}
+
+// SCRIPT
+
+guard CommandLine.arguments.count == 3 else {
+    usage()
+    exit(1)
+}
+
+do {
+    let base = try loadJson(fromFile: CommandLine.arguments[1])
+    let comparison = try loadJson(fromFile: CommandLine.arguments[2])
+    
+    guard base.count == comparison.count else {
+        throw Errors.reportLengthsAreDifferent
+    }
+    
+    var diffs = [URLTime]()
+    for index in 0 ..< base.count {
+        let baseTiming = base[index]
+        let comparisonTiming = comparison[index]
+        diffs.append(URLTime(url: baseTiming.url, time: baseTiming.time - comparisonTiming.time, trackers: baseTiming.trackers - comparisonTiming.trackers))
+    }
+    
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [ .prettyPrinted, .sortedKeys ]
+    guard let resultData = try? encoder.encode(diffs) else {
+        throw Errors.jsonEncodingFailed
+    }
+    
+    guard let result = String(data: resultData, encoding: .utf8) else {
+        throw Errors.stringFromDataFailed
+    }
+    print(result)
+    
+} catch {
+    print("Error: \(error)")
+    print()
+    usage()
+}

--- a/SpeedTests/main.swift
+++ b/SpeedTests/main.swift
@@ -1,5 +1,24 @@
 #!/usr/bin/swift
 
+//
+//  main.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
 import Foundation
 
 // TYPES

--- a/SpeedTests/speed_test_sites.json
+++ b/SpeedTests/speed_test_sites.json
@@ -1,0 +1,70 @@
+[
+  {
+    "url": "https:/duckduckgo.com",
+    "profile": "none"
+  },
+  {
+    "url": "https://duckduckgo.com/?q=edinburgh",
+    "profile": "none"
+  },
+  {
+    "url": "https://apple.com",
+    "profile": "none"
+  },
+  {
+    "url": "https://twitter.com",
+    "profile": "light"
+  },
+  {
+    "url": "https://twitter.com/duckduckgo",
+    "profile": "light"
+  },
+  {
+    "url": "https://twitter.com/watrcoolr",
+    "profile": "light"
+  },
+  {
+    "url": "https://evanscycles.com",
+    "profile": "medium"
+  },
+  {
+    "url": "https://www.evanscycles.com/bikes_c",
+    "profile": "medium"
+  },
+  {
+    "url": "https://www.evanscycles.com/bikes/mountain-bikes_c",
+    "profile": "medium"
+  },
+  {
+    "url": "https://duckduckgo.com/?q=cnn",
+    "profile": "none"
+  },
+  {
+    "url": "https://cnn.com",
+    "profile": "heavy"
+  },
+  {
+    "url": "https://edition.cnn.com/politics",
+    "profile": "heavy"
+  },
+  {
+    "url": "https://edition.cnn.com/election",
+    "profile": "heavy"
+  },
+  {
+    "url": "https://duckduckgo.com/?q=boingboing",
+    "profile": "none"
+  },
+  {
+    "url": "https://boingboing.net",
+    "profile": "heavy"
+  },
+  {
+    "url": "https://boingboing.net/tag/table-top-gaming",
+    "profile": "heavy"
+  },
+  {
+    "url": "https://store.boingboing.net/",
+    "profile": "heavy"
+  }
+]


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/561256581080450
Tech Design URL:
CC: 

**Description**:

* When browsing on the same site there is no need to re-inject the scripts
* Show progress at the earliest opportunity after the user decides to navigation (ie start showing progress as soon as the decision is considered allowed)
* Drop content blocking scripts for duckduckgo.com 

**Steps to test this PR**:

***Test 1***
1. Search for cnn https://duckduckgo.com?q=cnn 
1. Expected: site should be more responsive to load
1. Expected: content blocking scripts have not been injected (use Web Inspector to confirm)
1. Expected: Site has an A grade
1. Expected: Tab has correct favicon in Tabs view

***Test 2***
1. Follow link to cnn.com
1. Expected: Progress bar starts immediately
1. Expected: Appropriate site grade is displayed 

***Test 3***
1. Click on a link on cnn.com
1. Expected: loading seems more responsive to load
1. Expected: site grade and privacy details are appropriate 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
