### PR TITLE
app metrics

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -41,7 +41,7 @@ public struct AppUrls {
         static let feedback = "\(home)/feedback.js?type=app-feedback"
         static let faviconService = "\(home)/ip3/%@.ico"
         
-        static let pixel = "https://improving.duckduckgo.com/t/%@?p=ios&f=%@"
+        static let pixel = "https://improving.duckduckgo.com/t/%@_ios_%@"
     }
 
     private struct Param {

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -41,7 +41,7 @@ public struct AppUrls {
         static let feedback = "\(home)/feedback.js?type=app-feedback"
         static let faviconService = "\(home)/ip3/%@.ico"
         
-        static let pixel = "https://improving.duckduckgo.com/t/%@"
+        static let pixel = "https://improving.duckduckgo.com/t/%@?p=ios&f=%@"
     }
 
     private struct Param {
@@ -175,8 +175,9 @@ public struct AppUrls {
         return true
     }
     
-    public func pixelUrl(forPixelNamed pixelName: String) -> URL {
-        var url = URL(string: Url.pixel.format(arguments: pixelName))!
+    public func pixelUrl(forPixelNamed pixelName: String, deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) -> URL {
+        let formFactor = deviceType == .pad ? "tablet" : "phone"
+        var url = URL(string: Url.pixel.format(arguments: pixelName, formFactor))!
         url = url.addParam(name: Param.atb, value: statisticsStore.atbWithVariant ?? "")
         return url
     }

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -177,7 +177,9 @@ public struct AppUrls {
     }
     
     public func pixelUrl(forPixelNamed pixelName: String) -> URL {
-        return applyStatsParams(for: URL(string: Url.pixel.format(arguments: pixelName))!)
+        var url = URL(string: Url.pixel.format(arguments: pixelName))!
+        url = url.addParam(name: Param.atb, value: statisticsStore.atbWithVariant ?? "")
+        return url
     }
 
 }

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -41,8 +41,7 @@ public struct AppUrls {
         static let feedback = "\(home)/feedback.js?type=app-feedback"
         static let faviconService = "\(home)/ip3/%@.ico"
         
-        // TODO Change to improve.duckduckgo.com
-        static let pixel = "https://duckduckgo.com/t/%@"
+        static let pixel = "https://improving.duckduckgo.com/t/%@"
     }
 
     private struct Param {

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -40,6 +40,9 @@ public struct AppUrls {
         static let exti = "\(home)/exti/"
         static let feedback = "\(home)/feedback.js?type=app-feedback"
         static let faviconService = "\(home)/ip3/%@.ico"
+        
+        // TODO Change to improve.duckduckgo.com
+        static let pixel = "https://duckduckgo.com/t/%@"
     }
 
     private struct Param {
@@ -171,6 +174,10 @@ public struct AppUrls {
             return atbWithVariant == url.getParam(name: Param.atb)
         }
         return true
+    }
+    
+    public func pixelUrl(forPixelNamed pixelName: String) -> URL {
+        return applyStatsParams(for: URL(string: Url.pixel.format(arguments: pixelName))!)
     }
 
 }

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -41,7 +41,7 @@ public struct AppUrls {
         static let feedback = "\(home)/feedback.js?type=app-feedback"
         static let faviconService = "\(home)/ip3/%@.ico"
         
-        static let pixel = "https://improving.duckduckgo.com/t/%@_ios_%@"
+        static let pixel = "https://improving.\(domain)/t/%@_ios_%@"
     }
 
     private struct Param {

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -175,8 +175,7 @@ public struct AppUrls {
         return true
     }
     
-    public func pixelUrl(forPixelNamed pixelName: String, deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) -> URL {
-        let formFactor = deviceType == .pad ? "tablet" : "phone"
+    public func pixelUrl(forPixelNamed pixelName: String, formFactor: String) -> URL {
         var url = URL(string: Url.pixel.format(arguments: pixelName, formFactor))!
         url = url.addParam(name: Param.atb, value: statisticsStore.atbWithVariant ?? "")
         return url

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -32,11 +32,19 @@ public class Pixel {
 
     private static let appUrls = AppUrls()
     
+    private struct Constants {
+        
+        static let tablet = "tablet"
+        static let phone = "phone"
+        
+    }
+    
     private init() {
     }
     
-    public static func fire(pixel: PixelName) {
-        Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue)).response { data in
+    public static func fire(pixel: PixelName, deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        let formFactor = deviceType == .pad ? Constants.tablet : Constants.phone
+        Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor)).response { data in
             Logger.log(items: "Fire pixel \(pixel.rawValue) \(data)")
         }
     }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -23,7 +23,7 @@ import Alamofire
 public enum PixelDefinition: String {
     
     case appLaunch = "ml"
-    case fireButtonPressed = "mb"
+    case forgetAllExecuted = "mf"
     case privacyDashboardOpened = "mp"
     
 }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -1,0 +1,53 @@
+//
+//  Pixel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Alamofire
+
+public enum PixelDefinition: String {
+    
+    case appLaunch = "ml"
+    case fireButtonPressed = "mb"
+    case privacyDashboardOpened = "mp"
+    
+}
+
+public protocol PixelFiring {
+    
+    func fire(pixel: PixelDefinition)
+    
+}
+
+public class Pixel: PixelFiring {
+
+    private static let pixel = Pixel()
+    
+    private let appUrls = AppUrls()
+    
+    public static func shared() -> Pixel {
+        return pixel
+    }
+    
+    public func fire(pixel: PixelDefinition) {
+        Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue)).response { data in
+            Logger.log(items: "Fire pixel \(pixel.rawValue) \(data)")
+        }
+    }
+    
+}

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Alamofire
 
-public enum PixelDefinition: String {
+public enum PixelName: String {
     
     case appLaunch = "ml"
     case forgetAllExecuted = "mf"
@@ -28,23 +28,14 @@ public enum PixelDefinition: String {
     
 }
 
-public protocol PixelFiring {
-    
-    func fire(pixel: PixelDefinition)
-    
-}
+public class Pixel {
 
-public class Pixel: PixelFiring {
-
-    private static let pixel = Pixel()
+    private static let appUrls = AppUrls()
     
-    private let appUrls = AppUrls()
-    
-    public static func shared() -> Pixel {
-        return pixel
+    private init() {
     }
     
-    public func fire(pixel: PixelDefinition) {
+    public static func fire(pixel: PixelName) {
         Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue)).response { data in
             Logger.log(items: "Fire pixel \(pixel.rawValue) \(data)")
         }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		8536A1CA209AF6490050739E /* HomeRowReminderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8536A1C9209AF6480050739E /* HomeRowReminderTests.swift */; };
 		85393121203C5F1F009C0B12 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85393120203C5F1F009C0B12 /* main.swift */; };
 		8539D9F71FA756AD00BE8746 /* PrivacyProtectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8539D9F61FA756AD00BE8746 /* PrivacyProtectionController.swift */; };
+		853A717620F62FE800FE60BC /* Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717520F62FE800FE60BC /* Pixel.swift */; };
+		853A717820F645FB00FE60BC /* PixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717720F645FB00FE60BC /* PixelTests.swift */; };
 		85436C3F1FA74BC300F4EEE1 /* PrivacyProtection.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85436C3E1FA74BC300F4EEE1 /* PrivacyProtection.xcassets */; };
 		855D914D2063EF6A00C4B448 /* CompositeTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855D914C2063EF6A00C4B448 /* CompositeTransition.swift */; };
 		855D914F206563A000C4B448 /* TLD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855D914E206563A000C4B448 /* TLD.swift */; };
