### PR TITLE
Make home search better match omnibar

### DIFF
--- a/DuckDuckGo/Home.storyboard
+++ b/DuckDuckGo/Home.storyboard
@@ -31,7 +31,7 @@
                                 <rect key="frame" x="0.0" y="10" width="375" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="pwM-bh-TMk">
-                                        <rect key="frame" x="20" y="174.5" width="335" height="250"/>
+                                        <rect key="frame" x="20" y="174.5" width="335" height="246"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LogoWithText" translatesAutoresizingMaskIntoConstraints="NO" id="mpe-gG-Xvo">
                                                 <rect key="frame" x="67" y="0.0" width="201" height="160"/>
@@ -40,19 +40,19 @@
                                                 </constraints>
                                             </imageView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m48-2A-rff" customClass="RoundedRectangleView" customModule="Core">
-                                                <rect key="frame" x="0.0" y="200" width="335" height="50"/>
+                                                <rect key="frame" x="0.0" y="200" width="335" height="46"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sH7-xn-wYA">
-                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="46"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search or type URL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HWx-8c-7xM">
-                                                                <rect key="frame" x="18" y="17" width="269" height="16"/>
+                                                                <rect key="frame" x="18" y="15" width="269" height="16"/>
                                                                 <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                                 <color key="textColor" red="0.66666668653488159" green="0.66666668653488159" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="SearchLoupe" translatesAutoresizingMaskIntoConstraints="NO" id="GHd-JT-J5r">
-                                                                <rect key="frame" x="295" y="14" width="22" height="22"/>
+                                                                <rect key="frame" x="295" y="12" width="22" height="22"/>
                                                                 <color key="tintColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="22" id="5H8-2B-DqE"/>
@@ -73,7 +73,7 @@
                                                 <color key="backgroundColor" red="0.33333333329999998" green="0.33333333329999998" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="50" id="7Zd-26-hkc"/>
+                                                    <constraint firstAttribute="height" constant="46" id="7Zd-26-hkc"/>
                                                     <constraint firstItem="sH7-xn-wYA" firstAttribute="leading" secondItem="m48-2A-rff" secondAttribute="leading" id="E3f-j9-wWJ"/>
                                                     <constraint firstItem="sH7-xn-wYA" firstAttribute="top" secondItem="m48-2A-rff" secondAttribute="top" id="PJq-Ae-bX6"/>
                                                     <constraint firstAttribute="trailing" secondItem="sH7-xn-wYA" secondAttribute="trailing" id="lNh-ga-Cyd"/>
@@ -81,7 +81,7 @@
                                                 </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                        <real key="value" value="4"/>
+                                                        <real key="value" value="20"/>
                                                     </userDefinedRuntimeAttribute>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                                         <real key="value" value="2"/>
@@ -119,7 +119,7 @@
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="pwM-bh-TMk" secondAttribute="trailing" constant="20" id="HIA-K1-pE2"/>
                                     <constraint firstItem="pwM-bh-TMk" firstAttribute="leading" secondItem="eYX-Xc-kri" secondAttribute="leading" constant="20" id="e5Y-W7-YCP"/>
-                                    <constraint firstItem="pwM-bh-TMk" firstAttribute="centerY" secondItem="eYX-Xc-kri" secondAttribute="centerY" constant="-34" id="jR5-0V-F2Q"/>
+                                    <constraint firstItem="pwM-bh-TMk" firstAttribute="centerY" secondItem="eYX-Xc-kri" secondAttribute="centerY" constant="-36" id="jR5-0V-F2Q"/>
                                     <constraint firstItem="Fku-9C-PCe" firstAttribute="top" secondItem="eYX-Xc-kri" secondAttribute="top" constant="24" id="rcD-aS-v4Z"/>
                                     <constraint firstAttribute="trailing" secondItem="Fku-9C-PCe" secondAttribute="trailing" constant="24" id="uvr-yJ-gs3"/>
                                 </constraints>

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -25,8 +25,6 @@ class HomeViewController: UIViewController {
     
     private struct Constants {
         static let animationDuration = 0.25
-        static let omnibarCornerRadius: CGFloat = 20
-        static let searchBarCornerRadius: CGFloat = 4
     }
     
     @IBOutlet weak var passiveContent: UIView!
@@ -96,7 +94,7 @@ class HomeViewController: UIViewController {
     }
     
     private func moveSearchBarUp() {
-        guard let omniSearch = chromeDelegate?.omniBar.searchContainer else { return }
+        guard let omniSearch = chromeDelegate?.omniBar.editingBackground else { return }
         guard let convertedOrigin = searchBar.superview?.convert(searchBar.frame.origin, to: passiveContent) else { return }
         
         let xScale = omniSearch.frame.size.width / searchBar.frame.size.width
@@ -104,13 +102,11 @@ class HomeViewController: UIViewController {
         let xIdentityScale = searchBar.frame.size.width / omniSearch.frame.size.width
         let yIdentityScale = searchBar.frame.size.height / omniSearch.frame.size.height
         let searchBarToOmniTextRatio: CGFloat = 0.875
-        let searchTextMarginChange: CGFloat = -34
         passiveContent.transform.ty = -convertedOrigin.y
         searchBar.transform = CGAffineTransform(scaleX: xScale, y: yScale)
-        searchBar.layer.cornerRadius = Constants.omnibarCornerRadius
         searchBarContent.transform = CGAffineTransform(scaleX: xIdentityScale, y: yIdentityScale)
         searchText.transform = CGAffineTransform(scaleX: searchBarToOmniTextRatio, y: searchBarToOmniTextRatio)
-        searchText.transform.tx = searchTextMarginChange
+        searchText.transform.tx = -searchText.frame.origin.x
         searchImage.alpha = 0
     }
     
@@ -119,7 +115,6 @@ class HomeViewController: UIViewController {
         searchBar.transform = CGAffineTransform.identity
         searchBarContent.transform = CGAffineTransform.identity
         searchText.transform = CGAffineTransform.identity
-        searchBar.layer.cornerRadius = Constants.searchBarCornerRadius
         searchImage.alpha = 1
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/639024097472349/639667184941639
Tech Design URL: N/A

**Description**:
Makes the home home search better match the omnibar search.

**Steps to test this PR**:
1. Go to the home page
1. Note that the home searchbar is now rounded
1. Tap the searchbar and note that the animation looks ok

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
