### PR TITLE
Allow other apps to share with our app

### DIFF
--- a/Core/AppDeepLinks.swift
+++ b/Core/AppDeepLinks.swift
@@ -44,9 +44,6 @@ public struct AppDeepLinks {
     }
     
     public static func query(fromQuickLink url: URL) -> String {
-        let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true)!
-        components.scheme = nil // remove scheme
-        let string = String(components.url!.absoluteString.dropFirst(2)) // strip off '//' prefix
-        return string
+        return url.absoluteString.replacingOccurrences(of: quickLink , with: "", options: .caseInsensitive)
     }
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		8364F7131F961E5E00562989 /* DisconnectMeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364F7111F961DDB00562989 /* DisconnectMeStoreTests.swift */; };
 		836B6B6A1F67F11E0061ECFB /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836B6B691F67F11E0061ECFB /* ContentBlockerTests.swift */; };
 		8382E9F2207D61F000708757 /* TabIconMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8382E9F1207D61F000708757 /* TabIconMaker.swift */; };
+		8390446F20BDCE10006461CD /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8390446E20BDCE10006461CD /* ShareViewController.swift */; };
+		8390447220BDCE10006461CD /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8390447020BDCE10006461CD /* MainInterface.storyboard */; };
+		8390447620BDCE10006461CD /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 8390446C20BDCE10006461CD /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		8390447C20BDDCFC006461CD /* AppDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17D723B1E8BB374003E8B0E /* AppDeepLinks.swift */; };
 		83B8BDAF20AB14A70076D6A1 /* APIHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */; };
 		83D306A41F6D500B00ED7CE2 /* tosdr.json in Resources */ = {isa = PBXBuildFile; fileRef = 83D306A31F6D500B00ED7CE2 /* tosdr.json */; };
 		83DBCA7B1F7BBB5000DFD170 /* TopSitesReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DBCA7A1F7BBB5000DFD170 /* TopSitesReport.swift */; };
@@ -302,6 +306,13 @@
 			remoteGlobalIDString = 84E341911E2F7EFB00BDBA6F;
 			remoteInfo = DuckDuckGo;
 		};
+		8390447420BDCE10006461CD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84E3418A1E2F7EFB00BDBA6F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8390446B20BDCE10006461CD;
+			remoteInfo = ShareExtension;
+		};
 		83DBCA7D1F7BBB5000DFD170 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 84E3418A1E2F7EFB00BDBA6F /* Project object */;
