### PR TITLE
show url correctly on error

### DIFF
--- a/Core/WebEventsDelegate.swift
+++ b/Core/WebEventsDelegate.swift
@@ -42,5 +42,7 @@ public protocol WebEventsDelegate: class {
     func webpageDidFailToLoad()
     
     func faviconWasUpdated(_ favicon: URL, forUrl: URL)
+    
+    func webpageCanGoBackForwardChanged()
 
 }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -175,7 +175,9 @@ open class WebViewController: UIViewController {
     }
     
     private func urlDidChange() {
-        webEventsDelegate?.webView(webView, didChangeUrl: webView.url)
+        DispatchQueue.main.async {
+            self.webEventsDelegate?.webView(self.webView, didChangeUrl: self.webView.url)
+        }
     }
     
     private func canGoBackChanged() {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -26,6 +26,8 @@ open class WebViewController: UIViewController {
         static let estimatedProgress = "estimatedProgress"
         static let hasOnlySecureContent = "hasOnlySecureContent"
         static let url = "URL"
+        static let canGoBack = "canGoBack"
+        static let canGoForward = "canGoForward"
     }
     
     private struct Constants {
@@ -44,9 +46,10 @@ open class WebViewController: UIViewController {
 
     open private(set) var webView: WKWebView!
 
+    public var loadedURL: URL?
+    
     private var lastUpgradedDomain: String?
     private var lastError: Error?
-    private var loadedURL: URL?
     private var shouldReloadOnError = false
     
     private lazy var appUrls: AppUrls = AppUrls()
@@ -100,6 +103,8 @@ open class WebViewController: UIViewController {
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent), options: .new, context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
 
         webView.navigationDelegate = self
         webView.uiDelegate = self
@@ -158,6 +163,12 @@ open class WebViewController: UIViewController {
         case webViewKeyPaths.url:
             urlDidChange()
             
+        case webViewKeyPaths.canGoBack:
+            canGoBackChanged()
+
+        case webViewKeyPaths.canGoForward:
+            canGoForwardChanged()
+
         default:
             Logger.log(text: "Unhandled keyPath \(keyPath)")
         }
@@ -167,6 +178,14 @@ open class WebViewController: UIViewController {
         webEventsDelegate?.webView(webView, didChangeUrl: webView.url)
     }
     
+    private func canGoBackChanged() {
+        webEventsDelegate?.webpageCanGoBackForwardChanged()
+    }
+
+    private func canGoForwardChanged() {
+        webEventsDelegate?.webpageCanGoBackForwardChanged()
+    }
+
     private func onFaviconLoaded(_ favicon: URL) {
         self.favicon = favicon
         if let url = url {
@@ -207,6 +226,7 @@ open class WebViewController: UIViewController {
     open func goBack() {
         if isError {
             hideErrorMessage()
+            loadedURL = webView.url
             webEventsDelegate?.webpageDidStartLoading(httpsForced: false)
             webEventsDelegate?.webpageDidFinishLoading()
         } else {
@@ -224,6 +244,8 @@ open class WebViewController: UIViewController {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack))
         webView.removeFromSuperview()
         webEventsDelegate?.detached(webView: webView)
     }
@@ -308,7 +330,7 @@ extension WebViewController: WKNavigationDelegate {
             error.code == Constants.frameLoadInterruptedErrorCode {
             failingUrls.insert(domain)
         }
-        showErrorLater()
+        showErrorNow()
     }
     
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
@@ -367,12 +389,6 @@ extension WebViewController: WKNavigationDelegate {
         return .cancel
     }
 
-    private func showErrorLater() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            self?.showErrorNow()
-        }
-    }
-    
     private func showErrorNow() {
         guard let error = lastError else { return }
         hideProgressIndicator()

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -61,7 +61,7 @@ open class WebViewController: UIViewController {
     }
     
     public var url: URL? {
-        return webView.url
+        return isError ? loadedURL : webView.url
     }
     
     public var favicon: URL?

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -132,6 +132,7 @@ class MainViewController: UIViewController {
     
     @IBAction func onBackPressed() {
         currentTab?.goBack()
+        refreshOmniBar()
     }
     
     @IBAction func onForwardPressed() {
@@ -235,6 +236,8 @@ class MainViewController: UIViewController {
         }
 
         if !tab.isError {
+            omniBar.refreshText(forUrl: tab.loadedURL)
+        } else {
             omniBar.refreshText(forUrl: tab.link?.url)
         }
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -235,12 +235,7 @@ class MainViewController: UIViewController {
             return
         }
 
-        if !tab.isError {
-            omniBar.refreshText(forUrl: tab.loadedURL)
-        } else {
-            omniBar.refreshText(forUrl: tab.link?.url)
-        }
-
+        omniBar.refreshText(forUrl: tab.url)
         omniBar.updateSiteRating(tab.siteRating)
         omniBar.startBrowsing()
     }

--- a/DuckDuckGo/PrivacyProtectionFooterController.swift
+++ b/DuckDuckGo/PrivacyProtectionFooterController.swift
@@ -44,14 +44,7 @@ class PrivacyProtectionFooterController: UIViewController {
         self.contentBlocker.enabled = contentBlockingOn
         update()
     }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            self.update()
-        }
-    }
-    
+  
     private func update() {
         guard isViewLoaded else { return }
         leaderboard.update()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -53,7 +53,7 @@ class TabViewController: WebViewController {
     
     public var link: Link? {
         if isError {
-            if let url = URL(string: chromeDelegate?.omniBar.textField.text ?? "") {
+            if let url = loadedURL ?? webView.url ?? URL(string: "") {
                 return Link(title: errorText, url: url)
             }
         }
@@ -467,9 +467,7 @@ extension TabViewController: WebEventsDelegate {
         updateSiteRating()
         tabModel.link = link
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.delegate?.tabLoadingStateDidChange(tab: self!)
-        }
+        delegate?.tabLoadingStateDidChange(tab: self)
     }
     
     func webpageDidFailToLoad() {
@@ -480,9 +478,7 @@ extension TabViewController: WebEventsDelegate {
         siteRating?.finishedLoading = true
         updateSiteRating()
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.delegate?.tabLoadingStateDidChange(tab: self!)
-        }
+        self.delegate?.tabLoadingStateDidChange(tab: self)
     }
     
     func faviconWasUpdated(_ favicon: URL, forUrl url: URL) {
@@ -505,13 +501,15 @@ extension TabViewController: WebEventsDelegate {
         siteRating?.hasOnlySecureContent = hasOnlySecureContent
         updateSiteRating()
     }
-
-    func webView(_ webView: WKWebView, didChangeUrl url: URL?) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.delegate?.tabLoadingStateDidChange(tab: self!)
-        }
+    
+    func webpageCanGoBackForwardChanged() {
+        delegate?.tabLoadingStateDidChange(tab: self)
     }
-
+    
+    func webView(_ webView: WKWebView, didChangeUrl url: URL?) {
+        delegate?.tabLoadingStateDidChange(tab: self)
+    }
+    
 }
 
 extension TabViewController: UIPopoverPresentationControllerDelegate {


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/528096705273535
Tech Design URL:
CC:

**Description**:

Use feedback from WKWebView for back and forward state in order to remove asyncAfter calls (otherwise the subsequent update might override the omnibar text, and use loadedUrl when showing an error.

**Steps to test this PR**:

1. From a new tab, go a URL that does not exist.  Error page should show with entered URL and back button disabled

1. Visit a website, then go to a URL that does not exist.  Error page should show with entered URL and back button enabled

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)