### PR TITLE
crash fixes

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -245,8 +245,6 @@ open class WebViewController: UIViewController {
     }
     
     public func tearDown() {
-        guard let webView = webView else { return }
-        self.webView = nil
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -444,9 +444,11 @@ extension TabViewController: WebEventsDelegate {
             self.siteRating = SiteRating(url: siteRating.url, httpsForced: httpsForced, protectionId: siteRating.protectionId)
         } else {
             resetSiteRating()
-            reloadScripts(with: siteRating!.protectionId)
+            if let protectionId = siteRating?.protectionId {
+                reloadScripts(with: protectionId)
+            }
         }
-        
+
         tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/716678893422650
Tech Design URL:
CC: 

**Description**:

Harden the code in a couple of areas related to recent crash reports.

* DuckDuckGo: TabViewController.webpageDidStartLoading(httpsForced:) + 1360
* Core: WebViewController.showErrorNow() + 844
* Core: closure #1 in WebViewController.urlDidChange() + 240


**Steps to test this PR**:
1. Test openning and closing tabs
1. Test browsing around and check the site rating updates correctly


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
