### PR TITLE
add API headers to pixel request

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -42,9 +42,12 @@ public class Pixel {
     private init() {
     }
     
-    public static func fire(pixel: PixelName, deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+    public static func fire(pixel: PixelName,
+                            forDeviceType deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+                            withHeaders headers:HTTPHeaders = APIHeaders().defaultHeaders) {
         let formFactor = deviceType == .pad ? Constants.tablet : Constants.phone
-        Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor)).response { data in
+        Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor),
+                          headers: headers).response { data in
             Logger.log(items: "Fire pixel \(pixel.rawValue) \(data)")
         }
     }

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -9,16 +9,35 @@
 import XCTest
 import OHHTTPStubs
 import Core
+import Alamofire
 
 class PixelTests: XCTestCase {
     
     let host = "improving.duckduckgo.com"
+    let testAgent = "Test Agent"
+    let userAgentName = "User-Agent"
     
     override func tearDown() {
         OHHTTPStubs.removeAllStubs()
         super.tearDown()
     }
 
+    func testWhenPixelFiredThenAPIHeadersAreAdded() {
+        let expectation = XCTestExpectation()
+        
+        stub(condition: hasHeaderNamed(userAgentName, value: testAgent)) { _ -> OHHTTPStubsResponse in
+            expectation.fulfill()
+            return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        
+        var headers = Alamofire.SessionManager.defaultHTTPHeaders
+        headers[userAgentName] = testAgent
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .phone, withHeaders: headers)
+        
+        wait(for: [expectation], timeout: 1.0)
+
+    }
+    
     func testWhenAppLaunchPixelIsFiredFromPhoneThenCorrectURLRequestIsMade() {
         let expectation = XCTestExpectation()
         
@@ -27,7 +46,7 @@ class PixelTests: XCTestCase {
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
         
-        Pixel.fire(pixel: .appLaunch, deviceType: .phone)
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .phone)
                 
         wait(for: [expectation], timeout: 1.0)
     }
@@ -40,7 +59,7 @@ class PixelTests: XCTestCase {
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
         
-        Pixel.fire(pixel: .appLaunch, deviceType: .pad)
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .pad)
         
         wait(for: [expectation], timeout: 1.0)
     }
@@ -53,7 +72,7 @@ class PixelTests: XCTestCase {
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
         
-        Pixel.fire(pixel: .appLaunch, deviceType: .unspecified)
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .unspecified)
         
         wait(for: [expectation], timeout: 1.0)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/759546524375265
Tech Design URL:
CC:

**Description**:

Add API headers to pixel request


**Steps to test this PR**:
1. Launch the app 
1. Ensure API headers are present, e.g. `User-Agent` = `ddg_ios/7.8.1.0 (com.duckduckgo.mobile.ios; iOS 11.4)`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)