@@ -340,6 +351,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		83E282AC20BC1840005FBE88 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				8390447620BDCE10006461CD /* ShareExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F10307651E7D5B2C0059FEC7 /* Copy Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -380,6 +402,10 @@
 		836B6B6B1F67F11E0061ECFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		836B6B711F67F1590061ECFB /* TrackerPageMocks */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TrackerPageMocks; sourceTree = "<group>"; };
 		8382E9F1207D61F000708757 /* TabIconMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIconMaker.swift; sourceTree = "<group>"; };
+		8390446C20BDCE10006461CD /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		8390446E20BDCE10006461CD /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		8390447120BDCE10006461CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		8390447320BDCE10006461CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHeadersTests.swift; sourceTree = "<group>"; };
 		83D306A31F6D500B00ED7CE2 /* tosdr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tosdr.json; sourceTree = "<group>"; };
 		83DBCA781F7BBB5000DFD170 /* TopSitesReport.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TopSitesReport.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -686,6 +712,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8390446920BDCE10006461CD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		83DBCA751F7BBB5000DFD170 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -853,6 +886,16 @@
 			name = Converters;
 			sourceTree = "<group>";
 		};
+		8390446D20BDCE10006461CD /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				8390446E20BDCE10006461CD /* ShareViewController.swift */,
+				8390447020BDCE10006461CD /* MainInterface.storyboard */,
+				8390447320BDCE10006461CD /* Info.plist */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
 		83DBCA791F7BBB5000DFD170 /* TopSitesReport */ = {
 			isa = PBXGroup;
 			children = (
@@ -879,6 +922,7 @@
 				F143C2E51E4A4CD400CFDE3A /* Core */,
 				F1EEAC461EAFC708006128D9 /* Fonts */,
 				F1AA54621E48D90700223211 /* TodayExtension */,
+				8390446D20BDCE10006461CD /* ShareExtension */,
 				84E341A91E2F7EFB00BDBA6F /* UnitTests */,
 				836B6B681F67F11E0061ECFB /* IntegrationTests */,
 				83DBCA791F7BBB5000DFD170 /* TopSitesReport */,
@@ -903,6 +947,7 @@
 				83DBCA781F7BBB5000DFD170 /* TopSitesReport.xctest */,
 				85CC936B203C402C00690089 /* SpeedTests.xctest */,
 				8512BCB320612E500085E862 /* UITests.xctest */,
+				8390446C20BDCE10006461CD /* ShareExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1889,6 +1934,23 @@
 			productReference = 836B6B671F67F11E0061ECFB /* IntegrationTests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		8390446B20BDCE10006461CD /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8390447720BDCE10006461CD /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				8390446820BDCE10006461CD /* Sources */,
+				8390446920BDCE10006461CD /* Frameworks */,
+				8390446A20BDCE10006461CD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtension;
+			productName = ShareExtension;
+			productReference = 8390446C20BDCE10006461CD /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		83DBCA771F7BBB5000DFD170 /* TopSitesReport */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 83DBCA7F1F7BBB5000DFD170 /* Build configuration list for PBXNativeTarget "TopSitesReport" */;
@@ -1918,11 +1980,13 @@
 				F143C2F01E4A4CD400CFDE3A /* Embed Frameworks */,
 				F10307651E7D5B2C0059FEC7 /* Copy Frameworks */,
 				F17BA4411F1CD9D300460FFA /* Cathage Copy Frameworks */,
+				83E282AC20BC1840005FBE88 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				F143C2EA1E4A4CD400CFDE3A /* PBXTargetDependency */,
+				8390447520BDCE10006461CD /* PBXTargetDependency */,
 			);
 			name = DuckDuckGo;
 			productName = DuckDuckGo;
@@ -2025,7 +2089,7 @@
 		84E3418A1E2F7EFB00BDBA6F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
+				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = DuckDuckGo;
 				TargetAttributes = {
@@ -2035,6 +2099,11 @@
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 84E341911E2F7EFB00BDBA6F;
+					};
+					8390446B20BDCE10006461CD = {
+						CreatedOnToolsVersion = 9.3.1;
+						DevelopmentTeam = HKE973VLUW;
+						ProvisioningStyle = Automatic;
 					};
 					83DBCA771F7BBB5000DFD170 = {
 						CreatedOnToolsVersion = 8.3.3;
@@ -2110,11 +2179,12 @@
 			targets = (
 				84E341911E2F7EFB00BDBA6F /* DuckDuckGo */,
 				F143C2E31E4A4CD400CFDE3A /* Core */,
+				8390446B20BDCE10006461CD /* ShareExtension */,
+				F1AA545D1E48D90700223211 /* TodayExtension */,
 				84E341A51E2F7EFB00BDBA6F /* UnitTests */,
 				836B6B661F67F11E0061ECFB /* IntegrationTests */,
 				85CC936A203C402C00690089 /* SpeedTests */,
 				83DBCA771F7BBB5000DFD170 /* TopSitesReport */,
-				F1AA545D1E48D90700223211 /* TodayExtension */,
 				8512BCB220612E500085E862 /* UITests */,
 			);
 		};
@@ -2125,6 +2195,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8390446A20BDCE10006461CD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8390447220BDCE10006461CD /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2296,6 +2374,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				836B6B6A1F67F11E0061ECFB /* ContentBlockerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8390446820BDCE10006461CD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8390447C20BDDCFC006461CD /* AppDeepLinks.swift in Sources */,
+				8390446F20BDCE10006461CD /* ShareViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2574,6 +2661,11 @@
 			target = 84E341911E2F7EFB00BDBA6F /* DuckDuckGo */;
 			targetProxy = 836B6B6C1F67F11E0061ECFB /* PBXContainerItemProxy */;
 		};
+		8390447520BDCE10006461CD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8390446B20BDCE10006461CD /* ShareExtension */;
+			targetProxy = 8390447420BDCE10006461CD /* PBXContainerItemProxy */;
+		};
 		83DBCA7E1F7BBB5000DFD170 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 84E341911E2F7EFB00BDBA6F /* DuckDuckGo */;
