### PR TITLE
Fix #328

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -439,8 +439,8 @@ extension TabViewController: WebEventsDelegate {
         self.httpsForced = httpsForced
         delegate?.showBars()
 
-        // if host is the same use same protection id and don't inject scripts, otherwise, reset and reload
-        if let siteRating = siteRating, siteRating.url.host == url?.host {
+        // if host and scheme are the same, use same protection id and don't inject scripts, otherwise, reset and reload
+        if let siteRating = siteRating, siteRating.url.host == url?.host, siteRating.url.scheme == url?.scheme {
             self.siteRating = SiteRating(url: siteRating.url, httpsForced: httpsForced, protectionId: siteRating.protectionId)
         } else {
             resetSiteRating()


### PR DESCRIPTION
Refresh the site rating if the scheme is changed

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #328 
Tech Design URL:
CC:

**Description**:
Previously, the site rating is refreshed if and only if the site rating doesn't exit or the host is changed. However, the site rating should be refresh if the scheme is changed. Because changing scheme from `https` to/from `http` will also affect the rating

**Steps to test this PR**:
1. Go to `http://www.ust.hk`
1. Check the site rating, and the encryption type is `unencrypted`
1. Change `http` to `https` in the url
1. Check the site rating again and the encryption type is now `mixed`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
