### PR TITLE
Add user agent to API calls

### DIFF
--- a/Core/APIHeaders.swift
+++ b/Core/APIHeaders.swift
@@ -1,0 +1,34 @@
+//
+//  APIHeaders.swift
+//  Core
+//
+//  Created by duckduckgo on 14/05/2018.
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+public class APIHeaders {
+    
+    struct Name {
+        static let userAgent = "User-Agent"
+        static let etag = "ETag"
+    }
+    
+    private let appVersion: AppVersion
+    
+    public init(appVersion: AppVersion = AppVersion()) {
+        self.appVersion = appVersion
+    }
+
+    public var defaultHeaders: HTTPHeaders  {
+        get {
+            var headers = Alamofire.SessionManager.defaultHTTPHeaders
+            let agent = "DDG-iOS/\(appVersion.versionNumber).\(appVersion.buildNumber) (\(appVersion.identifier); iOS \(UIDevice.current.systemVersion))"
+            headers[Name.userAgent] = agent
+            return headers
+        }
+    }
+    
+}

--- a/Core/APIHeaders.swift
+++ b/Core/APIHeaders.swift
@@ -25,7 +25,7 @@ public class APIHeaders {
     public var defaultHeaders: HTTPHeaders  {
         get {
             var headers = Alamofire.SessionManager.defaultHTTPHeaders
-            let agent = "DDG-iOS/\(appVersion.versionNumber).\(appVersion.buildNumber) (\(appVersion.identifier); iOS \(UIDevice.current.systemVersion))"
+            let agent = "ddg_ios/\(appVersion.versionNumber).\(appVersion.buildNumber) (\(appVersion.identifier); iOS \(UIDevice.current.systemVersion))"
             headers[Name.userAgent] = agent
             return headers
         }

--- a/Core/APIHeaders.swift
+++ b/Core/APIHeaders.swift
@@ -24,9 +24,11 @@ public class APIHeaders {
 
     public var defaultHeaders: HTTPHeaders  {
         get {
+            let fullVersion = "\(appVersion.versionNumber).\(appVersion.buildNumber)"
+            let osVersion = UIDevice.current.systemVersion
+            let userAgent = "ddg_ios/\(fullVersion) (\(appVersion.identifier); iOS \(osVersion))"
             var headers = Alamofire.SessionManager.defaultHTTPHeaders
-            let agent = "ddg_ios/\(appVersion.versionNumber).\(appVersion.buildNumber) (\(appVersion.identifier); iOS \(UIDevice.current.systemVersion))"
-            headers[Name.userAgent] = agent
+            headers[Name.userAgent] = userAgent
             return headers
         }
     }

--- a/Core/APIHeaders.swift
+++ b/Core/APIHeaders.swift
@@ -2,8 +2,19 @@
 //  APIHeaders.swift
 //  Core
 //
-//  Created by duckduckgo on 14/05/2018.
 //  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Core/APIRequest.swift
+++ b/Core/APIRequest.swift
@@ -30,19 +30,14 @@ public class APIRequest {
 
         var data: Data?
         var etag: String?
-
+        
     }
 
-    struct HeaderNames {
-
-        static let etag = "ETag"
-
-    }
-
-    static func request(url: URL, completion: @escaping APIRequestCompletion) {
+    @discardableResult static func request(url: URL, completion: @escaping APIRequestCompletion) -> Request {
+        
         Logger.log(text: "Requesting \(url)")
-
-        Alamofire.request(url)
+        
+        return Alamofire.request(url, headers: APIHeaders().defaultHeaders)
             .validate(statusCode: 200..<300)
             .responseData(queue: DispatchQueue.global(qos: .utility)) { response in
 
@@ -51,13 +46,11 @@ public class APIRequest {
                 if let error = response.error {
                     completion(nil, error)
                 } else {
-                    let etag = response.response?.headerValue(for: HeaderNames.etag)
+                    let etag = response.response?.headerValue(for: APIHeaders.Name.etag)
                     completion(Response(data: response.data, etag: etag), nil)
                 }
             }
-
     }
-
 }
 
 fileprivate extension HTTPURLResponse {

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -152,7 +152,7 @@ public struct AppUrls {
     }
 
     private var appVersion: String {
-        return "\(ParamValue.appVersion)_\(version.versionNumber)_\(version.buildNumber)"
+        return "\(ParamValue.appVersion)_\(version.versionNumber).\(version.buildNumber)"
     }
     
     public func autocompleteUrl(forText text: String) -> URL {

--- a/Core/AppVersion.swift
+++ b/Core/AppVersion.swift
@@ -24,6 +24,7 @@ public struct AppVersion {
     
     struct Keys {
         static let name = kCFBundleNameKey as String
+        static let identifier = kCFBundleIdentifierKey as String
         static let buildNumber = kCFBundleVersionKey as String
         static let versionNumber = "CFBundleShortVersionString"
     }
@@ -36,6 +37,10 @@ public struct AppVersion {
     
     public var name: String {
         return bundle.object(forInfoDictionaryKey: Keys.name) as? String ?? ""
+    }
+    
+    public var identifier: String {
+        return bundle.object(forInfoDictionaryKey: Keys.identifier) as? String ?? ""
     }
     
     public var versionNumber: String {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		830C375E1F6C3A3B00E317A7 /* TermsOfServiceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C375D1F6C3A3B00E317A7 /* TermsOfServiceStore.swift */; };
 		830C37631F6C482E00E317A7 /* TermsOfServiceListParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C37621F6C482E00E317A7 /* TermsOfServiceListParser.swift */; };
 		830C37671F6C4A6200E317A7 /* TermsOfServiceParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C37651F6C4A1D00E317A7 /* TermsOfServiceParserTests.swift */; };
+		8331AEDE20AA37560024962B /* APIHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8331AEDD20AA37560024962B /* APIHeaders.swift */; };
 		833B46FF1F6CB7D4001ECFEC /* TermsOfServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833B46FD1F6CB7A0001ECFEC /* TermsOfServiceTests.swift */; };
 		8364F7101F95FA7600562989 /* DisconnectMeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364F70F1F95FA7600562989 /* DisconnectMeStore.swift */; };
 		8364F7131F961E5E00562989 /* DisconnectMeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364F7111F961DDB00562989 /* DisconnectMeStoreTests.swift */; };
@@ -372,6 +373,7 @@
 		830C37621F6C482E00E317A7 /* TermsOfServiceListParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceListParser.swift; sourceTree = "<group>"; };
 		830C37651F6C4A1D00E317A7 /* TermsOfServiceParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceParserTests.swift; sourceTree = "<group>"; };
 		8325A1201F68AFD900FF31B5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		8331AEDD20AA37560024962B /* APIHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHeaders.swift; sourceTree = "<group>"; };
 		833B46FD1F6CB7A0001ECFEC /* TermsOfServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceTests.swift; sourceTree = "<group>"; };
 		8364F70F1F95FA7600562989 /* DisconnectMeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectMeStore.swift; sourceTree = "<group>"; };
 		8364F7111F961DDB00562989 /* DisconnectMeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectMeStoreTests.swift; sourceTree = "<group>"; };
@@ -1270,6 +1272,7 @@
 			children = (
 				8570656F1F6ABFA40044DCB1 /* APIRequest.swift */,
 				F11E22F81ED33D8600523BC9 /* ApiRequestError.swift */,
+				8331AEDD20AA37560024962B /* APIHeaders.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -2531,6 +2534,7 @@
 				85B718F51FD071E50031A14F /* HTTPSUpgrade.xcdatamodeld in Sources */,
 				F1B88A101F3BA176000263D6 /* SiteGrade.swift in Sources */,
 				F1A886781F29394E0096251E /* WebCacheManager.swift in Sources */,
+				8331AEDE20AA37560024962B /* APIHeaders.swift in Sources */,
 				F1DA2F701EBCEA8B00313F51 /* SupportedExternalURLScheme.swift in Sources */,
 				F1134EB01F40AC6300B73467 /* AtbParser.swift in Sources */,
 				830C375E1F6C3A3B00E317A7 /* TermsOfServiceStore.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		8364F7131F961E5E00562989 /* DisconnectMeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364F7111F961DDB00562989 /* DisconnectMeStoreTests.swift */; };
 		836B6B6A1F67F11E0061ECFB /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836B6B691F67F11E0061ECFB /* ContentBlockerTests.swift */; };
 		8382E9F2207D61F000708757 /* TabIconMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8382E9F1207D61F000708757 /* TabIconMaker.swift */; };
