### PR TITLE
Remove easylist and easyprivacy

### DIFF
--- a/Core/BlockerListsLoader.swift
+++ b/Core/BlockerListsLoader.swift
@@ -41,6 +41,7 @@ public class BlockerListsLoader {
     public func start(completion: BlockerListsLoaderCompletion?) {
 
         DispatchQueue.global(qos: .background).async {
+            
             let semaphore = DispatchSemaphore(value: 0)
             let numberOfRequests = self.startRequests(with: semaphore)
 
@@ -51,7 +52,7 @@ public class BlockerListsLoader {
             Logger.log(items: "BlockerListsLoader", "completed", self.newDataItems)
             completion?(self.newDataItems > 0)
         }
-
+        easylistStore.removeLegacyLists()
     }
 
     private func startRequests(with semaphore: DispatchSemaphore) -> Int {
@@ -62,22 +63,6 @@ public class BlockerListsLoader {
             if let data = data {
                 self.newDataItems += 1
                 try? self.disconnectStore.persist(data: data)
-            }
-            semaphore.signal()
-        }
-
-        blockerListRequest.request(.easylist) { (data) in
-            if let data = data {
-                self.newDataItems += 1
-                self.easylistStore.persistEasylist(data: data)
-            }
-            semaphore.signal()
-        }
-
-        blockerListRequest.request(.easylistPrivacy) { (data) in
-            if let data = data {
-                self.newDataItems += 1
-                self.easylistStore.persistEasylistPrivacy(data: data)
             }
             semaphore.signal()
         }
@@ -108,5 +93,4 @@ public class BlockerListsLoader {
 
         return blockerListRequest.requestCount
     }
-
 }

--- a/Core/EasylistStore.swift
+++ b/Core/EasylistStore.swift
@@ -38,16 +38,16 @@ class EasylistStore {
 
     var hasData: Bool {
         get {
-            return exists(type: .easylist) && exists(type: .easylistPrivacy)
+            return exists(type: .easylistWhitelist)
         }
     }
-
+    
     var easylistPrivacy: String? {
         get {
             return load(.easylistPrivacy)
         }
     }
-
+    
     var easylist: String? {
         get {
             return load(.easylist)
@@ -104,6 +104,11 @@ class EasylistStore {
 
     private func persist(escapedEasylist: String, to: URL) throws {
         try escapedEasylist.write(to: to, atomically: true, encoding: .utf8)
+    }
+    
+    func removeLegacyLists() {
+        invalidateCache(named:  CacheNames.easylist)
+        invalidateCache(named:  CacheNames.easylistPrivacy)
     }
 
     private func escapedString(from data: Data) -> String? {

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -153,8 +153,8 @@ fileprivate class Loader {
         }
         
         javascriptLoader.load(script: .cachedEasylist, withReplacements: [
-            "${easylist_privacy_json}": "",
-            "${easylist_general_json}": "",
+            "${easylist_privacy_json}": "{}",
+            "${easylist_general_json}": "{}",
             "${easylist_whitelist_json}": cachedEasylistWhitelist ],
                               into: userContentController,
                               forMainFrameOnly: false)
@@ -164,8 +164,8 @@ fileprivate class Loader {
         Logger.log(text: "parsing easylist")
         
         javascriptLoader.load(script: .easylistParsing, withReplacements: [
-            "${easylist_privacy}": "{}",
-            "${easylist_general}": "{}",
+            "${easylist_privacy}": "",
+            "${easylist_general}": "",
             "${easylist_whitelist}": easylistWhitelist ],
                               into: userContentController,
                               forMainFrameOnly: false)

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -44,8 +44,8 @@ extension WKWebViewConfiguration {
         return configuration
     }
     
-    public func loadScripts(with id: String, restrictedDevice: Bool, contentBlocking: Bool) {
-        Loader(id, userContentController, restrictedDevice, contentBlocking).load()
+    public func loadScripts(with id: String, contentBlocking: Bool) {
+        Loader(id, userContentController, contentBlocking).load()
     }
     
 }
@@ -66,13 +66,11 @@ fileprivate class Loader {
     
     let id: String
     let userContentController: WKUserContentController
-    let restrictedDevice: Bool
     let contentBlocking: Bool
     
-    init(_ id: String, _ userContentController: WKUserContentController, _ restrictedDevice: Bool, _ contentBlocking: Bool) {
+    init(_ id: String, _ userContentController: WKUserContentController, _ contentBlocking: Bool) {
         self.id = id
         self.userContentController = userContentController
-        self.restrictedDevice = restrictedDevice
         self.contentBlocking = contentBlocking
     }
     
@@ -145,7 +143,7 @@ fileprivate class Loader {
         return surrogateJson
     }
     
-    fileprivate func injectCompiledEasylist(_ cachedEasylistPrivacy: String, _ cachedEasylist: String, _ cachedEasylistWhitelist: String) {
+    fileprivate func injectCompiledEasylist(_ cachedEasylistWhitelist: String) {
         Logger.log(text: "using cached easylist")
         
         if #available(iOS 10, *) {
@@ -155,19 +153,19 @@ fileprivate class Loader {
         }
         
         javascriptLoader.load(script: .cachedEasylist, withReplacements: [
-            "${easylist_privacy_json}": cachedEasylistPrivacy,
-            "${easylist_general_json}": cachedEasylist,
+            "${easylist_privacy_json}": "",
+            "${easylist_general_json}": "",
             "${easylist_whitelist_json}": cachedEasylistWhitelist ],
                               into: userContentController,
                               forMainFrameOnly: false)
     }
     
-    fileprivate func injectRawEasylist(_ easylistPrivacy: String, _ easylist: String, _ easylistWhitelist: String) {
+    fileprivate func injectRawEasylist(_ easylistWhitelist: String) {
         Logger.log(text: "parsing easylist")
         
         javascriptLoader.load(script: .easylistParsing, withReplacements: [
-            "${easylist_privacy}": restrictedDevice ? "" : easylistPrivacy,
-            "${easylist_general}": restrictedDevice ? "" : easylist,
+            "${easylist_privacy}": "{}",
+            "${easylist_general}": "{}",
             "${easylist_whitelist}": easylistWhitelist ],
                               into: userContentController,
                               forMainFrameOnly: false)
@@ -176,23 +174,14 @@ fileprivate class Loader {
     
     private func loadEasylist() {
         
-        if let cachedEasylist = cache.get(named: EasylistStore.CacheNames.easylist),
-            let cachedEasylistPrivacy = cache.get(named: EasylistStore.CacheNames.easylistPrivacy),
-            let cachedEasylistWhitelist = cache.get(named: EasylistStore.CacheNames.easylistWhitelist) {
-
-            injectCompiledEasylist(cachedEasylistPrivacy, cachedEasylist, cachedEasylistWhitelist)
-
+        if let cachedEasylistWhitelist = cache.get(named: EasylistStore.CacheNames.easylistWhitelist) {
+            injectCompiledEasylist(cachedEasylistWhitelist)
             return
         }
         
         let easylistStore = EasylistStore()
-        
-        if let easylist = easylistStore.easylist,
-            let easylistPrivacy = easylistStore.easylistPrivacy,
-            let easylistWhitelist = easylistStore.easylistWhitelist {
-            
-            injectRawEasylist(easylistPrivacy, easylist, easylistWhitelist)
-            
+        if let easylistWhitelist = easylistStore.easylistWhitelist {
+            injectRawEasylist(easylistWhitelist)
         }
     }
     

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -264,9 +264,9 @@ open class WebViewController: UIViewController {
         webView.isHidden = false
     }
 
-    open func reloadScripts(with protectionId: String, restrictedDevice: Bool) {
+    open func reloadScripts(with protectionId: String) {
         webView.configuration.userContentController.removeAllUserScripts()
-        webView.configuration.loadScripts(with: protectionId, restrictedDevice: restrictedDevice, contentBlocking: !isDuckDuckGoUrl())
+        webView.configuration.loadScripts(with: protectionId, contentBlocking: !isDuckDuckGoUrl())
     }
     
     private func isDuckDuckGoUrl() -> Bool {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -445,7 +445,7 @@ extension TabViewController: WebEventsDelegate {
             self.siteRating = SiteRating(url: siteRating.url, httpsForced: httpsForced, protectionId: siteRating.protectionId)
         } else {
             resetSiteRating()
-            reloadScripts(with: siteRating!.protectionId, restrictedDevice: UIDevice.current.isSlow())
+            reloadScripts(with: siteRating!.protectionId)
         }
         
         tabModel.link = link
@@ -565,38 +565,5 @@ extension TabViewController: PrivacyProtectionDelegate {
         chromeDelegate?.omniBar.becomeFirstResponder()
     }
 
-}
-
-fileprivate extension UIDevice {
-    
-    // see https://static1.squarespace.com/static/51adfbd9e4b095d664d9b869/t/5a577ff4e4966b1f7d784921/1515683829075/Matrix+16by9-8k.pdf
-    // A8 and lower are considered slow
-    // Anything not in this list is excluded by OS version or supported implicitly
-    static let slowDevices = [
-
-        DeviceType.iPadMini4.displayName,
-        DeviceType.iPodTouch6G.displayName,
-        DeviceType.iPadAir2.displayName,
-        DeviceType.iPhone6Plus.displayName,
-        DeviceType.iPhone6.displayName,
-        DeviceType.iPadMini3.displayName,
-//         // DeviceType.iPadMini2.displayName, Covered by iPadMini3 and iPadMini it seems
-        DeviceType.iPadAir.displayName,
-        DeviceType.iPhone5S.displayName,
-        DeviceType.iPhone5C.displayName,
-        DeviceType.iPad.displayName,
-        DeviceType.iPhone5.displayName,
-        DeviceType.iPadMini.displayName,
-        DeviceType.iPodTouch5G.displayName,
-        DeviceType.iPad.displayName,
-        DeviceType.iPhone4S.displayName,
-        DeviceType.iPad2.displayName
-        
-    ]
-    
-    func isSlow() -> Bool {
-        return UIDevice.slowDevices.contains(deviceType.displayName)
-    }
-    
 }
 

--- a/IntegrationTests/TrackerPageMocks/iframetrackers.html
+++ b/IntegrationTests/TrackerPageMocks/iframetrackers.html
@@ -8,8 +8,8 @@
     <body>
         
         <h1>Test: iFrame Trackers</h1>
-        Unique trackers: <div>7</div>
-        Total trackers: <div>7</div>
+        Unique trackers: <div>5</div>
+        Total trackers: <div>5</div>
         
         <!-- Test that an iframe that is a tracker is blocked -->
         <!-- Tracker detection source: Disconnect list -->

--- a/IntegrationTests/TrackerPageMocks/resourcetrackers.html
+++ b/IntegrationTests/TrackerPageMocks/resourcetrackers.html
@@ -7,12 +7,6 @@
         <script type="text/javascript" src="http://b.scorecardresearch.com/beacon.js"></script>
         <script type="text/javascript" src="http://web.adblade.com/js/ads/async/show.js"></script>
         
-        <!-- Tracker detection source: easylist -->
-        <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
-        
-        <!-- Tracker detection source: easyprivacy -->
-        <link rel="stylesheet" type="text/css" media="all" href="//cdn.tagcommander.com/1705/tc_catalog.css" />
-        
     </head>
     
     <body>
@@ -21,8 +15,8 @@
         <img src="https://www.adserver.yahoo.com/img.png" />
         
         <h1>Test: Resource Trackers</h1>
-        Unique trackers: <div>6</div>
-        Total trackers: <div>6</div>
+        Unique trackers: <div>4</div>
+        Total trackers: <div>4</div>
         
     </body>
 </html>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/643896211391321
Tech Design URL: https://app.asana.com/0/361428290920652/645811084455090

**Description**:
Removes easylist and easyprivacy from apps

**Steps to test this PR**:

**TEST ONE - Upgrade:**
1. From the develop branch, run the app in an emulator and allow it to sync
1. Visit a cnn.com
1. In the file browser note the easylist and easyprivacy files on the device
1. Now switch to this branch and allow another sync to happen
1. Note the files are now deleted
1. Go to cnn.com and ensure that blocking still works (via the disconnect list)

**TEST TWO - Clean installation:**
1. From this branch, run a clean installation of the app in an emulator and allow it to sync
1. Launch the app and visit cnn.com
1. Note that empty easylist and easyprivacy files are generated on the device
1. Now relaunch and note that the above files are deleted (and not recreated)
1. Go to cnn.com and ensure that blocking still works (via the disconnect list)

**TEST THREE**
Check that the js layer handles the blanking out of the lists (both pre and post-processed) ok.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
