### PR TITLE
Remove app version from search

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -128,8 +128,8 @@ public struct AppUrls {
     }
     
     /**
-     Generates a search url with the source (t) https://duck.co/help/privacy/t,
-     app version and cohort (atb) https://duck.co/help/privacy/atb
+     Generates a search url with the source (t) https://duck.co/help/privacy/t
+     and cohort (atb) https://duck.co/help/privacy/atb
      */
     public func searchUrl(text: String) -> URL {
         let searchUrl = home.addParam(name: Param.search, value: text)

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -44,21 +44,17 @@ public struct AppUrls {
     private struct Param {
         static let search = "q"
         static let source = "t"
-        static let appVersion = "tappv"
         static let atb = "atb"
         static let setAtb = "set_atb"
     }
 
     private struct ParamValue {
         static let source = "ddg_ios"
-        static let appVersion = "ios"
     }
     
-    let version: AppVersion
     let statisticsStore: StatisticsStore
     
-    public init(version: AppVersion = AppVersion(), statisticsStore: StatisticsStore = StatisticsUserDefaults()) {
-        self.version = version
+    public init(statisticsStore: StatisticsStore = StatisticsUserDefaults()) {
         self.statisticsStore = statisticsStore
     }
 
@@ -142,17 +138,11 @@ public struct AppUrls {
 
     public func applyStatsParams(for url: URL) -> URL {
         var searchUrl = url.addParam(name: Param.source, value: ParamValue.source)
-        searchUrl = searchUrl.addParam(name: Param.appVersion, value: appVersion)
-
         if let atb = statisticsStore.atb {
             searchUrl = searchUrl.addParam(name: Param.atb, value: atb)
         }
         
         return searchUrl
-    }
-
-    private var appVersion: String {
-        return "\(ParamValue.appVersion)_\(version.versionNumber).\(version.buildNumber)"
     }
     
     public func autocompleteUrl(forText text: String) -> URL {
@@ -167,7 +157,6 @@ public struct AppUrls {
 
     public func hasCorrectMobileStatsParams(url: URL) -> Bool {
         guard let source = url.getParam(name: Param.source), source == ParamValue.source  else { return false }
-        guard let version = url.getParam(name: Param.appVersion), version == appVersion else { return false }
         if let atb = statisticsStore.atb {
             return atb == url.getParam(name: Param.atb)
         }

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -29,73 +29,51 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
     
-    private var versionWithMockBundle: AppVersion {
-        let mockBundle = MockBundle()
-        mockBundle.add(name: AppVersion.Keys.versionNumber, value: "7")
-        mockBundle.add(name: AppVersion.Keys.buildNumber, value: "900")
-        return AppVersion(bundle: mockBundle)
-    }
-
     func testBaseUrlDoesNotHaveSubDomain() {
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
         XCTAssertEqual(testee.base, URL(string: "duckduckgo.com"))
     }
 
     func testWhenMobileStatsParamsAreAppliedThenTheyReturnAnUpdatedUrl() {
         mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let actual = testee.applyStatsParams(for: URL(string: "http://duckduckgo.com?atb=wrong&t=wrong&tappv=wrong")!)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let actual = testee.applyStatsParams(for: URL(string: "http://duckduckgo.com?atb=wrong&t=wrong")!)
         XCTAssertEqual(actual.getParam(name: "atb"), "x")
         XCTAssertEqual(actual.getParam(name: "t"), "ddg_ios")
-        XCTAssertEqual(actual.getParam(name: "tappv"), "ios_7.900")
     }
 
     func testWhenAtbMatchesThenHasMobileStatsParamsIsTrue() {
         mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios&tappv=ios_7.900")!)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios")!)
         XCTAssertTrue(result)
     }
 
     func testWhenAtbIsMismatchedThenHasMobileStatsParamsIsFalse() {
         mockStatisticsStore.atb = "y"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios&tappv=ios_7_900")!)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios")!)
         XCTAssertFalse(result)
     }
 
     func testWhenAtbIsMissingThenHasMobileStatsParamsIsFalse() {
         mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?t=ddg_ios&tappv=ios_7_900")!)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?t=ddg_ios")!)
         XCTAssertFalse(result)
     }
     
     func testWhenSourceIsMismatchedThenHasMobileStatsParamsIsFalse() {
         mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_desktop&tappv=ios_7_900")!)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_desktop")!)
         XCTAssertFalse(result)
     }
     
     func testWhenSourceIsMissingThenHasMobileStatsParamsIsFalse() {
         mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=y&tappv=ios_7_900")!)
-        XCTAssertFalse(result)
-    }
-    
-    func testWhenVersionIsMismatchedThenHasMobileStatsParamsIsFalse() {
-        mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios&tappv=ios_1_100")!)
-        XCTAssertFalse(result)
-    }
-    
-    func testWhenVersionIsMissingThenHasMobileStatsParamsIsFalse() {
-        mockStatisticsStore.atb = "x"
-        let testee = AppUrls(version: versionWithMockBundle, statisticsStore: mockStatisticsStore)
-        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=y&t=ddg_ios")!)
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=y")!)
         XCTAssertFalse(result)
     }
     
@@ -181,16 +159,6 @@ class AppUrlsTests: XCTestCase {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let url = testee.searchUrl(text: "query")
         XCTAssertEqual(url.getParam(name: "t"), "ddg_ios")
-    }
-
-    func testSearchUrlCreatesUrlWithAppVersionParam() {
-        let mockBundle = MockBundle()
-        mockBundle.add(name: AppVersion.Keys.buildNumber, value: "657")
-        mockBundle.add(name: AppVersion.Keys.versionNumber, value: "1.2.9")
-        
-        let testee = AppUrls(version: AppVersion(bundle: mockBundle), statisticsStore: mockStatisticsStore)
-        let url = testee.searchUrl(text: "query")
-        XCTAssertEqual(url.getParam(name: "tappv"), "ios_1.2.9.657")
     }
 
     func testWhenAtbValuesExistInStatisticsStoreThenSearchUrlCreatesUrlWithAtb() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/649057775699177

**Description**:
Remove tappv parameter from app searches

**Steps to test this PR**:
1. Run the app and watch network traffic
1. Submit a search
1. Ensure the tappv parameter is no longer on our urls

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
