### PR TITLE
only consume cookies if there's no tabs to speed up subsequent new tabs

### DIFF
--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -29,7 +29,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -47,7 +47,7 @@ class TabManager {
         let contentBlocker = ContentBlockerConfigurationUserDefaults()
         let configuration =  WKWebViewConfiguration.persistent()
         let controller = TabViewController.loadFromStoryboard(model: tab, contentBlocker: contentBlocker)
-        controller.attachWebView(configuration: configuration, andLoadUrl: url)
+        controller.attachWebView(configuration: configuration, andLoadUrl: url, consumeCookies: model.isEmpty)
         controller.delegate = delegate
         return controller
     }

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>7.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/TodayExtension/Info.plist
+++ b/TodayExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>7.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/785689884960634
Tech Design URL:
CC:

**Description**:

only consume cookies if there's no tabs to speed up subsequent new tabs

**Steps to test this PR**:

Ideally on a slow device:

1. Create some bookmarks 
1. For get all
1. Open a new tab and select a bookmark - loading maybe have a slight delay
1. Open a new tab and select a different bookmark - loading should be faster

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
