### PR TITLE
improve perception of slow loading and fix progress bar not hiding

### DIFF
--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -117,7 +117,7 @@ open class WebViewController: UIViewController {
         webView.uiDelegate = self
         webViewContainer.addSubview(webView)
         webEventsDelegate?.attached(webView: webView)
-
+        
         webView.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { _ in
             WebCacheManager.consumeCookies()
             if let url = url {
@@ -125,6 +125,11 @@ open class WebViewController: UIViewController {
             }
         }
 
+        if let url = url {
+            webEventsDelegate?.webView(webView, didChangeUrl: url)
+            webEventsDelegate?.webpageDidStartLoading(httpsForced: false)
+        }
+        
     }
 
     private func attachLongPressHandler(webView: WKWebView) {
@@ -338,6 +343,7 @@ extension WebViewController: WKNavigationDelegate {
     }
 
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        hideProgressIndicator()
         lastError = error
         let error = error as NSError
 
@@ -364,10 +370,6 @@ extension WebViewController: WKNavigationDelegate {
             decision == .allow,
             appUrls.isDuckDuckGoSearch(url: url) {
             StatisticsLoader.shared.refreshRetentionAtb()
-        }
-        
-        if decision == .allow && navigationAction.isTargettingMainFrame() {
-            showProgressIndicator()
         }
         
         decisionHandler(decision)


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/785689884960634
Tech Design URL:
CC:

**Description**:

This doesn't really fix the slow load, just the perception of it.  The slow load is caused by us restoring the cookies asynchronously and then loading the URL once that is done. The slowness was introduced because we were originally loading the URL immediately before the cookies had been re-added, thus causing two ATB calls once the async part finished.  Now we just do the async part.

It also fixes a bug which would make the progress bar show when nothing was really happening.  This was added previously to give the user the perception of responsiveness.  But an allow policy targeting the main frame can happen and then webkit decide not to do anything. As a result we don't get an opportunity to hide the progress bar again.

**Steps to test this PR**:

Slowness:
1. Create some bookmarks
1. Open a tab and launch a bookmark
1. Visit the SERP - set region to UK
1. Execute forget all and visit the SERP - the region should still be UK

Progress bar:
1. Forget all
1. Visit www.schwinnproducefarm.com 
1. When the cookies prompt appears tap "I accept" - the progress bar should not show

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
