### PR TITLE
combine tracker networks

### DIFF
--- a/Core/MajorTrackerNetwork.swift
+++ b/Core/MajorTrackerNetwork.swift
@@ -29,12 +29,12 @@ public protocol MajorTrackerNetworkStore {
 
 public struct MajorTrackerNetwork {
 
-    let name: String
-    let domain: String
-    let perentageOfPages: Int
+    public let name: String
+    public let domain: String
+    public let percentageOfPages: Int
 
-    var score: Int {
-        return Int(ceil(Double(perentageOfPages) / 10.0))
+    public var score: Int {
+        return Int(ceil(Double(percentageOfPages) / 10.0))
     }
 
 }
@@ -62,16 +62,16 @@ public class InMemoryMajorNetworkStore: MajorTrackerNetworkStore {
 public class EmbeddedMajorTrackerNetworkStore: InMemoryMajorNetworkStore {
 
     private static let networks = [
-        MajorTrackerNetwork(name: "google",     domain: "google.com",       perentageOfPages: 84),
-        MajorTrackerNetwork(name: "facebook",   domain: "facebook.com",     perentageOfPages: 36),
-        MajorTrackerNetwork(name: "twitter",    domain: "twitter.com",      perentageOfPages: 16),
-        MajorTrackerNetwork(name: "amazon.com", domain: "amazon.com",       perentageOfPages: 14),
-        MajorTrackerNetwork(name: "appnexus",   domain: "appnexus.com",     perentageOfPages: 10),
-        MajorTrackerNetwork(name: "oracle",     domain: "oracle.com",       perentageOfPages: 10),
-        MajorTrackerNetwork(name: "mediamath",  domain: "mediamath.com",    perentageOfPages: 9),
-        MajorTrackerNetwork(name: "yahoo!",     domain: "yahoo.com",        perentageOfPages: 9),
-        MajorTrackerNetwork(name: "stackpath",  domain: "stackpath.com",    perentageOfPages: 7),
-        MajorTrackerNetwork(name: "automattic", domain: "automattic.com",   perentageOfPages: 7),
+        MajorTrackerNetwork(name: "google",     domain: "google.com",       percentageOfPages: 84),
+        MajorTrackerNetwork(name: "facebook",   domain: "facebook.com",     percentageOfPages: 36),
+        MajorTrackerNetwork(name: "twitter",    domain: "twitter.com",      percentageOfPages: 16),
+        MajorTrackerNetwork(name: "amazon.com", domain: "amazon.com",       percentageOfPages: 14),
+        MajorTrackerNetwork(name: "appnexus",   domain: "appnexus.com",     percentageOfPages: 10),
+        MajorTrackerNetwork(name: "oracle",     domain: "oracle.com",       percentageOfPages: 10),
+        MajorTrackerNetwork(name: "mediamath",  domain: "mediamath.com",    percentageOfPages: 9),
+        MajorTrackerNetwork(name: "yahoo!",     domain: "yahoo.com",        percentageOfPages: 9),
+        MajorTrackerNetwork(name: "stackpath",  domain: "stackpath.com",    percentageOfPages: 7),
+        MajorTrackerNetwork(name: "automattic", domain: "automattic.com",   percentageOfPages: 7),
         ]
 
     public init() {

--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -87,7 +87,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94117647059999998" green="0.94117647059999998" blue="0.94117647059999998" alpha="1" colorSpace="calibratedRGB"/>
                         <containerView key="tableFooterView" opaque="NO" contentMode="scaleToFill" id="JbX-Lu-cAx">
-                            <rect key="frame" x="0.0" y="431" width="375" height="164"/>
+                            <rect key="frame" x="0.0" y="374" width="375" height="164"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                             <connections>
                                 <outletCollection property="gestureRecognizers" destination="uVQ-4K-5eS" appends="YES" id="nNa-rb-pZI"/>
@@ -215,49 +215,8 @@
                                             <segue destination="7u1-pv-hRO" kind="show" id="g4j-xJ-5Kr"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="57" id="Wkd-gv-dQz" customClass="SummaryCell" customModule="DuckDuckGo" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="317" width="375" height="57"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Wkd-gv-dQz" id="Nfx-4o-djA">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="56.666666666666664"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" image="PP Icon Major Networks Off" translatesAutoresizingMaskIntoConstraints="NO" id="Adc-1u-8dC">
-                                                    <rect key="frame" x="24" y="8.6666666666666643" width="40" height="40"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="40" id="qyd-BB-bjr"/>
-                                                        <constraint firstAttribute="width" constant="40" id="yPM-mR-fUT"/>
-                                                    </constraints>
-                                                </imageView>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="3 Major Tracker Networks Blocked" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pRX-q4-dPP">
-                                                    <rect key="frame" x="74" y="19.666666666666668" width="277" height="16.000000000000004"/>
-                                                    <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
-                                                    <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Arrow Forward" translatesAutoresizingMaskIntoConstraints="NO" id="gv1-Un-0MC">
-                                                    <rect key="frame" x="341" y="20" width="10" height="16"/>
-                                                </imageView>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="pRX-q4-dPP" firstAttribute="leading" secondItem="Adc-1u-8dC" secondAttribute="trailing" constant="10" id="14v-WK-Afx"/>
-                                                <constraint firstItem="pRX-q4-dPP" firstAttribute="centerY" secondItem="Nfx-4o-djA" secondAttribute="centerY" id="1Se-6g-9kT"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="pRX-q4-dPP" secondAttribute="trailing" constant="8" id="5ux-FG-g0J"/>
-                                                <constraint firstItem="gv1-Un-0MC" firstAttribute="centerY" secondItem="Nfx-4o-djA" secondAttribute="centerY" id="HHk-aN-0bM"/>
-                                                <constraint firstAttribute="trailing" secondItem="gv1-Un-0MC" secondAttribute="trailing" constant="24" id="LQ3-BO-WXB"/>
-                                                <constraint firstItem="Adc-1u-8dC" firstAttribute="leading" secondItem="Nfx-4o-djA" secondAttribute="leadingMargin" constant="8" id="QM5-o3-zKe"/>
-                                                <constraint firstItem="Adc-1u-8dC" firstAttribute="centerY" secondItem="Nfx-4o-djA" secondAttribute="centerY" id="wZ5-Cm-0eP"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <color key="backgroundColor" cocoaTouchSystemColor="tableCellGroupedBackgroundColor"/>
-                                        <connections>
-                                            <outlet property="summaryImage" destination="Adc-1u-8dC" id="BbF-vL-Cxf"/>
-                                            <outlet property="summaryLabel" destination="pRX-q4-dPP" id="i8i-VU-qhN"/>
-                                            <segue destination="7u1-pv-hRO" kind="show" identifier="Major" id="iUG-hs-pjP"/>
-                                        </connections>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="57" id="7tG-Dt-rZf" customClass="SummaryCell" customModule="DuckDuckGo" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="374" width="375" height="57"/>
+                                        <rect key="frame" x="0.0" y="317" width="375" height="57"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7tG-Dt-rZf" id="REe-ji-zYW">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="56.666666666666664"/>
@@ -308,13 +267,10 @@
                     <navigationItem key="navigationItem" title="Root View Controller" id="lwf-bc-TtK"/>
                     <connections>
                         <outlet property="encryptionCell" destination="goO-wb-Nup" id="oyA-Bs-y4l"/>
-                        <outlet property="majorTrackersCell" destination="Wkd-gv-dQz" id="q51-cY-iaI"/>
                         <outlet property="privacyPracticesCell" destination="7tG-Dt-rZf" id="bRZ-1X-bt7"/>
                         <outlet property="trackersCell" destination="izo-7V-yei" id="X6C-vM-6Xq"/>
                         <outletCollection property="margins" destination="NhZ-5w-YOh" collectionClass="NSMutableArray" id="PUe-zm-Jb2"/>
                         <outletCollection property="margins" destination="3Kx-n4-AUs" collectionClass="NSMutableArray" id="sU8-Lu-Y7U"/>
-                        <outletCollection property="margins" destination="QM5-o3-zKe" collectionClass="NSMutableArray" id="7Dj-Nf-xg9"/>
-                        <outletCollection property="margins" destination="5ux-FG-g0J" collectionClass="NSMutableArray" id="dLO-wp-r5f"/>
                         <outletCollection property="margins" destination="bzH-Rj-FGO" collectionClass="NSMutableArray" id="ICM-Xz-Zcm"/>
                         <outletCollection property="margins" destination="Cqa-9f-z0l" collectionClass="NSMutableArray" id="Hoy-ql-gcz"/>
                         <outletCollection property="margins" destination="Hf5-y4-Z8m" collectionClass="NSMutableArray" id="3Dt-xn-CFA"/>
@@ -961,10 +917,11 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qwM-eP-cbc">
                                             <rect key="frame" x="0.0" y="155" width="375" height="85"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="VYv-1m-cZo">
-                                                    <rect key="frame" x="23.666666666666657" y="22.333333333333343" width="327" height="42"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="VYv-1m-cZo">
+                                                    <rect key="frame" x="24" y="15.333333333333343" width="327" height="56"/>
                                                     <attributedString key="attributedText">
-                                                        <fragment content="Tracker networks aggregate your web history into a data profile about you, used to target ads at you across the internet.">
+                                                        <fragment>
+                                                            <string key="content">Tracker networks aggregate your web history into a data profile about you.  Major tracker networks are more harmful because they can track and target you across more of the internet.</string>
                                                             <attributes>
                                                                 <color key="NSColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <font key="NSFont" size="14" name="ProximaNova-Regular"/>
@@ -1765,7 +1722,6 @@
         <image name="PP Hero Privacy Good On" width="48" height="65"/>
         <image name="PP Icon Connection Bad" width="19" height="28"/>
         <image name="PP Icon Connection Off" width="19" height="28"/>
-        <image name="PP Icon Major Networks Off" width="27" height="30"/>
         <image name="PP Icon Networks Off" width="22" height="29"/>
         <image name="PP Icon Privacy Bad Off" width="23" height="30"/>
         <image name="PP Icon Result Fail" width="22" height="22"/>
@@ -1774,7 +1730,4 @@
         <image name="PP Inline C" width="16" height="16"/>
         <image name="PP Unknown" width="53" height="53"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="iUG-hs-pjP"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/DuckDuckGo/PrivacyProtectionOverviewController.swift
+++ b/DuckDuckGo/PrivacyProtectionOverviewController.swift
@@ -33,7 +33,6 @@ class PrivacyProtectionOverviewController: UITableViewController {
 
     @IBOutlet weak var encryptionCell: SummaryCell!
     @IBOutlet weak var trackersCell: SummaryCell!
-    @IBOutlet weak var majorTrackersCell: SummaryCell!
     @IBOutlet weak var privacyPracticesCell: SummaryCell!
 
     fileprivate weak var popRecognizer: InteractivePopRecognizer!
@@ -54,10 +53,6 @@ class PrivacyProtectionOverviewController: UITableViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let displayInfo = segue.destination as? PrivacyProtectionInfoDisplaying {
             displayInfo.using(siteRating: siteRating, contentBlocker: contentBlocker)
-        }
-
-        if let controller = segue.destination as? PrivacyProtectionTrackerNetworksController {
-            controller.majorOnly = segue.identifier == "Major"
         }
 
         if let header = segue.destination as? PrivacyProtectionHeaderController {
@@ -81,7 +76,6 @@ class PrivacyProtectionOverviewController: UITableViewController {
         header.using(siteRating: siteRating, contentBlocker: contentBlocker)
         updateEncryption()
         updateTrackers()
-        updateMajorTrackers()
         updatePrivacyPractices()
     }
 
@@ -100,20 +94,11 @@ class PrivacyProtectionOverviewController: UITableViewController {
         trackersCell.summaryLabel.text = siteRating.networksText(contentBlocker: contentBlocker)
 
         if protecting() || siteRating.uniqueTrackersDetected == 0 {
-            trackersCell.summaryImage.image = #imageLiteral(resourceName: "PP Icon Networks On")
+            trackersCell.summaryImage.image = #imageLiteral(resourceName: "PP Icon Major Networks On")
         } else {
-            trackersCell.summaryImage.image = #imageLiteral(resourceName: "PP Icon Networks Bad")
+            trackersCell.summaryImage.image = #imageLiteral(resourceName: "PP Icon Major Networks Bad")
         }
 
-    }
-
-    private func updateMajorTrackers() {
-        majorTrackersCell.summaryLabel.text = siteRating.majorNetworksText(contentBlocker: contentBlocker)
-        if protecting() || siteRating.uniqueMajorTrackerNetworksDetected == 0 {
-            majorTrackersCell.summaryImage.image = #imageLiteral(resourceName: "PP Icon Major Networks On")
-        } else {
-            majorTrackersCell.summaryImage.image = #imageLiteral(resourceName: "PP Icon Major Networks Bad")
-        }
     }
 
     private func updatePrivacyPractices() {

--- a/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
+++ b/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
@@ -80,7 +80,6 @@ class PrivacyProtectionTrackerNetworksController: UIViewController {
     }
 
     private func initMessage() {
-        // messageLabel.text = UserText.ppTrackerNetworksMajorMessage
         messageLabel.adjustPlainTextLineHeight(1.286)
     }
 
@@ -172,7 +171,7 @@ class SiteRatingTrackerNetworkSectionBuilder {
     private func toSections(trackers: [DetectedTracker: Int]) -> [PrivacyProtectionTrackerNetworksController.Section] {
         var sections = [PrivacyProtectionTrackerNetworksController.Section]()
 
-        // work around bug in first party detection - everything *should* have a URL
+        // work around bug in first party detection - everything *should* have a URL with host
         let trackers = trackers.flatMap({ $0.key }).filter( { $0.domain != nil } ).sorted(by: { $0.domain! < $1.domain! })
         
         // group by tracker types, sorted appropriately

--- a/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
+++ b/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
@@ -172,7 +172,10 @@ class SiteRatingTrackerNetworkSectionBuilder {
     private func toSections(trackers: [DetectedTracker: Int]) -> [PrivacyProtectionTrackerNetworksController.Section] {
         var sections = [PrivacyProtectionTrackerNetworksController.Section]()
 
-        let trackers = trackers.flatMap({ $0.key }).sorted(by: { $0.domain! < $1.domain! })
+        // work around bug in first party detection - everything *should* have a URL
+        let trackers = trackers.flatMap({ $0.key }).filter( { $0.domain != nil } ).sorted(by: { $0.domain! < $1.domain! })
+        
+        // group by tracker types, sorted appropriately
         let majorTrackers = trackers.filter({ $0.isMajor(majorTrackerNetworksStore) }).sorted(by: { $0.percentage(majorTrackerNetworksStore) > $1.percentage(majorTrackerNetworksStore) })
         let nonMajorKnownTrackers = trackers.filter({ $0.networkName != nil && !$0.isMajor(majorTrackerNetworksStore) }).sorted(by: { $0.networkName! < $1.networkName! })
         let unknownTrackers = trackers.filter({ $0.networkName == nil })

--- a/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
+++ b/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
@@ -94,7 +94,7 @@ class PrivacyProtectionTrackerNetworksController: UIViewController {
 
     private func updateIcon() {
 
-        if protecting() || siteRating.uniqueMajorTrackerNetworksDetected == 0 {
+        if protecting() || siteRating.uniqueTrackerNetworksDetected == 0 {
             iconImage.image = #imageLiteral(resourceName: "PP Hero Major On")
         } else {
             iconImage.image = #imageLiteral(resourceName: "PP Hero Major Bad")

--- a/DuckDuckGoTests/PrivacyProtectionTrackerNetworksTests.swift
+++ b/DuckDuckGoTests/PrivacyProtectionTrackerNetworksTests.swift
@@ -139,6 +139,29 @@ class PrivacyProtectionTrackerNetworksTests: XCTestCase {
         
     }
 
+    func testWhenNoProtocolThenTrackerAddedByDomain() {
+        
+        let trackers = [
+            DetectedTracker(url: "//tracker.com", networkName: nil, category: "Category 1", blocked: true): 1,
+            ]
+        
+        let sections = SiteRatingTrackerNetworkSectionBuilder(trackers: trackers, majorTrackerNetworksStore: MockMajorTrackerNetworkStore()).build()
+        
+        XCTAssertEqual(1, sections.count)
+        XCTAssertEqual("tracker.com", sections[0].name)
+    }
+
+    func testWhenNoDomainThenTrackerIgnored() {
+        
+        let trackers = [
+            DetectedTracker(url: "/tracker3.js", networkName: nil, category: "Category 1", blocked: true): 1,
+            ]
+        
+        let sections = SiteRatingTrackerNetworkSectionBuilder(trackers: trackers, majorTrackerNetworksStore: MockMajorTrackerNetworkStore()).build()
+        
+        XCTAssertEqual(0, sections.count)
+    }
+
 }
 
 fileprivate class MockMajorTrackerNetworkStore: MajorTrackerNetworkStore {

--- a/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingPrivacyProtectionExtensionTests.swift
@@ -88,7 +88,7 @@ class SiteRatingPrivacyProtectionExtensionTests: XCTestCase {
 
 fileprivate class MockMajorTrackerNetworkStore: MajorTrackerNetworkStore {
     func network(forName name: String) -> MajorTrackerNetwork? {
-        return MajorTrackerNetwork(name: name, domain: name, perentageOfPages: 50)
+        return MajorTrackerNetwork(name: name, domain: name, percentageOfPages: 50)
     }
 
     func network(forDomain domain: String) -> MajorTrackerNetwork? {

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -101,8 +101,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(3, SiteRatingCache.shared.get(url: Url.https))
     }
 
-/*  Broken due to algorithm being broken.
-    func testWhenHTTPSAndClassATOSBeforeScoreIncreasesByOneForEveryTenTrackersDetectedRoundedUpAndAfterScoreIsZero() {
+    func testWhenHTTPSAndClassATOSBeforeScoreIncreasesByOneForEveryTenTrackersDetectedRoundedDownAndAfterScoreIsZero() {
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
 
         for _ in 0 ..< 11 {
@@ -110,26 +109,25 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         }
 
         let score = testee.siteScore()
-        XCTAssertEqual(2, score.before)
-        XCTAssertEqual(0, score.after)
-    }
-
-    func testWhenSingleTrackerDetectedAndHTTPSAndClassATOSBeforeScoreIsOneAfterScoreIsZero() {
-        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
-        testee.trackerDetected(MockTrackerBuilder.standard(blocked: false))
-        let score = testee.siteScore()
         XCTAssertEqual(1, score.before)
         XCTAssertEqual(0, score.after)
     }
 
-    func testWhenObsecureTrackerDetectedAndHTTPSAndClassATOSBeforeScoreIsTwoAfterScoreIsZero() {
+    func testWhenSingleTrackerDetectedAndHTTPSAndClassATOSBeforeScoreIsZeroAndAfterScoreIsZero() {
+        let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
+        testee.trackerDetected(MockTrackerBuilder.standard(blocked: false))
+        let score = testee.siteScore()
+        XCTAssertEqual(0, score.before)
+        XCTAssertEqual(0, score.after)
+    }
+
+    func testWhenObsecureTrackerDetectedAndHTTPSAndClassATOSBeforeScoreIsOneAndAfterScoreIsZero() {
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
         testee.trackerDetected(MockTrackerBuilder.ipTracker(blocked: true))
         let score = testee.siteScore()
-        XCTAssertEqual(2, score.before)
+        XCTAssertEqual(1, score.before)
         XCTAssertEqual(0, score.after)
     }
-*/
 
     func testWhenNoTrackersHTTPSAndClassATOSThenLoadsInsecureResourceScoreIsOne() {
         let testee = SiteRating(url: Url.https, termsOfServiceStore: MockTermsOfServiceStore().add(domain: Url.https.host!, classification: .a, score: 0))
@@ -146,17 +144,15 @@ class SiteRatingScoreExtensionTests: XCTestCase {
         XCTAssertEqual(1, score.after)
     }
 
-/*  Broken due to algorithm being broken.
-    func testWhenTrackerDetectedInMajorTrackerNetworkAndHTTPSAndClassATOSBeforeScoreIsTwoAfterScoreIsOne() {
+    func testWhenTrackerDetectedInMajorTrackerNetworkAndHTTPSAndClassATOSBeforeScoreIsOneAndAfterScoreIsOne() {
         let disconnectMeTrackers = [Url.https.host!: DisconnectMeTracker(url: Url.googleNetwork.absoluteString, networkName: "Google")]
-        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, perentageOfPages: 84))
+        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, percentageOfPages: 84))
         let testee = SiteRating(url: URL(string: "https://another.com")!, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)
         testee.trackerDetected(DetectedTracker(url: "https://tracky.com/tracker.js", networkName: nil, category: nil, blocked: false))
         let score = testee.siteScore()
-        XCTAssertEqual(2, score.before)
+        XCTAssertEqual(1, score.before)
         XCTAssertEqual(1, score.after)
     }
-*/
 
     func testWhenSiteIsMajorTrackerNetworkAndHTTPSAndClassATOSScoreIsTen() {
         let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, percentageOfPages: 84))

--- a/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
+++ b/DuckDuckGoTests/SiteRatingScoreExtensionTests.swift
@@ -56,7 +56,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
     
     func testWhenNetworkExistsForMajorDomainNotInDisconnectItIsReturned() {
         let disconnectMeTrackers = ["sometracker.com": DisconnectMeTracker(url: Url.http.absoluteString, networkName: "TrickyAds", category: .social ) ]
-        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Major", domain: "major.com", perentageOfPages: 5))
+        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Major", domain: "major.com", percentageOfPages: 5))
         let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)
         let nameAndCategory = testee.networkNameAndCategory(forDomain: "major.com")
         XCTAssertEqual("Major", nameAndCategory.networkName)
@@ -159,7 +159,7 @@ class SiteRatingScoreExtensionTests: XCTestCase {
 */
 
     func testWhenSiteIsMajorTrackerNetworkAndHTTPSAndClassATOSScoreIsTen() {
-        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, perentageOfPages: 84))
+        let networkStore = MockMajorTrackerNetworkStore().adding(network: MajorTrackerNetwork(name: "Google", domain: Url.googleNetwork.host!, percentageOfPages: 84))
         let testee = SiteRating(url: Url.googleNetwork, disconnectMeTrackers: disconnectMeTrackers, termsOfServiceStore: classATOS, majorTrackerNetworkStore: networkStore)
         let score = testee.siteScore()
         XCTAssertEqual(10, score.before)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/490128800115961
Tech Design URL: n/a
CC:

**Description**:

Combines tracker networks at the top level.

* No differentiation between networks and major networks
* Major networks are sorted to the top ordered by percentage of sites on the web
* Trackers without a network are sorted to the bottom
* Trackers without a network show the domain as the network and don't show the domain as sub item (see comments in Asana)
* Question mark icon no longer used (see comments in Asana)
* Updated unit tests commented during Privacy Day event
* Fixed typo in name of `percentageOfPages` variable

**Steps to test this PR**:

1. Visit a tracker heavy site (e.g. cnn, the hill, etc)
1. Open privacy dashboard - now just a single item for tracker networks
1. Drill into trackers networks and confirm it looks correct based on above description.
1. Open score card and confirm major trackers and networks shown separately as before.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)