@@ -2602,6 +2694,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		8390447020BDCE10006461CD /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8390447120BDCE10006461CD /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		84E341991E2F7EFB00BDBA6F /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -2690,6 +2790,52 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = DuckDuckGo;
+			};
+			name = Release;
+		};
+		8390447820BDCE10006461CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HKE973VLUW;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.mobile.ios.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8390447920BDCE10006461CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = HKE973VLUW;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.mobile.ios.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2844,6 +2990,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = DuckDuckGo/DuckDuckGo.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = HKE973VLUW;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2867,6 +3014,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = DuckDuckGo/DuckDuckGo.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = HKE973VLUW;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3119,6 +3267,15 @@
 			buildConfigurations = (
 				836B6B6E1F67F11E0061ECFB /* Debug */,
 				836B6B6F1F67F11E0061ECFB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8390447720BDCE10006461CD /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8390447820BDCE10006461CD /* Debug */,
+				8390447920BDCE10006461CD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -19,10 +19,10 @@
 		8364F7131F961E5E00562989 /* DisconnectMeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364F7111F961DDB00562989 /* DisconnectMeStoreTests.swift */; };
 		836B6B6A1F67F11E0061ECFB /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836B6B691F67F11E0061ECFB /* ContentBlockerTests.swift */; };
 		8382E9F2207D61F000708757 /* TabIconMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8382E9F1207D61F000708757 /* TabIconMaker.swift */; };
+		838306B320C704050045E854 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F143C2E41E4A4CD400CFDE3A /* Core.framework */; };
 		8390446F20BDCE10006461CD /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8390446E20BDCE10006461CD /* ShareViewController.swift */; };
 		8390447220BDCE10006461CD /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8390447020BDCE10006461CD /* MainInterface.storyboard */; };
 		8390447620BDCE10006461CD /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 8390446C20BDCE10006461CD /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		8390447C20BDDCFC006461CD /* AppDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17D723B1E8BB374003E8B0E /* AppDeepLinks.swift */; };
 		83B8BDAF20AB14A70076D6A1 /* APIHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */; };
 		83D306A41F6D500B00ED7CE2 /* tosdr.json in Resources */ = {isa = PBXBuildFile; fileRef = 83D306A31F6D500B00ED7CE2 /* tosdr.json */; };
 		83DBCA7B1F7BBB5000DFD170 /* TopSitesReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DBCA7A1F7BBB5000DFD170 /* TopSitesReport.swift */; };
@@ -716,6 +716,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				838306B320C704050045E854 /* Core.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2381,7 +2382,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8390447C20BDDCFC006461CD /* AppDeepLinks.swift in Sources */,
 				8390446F20BDCE10006461CD /* ShareViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -404,6 +404,19 @@
 		836B6B711F67F1590061ECFB /* TrackerPageMocks */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TrackerPageMocks; sourceTree = "<group>"; };
 		8382E9F1207D61F000708757 /* TabIconMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIconMaker.swift; sourceTree = "<group>"; };
 		838306E220C733010045E854 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306E520C734D80045E854 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306E620C735140045E854 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306E720C735F60045E854 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306E820C7361E0045E854 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306E920C7366C0045E854 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306EA20C7367D0045E854 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306EB20C7368A0045E854 /* no */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = no; path = no.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306EC20C736A80045E854 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306ED20C736B10045E854 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306EE20C736BA0045E854 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306EF20C736C50045E854 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		838306F020C736D00045E854 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		838306F120C736DF0045E854 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		8390446C20BDCE10006461CD /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8390446E20BDCE10006461CD /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		8390447120BDCE10006461CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -2175,6 +2188,18 @@
 			knownRegions = (
 				en,
 				Base,
+				es,
+				fi,
+				id,
+				ja,
+				ko,
+				no,
+				pt,
+				ru,
+				sv,
+				tr,
+				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = 84E341891E2F7EFB00BDBA6F;
 			productRefGroup = 84E341931E2F7EFB00BDBA6F /* Products */;
@@ -2702,6 +2727,19 @@
 			isa = PBXVariantGroup;
 			children = (
 				838306E220C733010045E854 /* en */,
+				838306E520C734D80045E854 /* fr */,
+				838306E620C735140045E854 /* es */,
+				838306E720C735F60045E854 /* fi */,
+				838306E820C7361E0045E854 /* id */,
+				838306E920C7366C0045E854 /* ja */,
+				838306EA20C7367D0045E854 /* ko */,
+				838306EB20C7368A0045E854 /* no */,
+				838306EC20C736A80045E854 /* pt */,
+				838306ED20C736B10045E854 /* ru */,
+				838306EE20C736BA0045E854 /* sv */,
+				838306EF20C736C50045E854 /* tr */,
+				838306F020C736D00045E854 /* zh-Hans */,
+				838306F120C736DF0045E854 /* zh-Hant */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		836B6B6A1F67F11E0061ECFB /* ContentBlockerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836B6B691F67F11E0061ECFB /* ContentBlockerTests.swift */; };
 		8382E9F2207D61F000708757 /* TabIconMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8382E9F1207D61F000708757 /* TabIconMaker.swift */; };
 		838306B320C704050045E854 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F143C2E41E4A4CD400CFDE3A /* Core.framework */; };