+		83B8BDAF20AB14A70076D6A1 /* APIHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */; };
 		83D306A41F6D500B00ED7CE2 /* tosdr.json in Resources */ = {isa = PBXBuildFile; fileRef = 83D306A31F6D500B00ED7CE2 /* tosdr.json */; };
 		83DBCA7B1F7BBB5000DFD170 /* TopSitesReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DBCA7A1F7BBB5000DFD170 /* TopSitesReport.swift */; };
 		83DBCA841F7BBB7E00DFD170 /* top500_sites.json in Resources */ = {isa = PBXBuildFile; fileRef = 83DBCA821F7BBB7E00DFD170 /* top500_sites.json */; };
@@ -382,6 +383,7 @@
 		836B6B6B1F67F11E0061ECFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		836B6B711F67F1590061ECFB /* TrackerPageMocks */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TrackerPageMocks; sourceTree = "<group>"; };
 		8382E9F1207D61F000708757 /* TabIconMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIconMaker.swift; sourceTree = "<group>"; };
+		83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHeadersTests.swift; sourceTree = "<group>"; };
 		83D306A31F6D500B00ED7CE2 /* tosdr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tosdr.json; sourceTree = "<group>"; };
 		83DBCA781F7BBB5000DFD170 /* TopSitesReport.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TopSitesReport.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		83DBCA7A1F7BBB5000DFD170 /* TopSitesReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSitesReport.swift; sourceTree = "<group>"; };
@@ -871,6 +873,7 @@
 			isa = PBXGroup;
 			children = (
 				F1FCF3B11F354F7200C23128 /* APIRequestTests.swift */,
