### PR TITLE
add fatal error if tearDown called twice

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -56,6 +56,8 @@ open class WebViewController: UIViewController {
     private lazy var httpsUpgrade = HTTPSUpgrade()
     private lazy var tld = TLD()
 
+    private var tearDownCount = 0
+    
     public var name: String? {
         return webView.title
     }
@@ -252,10 +254,10 @@ open class WebViewController: UIViewController {
     }
     
     public func tearDown() {
-        if #available(iOS 11, *) {
-            // prevents a crash if the observers were not there for some reason (e.g. WKWebView process crashed)
-            addObservers()
+        guard tearDownCount == 0 else {
+            fatalError("tearDown has already happened")
         }
+        tearDownCount += 1
         removeObservers()
         webView.removeFromSuperview()
         webEventsDelegate?.detached(webView: webView)

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -252,7 +252,10 @@ open class WebViewController: UIViewController {
     }
     
     public func tearDown() {
-        addObservers() // prevents a crash if the observers were not there for some reason (e.g. WKWebView process crashed)
+        if #available(iOS 11, *) {
+            // prevents a crash if the observers were not there for some reason (e.g. WKWebView process crashed)
+            addObservers()
+        }
         removeObservers()
         webView.removeFromSuperview()
         webEventsDelegate?.detached(webView: webView)

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -93,17 +93,21 @@ open class WebViewController: UIViewController {
         shouldReloadOnError = true
     }
 
+    fileprivate func addObservers() {
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
+    }
+    
     open func attachWebView(configuration: WKWebViewConfiguration) {
         webView = WKWebView(frame: view.bounds, configuration: configuration)
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         attachLongPressHandler(webView: webView)
         webView.allowsBackForwardNavigationGestures = true
 
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent), options: .new, context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
+        addObservers()
 
         webView.navigationDelegate = self
         webView.uiDelegate = self
@@ -239,12 +243,17 @@ open class WebViewController: UIViewController {
         webView.goForward()
     }
 
-    public func tearDown() {
+    fileprivate func removeObservers() {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack))
+    }
+    
+    public func tearDown() {
+        addObservers() // prevents a crash if the observers were not there for some reason (e.g. WKWebView process crashed)
+        removeObservers()
         webView.removeFromSuperview()
         webEventsDelegate?.detached(webView: webView)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/757819156125520
Tech Design URL:
CC:

**Description**:

Attempts to fix a crash caused when the WKWebView process crashes where it appears the Notification Center is unable to remove observers.

**Steps to test this PR**:

On a physical device:
1. Visit https://www.falkirkrpg.org.uk/noxwall/js.html
1. Press the button until the WebView crashes 
1. Confirm page reloads and app continues without error
1. Confirm no memory leaks
1. Browse, open new tabs, forget all a few times to ensure no regression

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)