### PR TITLE
fix autocomplete glitch during a call

### DIFF
--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -54,9 +54,16 @@ class AutocompleteViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        adjustForInCall()
         configureNavigationBar()
     }
-    
+
+    // If auto complete is used after the in-call banner is shown it has the wrong y position (should be zero)
+    private func adjustForInCall() {
+        let frame = self.view.frame
+        self.view.frame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
+    }
+
     private func configureNavigationBar() {
         hidesBarsOnSwipeDefault = navigationController?.hidesBarsOnSwipe ?? hidesBarsOnSwipeDefault
         navigationController?.hidesBarsOnSwipe = false


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/582693283193900
Tech Design URL:
CC:

**Description**:

Fix glitch when in-call bar is showing before autocomplete is used.


**Steps to test this PR**:

Test 1
1. On a non- iPhone X simulator, toggle the in-call status bar
1. Start typing so an auto complete appears - there should no longer be a gap

Test 2
1. Start typing so auto complete appears
1. Toggle in call status - auto complete shows correctly



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)