### PR TITLE
add pixels for long press and the dashboard

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -35,7 +35,7 @@ public enum PixelName: String {
     case longPressMenuOpened = "mlp"
     case longPressMenuNewTabItem = "mlp_t"
     case longPressMenuOpenItem = "mlp_o"
-    case longPressMenuReadingListItem = "ml_r"
+    case longPressMenuReadingListItem = "mlp_r"
     case longPressMenuCopyItem = "mlp_c"
     case longPressMenuShareItem = "mlp_s"
 

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -24,8 +24,21 @@ public enum PixelName: String {
     
     case appLaunch = "ml"
     case forgetAllExecuted = "mf"
-    case privacyDashboardOpened = "mp"
     
+    case privacyDashboardOpened = "mp"
+    case privacyDashboardScorecard = "mp_c"
+    case privacyDashboardEncryption = "mp_e"
+    case privacyDashboardNetworks = "mp_n"
+    case privacyDashboardPrivacyPractices = "mp_p"
+    case privacyDashboardGlobalStats = "mp_s"
+    
+    case longPressMenuOpened = "mlp"
+    case longPressMenuNewTabItem = "mlp_t"
+    case longPressMenuOpenItem = "mlp_o"
+    case longPressMenuReadingListItem = "ml_r"
+    case longPressMenuCopyItem = "mlp_c"
+    case longPressMenuShareItem = "mlp_s"
+
 }
 
 public class Pixel {

--- a/DuckDuckGo/PrivacyProtectionEncryptionDetailController.swift
+++ b/DuckDuckGo/PrivacyProtectionEncryptionDetailController.swift
@@ -46,6 +46,8 @@ class PrivacyProtectionEncryptionDetailController: UIViewController {
 
     override func viewDidLoad() {
 
+        Pixel.fire(pixel: .privacyDashboardEncryption)
+        
         initTableView()
         initHttpsStatus()
         initDomain()

--- a/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
+++ b/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
@@ -45,6 +45,8 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        Pixel.fire(pixel: .privacyDashboardGlobalStats)
+        
         initHeroIcon()
         initResetButton()
         initDomainLabel()

--- a/DuckDuckGo/PrivacyProtectionPracticesController.swift
+++ b/DuckDuckGo/PrivacyProtectionPracticesController.swift
@@ -48,6 +48,9 @@ class PrivacyProtectionPracticesController: UIViewController {
     var rows = [Row]()
 
     override func viewDidLoad() {
+
+        Pixel.fire(pixel: .privacyDashboardPrivacyPractices)
+        
         initTable()
         update()
     }

--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -35,6 +35,9 @@ class PrivacyProtectionScoreCardController: UITableViewController {
     weak var header: PrivacyProtectionHeaderController!
 
     override func viewDidLoad() {
+        
+        Pixel.fire(pixel: .privacyDashboardScorecard)
+        
         update()
     }
 

--- a/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
+++ b/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
@@ -55,6 +55,9 @@ class PrivacyProtectionTrackerNetworksController: UIViewController {
     var sections = [Section]()
 
     override func viewDidLoad() {
+        
+        Pixel.fire(pixel: .privacyDashboardNetworks)
+        
         initTableView()
         update()
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -208,6 +208,8 @@ class TabViewController: WebViewController {
     }
 
     func launchLongPressMenu(atPoint point: Point, forUrl url: URL) {
+        Pixel.fire(pixel: .longPressMenuOpened)
+        
         let alert = UIAlertController(title: nil, message: url.absoluteString, preferredStyle: .actionSheet)
         alert.addAction(newTabAction(forUrl: url))
         alert.addAction(openAction(forUrl: url))
@@ -268,6 +270,7 @@ class TabViewController: WebViewController {
     private func newTabAction(forUrl url: URL) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionNewTabForUrl, style: .default) { [weak self] _ in
             if let weakSelf = self {
+                Pixel.fire(pixel: .longPressMenuNewTabItem)
                 weakSelf.delegate?.tab(weakSelf, didRequestNewTabForUrl: url)
             }
         }
@@ -276,6 +279,7 @@ class TabViewController: WebViewController {
     private func openAction(forUrl url: URL) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionOpen, style: .default) { [weak self] _ in
             if let webView = self?.webView {
+                Pixel.fire(pixel: .longPressMenuOpenItem)
                 webView.load(URLRequest(url: url))
             }
         }
@@ -283,6 +287,7 @@ class TabViewController: WebViewController {
 
     private func readingAction(forUrl url: URL) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionReadingList, style: .default) { _ in
+            Pixel.fire(pixel: .longPressMenuReadingListItem)
             try? SSReadingList.default()?.addItem(with: url, title: nil, previewText: nil)
         }
     }
@@ -290,12 +295,14 @@ class TabViewController: WebViewController {
     private func copyAction(forUrl url: URL) -> UIAlertAction {
         let copyText = url.absoluteString
         return UIAlertAction(title: UserText.actionCopy, style: .default) { (_) in
+            Pixel.fire(pixel: .longPressMenuCopyItem)
             UIPasteboard.general.string = copyText
         }
     }
 
     private func shareAction(forLink link: Link) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] _ in
+            Pixel.fire(pixel: .longPressMenuShareItem)
             guard let menu = self?.chromeDelegate?.omniBar.menuButton else { return }
             self?.presentShareSheet(withItems: [ link.url, link ], fromView: menu)
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -302,7 +302,6 @@ class TabViewController: WebViewController {
 
     private func shareAction(forLink link: Link) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] _ in
-            Pixel.fire(pixel: .longPressMenuShareItem)
             guard let menu = self?.chromeDelegate?.omniBar.menuButton else { return }
             self?.presentShareSheet(withItems: [ link.url, link ], fromView: menu)
         }
@@ -310,6 +309,7 @@ class TabViewController: WebViewController {
 
     private func shareAction(forUrl url: URL, atPoint point: Point) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] _ in
+            Pixel.fire(pixel: .longPressMenuShareItem)
             guard let webView = self?.webView else { return }
             self?.presentShareSheet(withItems: [url], fromView: webView, atPoint: point)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/772541567088306
Tech Design URL: 
CC: 

**Description**:

Adds new pixels for the Privacy Dashboard and Long Press Menu.

Note, is subject to pixels.json changes being approved but currently has no conflicts.

**Steps to test this PR**:

Check each pixel is fired under the specified circumstances.  Can be verified by monitoring Kibana with specified query or using network proxy to sniff traffic.

Privacy Protection dashboard:

Kibana `ddg_app:pixel AND pixel_id:mp AND url:/\/t\/mp_._(.?+)_(.?+)/`

1. Tap on grade to view score card, fires `mp_c`
1. Tap on encryption type, fires `mp_e`
1. Tap on Tracker Networks found/blocked, fires `mp_n`
1. Tap on Privacy Practices, fires `mp_p`
1. Tap on Global Stats, fires `mp_s`

Long press menu:

Kibana `ddg_app:pixel AND pixel_id:mlp AND url:/\/t\/mlp.?+/`

1. Long press menu opened, fires `mlp`
1. New Tab selected, fires `mlp_t`
1. Open selected, fires `mlp_o`
1. Reading list selected, fires `mlp_r`
1. Copy selected, fires `mlp_c`
1. Share selected, fires `mlp_s`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)