### PR TITLE
Tweak version formatting

### DIFF
--- a/DuckDuckGo/AppVersionExtension.swift
+++ b/DuckDuckGo/AppVersionExtension.swift
@@ -22,11 +22,11 @@ import Core
 
 extension AppVersion {
     
-    public var versionNumberAndBuild: String {
+    public var versionAndBuildNumber: String {
         return "\(versionNumber).\(buildNumber)"
     }
     
     public var localized: String {
-        return "\(name) \(versionNumberAndBuild)"
+        return "\(name) \(versionAndBuildNumber)"
     }
 }

--- a/DuckDuckGo/AppVersionExtension.swift
+++ b/DuckDuckGo/AppVersionExtension.swift
@@ -22,11 +22,11 @@ import Core
 
 extension AppVersion {
     
-    public var localized: String {
-        guard versionNumber != buildNumber else {
-            return String.localizedStringWithFormat(UserText.appInfo, name, versionNumber)
-        }
-        return String.localizedStringWithFormat(UserText.appInfoWithBuild, name, versionNumber, buildNumber)
+    public var versionNumberAndBuild: String {
+        return "\(versionNumber).\(buildNumber)"
     }
-
+    
+    public var localized: String {
+        return "\(name) \(versionNumberAndBuild)"
+    }
 }

--- a/DuckDuckGo/FeedbackSender.swift
+++ b/DuckDuckGo/FeedbackSender.swift
@@ -58,7 +58,7 @@ struct FeedbackSubmitter: FeedbackSender {
             "os": UIDevice.current.systemVersion,
             "manufacturer": "Apple",
             "model" : UIDevice.current.deviceType.displayName,
-            "v": versionProvider.localized,
+            "v": versionProvider.versionNumberAndBuild,
             "atb": statisticsStore.atbWithVariant ?? ""
         ]
         

--- a/DuckDuckGo/FeedbackSender.swift
+++ b/DuckDuckGo/FeedbackSender.swift
@@ -58,7 +58,7 @@ struct FeedbackSubmitter: FeedbackSender {
             "os": UIDevice.current.systemVersion,
             "manufacturer": "Apple",
             "model" : UIDevice.current.deviceType.displayName,
-            "v": versionProvider.versionNumberAndBuild,
+            "v": versionProvider.versionAndBuildNumber,
             "atb": statisticsStore.atbWithVariant ?? ""
         ]
         

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -23,7 +23,6 @@ import Core
 
 public struct UserText {
     
-    public static let appTitle = NSLocalizedString("app.title", comment: "DuckDuckGo")
     public static let appUnlock = NSLocalizedString("app.authentication.unlock", comment: "Unlock DuckDuckGo")
     public static let homeLinkTitle = NSLocalizedString("home.link.title", comment: "DuckDuckGo Home")
     public static let searchDuckDuckGo = NSLocalizedString("search.hint.duckduckgo", comment: "Search or type URL")

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -24,8 +24,6 @@ import Core
 public struct UserText {
     
     public static let appTitle = NSLocalizedString("app.title", comment: "DuckDuckGo")
-    public static let appInfo = NSLocalizedString("app.info", comment: "DuckDuckGo version")
-    public static let appInfoWithBuild = NSLocalizedString("app.infoWithBuild", comment:  "DuckDuckGo version (build)")
     public static let appUnlock = NSLocalizedString("app.authentication.unlock", comment: "Unlock DuckDuckGo")
     public static let homeLinkTitle = NSLocalizedString("home.link.title", comment: "DuckDuckGo Home")
     public static let searchDuckDuckGo = NSLocalizedString("search.hint.duckduckgo", comment: "Search or type URL")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -17,8 +17,6 @@
   limitations under the License.
 */
 
-"app.info" = "%@ %@";
-"app.infoWithBuild" = "%@ %@ (%@)";
 "app.authentication.unlock" = "Unlock DuckDuckGo";
 "home.link.title" = "DuckDuckGo Home";
 "search.hint.duckduckgo" = "Search or type URL";

--- a/DuckDuckGoTests/AppVersionExtensionTests.swift
+++ b/DuckDuckGoTests/AppVersionExtensionTests.swift
@@ -37,18 +37,18 @@ class AppVersionExtensionTests: XCTestCase {
         mockBundle = MockBundle()
         testee = AppVersion(bundle: mockBundle)
     }
+
+    func testVersionAndBuildContainsCorrectInformation() {
+        mockBundle.add(name: AppVersion.Keys.name, value: Constants.name)
+        mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
+        mockBundle.add(name: AppVersion.Keys.buildNumber, value: Constants.build)
+        XCTAssertEqual("2.0.4.14", testee.versionNumberAndBuild)
+    }
     
     func testLocalisedTextContainsNameVersionAndBuild() {
         mockBundle.add(name: AppVersion.Keys.name, value: Constants.name)
         mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
         mockBundle.add(name: AppVersion.Keys.buildNumber, value: Constants.build)
-        XCTAssertEqual("DuckDuckGo 2.0.4 (14)", testee.localized)
-    }
-    
-    func testLocalisedTextContainsNameAndVersionButNotBuildWhenBuildAndVersionSame() {
-        mockBundle.add(name: AppVersion.Keys.name, value: Constants.name)
-        mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
-        mockBundle.add(name: AppVersion.Keys.buildNumber, value: Constants.version)
-        XCTAssertEqual("DuckDuckGo 2.0.4", testee.localized)
+        XCTAssertEqual("DuckDuckGo 2.0.4.14", testee.localized)
     }
 }

--- a/DuckDuckGoTests/AppVersionExtensionTests.swift
+++ b/DuckDuckGoTests/AppVersionExtensionTests.swift
@@ -42,7 +42,7 @@ class AppVersionExtensionTests: XCTestCase {
         mockBundle.add(name: AppVersion.Keys.name, value: Constants.name)
         mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
         mockBundle.add(name: AppVersion.Keys.buildNumber, value: Constants.build)
-        XCTAssertEqual("2.0.4.14", testee.versionNumberAndBuild)
+        XCTAssertEqual("2.0.4.14", testee.versionAndBuildNumber)
     }
     
     func testLocalisedTextContainsNameVersionAndBuild() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/731096826873594/733111159210424

**Description**:
• Tweak format of build number in version text to contain a dot instead of brackets
• Remove app name from feedback version

**Steps to test this PR**:
TEST ONE:
1. Open the feedback form and submit feedback
1. Check the feedback in Asana  to ensure a) the title does not contain the app name b) the build number is formatted with dots rather than brackets e.g 7.8.9.1 rather than 7.8.9 (1)
1. Delete test Asana Feedback task!

TEST TWO:
1. Open settings
1. Again, note that the build number is formatted with dots rather than brackets e.g 7.8.9.1 rather than 7.8.9 (1)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
