### PR TITLE
Release/7.3.0.3 - XHR fix

### DIFF
--- a/Core/detection.js
+++ b/Core/detection.js
@@ -86,8 +86,12 @@
             duckduckgoMessaging.log(body)
             if (duckduckgoContentBlocking.shouldBlock(this.trackerUrl, "xmlhttprequest", function(url, block) { } )) { 
                 duckduckgoMessaging.log("blocking xhr")
-                xhr.abort()
-                return 
+                try { 
+                    xhr.abort() 
+                    return 
+                } catch(error) { 
+
+                }
             }
 
             duckduckgoMessaging.log("xhr ok: " + this.trackerUrl)        

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -29,7 +29,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/fastlane/metadata/default/release_notes.txt
+++ b/fastlane/metadata/default/release_notes.txt
@@ -1,1 +1,3 @@
 This release we have focussed on improving the UI of our privacy dashboard, as well as other cosmetic fixes though out the app.
+
+Additionally, we have fixed a bug in our tracker blocking logic which may have caused some sites to break.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/628429840777099
Tech Design URL:
CC:

**Description**:

If an XHR resource should be blocked and we try to abort it then previously we could break the page if the abort function throws an error.

Also, XHRs need to be applied or aborted otherwise the page can get in to a weird state waiting for resources that never appear.

This fix simply wraps an abort in a try-catch to prevent page breakages.

**Steps to test this PR**:
1. Go to DuckDuckGo.com
1. Start a Javascript debugging session
1. Navigate to freep.com
1. Check the console - there should be no errors related to XHRs
1. Check a few other sites to ensure no regressions

Note that freep.com may not work entirely properly until some resources we are blocking are either whitelisted or added to the Disconnect list.  This will come later.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
