### PR TITLE
Fix new home screen animation glitch

### DIFF
--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -32,7 +32,7 @@ class HomeViewController: UIViewController {
 
     var frame: CGRect!
     
-    private var viewLoadingHasSettled = false
+    private var viewHasAppeared = false
 
     static func loadFromStoryboard() -> HomeViewController {
         return UIStoryboard(name: "Home", bundle: nil).instantiateViewController(withIdentifier: "HomeViewController") as! HomeViewController
@@ -58,9 +58,7 @@ class HomeViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.viewLoadingHasSettled = true
-        }
+        viewHasAppeared = true
     }
     
     @IBAction func hideKeyboard() {
@@ -95,7 +93,7 @@ class HomeViewController: UIViewController {
 
         view.setNeedsUpdateConstraints()
 
-        if (viewLoadingHasSettled) {
+        if (viewHasAppeared) {
             UIView.animate(withDuration: duration) { self.view.layoutIfNeeded() }
         }
     }

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -31,6 +31,8 @@ class HomeViewController: UIViewController {
     weak var chromeDelegate: BrowserChromeDelegate?
 
     var frame: CGRect!
+    
+    private var viewLoadingHasSettled = false
 
     static func loadFromStoryboard() -> HomeViewController {
         return UIStoryboard(name: "Home", bundle: nil).instantiateViewController(withIdentifier: "HomeViewController") as! HomeViewController
@@ -51,7 +53,14 @@ class HomeViewController: UIViewController {
         let feature = HomeRowOnboarding()
         if !feature.showNow() {
             hideCallToAction()
-        }    
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.viewLoadingHasSettled = true
+        }
     }
     
     @IBAction func hideKeyboard() {
@@ -75,7 +84,7 @@ class HomeViewController: UIViewController {
         guard let beginFrame = notification.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? CGRect else { return }
         guard let endFrame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
         guard let duration = notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as? Double else { return }
-
+       
         let diff = beginFrame.origin.y - endFrame.origin.y
 
         if diff > 0 {
@@ -85,9 +94,9 @@ class HomeViewController: UIViewController {
         }
 
         view.setNeedsUpdateConstraints()
-        
-        UIView.animate(withDuration: duration) {
-            self.view.layoutIfNeeded()
+
+        if (viewLoadingHasSettled) {
+            UIView.animate(withDuration: duration) { self.view.layoutIfNeeded() }
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/487656199561568

**Description**:
Fixes an animation glitch when launching a new home screen tab (see video in Asana ticket)

**Steps to test this PR**:
1. Open a new tab
1. Ensure "glide from right" glitch does not happen
1. Tap to dismiss the keybord, note the logo still animates nicely
1. Tap in the search bar to open the keyboard, note that the logo again animates nicely

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
