### PR TITLE
separate atb and variant to remove duplicate variant storage

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -96,8 +96,8 @@ public struct AppUrls {
 
     public var atb: URL {
         var url = URL(string: Url.atb)!
-        if let atb = statisticsStore.atb, let setAtb = statisticsStore.retentionAtb {
-            url = url.addParam(name: Param.atb, value: atb)
+        if let atbWithVariant = statisticsStore.atbWithVariant, let setAtb = statisticsStore.retentionAtb {
+            url = url.addParam(name: Param.atb, value: atbWithVariant)
             url = url.addParam(name: Param.setAtb, value: setAtb)
         }
         return url
@@ -138,8 +138,8 @@ public struct AppUrls {
 
     public func applyStatsParams(for url: URL) -> URL {
         var searchUrl = url.addParam(name: Param.source, value: ParamValue.source)
-        if let atb = statisticsStore.atb {
-            searchUrl = searchUrl.addParam(name: Param.atb, value: atb)
+        if let atbWithVariant = statisticsStore.atbWithVariant {
+            searchUrl = searchUrl.addParam(name: Param.atb, value: atbWithVariant)
         }
         
         return searchUrl
@@ -157,8 +157,8 @@ public struct AppUrls {
 
     public func hasCorrectMobileStatsParams(url: URL) -> Bool {
         guard let source = url.getParam(name: Param.source), source == ParamValue.source  else { return false }
-        if let atb = statisticsStore.atb {
-            return atb == url.getParam(name: Param.atb)
+        if let atbWithVariant = statisticsStore.atbWithVariant {
+            return atbWithVariant == url.getParam(name: Param.atb)
         }
         return true
     }

--- a/Core/AtbAndVariantCleanup.swift
+++ b/Core/AtbAndVariantCleanup.swift
@@ -1,0 +1,39 @@
+//
+//  AtbAndVariantCleanup.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public class AtbAndVariantCleanup {
+    
+    public static func cleanup(statisticsStorage: StatisticsStore = StatisticsUserDefaults(), variantManager: VariantManager = DefaultVariantManager()) {
+        guard let variant = statisticsStorage.variant else { return }
+        
+        // clean up ATB
+        if let atb = statisticsStorage.atb, atb.hasSuffix(variant) {
+            statisticsStorage.atb = String(atb.dropLast(variant.count))
+        }
+
+        // remove existing variant if not in an experiment
+        if variantManager.currentVariant == nil {
+            statisticsStorage.variant = nil
+        }
+        
+    }
+
+}

--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -70,7 +70,7 @@ public class StatisticsLoader {
                 completion()
                 return
             }
-            self.statisticsStore.atb = installAtb
+            self.statisticsStore.atb = atb.version
             self.statisticsStore.retentionAtb = retentionAtb
             completion()
         }

--- a/Core/StatisticsStore.swift
+++ b/Core/StatisticsStore.swift
@@ -26,5 +26,7 @@ public protocol StatisticsStore: class {
     var atb: String? { get set }
     var retentionAtb: String? { get set }
     var variant: String? { get set }
+
+    var atbWithVariant: String? { get }
     
 }

--- a/Core/StatisticsUserDefaults.swift
+++ b/Core/StatisticsUserDefaults.swift
@@ -36,11 +36,6 @@ public class StatisticsUserDefaults: StatisticsStore {
     
     public init(groupName: String = "group.com.duckduckgo.statistics") {
         self.groupName = groupName
-        
-        if let atb = atb, let variant = variant, atb.hasSuffix(variant) {
-            self.atb = String(atb.dropLast(variant.count))
-        }
-        
     }
     
     public var hasInstallStatistics: Bool {

--- a/Core/StatisticsUserDefaults.swift
+++ b/Core/StatisticsUserDefaults.swift
@@ -34,8 +34,13 @@ public class StatisticsUserDefaults: StatisticsStore {
         return UserDefaults(suiteName: groupName)
     }
     
-    public init(groupName: String =  "group.com.duckduckgo.statistics") {
+    public init(groupName: String = "group.com.duckduckgo.statistics") {
         self.groupName = groupName
+        
+        if let atb = atb, let variant = variant, atb.hasSuffix(variant) {
+            self.atb = String(atb.dropLast(variant.count))
+        }
+        
     }
     
     public var hasInstallStatistics: Bool {
@@ -68,6 +73,11 @@ public class StatisticsUserDefaults: StatisticsStore {
         set{
             userDefaults?.setValue(newValue, forKey: Keys.variant)
         }
+    }
+    
+    public var atbWithVariant: String? {
+        guard let atb = atb else { return nil }
+        return "\(atb)\(variant ?? "")"
     }
     
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		84E341961E2F7EFB00BDBA6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E341951E2F7EFB00BDBA6F /* AppDelegate.swift */; };
 		84E3419B1E2F7EFB00BDBA6F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84E341991E2F7EFB00BDBA6F /* Main.storyboard */; };
 		84E341A01E2F7EFB00BDBA6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84E3419E1E2F7EFB00BDBA6F /* LaunchScreen.storyboard */; };
+		850250B320D803F4002199C7 /* AtbAndVariantCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850250B220D803F4002199C7 /* AtbAndVariantCleanup.swift */; };
+		850250B520D80419002199C7 /* AtbAndVariantCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850250B420D80419002199C7 /* AtbAndVariantCleanupTests.swift */; };
 		85047B821F6827AD002A95D8 /* blockerdata.js in Resources */ = {isa = PBXBuildFile; fileRef = 85047B811F6827AD002A95D8 /* blockerdata.js */; };
 		85047B861F6887D2002A95D8 /* BlockerListsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85047B851F6887D2002A95D8 /* BlockerListsLoader.swift */; };
 		85047B881F6966ED002A95D8 /* disconnectme.js in Resources */ = {isa = PBXBuildFile; fileRef = 85047B871F6966ED002A95D8 /* disconnectme.js */; };
@@ -439,6 +441,8 @@
 		84E341A11E2F7EFB00BDBA6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84E341A61E2F7EFB00BDBA6F /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		84E341AC1E2F7EFB00BDBA6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		850250B220D803F4002199C7 /* AtbAndVariantCleanup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtbAndVariantCleanup.swift; sourceTree = "<group>"; };
+		850250B420D80419002199C7 /* AtbAndVariantCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtbAndVariantCleanupTests.swift; sourceTree = "<group>"; };
 		85047B811F6827AD002A95D8 /* blockerdata.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = blockerdata.js; sourceTree = "<group>"; };
 		85047B851F6887D2002A95D8 /* BlockerListsLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockerListsLoader.swift; sourceTree = "<group>"; };
 		85047B871F6966ED002A95D8 /* disconnectme.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = disconnectme.js; sourceTree = "<group>"; };
@@ -1234,6 +1238,7 @@
 		F1134EA71F3E2B3500B73467 /* Statistics */ = {
 			isa = PBXGroup;
 			children = (
+				850250B220D803F4002199C7 /* AtbAndVariantCleanup.swift */,
 				85C11E3D20904B8400BFFEB4 /* VariantManager.swift */,
 				F1134EB41F40AEEA00B73467 /* StatisticsLoader.swift */,
 				F1134EB11F40AC6A00B73467 /* Domain */,
@@ -1275,6 +1280,7 @@
 				F1134ECB1F40EA0300B73467 /* Parser */,
 				83EDCC3F1F86B895005CDFCD /* StatisticsLoaderTests.swift */,
 				85C11E4020904BBE00BFFEB4 /* VariantManagerTests.swift */,
+				850250B420D80419002199C7 /* AtbAndVariantCleanupTests.swift */,
 			);
 			name = Statistics;
 			sourceTree = "<group>";
@@ -2580,6 +2586,7 @@
 				F1134ED21F40EF3A00B73467 /* JsonTestDataLoader.swift in Sources */,
 				85A1B3B420C6D07100C18F15 /* CookieStorageTests.swift in Sources */,
 				85F591251FD1BFAA00746C77 /* DisconnectMeTrackerTests.swift in Sources */,
+				850250B520D80419002199C7 /* AtbAndVariantCleanupTests.swift in Sources */,
 				F17D72391E8B35C6003E8B0E /* AppUrlsTests.swift in Sources */,
 				F1134ED61F40F29F00B73467 /* StatisticsUserDefaultsTests.swift in Sources */,
 				83B8BDAF20AB14A70076D6A1 /* APIHeadersTests.swift in Sources */,
@@ -2656,6 +2663,7 @@
 				85BA79911F6FF75000F59015 /* ContentBlockerStoreConstants.swift in Sources */,
 				85047B861F6887D2002A95D8 /* BlockerListsLoader.swift in Sources */,
 				F1134EDA1F40FC3F00B73467 /* InfoBundle.swift in Sources */,
+				850250B320D803F4002199C7 /* AtbAndVariantCleanup.swift in Sources */,
 				F143C3181E4A99D200CFDE3A /* Link.swift in Sources */,
 				8364F7101F95FA7600562989 /* DisconnectMeStore.swift in Sources */,
 				F1CE42A61ECA0A460074A8DF /* BookmarkUserDefaults.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -46,6 +46,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // assign it here, because "did become active" is already too late and "viewWillAppear"
         // has already been called on the HomeViewController so won't show the home row CTA
+        AtbAndVariantCleanup.cleanup()
         DefaultVariantManager().assignVariantIfNeeded()
         
         appIsLaunching = true

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -35,7 +35,7 @@ class AppUrlsTests: XCTestCase {
     }
 
     func testWhenMobileStatsParamsAreAppliedThenTheyReturnAnUpdatedUrl() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let actual = testee.applyStatsParams(for: URL(string: "http://duckduckgo.com?atb=wrong&t=wrong")!)
         XCTAssertEqual(actual.getParam(name: "atb"), "x")
@@ -43,35 +43,35 @@ class AppUrlsTests: XCTestCase {
     }
 
     func testWhenAtbMatchesThenHasMobileStatsParamsIsTrue() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios")!)
         XCTAssertTrue(result)
     }
 
     func testWhenAtbIsMismatchedThenHasMobileStatsParamsIsFalse() {
-        mockStatisticsStore.atb = "y"
+        mockStatisticsStore.atbWithVariant = "y"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_ios")!)
         XCTAssertFalse(result)
     }
 
     func testWhenAtbIsMissingThenHasMobileStatsParamsIsFalse() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?t=ddg_ios")!)
         XCTAssertFalse(result)
     }
     
     func testWhenSourceIsMismatchedThenHasMobileStatsParamsIsFalse() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=x&t=ddg_desktop")!)
         XCTAssertFalse(result)
     }
     
     func testWhenSourceIsMissingThenHasMobileStatsParamsIsFalse() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let result = testee.hasCorrectMobileStatsParams(url: URL(string: "http://duckduckgo.com?atb=y")!)
         XCTAssertFalse(result)
@@ -135,7 +135,7 @@ class AppUrlsTests: XCTestCase {
     }
 
     func testWhenAtbParamsPersistsedThenAtbUrlHasParams() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         mockStatisticsStore.retentionAtb = "y"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let url = testee.atb
@@ -162,7 +162,7 @@ class AppUrlsTests: XCTestCase {
     }
 
     func testWhenAtbValuesExistInStatisticsStoreThenSearchUrlCreatesUrlWithAtb() {
-        mockStatisticsStore.atb = "x"
+        mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let urlWithAtb = testee.searchUrl(text: "query")
         XCTAssertEqual(urlWithAtb.getParam(name: "atb"), "x")

--- a/DuckDuckGoTests/AtbAndVariantCleanupTests.swift
+++ b/DuckDuckGoTests/AtbAndVariantCleanupTests.swift
@@ -1,0 +1,60 @@
+//
+//  AtbAndVariantCleanupTests.swift
+//  UnitTests
+//
+//  Created by Chris Brind on 18/06/2018.
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Core
+
+class AtbAndVariantCleanupTests: XCTestCase {
+
+    struct Constants {
+        
+        static let atb = "atb"
+        static let variant = "variant"
+        
+    }
+    
+    let mockStorage = MockStatisticsStore()
+    let mockVariantManager = MockVariantManager()
+
+    func testWhenAtbHasVariantThenAtbStoredWithVariantRemoved() {
+        
+        mockStorage.atb = "\(Constants.atb)\(Constants.variant)"
+        mockStorage.variant = Constants.variant
+        
+        AtbAndVariantCleanup.cleanup(statisticsStorage: mockStorage, variantManager: mockVariantManager)
+        
+        XCTAssertEqual(Constants.atb, mockStorage.atb)
+        
+    }
+   
+    func testWhenVariantIsNotInCurrentExperimentThenVariantRemovedFromStorage() {
+        
+        mockStorage.atb = "\(Constants.atb)\(Constants.variant)"
+        mockStorage.variant = Constants.variant
+
+        AtbAndVariantCleanup.cleanup(statisticsStorage: mockStorage, variantManager: mockVariantManager)
+        
+        XCTAssertNil(mockStorage.variant)
+        
+    }
+    
+    func testWhenVariantIsNInCurrentExperimentThenVariantIsNotRemovedFromStorage() {
+
+        let mockVariantManager = MockVariantManager(currentVariant: Variant(name: Constants.variant, percent: 100, features: []))
+        
+        mockStorage.atb = "\(Constants.atb)\(Constants.variant)"
+        mockStorage.variant = Constants.variant
+
+        AtbAndVariantCleanup.cleanup(statisticsStorage: mockStorage, variantManager: mockVariantManager)
+        
+        XCTAssertEqual(Constants.variant, mockStorage.variant)
+        
+    }
+
+}

--- a/DuckDuckGoTests/AtbAndVariantCleanupTests.swift
+++ b/DuckDuckGoTests/AtbAndVariantCleanupTests.swift
@@ -44,7 +44,7 @@ class AtbAndVariantCleanupTests: XCTestCase {
         
     }
     
-    func testWhenVariantIsNInCurrentExperimentThenVariantIsNotRemovedFromStorage() {
+    func testWhenVariantIsInCurrentExperimentThenVariantIsNotRemovedFromStorage() {
 
         let mockVariantManager = MockVariantManager(currentVariant: Variant(name: Constants.variant, percent: 100, features: []))
         

--- a/DuckDuckGoTests/MockStatisticsStore.swift
+++ b/DuckDuckGoTests/MockStatisticsStore.swift
@@ -31,4 +31,6 @@ class MockStatisticsStore: StatisticsStore {
     
     var variant: String?
     
+    var atbWithVariant: String?
+    
 }

--- a/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -47,7 +47,7 @@ class StatisticsLoaderTests: XCTestCase {
         let expect = expectation(description: "Successfult atb and exti updates store")
         testee.load { () in
             XCTAssertTrue(self.mockStatisticsStore.hasInstallStatistics)
-            XCTAssertEqual(self.mockStatisticsStore.atb, "v77-5x1")
+            XCTAssertEqual(self.mockStatisticsStore.atb, "v77-5")
             XCTAssertEqual(self.mockStatisticsStore.retentionAtb, "v77-5")
             expect.fulfill()
         }

--- a/DuckDuckGoTests/StatisticsUserDefaultsTests.swift
+++ b/DuckDuckGoTests/StatisticsUserDefaultsTests.swift
@@ -37,7 +37,27 @@ class StatisticsUserDefaultsTests: XCTestCase {
         UserDefaults().removePersistentDomain(forName: Constants.userDefaultsSuit)
         testee = StatisticsUserDefaults(groupName: Constants.userDefaultsSuit)
     }
+    
+    func testWhenStoreIsConstructedAndCombinedAtbVariantExistsThenAtbIsCleanedUp() {
+        testee.atb = "\(Constants.atb)\(Constants.variant)"
+        testee.variant = Constants.variant
 
+        let newInstance = StatisticsUserDefaults(groupName: Constants.userDefaultsSuit)
+        XCTAssertEqual(newInstance.atb, Constants.atb)
+    }
+
+    func testWhenAtbAndVariantThenAtbWithVariantThenReturnsAtbWithVariant() {
+        testee.atb = Constants.atb
+        testee.variant = Constants.variant
+        XCTAssertEqual(testee.atbWithVariant, "\(Constants.atb)\(Constants.variant)")
+    }
+    
+    func testWhenAtbAndNoVariantThenAtbWithVariantThenReturnsAtb() {
+        testee.atb = Constants.atb
+        testee.variant = nil
+        XCTAssertEqual(testee.atbWithVariant, Constants.atb)
+    }
+    
     func testWhenVariantSetThenDefaultsIsUpdated() {
         testee.variant = Constants.variant
         XCTAssertEqual(testee.variant, Constants.variant)

--- a/DuckDuckGoTests/StatisticsUserDefaultsTests.swift
+++ b/DuckDuckGoTests/StatisticsUserDefaultsTests.swift
@@ -38,14 +38,6 @@ class StatisticsUserDefaultsTests: XCTestCase {
         testee = StatisticsUserDefaults(groupName: Constants.userDefaultsSuit)
     }
     
-    func testWhenStoreIsConstructedAndCombinedAtbVariantExistsThenAtbIsCleanedUp() {
-        testee.atb = "\(Constants.atb)\(Constants.variant)"
-        testee.variant = Constants.variant
-
-        let newInstance = StatisticsUserDefaults(groupName: Constants.userDefaultsSuit)
-        XCTAssertEqual(newInstance.atb, Constants.atb)
-    }
-
     func testWhenAtbAndVariantThenAtbWithVariantThenReturnsAtbWithVariant() {
         testee.atb = Constants.atb
         testee.variant = Constants.variant


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
* https://app.asana.com/0/414235014887631/680773729972894
* https://app.asana.com/0/414235014887631/680773729972895

Tech Design URL: 
CC:

**Description**:

* Removes duplicate ATB storage
* Cleans up any existing duplication
* Removes variant if not in current experiment

**Steps to test this PR**:

Upgrade
1. Install old version of the app
1. Install this version, check that /exti and search requests contain the correct atb and variant

Install
1. Clean install of this app
1. Check that /exti and search requests contain the correct atb variant


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)