+				83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -2475,6 +2478,7 @@
 				85F591251FD1BFAA00746C77 /* DisconnectMeTrackerTests.swift in Sources */,
 				F17D72391E8B35C6003E8B0E /* AppUrlsTests.swift in Sources */,
 				F1134ED61F40F29F00B73467 /* StatisticsUserDefaultsTests.swift in Sources */,
+				83B8BDAF20AB14A70076D6A1 /* APIHeadersTests.swift in Sources */,
 				8536A1CA209AF6490050739E /* HomeRowReminderTests.swift in Sources */,
 				F11E23091ED3559700523BC9 /* DisconnectMeTrackersParserTests.swift in Sources */,
 			);

--- a/DuckDuckGo/AutocompleteRequest.swift
+++ b/DuckDuckGo/AutocompleteRequest.swift
@@ -36,7 +36,10 @@ class AutocompleteRequest {
     
     func execute(completion: @escaping Completion)  {
         let parser = autocompleteParser
-        task = URLSession.shared.dataTask(with: URLRequest(url: url)) { [weak self] (data, response, error) -> Void in
+        var request = URLRequest(url: url)
+        request.allHTTPHeaderFields = APIHeaders().defaultHeaders
+        
+        task = URLSession.shared.dataTask(with: request) { [weak self] (data, response, error) -> Void in
             guard let weakSelf = self else { return }
             do {
                 let suggestions = try weakSelf.processResult(parser: parser, data: data, error: error)

--- a/DuckDuckGoTests/APIHeadersTests.swift
+++ b/DuckDuckGoTests/APIHeadersTests.swift
@@ -1,0 +1,30 @@
+//
+//  APIHeadersTests.swift
+//  DuckDuckGo
+//
+//  Created by duckduckgo on 15/05/2018.
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Core
+
+class APIHeadersTests: XCTestCase {
+    
+    func testWhenHeadersRequestedThenHeadersContainUserAgent() {
+        let testee = APIHeaders(appVersion: appVersion())
+        let expected = "ddg_ios/7.0.4.5 (com.duckduckgo.mobile.ios; iOS \(UIDevice.current.systemVersion))"
+        let actual = testee.defaultHeaders[APIHeaders.Name.userAgent]
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func appVersion() -> AppVersion {
+        let mockBundle = MockBundle()
+        mockBundle.add(name: AppVersion.Keys.identifier, value: "com.duckduckgo.mobile.ios")
+        mockBundle.add(name: AppVersion.Keys.versionNumber, value: "7.0.4")
+        mockBundle.add(name: AppVersion.Keys.buildNumber, value: "5")
+        return AppVersion(bundle: mockBundle)
+    }
+
+}

--- a/DuckDuckGoTests/APIHeadersTests.swift
+++ b/DuckDuckGoTests/APIHeadersTests.swift
@@ -2,8 +2,20 @@
 //  APIHeadersTests.swift
 //  DuckDuckGo
 //
-//  Created by duckduckgo on 15/05/2018.
 //  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/DuckDuckGoTests/APIRequestTests.swift
+++ b/DuckDuckGoTests/APIRequestTests.swift
@@ -31,6 +31,36 @@ class APIRequestTests: XCTestCase {
         super.tearDown()
     }
 
+    func testWhenRequestMadeThenUserAgentIsAdded() {
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 200, headers: nil)
+        }
+        
+        let expect = expectation(description: "testWhenRequestMadeThenUserAgentIsAdded")
+        let request = APIRequest.request(url: url) { (data, error) in
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+        let userAgent = request.request!.allHTTPHeaderFields![APIHeaders.Name.userAgent]!
+        XCTAssertTrue(userAgent.hasPrefix("ddg_ios"))
+    }
+    
+    func testWhenRequestWithUserAgentMadeThenUserAgentIsUpdaded() {
+        stub(condition: isHost(host)) { _ in
+            return fixture(filePath: self.validJson(), status: 200, headers: [ APIHeaders.Name.userAgent: "old ua"])
+        }
+        
+        let expect = expectation(description: "testWhenRequestWithUserAgentMadeThenUserAgentIsUpdaded")
+        let request = APIRequest.request(url: url) { (data, error) in
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0, handler: nil)
+        let userAgent = request.request!.allHTTPHeaderFields![APIHeaders.Name.userAgent]!
+        XCTAssertTrue(userAgent.hasPrefix("ddg_ios"))
+    }
+    
     func testWhenStatus200WithEtagThenRequestCompletesWithEtag() {
         stub(condition: isHost(host)) { _ in
             return fixture(filePath: self.validJson(), status: 200, headers: [ "ETag": "an etag"] )
@@ -43,9 +73,7 @@ class APIRequestTests: XCTestCase {
             expect.fulfill()
         }
         waitForExpectations(timeout: 1.0, handler: nil)
-
     }
-    
 
     func testWhenStatus200ThenRequestCompletesWithData() {
         stub(condition: isHost(host)) { _ in

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -47,13 +47,13 @@ class AppUrlsTests: XCTestCase {
         let actual = testee.applyStatsParams(for: URL(string: "http://duckduckgo.com?atb=wrong&t=wrong&tappv=wrong")!)
         XCTAssertEqual(actual.getParam(name: "atb"), "x")
         XCTAssertEqual(actual.getParam(name: "t"), "ddg_ios")
-        XCTAssertEqual(actual.getParam(name: "tappv"), "ios_7_900")
+        XCTAssertEqual(actual.getParam(name: "tappv"), "ios_7.900")
     }
 
     func testWhenAtbMatchesThenHasMobileStatsParamsIsTrue() {
         mockStatisticsStore.atb = "x"
         let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios&tappv=ios_7_900")!)
+        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios&tappv=ios_7.900")!)
         XCTAssertTrue(result)
     }
 
@@ -190,7 +190,7 @@ class AppUrlsTests: XCTestCase {
         
         let testee = AppUrls(version: AppVersion(bundle: mockBundle), statisticsStore: mockStatisticsStore)
         let url = testee.searchUrl(text: "query")
-        XCTAssertEqual(url.getParam(name: "tappv"), "ios_1.2.9_657")
+        XCTAssertEqual(url.getParam(name: "tappv"), "ios_1.2.9.657")
     }
 
     func testWhenAtbValuesExistInStatisticsStoreThenSearchUrlCreatesUrlWithAtb() {

--- a/DuckDuckGoTests/AppVersionTests.swift
+++ b/DuckDuckGoTests/AppVersionTests.swift
@@ -27,6 +27,7 @@ class AppVersionTests: XCTestCase {
         static let name = "DuckDuckGo"
         static let version = "2.0.4"
         static let build = "14"
+        static let identifier = "com.duckduckgo.mobile.ios"
     }
     
     private var mockBundle: MockBundle!
@@ -45,6 +46,11 @@ class AppVersionTests: XCTestCase {
     func testVersionNumber() {
         mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
         XCTAssertEqual(Constants.version, testee.versionNumber)
+    }
+    
+    func testIdentifier() {
+        mockBundle.add(name: AppVersion.Keys.identifier, value: Constants.identifier)
+        XCTAssertEqual(Constants.identifier, testee.identifier)
     }
     
     func testBuildNumber() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:  https://app.asana.com/0/193817002363848/661090964923373
CC: @nilnilnil 

**Description**:
Adds a custom user agent to API requests. Also updates the version build number to use a dot rather than underscore

**Steps to test this PR**:
1. Run a fresh install of the app and watch traffic using a traffic sniffing tool e.g Charles
1. Ensure that api requests (e.g atb, exti, contentblocking.js?l=https2, contentblocking.js?l=disconnect, https2 etc) now contain a full user agent string e.g `ddg_ios/7.5.2.0 (com.duckduckgo.mobile.ios; iOS 10.3.1)` and not `DuckDuckGo/7.2.0 (com.duckduckgo.mobile.ios; build:1; iOS 11.2.0) Alamofire/4.5.0`
1. Run the app again and ensure that caching still works e.g contentblocking.js?l=disconnect should respond with a 304 now

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