@@ -489,6 +491,8 @@
 		8536A1C9209AF6480050739E /* HomeRowReminderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeRowReminderTests.swift; sourceTree = "<group>"; };
 		85393120203C5F1F009C0B12 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8539D9F61FA756AD00BE8746 /* PrivacyProtectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionController.swift; sourceTree = "<group>"; };
+		853A717520F62FE800FE60BC /* Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pixel.swift; sourceTree = "<group>"; };
+		853A717720F645FB00FE60BC /* PixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTests.swift; sourceTree = "<group>"; };
 		85436C3E1FA74BC300F4EEE1 /* PrivacyProtection.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PrivacyProtection.xcassets; sourceTree = "<group>"; };
 		855D914C2063EF6A00C4B448 /* CompositeTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeTransition.swift; sourceTree = "<group>"; };
 		855D914E206563A000C4B448 /* TLD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLD.swift; sourceTree = "<group>"; };
@@ -1299,6 +1303,7 @@
 				F1134EB11F40AC6A00B73467 /* Domain */,
 				F1134EAE1F40AB2300B73467 /* Parser */,
 				F1134EA91F3E2BA700B73467 /* Store */,
+				853A717520F62FE800FE60BC /* Pixel.swift */,
 			);
 			name = Statistics;
 			sourceTree = "<group>";