+		838306E320C733010045E854 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 838306E120C733010045E854 /* InfoPlist.strings */; };
 		8390446F20BDCE10006461CD /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8390446E20BDCE10006461CD /* ShareViewController.swift */; };
 		8390447220BDCE10006461CD /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8390447020BDCE10006461CD /* MainInterface.storyboard */; };
 		8390447620BDCE10006461CD /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 8390446C20BDCE10006461CD /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -402,6 +403,7 @@
 		836B6B6B1F67F11E0061ECFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		836B6B711F67F1590061ECFB /* TrackerPageMocks */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TrackerPageMocks; sourceTree = "<group>"; };
 		8382E9F1207D61F000708757 /* TabIconMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIconMaker.swift; sourceTree = "<group>"; };
+		838306E220C733010045E854 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8390446C20BDCE10006461CD /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8390446E20BDCE10006461CD /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		8390447120BDCE10006461CD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -893,6 +895,7 @@
 				8390446E20BDCE10006461CD /* ShareViewController.swift */,
 				8390447020BDCE10006461CD /* MainInterface.storyboard */,
 				8390447320BDCE10006461CD /* Info.plist */,
+				838306E120C733010045E854 /* InfoPlist.strings */,
 			);
 			path = ShareExtension;
 			sourceTree = "<group>";
