### PR TITLE
use alternative data store remove data method and retain cookies for duckduckgo

### DIFF
--- a/Core/CookieStorage.swift
+++ b/Core/CookieStorage.swift
@@ -1,0 +1,77 @@
+//
+//  CookieStorage.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+class CookieStorage {
+    
+    struct Constants {
+        static let key = "com.duckduckgo.allowedCookies"
+    }
+    
+    private var userDefaults: UserDefaults
+    
+    var cookies: [HTTPCookie] {
+        
+        var storedCookies = [HTTPCookie]()
+        if let cookies = userDefaults.object(forKey: Constants.key) as? [[String: Any?]] {
+            for cookieData in cookies {
+                var properties = [HTTPCookiePropertyKey: Any]()
+                cookieData.forEach({
+                    properties[HTTPCookiePropertyKey(rawValue: $0.key)] = $0.value
+                })
+                
+                if let cookie = HTTPCookie(properties: properties) {
+                    Logger.log(items: "read cookie", cookie.domain, cookie.name, cookie.value)
+                    storedCookies.append(cookie)
+                }
+            }
+        }
+        
+        return storedCookies
+    }
+    
+    init(userDefaults: UserDefaults = UserDefaults.standard) {
+        self.userDefaults = userDefaults
+    }
+    
+    func clear() {
+        userDefaults.removeObject(forKey: Constants.key)
+        Logger.log(items: "cleared cookies")
+    }
+    
+    func setCookie(_ cookie: HTTPCookie) {
+        Logger.log(items: "storing cookie", cookie.domain, cookie.name, cookie.value)
+        var cookieData = [String: Any?]()
+        cookie.properties?.forEach({
+            cookieData[$0.key.rawValue] = $0.value
+        })
+        setCookie(cookieData)
+    }
+
+    private func setCookie(_ cookieData: [String: Any?]) {
+        var cookies = userDefaults.object(forKey: Constants.key) as? [[String: Any?]]
+        if cookies == nil {
+            cookies = [[String: Any?]]()
+        }
+        cookies?.append(cookieData)
+        userDefaults.set(cookies, forKey: Constants.key)
+    }
+
+}

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -22,24 +22,19 @@ import WebKit
 
 public class WebCacheManager {
 
-    public static var instance = WebCacheManager()
-    
     private struct Constants {
         static let cookieDomain = "duckduckgo.com"
     }
     
-    private var allDataTypes: Set<String> {
+    private static var allDataTypes: Set<String> {
         return WKWebsiteDataStore.allWebsiteDataTypes()
     }
     
-    private var dataStore: WKWebsiteDataStore {
+    private static var dataStore: WKWebsiteDataStore {
         return WKWebsiteDataStore.default()
     }
     
-    private init() {
-    }
-
-    public func consumeCookies(intoDataStore dataStore: WKWebsiteDataStore) {
+    public static func consumeCookies(intoDataStore dataStore: WKWebsiteDataStore) {
         if #available(iOS 11, *) {
             let storage = HTTPCookieStorage.shared
             for cookie in storage.cookies ?? [] {
@@ -53,7 +48,7 @@ public class WebCacheManager {
     /**
      Clears the cache of all data, except duckduckgo cookies
      */
-    public func clear() {
+    public static func clear() {
         if #available(iOS 11, *) {
             extractAllowedCookiesThenClear(in: dataStore.httpCookieStore)
         } else {
@@ -62,7 +57,7 @@ public class WebCacheManager {
     }
 
     @available(iOS 11, *)
-    func extractAllowedCookiesThenClear(in cookieStore: WKHTTPCookieStore) {
+    private static func extractAllowedCookiesThenClear(in cookieStore: WKHTTPCookieStore) {
         cookieStore.getAllCookies { cookies in
             let cookies = cookies.filter({ $0.domain == Constants.cookieDomain })
             let storage = HTTPCookieStorage.shared

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -39,7 +39,7 @@ public class WebCacheManager {
         
         let cookieStorage = CookieStorage()
         for cookie in cookieStorage.cookies {
-            dataStore.httpCookieStore.setCookie(cookie)
+            WebCacheManager.dataStore.httpCookieStore.setCookie(cookie)
         }
         cookieStorage.clear()
     }
@@ -49,9 +49,9 @@ public class WebCacheManager {
      */
     public static func clear() {
         if #available(iOS 11, *) {
-            extractAllowedCookiesThenClear(in: dataStore.httpCookieStore)
+            extractAllowedCookiesThenClear(in: WebCacheManager.dataStore.httpCookieStore)
         } else {
-            dataStore.removeData(ofTypes: allDataTypes, modifiedSince: Date.distantPast) { }
+            WebCacheManager.dataStore.removeData(ofTypes: allDataTypes, modifiedSince: Date.distantPast) { }
         }
     }
 
@@ -64,7 +64,7 @@ public class WebCacheManager {
                 cookieStorage.setCookie(cookie)
                 
             }
-            self.dataStore.removeData(ofTypes: self.allDataTypes, modifiedSince: Date.distantPast) {}
+            WebCacheManager.dataStore.removeData(ofTypes: self.allDataTypes, modifiedSince: Date.distantPast) {}
         }
     }
     

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -34,15 +34,14 @@ public class WebCacheManager {
         return WKWebsiteDataStore.default()
     }
     
-    public static func consumeCookies(intoDataStore dataStore: WKWebsiteDataStore) {
-        if #available(iOS 11, *) {
-            let storage = HTTPCookieStorage.shared
-            for cookie in storage.cookies ?? [] {
-                Logger.log(items: "consuming cookie", cookie.domain, cookie.name, cookie.value)
-                dataStore.httpCookieStore.setCookie(cookie)
-                storage.deleteCookie(cookie)
-            }            
+    public static func consumeCookies() {
+        guard #available(iOS 11, *) else { return }
+        
+        let cookieStorage = CookieStorage()
+        for cookie in cookieStorage.cookies {
+            dataStore.httpCookieStore.setCookie(cookie)
         }
+        cookieStorage.clear()
     }
     
     /**
@@ -58,11 +57,12 @@ public class WebCacheManager {
 
     @available(iOS 11, *)
     private static func extractAllowedCookiesThenClear(in cookieStore: WKHTTPCookieStore) {
+        let cookieStorage = CookieStorage()
         cookieStore.getAllCookies { cookies in
             let cookies = cookies.filter({ $0.domain == Constants.cookieDomain })
-            let storage = HTTPCookieStorage.shared
             for cookie in cookies {
-                storage.setCookie(cookie)
+                cookieStorage.setCookie(cookie)
+                
             }
             self.dataStore.removeData(ofTypes: self.allDataTypes, modifiedSince: Date.distantPast) {}
         }

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -41,14 +41,12 @@ public class WebCacheManager {
 
     public func consumeCookies(intoDataStore dataStore: WKWebsiteDataStore) {
         if #available(iOS 11, *) {
-            
             let storage = HTTPCookieStorage.shared
             for cookie in storage.cookies ?? [] {
                 Logger.log(items: "consuming cookie", cookie.domain, cookie.name, cookie.value)
                 dataStore.httpCookieStore.setCookie(cookie)
                 storage.deleteCookie(cookie)
-            }
-            
+            }            
         }
     }
     
@@ -57,24 +55,22 @@ public class WebCacheManager {
      */
     public func clear() {
         if #available(iOS 11, *) {
-            extractAllowedCookies(in: dataStore.httpCookieStore)
+            extractAllowedCookiesThenClear(in: dataStore.httpCookieStore)
+        } else {
+            dataStore.removeData(ofTypes: allDataTypes, modifiedSince: Date.distantPast) { }
         }
-        
-        dataStore.removeData(ofTypes: allDataTypes, modifiedSince: Date.distantPast) {}
     }
 
     @available(iOS 11, *)
-    func extractAllowedCookies(in cookieStore: WKHTTPCookieStore) {
-        
+    func extractAllowedCookiesThenClear(in cookieStore: WKHTTPCookieStore) {
         cookieStore.getAllCookies { cookies in
             let cookies = cookies.filter({ $0.domain == Constants.cookieDomain })
             let storage = HTTPCookieStorage.shared
             for cookie in cookies {
-                Logger.log(items: "storing cookie", cookie.domain, cookie.name, cookie.value)
                 storage.setCookie(cookie)
             }
+            self.dataStore.removeData(ofTypes: self.allDataTypes, modifiedSince: Date.distantPast) {}
         }
-        
     }
     
 }

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -46,9 +46,7 @@ public class WebCacheManager {
         
         if #available(iOS 11, *) {
             for cookie in cookies {
-                dataStore.httpCookieStore.setCookie(cookie) {
-                    // no-op
-                }
+                dataStore.httpCookieStore.setCookie(cookie)
             }
         }
     }
@@ -61,15 +59,13 @@ public class WebCacheManager {
             extractAllowedCookies(in: dataStore.httpCookieStore)
         }
         
-        dataStore.removeData(ofTypes: allDataTypes, modifiedSince: Date.distantPast) {
-            // no-op
-        }
+        dataStore.removeData(ofTypes: allDataTypes, modifiedSince: Date.distantPast) {}
     }
 
     @available(iOS 11, *)
     func extractAllowedCookies(in cookieStore: WKHTTPCookieStore) {
         
-        cookieStore.getAllCookies { (cookies) in
+        cookieStore.getAllCookies { cookies in
             self.cookies = cookies.filter({ $0.domain == Constants.cookieDomain })
             let storage = HTTPCookieStorage.shared
             for cookie in self.cookies {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -111,6 +111,8 @@ open class WebViewController: UIViewController {
         webViewContainer.addSubview(webView)
         webEventsDelegate?.attached(webView: webView)
         
+        WebCacheManager.instance.injectCookies(dataStore: webView.configuration.websiteDataStore)
+        
         if let url = url {
             load(url: url)
         }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -112,7 +112,7 @@ open class WebViewController: UIViewController {
         webEventsDelegate?.attached(webView: webView)
         
         webView.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-            WebCacheManager.instance.injectCookies(dataStore: self.webView.configuration.websiteDataStore)
+            WebCacheManager.instance.consumeCookies(intoDataStore: self.webView.configuration.websiteDataStore)
             if let url = self.url {
                 self.load(url: url)
             }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -111,11 +111,13 @@ open class WebViewController: UIViewController {
         webViewContainer.addSubview(webView)
         webEventsDelegate?.attached(webView: webView)
         
-        WebCacheManager.instance.injectCookies(dataStore: webView.configuration.websiteDataStore)
-        
-        if let url = url {
-            load(url: url)
+        webView.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
+            WebCacheManager.instance.injectCookies(dataStore: self.webView.configuration.websiteDataStore)
+            if let url = self.url {
+                self.load(url: url)
+            }
         }
+        
     }
     
     private func attachLongPressHandler(webView: WKWebView) {

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -112,7 +112,7 @@ open class WebViewController: UIViewController {
         webEventsDelegate?.attached(webView: webView)
         
         webView.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-            WebCacheManager.consumeCookies(intoDataStore: self.webView.configuration.websiteDataStore)
+            WebCacheManager.consumeCookies()
             if let url = self.url {
                 self.load(url: url)
             }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -112,7 +112,7 @@ open class WebViewController: UIViewController {
         webEventsDelegate?.attached(webView: webView)
         
         webView.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-            WebCacheManager.instance.consumeCookies(intoDataStore: self.webView.configuration.websiteDataStore)
+            WebCacheManager.consumeCookies(intoDataStore: self.webView.configuration.websiteDataStore)
             if let url = self.url {
                 self.load(url: url)
             }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		857EEB752095FFAC008A005C /* HomeRowInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857EEB742095FFAC008A005C /* HomeRowInstructionsViewController.swift */; };
 		85923C401FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85923C3F1FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift */; };
 		859872241F5743D800041CB8 /* FireAnimation.xib in Resources */ = {isa = PBXBuildFile; fileRef = 859872231F5743D800041CB8 /* FireAnimation.xib */; };
+		85A1B3B220C6CD9900C18F15 /* CookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B3B120C6CD9900C18F15 /* CookieStorage.swift */; };
+		85A1B3B420C6D07100C18F15 /* CookieStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B3B320C6D07100C18F15 /* CookieStorageTests.swift */; };
 		85A313972028E78A00327D00 /* release_notes.txt in Resources */ = {isa = PBXBuildFile; fileRef = 85A313962028E78A00327D00 /* release_notes.txt */; };
 		85A53ECA200D1FA20010D13F /* SurrogateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A53EC9200D1FA20010D13F /* SurrogateStore.swift */; };
 		85AB24A81FA7449D00896A5F /* PrivacyProtection.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 85AB24A71FA7449D00896A5F /* PrivacyProtection.storyboard */; };
@@ -454,6 +456,8 @@
 		859151E81F543C7500F5FB53 /* SimulatorStatusMagiciOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SimulatorStatusMagiciOS.framework; path = Carthage/Build/iOS/SimulatorStatusMagiciOS.framework; sourceTree = "<group>"; };
 		85923C3F1FD2F8D10097204B /* PrivacyProtectionTrackerNetworksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionTrackerNetworksTests.swift; sourceTree = "<group>"; };
 		859872231F5743D800041CB8 /* FireAnimation.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FireAnimation.xib; sourceTree = "<group>"; };
+		85A1B3B120C6CD9900C18F15 /* CookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieStorage.swift; sourceTree = "<group>"; };
+		85A1B3B320C6D07100C18F15 /* CookieStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieStorageTests.swift; sourceTree = "<group>"; };
 		85A313962028E78A00327D00 /* release_notes.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = release_notes.txt; path = fastlane/metadata/default/release_notes.txt; sourceTree = "<group>"; };
 		85A53EC9200D1FA20010D13F /* SurrogateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurrogateStore.swift; sourceTree = "<group>"; };
 		85AB24A71FA7449D00896A5F /* PrivacyProtection.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PrivacyProtection.storyboard; sourceTree = "<group>"; };
@@ -1446,13 +1450,14 @@
 		F143C3311E4A9A6A00CFDE3A /* Web */ = {
 			isa = PBXGroup;
 			children = (
-				F143C3391E4A9A9200CFDE3A /* WebViewController.swift */,
-				F143C3381E4A9A9200CFDE3A /* WebEventsDelegate.swift */,
-				F143C33A1E4A9A9200CFDE3A /* WKWebViewExtension.swift */,
-				830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */,
+				85A1B3B120C6CD9900C18F15 /* CookieStorage.swift */,
+				F18326861E60542100240060 /* JavascriptLoader.swift */,
 				F1A886771F29394E0096251E /* WebCacheManager.swift */,
 				F159BDA61F0C073D00B4A01D /* WebCacheSummary.swift */,
-				F18326861E60542100240060 /* JavascriptLoader.swift */,
+				F143C3381E4A9A9200CFDE3A /* WebEventsDelegate.swift */,
+				F143C3391E4A9A9200CFDE3A /* WebViewController.swift */,
+				830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */,
+				F143C33A1E4A9A9200CFDE3A /* WKWebViewExtension.swift */,
 			);
 			name = Web;
 			sourceTree = "<group>";
@@ -1652,6 +1657,7 @@
 			isa = PBXGroup;
 			children = (
 				F198D7971E3A45D90088DA8A /* WKWebViewExtensionTests.swift */,
+				85A1B3B320C6D07100C18F15 /* CookieStorageTests.swift */,
 			);
 			name = Web;
 			sourceTree = "<group>";
@@ -2456,6 +2462,7 @@
 				22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */,
 				830C37671F6C4A6200E317A7 /* TermsOfServiceParserTests.swift in Sources */,
 				F1134ED21F40EF3A00B73467 /* JsonTestDataLoader.swift in Sources */,
+				85A1B3B420C6D07100C18F15 /* CookieStorageTests.swift in Sources */,
 				85F591251FD1BFAA00746C77 /* DisconnectMeTrackerTests.swift in Sources */,
 				F17D72391E8B35C6003E8B0E /* AppUrlsTests.swift in Sources */,
 				F1134ED61F40F29F00B73467 /* StatisticsUserDefaultsTests.swift in Sources */,
@@ -2511,6 +2518,7 @@
 				F1DE785A1E5CD2A70058895A /* UIViewExtension.swift in Sources */,
 				F143C33D1E4A9A9200CFDE3A /* WKWebViewExtension.swift in Sources */,
 				F11E22F61ED31CB600523BC9 /* JsonError.swift in Sources */,
+				85A1B3B220C6CD9900C18F15 /* CookieStorage.swift in Sources */,
 				F1134EB51F40AEEA00B73467 /* StatisticsLoader.swift in Sources */,
 				85C271D11FCF33C8007216B4 /* DetectedTracker.swift in Sources */,
 				F143C3281E4A9A0E00CFDE3A /* StringExtension.swift in Sources */,

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -46,7 +46,6 @@ class MainViewController: UIViewController {
     fileprivate var homeController: HomeViewController?
     fileprivate var autocompleteController: AutocompleteViewController?
     
-    private let webCacheManager = WebCacheManager.instance
     private lazy var appUrls: AppUrls = AppUrls()
 
     fileprivate var tabManager: TabManager!
@@ -229,7 +228,7 @@ class MainViewController: UIViewController {
     
     fileprivate func forgetAll(completion: @escaping () -> Void) {
         ServerTrustCache.shared.clear()
-        webCacheManager.clear()
+        WebCacheManager.clear()
         FireAnimation.animate() {
             self.tabManager.removeAll()
             self.attachHomeScreen()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -60,14 +60,8 @@ class MainViewController: UIViewController {
         return tabManager?.current
     }
 
-    var preloader: WebViewPreloader? = WebViewPreloader()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        preloader?.preloadThen {
-            self.preloader = nil
-        }
         
         chromeManager = BrowserChromeManager(delegate: self)
         attachOmniBar()
@@ -577,26 +571,3 @@ extension MainViewController: BookmarksDelegate {
     }
 }
 
-// This preloads a webview so that the datastore can then receive cookies, otherwise nothing happens until subsequent webviews are shown
-// Seems to be related to the bug discussed here: https://forums.developer.apple.com/thread/99674
-class WebViewPreloader: NSObject, WKNavigationDelegate {
-    
-    var webView = WKWebView(frame: CGRect.zero)
-    
-    var completion: (() -> Void)?
-    
-    func preloadThen(_ completion: @escaping () -> Void) {
-        self.completion = completion
-        webView.navigationDelegate = self
-        webView.load(URLRequest(url: URL(string: "about:blank")!))
-    }
-
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        completion?()
-    }
-    
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        completion?()
-    }
-    
-}

--- a/DuckDuckGoTests/CookieStorageTests.swift
+++ b/DuckDuckGoTests/CookieStorageTests.swift
@@ -1,0 +1,82 @@
+//
+//  CookieStorageTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+import XCTest
+@testable import Core
+
+class CookieStorageTests: XCTestCase {
+
+    var testee: CookieStorage!
+    let testGroupName = "test"
+    
+    var userDefaults: UserDefaults {
+        return UserDefaults(suiteName: testGroupName)!
+    }
+    
+    override func setUp() {
+        userDefaults.removePersistentDomain(forName: testGroupName)
+        testee = CookieStorage(userDefaults: userDefaults)
+    }
+
+    func testWhenMultipleCookiesAreSetThenClearCookiesOnNewInstanceClearsAll() {
+        testee.setCookie(cookie("name", "value"))
+        testee.setCookie(cookie("name2", "value2"))
+        testee = CookieStorage(userDefaults: userDefaults)
+        testee.clear()
+        XCTAssertTrue(testee.cookies.isEmpty)
+    }
+
+    func testWhenMultipleCookiesAreSetBetweenInstancesThenCookiesCountMatches() {
+        testee.setCookie(cookie("name", "value"))
+        testee = CookieStorage(userDefaults: userDefaults)
+        testee.setCookie(cookie("name2", "value2"))
+        XCTAssertEqual(testee.cookies.count, 2)
+    }
+
+    func testWhenMultipleCookieIsSetThenClearRemovesIt() {
+        testee.setCookie(cookie("name", "value"))
+        testee.clear()
+        XCTAssertTrue(testee.cookies.isEmpty)
+    }
+
+    func testWhenMultipleCookiesAreSetThenCookiesCountMatches() {
+        testee.setCookie(cookie("name", "value"))
+        testee.setCookie(cookie("name2", "value2"))
+        XCTAssertEqual(testee.cookies.count, 2)
+    }
+    
+    func testWhenCookieIsSetThenCookiesContainsIt() {
+        testee.setCookie(cookie("name", "value"))
+        
+        XCTAssertEqual(testee.cookies.count, 1)
+        XCTAssertEqual(testee.cookies[0].name, "name")
+        XCTAssertEqual(testee.cookies[0].value, "value")
+
+    }
+    
+    func testWhenNewThenCookiesIsEmpty() {
+        XCTAssertTrue(testee.cookies.isEmpty)
+    }
+    
+    private func cookie(_ name: String, _ value: String) -> HTTPCookie {
+        return HTTPCookie(properties: [.name: name, .value: value, .path: "/", .domain: "example.com"])!
+    }
+    
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/681801063131984
Tech Design URL:
CC:

**Description**:

Clears all data and retains cookies for DuckDuckGo.

Data expunging should work on both iOS 10 and 11, but retaining the cookies will only work on iOS 11.

**Steps to test this PR**:

Test 1

1. Visit https://cdn.cliqz.com/browser-f/fun-demo/test-webworker-indexed-db.html
1. Refresh the page and observe counter incrementing
1. Forget all 🔥 
1. Visit https://cdn.cliqz.com/browser-f/fun-demo/test-webworker-indexed-db.html and observe counter back at 1

Test 2

1. Visit DuckDuckGo.com, apply some settings (e.g. location, safe search off)
1. Forget all 🔥 
1. Visit DuckDuckGo.com, settings should still be applied

Test 3

1. Visit DuckDuckGo.com, apply some settings (e.g. location, safe search off)
1. Forget all 🔥 
1. Stop the app
1. Launch the app
1. Visit DuckDuckGo.com, settings should still be applied

Test 4

1. Login to a site that uses cookies
1. Forget all 🔥 
1. Return to previous site
1. Should now be logged out

Test 5
1. Visit DuckDuckGo.com, apply some settings (e.g. location, safe search off)
1. Forget all 🔥 
1. Visit DuckDuckGo.com, and change a setting
1. Kill the app
1. Launch the app (latest settings should apply)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)