### PR TITLE
xhr improvements

### DIFF
--- a/Core/detection.js
+++ b/Core/detection.js
@@ -80,13 +80,14 @@
         var xhr = XMLHttpRequest.prototype
         var originalOpen = xhr.open
 
-        xhr.open = function(method, url) {
-            var trackerUrl = null
+        xhr.open = function() {
+            var args = arguments
+            var url = arguments[1]
             duckduckgoContentBlocking.shouldBlock(url, "xmlhttprequest", function(url, block) {                                                  
-                trackerUrl = block ? "about:blank" : url 
+                args[1] = block ? "about:blank" : url 
             })
-            duckduckgoMessaging.log("sending xhr " + url + " to " + trackerUrl)
-            return originalOpen.apply(this, [method, trackerUrl]);
+            duckduckgoMessaging.log("sending xhr " + url + " to " + args[1])
+            return originalOpen.apply(this, args);
         }
 
     } catch(error) {

--- a/Core/detection.js
+++ b/Core/detection.js
@@ -84,8 +84,8 @@
             var trackerUrl = null
             duckduckgoContentBlocking.shouldBlock(url, "xmlhttprequest", function(url, block) {                                                  
                 trackerUrl = block ? "about:blank" : url 
-                duckduckgoMessaging.log("sending xhr " + url + " to " + trackerUrl)
             })
+            duckduckgoMessaging.log("sending xhr " + url + " to " + trackerUrl)
             return originalOpen.apply(this, [method, trackerUrl]);
         }
 

--- a/Core/detection.js
+++ b/Core/detection.js
@@ -79,29 +79,16 @@
 
         var xhr = XMLHttpRequest.prototype
         var originalOpen = xhr.open
-        var originalSend = xhr.send
 
         xhr.open = function(method, url) {
-            this.trackerUrl = url;
-            return originalOpen.apply(this, arguments);
+            var trackerUrl = null
+            duckduckgoContentBlocking.shouldBlock(url, "xmlhttprequest", function(url, block) {                                                  
+                trackerUrl = block ? "about:blank" : url 
+                duckduckgoMessaging.log("sending xhr " + url + " to " + trackerUrl)
+            })
+            return originalOpen.apply(this, [method, trackerUrl]);
         }
 
-        xhr.send = function(body) {
- 
-            var sendArgs = arguments
-            var instance = this
-            duckduckgoContentBlocking.shouldBlock(this.trackerUrl, "xmlhttprequest", function(url, block) {
-                if (block) {
-                    instance.abort()
-                    duckduckgoMessaging.log("blocked xhr: " + url)
-                } else {
-                    duckduckgoMessaging.log("allowing xhr: " + url)
-                    originalSend.apply(instance, sendArgs)
-                } 
-
-            })
-
-        }           
     } catch(error) {
         duckduckgoMessaging.log("failed to install xhr detection")
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/569473074191537/632684929109461
Tech Design URL:
CC:

**Description**:

Lowes website was broken because we were aborting XHR requests.  This approach redirects blocked XHR requests to about:blank instead and does not interfere with the "send" function at all.  

I've been running this locally for the weekend and had no problems.


**Steps to test this PR**:

1. Visit lowes.com - it should function correctly (bug was that it was a blank screen)
1. Login in to social media to check regression in XHR (Twitter, Facebook, etc)
1. Browse other sites to check for XHR regressions

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)