@@ -2204,6 +2207,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8390447220BDCE10006461CD /* MainInterface.storyboard in Resources */,
+				838306E320C733010045E854 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2694,6 +2698,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		838306E120C733010045E854 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				838306E220C733010045E854 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		8390447020BDCE10006461CD /* MainInterface.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/ShareExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/ShareExtension.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8390446B20BDCE10006461CD"
+               BuildableName = "ShareExtension.appex"
+               BlueprintName = "ShareExtension"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+               BuildableName = "DuckDuckGo.app"
+               BlueprintName = "DuckDuckGo"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8390446B20BDCE10006461CD"
+            BuildableName = "ShareExtension.appex"
+            BlueprintName = "ShareExtension"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DuckDuckGoTests/AppDeepLinksTests.swift
+++ b/DuckDuckGoTests/AppDeepLinksTests.swift
@@ -22,32 +22,51 @@ import XCTest
 
 class AppDeepLinksTests: XCTestCase {
     
-    func testLowercaseQuickLinkIsDetected() {
-        XCTAssert(AppDeepLinks.isQuickLink(url: URL(string: "ddgquicklink://foo.bar")!))
+    func testWhenLinkIsLowercaseQuickLinkThenDetected() {
+        XCTAssertTrue(AppDeepLinks.isQuickLink(url: URL(string: "ddgquicklink://foo.bar")!))
     }
     
-    func testUppercaseQuickLinkIsDetected() {
-        XCTAssert(AppDeepLinks.isQuickLink(url: URL(string: "DDGQUICKLINK://foo.bar")!))
+    func testWhenLinkIsUppercaseQuicklinkThenDetected() {
+        XCTAssertTrue(AppDeepLinks.isQuickLink(url: URL(string: "DDGQUICKLINK://foo.bar")!))
     }
     
-    func testCamelCaseQuickLinkIsDetected() {
-        XCTAssert(AppDeepLinks.isQuickLink(url: URL(string: "ddgQuickLink://foo.bar")!))
+    func testWhenLinkIsCamelCaseQuickLinkThenDetected() {
+        XCTAssertTrue(AppDeepLinks.isQuickLink(url: URL(string: "ddgQuickLink://foo.bar")!))
     }
     
-    func testLowercaseQuickLinkQueryIsExtracted() {
+    func testWhenLinkIsNotQuickLinkThenNotDetected() {
+        XCTAssertFalse(AppDeepLinks.isQuickLink(url: URL(string: "someOtherType://foo.bar")!))
+    }
+    
+    func testWhenLinkIsLowercaseQuickLinkThenQueryIsExtracted() {
         XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar")!), "foo.bar")
     }
     
-    func testLowercaseQuickLinkQueryIsExtractedURLPathPreserved() {
-        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123")!), "foo.bar/baz/123")
+    func testWhenLinkIsUppercaseQuickLinkThenQueryIsExtracted() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "DDGQUICKLINK://foo.bar")!), "foo.bar")
     }
     
-    func testLowercaseQuickLinkQueryIsExtractedURLQueryPreserved() {
+    func testWhenLinkIsCamelCaseQuickLinkThenQueryIsExtracted() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgQuickLink://foo.bar")!), "foo.bar")
+    }
+    
+    func testWhenLinkIsNotQuickLinkThenQueryIsSame() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "someOtherType://foo.bar")!), "someOtherType://foo.bar")
+    }
+    
+    func testWhenQuickLinkIsExtractedThenURLSchemeIsPreserved() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://https://foo.bar")!), "https://foo.bar")
+    }
+    
+    func testWhenQuickLinkIsExtractedThenURLPathPreserved() {
+        XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123")!), "foo.bar/baz/123")
+    }
+ 
+    func testWhenQuickLinkIsExtractedThenURLQueryPreserved() {
         XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123?A=b&c=D")!), "foo.bar/baz/123?A=b&c=D")
     }
     
-    func testLowercaseQuickLinkQueryIsExtractedURLFragmentPreserved() {
+    func testWhenQuickLinkIsExtractedThenURLFragmentPreserved() {
         XCTAssertEqual(AppDeepLinks.query(fromQuickLink: URL(string: "ddgquicklink://foo.bar/baz/123#hello-world?A=b&c=D")!), "foo.bar/baz/123#hello-world?A=b&c=D")
     }
-    
 }

--- a/ShareExtension/Base.lproj/MainInterface.storyboard
+++ b/ShareExtension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A278a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ShareExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Open in DuckDuckGo</string>
+	<string>DuckDuckGo</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -25,7 +25,12 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<string>TRUEPREDICATE</string>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+			</dict>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>ShareExtension</string>
+	<string>Open in DuckDuckGo</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -1,0 +1,89 @@
+//
+//  ShareViewController.swift
+//  ShareExtension
+//
+//  Copyright © 2017 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import Social
+
+class ShareViewController: SLComposeServiceViewController {
+    
+    struct Identifier {
+        static let url = "public.url"
+        static let text = "public.plain-text"
+    }
+    
+    struct Constants {
+        static let openURLSelector = "openURL:"
+    }
+    
+    override func configurationItems() -> [Any]! {
+        if let urlProvider = getItemProvider(identifier: Identifier.url) {
+            loadUrl(fromUrlProvider: urlProvider)
+        }
+        if let textProvider = getItemProvider(identifier: Identifier.text) {
+            loadText(fromTextProvider: textProvider)
+        }
+        return []
+    }
+    
+    private func getItemProvider(identifier: String) -> NSItemProvider? {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem else {
+            return nil
+        }
+        guard let itemProvider = item.attachments?.first as? NSItemProvider else {
+            return nil
+        }
+        if itemProvider.hasItemConformingToTypeIdentifier(identifier) {
+            return itemProvider
+        }
+        return nil
+    }
+    
+    private func loadUrl(fromUrlProvider urlProvider: NSItemProvider) {
+        urlProvider.loadItem(forTypeIdentifier: Identifier.url, options: nil) { [weak self] (item, error) in
+            if let url = item as? URL {
+                self?.open(query: url.absoluteString)
+            }
+        }
+    }
+    
+    private func loadText(fromTextProvider textProvider: NSItemProvider) {
+        textProvider.loadItem(forTypeIdentifier: Identifier.text, options: nil) { [weak self] (item, error) in
+            guard let query = item as? String else { return }
+            self?.open(query: query)
+        }
+    }
+    
+    private func open(query: String) {
+        let selector = sel_registerName(Constants.openURLSelector)
+        let deepLink = URL(string: "\(AppDeepLinks.quickLink)\(query)")!
+
+        var responder = self as UIResponder?
+        while (responder != nil) {
+            if responder!.responds(to: selector) {
+                _ = responder?.perform(selector, with: deepLink, with: {})
+            }
+            responder = responder!.next
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.cancel()
+        }
+    }
+    
+}

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -19,6 +19,7 @@
 
 import UIKit
 import Social
+import Core
 
 class ShareViewController: SLComposeServiceViewController {
     
@@ -57,7 +58,7 @@ class ShareViewController: SLComposeServiceViewController {
     private func loadUrl(fromUrlProvider urlProvider: NSItemProvider) {
         urlProvider.loadItem(forTypeIdentifier: Identifier.url, options: nil) { [weak self] (item, error) in
             if let url = item as? URL {
-                self?.open(query: url.absoluteString)
+                self?.open(url: url)
             }
         }
     }
@@ -65,13 +66,12 @@ class ShareViewController: SLComposeServiceViewController {
     private func loadText(fromTextProvider textProvider: NSItemProvider) {
         textProvider.loadItem(forTypeIdentifier: Identifier.text, options: nil) { [weak self] (item, error) in
             guard let query = item as? String else { return }
-            self?.open(query: query)
+            self?.open(url: AppUrls().url(forQuery: query))
         }
     }
-    
-    private func open(query: String) {
+    private func open(url: URL) {
         let selector = sel_registerName(Constants.openURLSelector)
-        let deepLink = URL(string: "\(AppDeepLinks.quickLink)\(query)")!
+        let deepLink = URL(string: "\(AppDeepLinks.quickLink)\(url)")!
 
         var responder = self as UIResponder?
         while (responder != nil) {

--- a/ShareExtension/en.lproj/InfoPlist.strings
+++ b/ShareExtension/en.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "Open in DuckDuckGo";
+

--- a/ShareExtension/es.lproj/InfoPlist.strings
+++ b/ShareExtension/es.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/fi.lproj/InfoPlist.strings
+++ b/ShareExtension/fi.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/fr.lproj/InfoPlist.strings
+++ b/ShareExtension/fr.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/id.lproj/InfoPlist.strings
+++ b/ShareExtension/id.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/ja.lproj/InfoPlist.strings
+++ b/ShareExtension/ja.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/ko.lproj/InfoPlist.strings
+++ b/ShareExtension/ko.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/no.lproj/InfoPlist.strings
+++ b/ShareExtension/no.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/pt.lproj/InfoPlist.strings
+++ b/ShareExtension/pt.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/ru.lproj/InfoPlist.strings
+++ b/ShareExtension/ru.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/sv.lproj/InfoPlist.strings
+++ b/ShareExtension/sv.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/tr.lproj/InfoPlist.strings
+++ b/ShareExtension/tr.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/zh-Hans.lproj/InfoPlist.strings
+++ b/ShareExtension/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+

--- a/ShareExtension/zh-Hant.lproj/InfoPlist.strings
+++ b/ShareExtension/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "DuckDuckGo";
+


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/683523325946469
Tech Design URL:
CC:

**Description**:
• Allows other apps to share text and urls with our app
• Also fixes a bug that garbled the scheme of shared urls turning them into a query (e.g urls pasted via force touch)

**Steps to test this PR**:
**TEST 1**
1. Kill the ddg app
1. Open safari and navigate to a url e.g example.com
1. Share the url with our app
1. Ensure the url opens in a new tab

**TEST 2**
Repeat previous test, this time skipping step 1 (don't kill the app first)

**TEST 3**
1. Kill the ddg app
1. Open safari and navigate to a url e.g example.com
1. Highlight some text e.g "This domain is established" from example.com and share it with our app
1. Ensure the shared text opens as a query in a new tab

**TEST 4**
Repeat previous test, this time skipping step 1 (don't kill the app first)

**TEST 5**
1. From safari, copy a full url to the clipboard
1. Now force touch on our app icon and select "Paste from clipboard"
1. Ensure the url opens (rather than a query on our serp)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