@@ -1337,6 +1342,7 @@
 				85C11E4020904BBE00BFFEB4 /* VariantManagerTests.swift */,
 				850250B420D80419002199C7 /* AtbAndVariantCleanupTests.swift */,
 				850250AD20D7B82E002199C7 /* VariantTests.swift */,
+				853A717720F645FB00FE60BC /* PixelTests.swift */,
 			);
 			name = Statistics;
 			sourceTree = "<group>";
@@ -2608,6 +2614,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				853A717820F645FB00FE60BC /* PixelTests.swift in Sources */,
 				85C271CF1FCDB869007216B4 /* MajorTrackerNetworkTests.swift in Sources */,
 				85200F9A1FBBC012001AF290 /* NetworkLeaderboardTests.swift in Sources */,
 				85F1C3CD1F7A76EF00161346 /* ContentBlockerStringCacheTests.swift in Sources */,
@@ -2709,6 +2716,7 @@
 				85C271DD1FD04459007216B4 /* HTTPSUpgrade.swift in Sources */,
 				F1B745221E549D550072547E /* UIColorExtension.swift in Sources */,
 				F143C33B1E4A9A9200CFDE3A /* WebEventsDelegate.swift in Sources */,
+				853A717620F62FE800FE60BC /* Pixel.swift in Sources */,
 				F16394071ECE01E400DDD653 /* DisconnectMeTrackersParser.swift in Sources */,
 				85A53ECA200D1FA20010D13F /* SurrogateStore.swift in Sources */,
 				F1134EB31F40AD2500B73467 /* Atb.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
 
-        Pixel.shared().fire(pixel: .appLaunch)
+        Pixel.fire(pixel: .appLaunch)
         startMigration(application: application)
         StatisticsLoader.shared.load()
         startOnboardingFlowIfNotSeenBefore()

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -55,6 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
 
+        Pixel.shared().fire(pixel: .appLaunch)
         startMigration(application: application)
         StatisticsLoader.shared.load()
         startOnboardingFlowIfNotSeenBefore()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -236,6 +236,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func forgetAll(completion: @escaping () -> Void) {
+        Pixel.shared().fire(pixel: .forgetAllExecuted)
         ServerTrustCache.shared.clear()
         WebCacheManager.clear()
         FireAnimation.animate {
@@ -307,7 +308,6 @@ class MainViewController: UIViewController {
 
     private func forgetAllAction() -> UIAlertAction {
         return UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] _ in
-            Pixel.shared().fire(pixel: .forgetAllExecuted)
             self?.forgetAll {}
         }
     }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -236,7 +236,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func forgetAll(completion: @escaping () -> Void) {
-        Pixel.shared().fire(pixel: .forgetAllExecuted)
+        Pixel.fire(pixel: .forgetAllExecuted)
         ServerTrustCache.shared.clear()
         WebCacheManager.clear()
         FireAnimation.animate {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -307,6 +307,7 @@ class MainViewController: UIViewController {
 
     private func forgetAllAction() -> UIAlertAction {
         return UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] _ in
+            Pixel.shared().fire(pixel: .fireButtonPressed)
             self?.forgetAll {}
         }
     }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -307,7 +307,7 @@ class MainViewController: UIViewController {
 
     private func forgetAllAction() -> UIAlertAction {
         return UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] _ in
-            Pixel.shared().fire(pixel: .fireButtonPressed)
+            Pixel.shared().fire(pixel: .forgetAllExecuted)
             self?.forgetAll {}
         }
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -140,6 +140,7 @@ class TabViewController: WebViewController {
     }
 
     func showPrivacyProtection() {
+        Pixel.shared().fire(pixel: .privacyDashboardOpened)
         if UIUserInterfaceIdiom.pad == UIDevice.current.userInterfaceIdiom {
             performSegue(withIdentifier: "PrivacyProtectionTablet", sender: self)
         } else {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -140,7 +140,7 @@ class TabViewController: WebViewController {
     }
 
     func showPrivacyProtection() {
-        Pixel.shared().fire(pixel: .privacyDashboardOpened)
+        Pixel.fire(pixel: .privacyDashboardOpened)
         if UIUserInterfaceIdiom.pad == UIDevice.current.userInterfaceIdiom {
             performSegue(withIdentifier: "PrivacyProtectionTablet", sender: self)
         } else {

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -29,6 +29,27 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
+    func testWhenPixelUrlRequestedOnUnspecifiedDeviceIdiomThenFormFactorIsPhone() {
+        mockStatisticsStore.atbWithVariant = "x"
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .unspecified)
+        XCTAssertEqual("phone", pixelUrl.getParam(name: "f"))
+    }
+
+    func testWhenPixelUrlRequestedOniPhoneThenFormFactorIsPhone() {
+        mockStatisticsStore.atbWithVariant = "x"
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .phone)
+        XCTAssertEqual("phone", pixelUrl.getParam(name: "f"))
+    }
+
+    func testWhenPixelUrlRequestedOniPadThenFormFactorIsTablet() {
+        mockStatisticsStore.atbWithVariant = "x"
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .pad)
+        XCTAssertEqual("tablet", pixelUrl.getParam(name: "f"))
+    }
+    
     func testWhenPixelUrlRequestThenCorrectURLIsReturned() {
         mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
@@ -37,7 +58,7 @@ class AppUrlsTests: XCTestCase {
         XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
         XCTAssertEqual("/t/ml", pixelUrl.path)
         XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
-
+        XCTAssertEqual("ios", pixelUrl.getParam(name: "p"))
     }
     
     func testWhenFaviconUrlForDomainRequestedThenCorrectDomainIsCreated() {

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -37,7 +37,6 @@ class AppUrlsTests: XCTestCase {
         XCTAssertEqual("duckduckgo.com", pixelUrl.host)
         XCTAssertEqual("/t/ml", pixelUrl.path)
         XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
-        XCTAssertEqual("ddg_ios", pixelUrl.getParam(name: "t"))
 
     }
     

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -29,36 +29,34 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
-    func testWhenPixelUrlRequestedOnUnspecifiedDeviceIdiomThenFormFactorIsPhone() {
+    func testWhenPixelUrlRequestForUnspecifiedThenCorrectURLIsReturnedUsingPhone() {
         mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .unspecified)
-        XCTAssertEqual("phone", pixelUrl.getParam(name: "f"))
+        
+        XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
+        XCTAssertEqual("/t/ml_ios_phone", pixelUrl.path)
+        XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
     }
 
-    func testWhenPixelUrlRequestedOniPhoneThenFormFactorIsPhone() {
+    func testWhenPixelUrlRequestForPhoneThenCorrectURLIsReturned() {
         mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .phone)
-        XCTAssertEqual("phone", pixelUrl.getParam(name: "f"))
+        
+        XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
+        XCTAssertEqual("/t/ml_ios_phone", pixelUrl.path)
+        XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
     }
 
-    func testWhenPixelUrlRequestedOniPadThenFormFactorIsTablet() {
-        mockStatisticsStore.atbWithVariant = "x"
-        let testee = AppUrls(statisticsStore: mockStatisticsStore)
-        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .pad)
-        XCTAssertEqual("tablet", pixelUrl.getParam(name: "f"))
-    }
-    
     func testWhenPixelUrlRequestThenCorrectURLIsReturned() {
         mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
-        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml")
+        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .pad)
         
         XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
-        XCTAssertEqual("/t/ml", pixelUrl.path)
+        XCTAssertEqual("/t/ml_ios_tablet", pixelUrl.path)
         XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
-        XCTAssertEqual("ios", pixelUrl.getParam(name: "p"))
     }
     
     func testWhenFaviconUrlForDomainRequestedThenCorrectDomainIsCreated() {

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -29,6 +29,18 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
+    func testWhenPixelUrlRequestThenCorrectURLIsReturned() {
+        mockStatisticsStore.atbWithVariant = "x"
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml")
+        
+        XCTAssertEqual("duckduckgo.com", pixelUrl.host)
+        XCTAssertEqual("/t/ml", pixelUrl.path)
+        XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
+        XCTAssertEqual("ddg_ios", pixelUrl.getParam(name: "t"))
+
+    }
+    
     func testWhenFaviconUrlForDomainRequestedThenCorrectDomainIsCreated() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let faviconURL = testee.faviconUrl(forDomain: "example.com")

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -29,33 +29,13 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
-    func testWhenPixelUrlRequestForUnspecifiedThenCorrectURLIsReturnedUsingPhone() {
-        mockStatisticsStore.atbWithVariant = "x"
-        let testee = AppUrls(statisticsStore: mockStatisticsStore)
-        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .unspecified)
-        
-        XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
-        XCTAssertEqual("/t/ml_ios_phone", pixelUrl.path)
-        XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
-    }
-
-    func testWhenPixelUrlRequestForPhoneThenCorrectURLIsReturned() {
-        mockStatisticsStore.atbWithVariant = "x"
-        let testee = AppUrls(statisticsStore: mockStatisticsStore)
-        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .phone)
-        
-        XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
-        XCTAssertEqual("/t/ml_ios_phone", pixelUrl.path)
-        XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
-    }
-
     func testWhenPixelUrlRequestThenCorrectURLIsReturned() {
         mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
-        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", deviceType: .pad)
+        let pixelUrl = testee.pixelUrl(forPixelNamed: "ml", formFactor: "formfactor")
         
         XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
-        XCTAssertEqual("/t/ml_ios_tablet", pixelUrl.path)
+        XCTAssertEqual("/t/ml_ios_formfactor", pixelUrl.path)
         XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
     }
     

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -34,7 +34,7 @@ class AppUrlsTests: XCTestCase {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let pixelUrl = testee.pixelUrl(forPixelNamed: "ml")
         
-        XCTAssertEqual("duckduckgo.com", pixelUrl.host)
+        XCTAssertEqual("improving.duckduckgo.com", pixelUrl.host)
         XCTAssertEqual("/t/ml", pixelUrl.path)
         XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
 

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -12,7 +12,7 @@ import Core
 
 class PixelTests: XCTestCase {
     
-    let host = "duckduckgo.com"
+    let host = "improving.duckduckgo.com"
     
     override func tearDown() {
         OHHTTPStubs.removeAllStubs()

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -22,7 +22,7 @@ class PixelTests: XCTestCase {
     func testWhenAppLaunchPixelIsFiredThenCorrectURLRequestIsMade() {
         let expectation = XCTestExpectation()
         
-        stub(condition: isHost(host) && isPath("/t/ml")) { _ -> OHHTTPStubsResponse in
+        stub(condition: isHost(host) && pathStartsWith("/t/ml_ios_")) { _ -> OHHTTPStubsResponse in
             expectation.fulfill()
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -19,17 +19,43 @@ class PixelTests: XCTestCase {
         super.tearDown()
     }
 
-    func testWhenAppLaunchPixelIsFiredThenCorrectURLRequestIsMade() {
+    func testWhenAppLaunchPixelIsFiredFromPhoneThenCorrectURLRequestIsMade() {
         let expectation = XCTestExpectation()
         
-        stub(condition: isHost(host) && pathStartsWith("/t/ml_ios_")) { _ -> OHHTTPStubsResponse in
+        stub(condition: isHost(host) && isPath("/t/ml_ios_phone")) { _ -> OHHTTPStubsResponse in
             expectation.fulfill()
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
         
-        Pixel.fire(pixel: .appLaunch)
+        Pixel.fire(pixel: .appLaunch, deviceType: .phone)
                 
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
+    func testWhenAppLaunchPixelIsFiredFromTabletThenCorrectURLRequestIsMade() {
+        let expectation = XCTestExpectation()
+        
+        stub(condition: isHost(host) && isPath("/t/ml_ios_tablet")) { _ -> OHHTTPStubsResponse in
+            expectation.fulfill()
+            return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        
+        Pixel.fire(pixel: .appLaunch, deviceType: .pad)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testWhenAppLaunchPixelIsFiredFromUnspecifiedThenCorrectURLRequestIsMadeAsPhone() {
+        let expectation = XCTestExpectation()
+        
+        stub(condition: isHost(host) && isPath("/t/ml_ios_phone")) { _ -> OHHTTPStubsResponse in
+            expectation.fulfill()
+            return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        
+        Pixel.fire(pixel: .appLaunch, deviceType: .unspecified)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+
 }

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -27,7 +27,7 @@ class PixelTests: XCTestCase {
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
         
-        Pixel.shared().fire(pixel: .appLaunch)
+        Pixel.fire(pixel: .appLaunch)
                 
         wait(for: [expectation], timeout: 1.0)
     }

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -1,0 +1,35 @@
+//
+//  PixelTests.swift
+//  UnitTests
+//
+//  Created by Chris Brind on 11/07/2018.
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+
+import XCTest
+import OHHTTPStubs
+import Core
+
+class PixelTests: XCTestCase {
+    
+    let host = "duckduckgo.com"
+    
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+
+    func testWhenAppLaunchPixelIsFiredThenCorrectURLRequestIsMade() {
+        let expectation = XCTestExpectation()
+        
+        stub(condition: isHost(host) && isPath("/t/ml")) { _ -> OHHTTPStubsResponse in
+            expectation.fulfill()
+            return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        
+        Pixel.shared().fire(pixel: .appLaunch)
+                
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+}

--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ Contact us at https://duckduckgo.com/feedback if you have feedback, questions or
 
 ## License
 DuckDuckGo Search & Stories is distributed under the Apache 2.0 [license](https://github.com/duckduckgo/ios/blob/master/LICENSE).
+
+


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 

* Implement pixel request: https://app.asana.com/0/392891325557410/738818866019757
* Grafana parameters: https://app.asana.com/0/392891325557410/751512552599843

Tech Design URL: https://app.asana.com/0/392891325557410/726260612891763
CC:

**Description**:

* When user launches the app, executes forget all, or opens the privacy dashboard a pixel request is triggered.
* A pixel request is in the following format https://improving.duckduckgo.com/t/{pixel}_{platform}_{form_factor}?atb={atb}
  * atb: a valid atb or blank for the very first launch
  * platform: `ios`
  * form factor: `phone` or `tablet` as determined by the device being used


**Steps to test this PR**:

***Pixel requests***:
1. Open kibana and use this query: `(pixel_id:ml) OR (pixel_id:mf) OR (pixel_id:mp)`
1. Launch the app, wait a few seconds and run the query, the ml request should appear
1. Perform a forget all while browsing or from the home screen, wait a few seconds and run the query, the mf request should appear
1. Perform a forget all in the tab switcher, wait a few seconds and run the query, the mf request should appear
1. Open the privacy dashboard, wait a few seconds and run the query, the mf request should appear


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)