### PR TITLE
improve tab state handling in tab switcher

### DIFF
--- a/DuckDuckGo/Tab.swift
+++ b/DuckDuckGo/Tab.swift
@@ -19,6 +19,12 @@
 
 import Core
 
+protocol TabObserver: class {
+ 
+    func didChange(tab: Tab)
+    
+}
+
 public class Tab: NSObject, NSCoding {
 
     struct NSCodingKeys {
@@ -26,8 +32,18 @@ public class Tab: NSObject, NSCoding {
         static let viewed = "viewed"
     }
 
-    var link: Link?
-    var viewed: Bool = true
+    var observers = [TabObserver]()
+    
+    var link: Link? {
+        didSet {
+            notifyObservers()
+        }
+    }
+    var viewed: Bool = true {
+        didSet {
+            notifyObservers()
+        }
+    }
 
     init(link: Link?, viewed: Bool = true) {
         self.link = link
@@ -49,4 +65,25 @@ public class Tab: NSObject, NSCoding {
         guard let other = other as? Tab else { return false }
         return link == other.link
     }
+    
+    func addObserver(_ observer: TabObserver) {
+        guard indexOf(observer) == nil else { return }
+        observers.append(observer)
+    }
+    
+    func removeObserver(_ observer: TabObserver) {
+        guard let index = indexOf(observer) else { return }
+        observers.remove(at: index)
+    }
+    
+    private func indexOf(_ observer: TabObserver) -> Int? {
+        return observers.index(where: { $0 === observer })
+    }
+    
+    private func notifyObservers() {
+        for observer in observers {
+            observer.didChange(tab: self)
+        }
+    }
+    
 }

--- a/DuckDuckGo/Tab.swift
+++ b/DuckDuckGo/Tab.swift
@@ -36,7 +36,7 @@ public class Tab: NSObject, NSCoding {
         static let viewed = "viewed"
     }
 
-    var observersHolder = [WeaklyHeldTabObserver]()
+    private var observersHolder = [WeaklyHeldTabObserver]()
     
     var link: Link? {
         didSet {
@@ -81,18 +81,17 @@ public class Tab: NSObject, NSCoding {
     }
     
     private func indexOf(_ observer: TabObserver) -> Int? {
-        return liveHolders().index(where: { $0.observer === observer })
+        pruneHolders()
+        return observersHolder.index(where: { $0.observer === observer })
     }
     
     private func notifyObservers() {
-        for holder in liveHolders() {
-            holder.observer?.didChange(tab: self)
-        }
+        pruneHolders()
+        observersHolder.forEach { $0.observer?.didChange(tab: self) }
     }
-    
-    private func liveHolders() -> [WeaklyHeldTabObserver] {
-        observersHolder = observersHolder.filter({ $0.observer != nil })
-        return observersHolder
+
+    private func pruneHolders() {
+        observersHolder = observersHolder.filter { $0.observer != nil }
     }
     
 }

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -65,6 +65,10 @@ class TabSwitcherViewController: UIViewController {
     }
 
     @IBAction func onDonePressed(_ sender: UIBarButtonItem) {
+        if let current = tabsModel.currentIndex {
+            tabsModel.get(tabAt: current).viewed = true
+            tabsModel.save()
+        }
         dismiss()
     }
 
@@ -100,6 +104,10 @@ extension TabSwitcherViewController: TabViewCellDelegate {
             collectionView.reloadData()
         }
     }
+    
+    func isCurrent(tab: Tab) -> Bool {
+        return tabsModel.currentIndex == tabsModel.indexOf(tab: tab)
+    }
 
 }
 
@@ -114,8 +122,8 @@ extension TabSwitcherViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TabViewCell.reuseIdentifier, for: indexPath) as? TabViewCell else {
             fatalError("Failed to dequeue cell \(TabViewCell.reuseIdentifier) as TablViewCell")
         }
-        cell.update(withTab: tab, isCurrent: indexPath.row == tabsModel.currentIndex)
         cell.delegate = self
+        cell.update(withTab: tab)
         return cell
     }
 

--- a/DuckDuckGo/TabViewCell.swift
+++ b/DuckDuckGo/TabViewCell.swift
@@ -42,6 +42,7 @@ class TabViewCell: UICollectionViewCell {
 
     weak var delegate: TabViewCellDelegate?
     weak var tab: Tab?
+    var isCurrent = false
 
     @IBOutlet weak var background: UIView!
     @IBOutlet weak var favicon: UIImageView!
@@ -51,8 +52,12 @@ class TabViewCell: UICollectionViewCell {
     @IBOutlet weak var unread: UIView!
 
     func update(withTab tab: Tab, isCurrent: Bool) {
+        removeTabObserver()
+        
+        tab.addObserver(self)
         self.tab = tab
         isHidden = false
+        self.isCurrent = isCurrent
         
         background.layer.borderWidth = isCurrent ? Constants.selectedBorderWidth : Constants.unselectedBorderWidth
         background.layer.borderColor = UIColor.skyBlue.cgColor
@@ -65,6 +70,10 @@ class TabViewCell: UICollectionViewCell {
         configureFavicon(forDomain: tab.link?.url.host)
     }
 
+    private func removeTabObserver() {
+        tab?.removeObserver(self)
+    }
+    
     @IBAction func deleteTab() {
 
         guard let tab = tab else { return }
@@ -87,4 +96,12 @@ class TabViewCell: UICollectionViewCell {
             favicon.kf.setImage(with: faviconUrl, placeholder: placeholder)
         }
     }
+}
+
+extension TabViewCell: TabObserver {
+    
+    func didChange(tab: Tab) {
+        update(withTab: tab, isCurrent: isCurrent)
+    }
+    
 }

--- a/DuckDuckGo/TabViewCell.swift
+++ b/DuckDuckGo/TabViewCell.swift
@@ -25,6 +25,8 @@ protocol TabViewCellDelegate: class {
 
     func deleteTab(tab: Tab)
 
+    func isCurrent(tab: Tab) -> Bool
+    
 }
 
 class TabViewCell: UICollectionViewCell {
@@ -51,13 +53,13 @@ class TabViewCell: UICollectionViewCell {
     @IBOutlet weak var removeButton: UIButton!
     @IBOutlet weak var unread: UIView!
 
-    func update(withTab tab: Tab, isCurrent: Bool) {
+    func update(withTab tab: Tab) {
         removeTabObserver()
-        
         tab.addObserver(self)
         self.tab = tab
+        
         isHidden = false
-        self.isCurrent = isCurrent
+        isCurrent = delegate?.isCurrent(tab: tab) ?? false
         
         background.layer.borderWidth = isCurrent ? Constants.selectedBorderWidth : Constants.unselectedBorderWidth
         background.layer.borderColor = UIColor.skyBlue.cgColor
@@ -77,12 +79,12 @@ class TabViewCell: UICollectionViewCell {
     @IBAction func deleteTab() {
 
         guard let tab = tab else { return }
+        self.delegate?.deleteTab(tab: tab)
 
         UIView.animate(withDuration: 0.3, animations: {
             self.transform.tx = -self.superview!.frame.width * 1.5
         }, completion: { _ in
-            self.isHidden = true
-            self.delegate?.deleteTab(tab: tab)
+            self.transform.tx = 0
         })
 
     }
@@ -101,7 +103,7 @@ class TabViewCell: UICollectionViewCell {
 extension TabViewCell: TabObserver {
     
     func didChange(tab: Tab) {
-        update(withTab: tab, isCurrent: isCurrent)
+        update(withTab: tab)
     }
     
 }

--- a/DuckDuckGoTests/TabTests.swift
+++ b/DuckDuckGoTests/TabTests.swift
@@ -29,6 +29,50 @@ class TabTests: XCTestCase {
         static let differentUrl = URL(string: "https://aDifferentUrl.com")!
     }
 
+    func testWhenTabObserverIsOutOfScopeThenUpdatesAreSuccessful() {
+        var observer: MockTabObserver? = MockTabObserver()
+        let tab = Tab(coder: CoderWithViewedPropertyStub())
+        tab?.addObserver(observer!)
+        
+        observer = nil
+        
+        tab?.viewed = true
+
+        XCTAssertTrue(tab?.viewed ?? false)
+    }
+    
+    func testWhenTabObserverIsOutOfScopeThenItIsNotRetained() {
+        var observer: MockTabObserver? = MockTabObserver()
+        let tab = Tab(coder: CoderWithViewedPropertyStub())
+        tab?.addObserver(observer!)
+        
+        observer = nil
+        
+        XCTAssertNil(tab?.observersHolder[0].observer)
+    }
+    
+    func testWhenTabLinkChangesThenObserversAreNotified() {
+        let observer = MockTabObserver()
+        
+        let tab = Tab(coder: CoderWithViewedPropertyStub())
+        tab?.addObserver(observer)
+        
+        tab?.link = Link(title: nil, url: Constants.url)
+
+        XCTAssertNotNil(observer.didChangeTab)
+    }
+
+    func testWhenTabViewedChangesThenObserversAreNotified() {
+        let observer = MockTabObserver()
+        
+        let tab = Tab(coder: CoderWithViewedPropertyStub())
+        tab?.addObserver(observer)
+        
+        tab?.viewed = true
+        
+        XCTAssertNotNil(observer.didChangeTab)
+    }
+
     func testWhenTabWithViewedDecodedThenItDecodesSuccessfully() {
 
         let tab = Tab(coder: CoderWithViewedPropertyStub())
@@ -88,4 +132,14 @@ private class CoderWithViewedPropertyStub: NSCoder {
         return false
     }
 
+}
+
+private class MockTabObserver: NSObject, TabObserver {
+    
+    var didChangeTab: Tab?
+    
+    func didChange(tab: Tab) {
+        didChangeTab = tab
+    }
+    
 }

--- a/DuckDuckGoTests/TabTests.swift
+++ b/DuckDuckGoTests/TabTests.swift
@@ -41,16 +41,6 @@ class TabTests: XCTestCase {
         XCTAssertTrue(tab?.viewed ?? false)
     }
     
-    func testWhenTabObserverIsOutOfScopeThenItIsNotRetained() {
-        var observer: MockTabObserver? = MockTabObserver()
-        let tab = Tab(coder: CoderWithViewedPropertyStub())
-        tab?.addObserver(observer!)
-        
-        observer = nil
-        
-        XCTAssertNil(tab?.observersHolder[0].observer)
-    }
-    
     func testWhenTabLinkChangesThenObserversAreNotified() {
         let observer = MockTabObserver()
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/487656199561838
Tech Design URL:
CC:

**Description**:

Makes tabs weakly observable so that changes of tabs loading in the background are reflected in the tab switcher.

**Steps to test this PR**:

1. Go to https://news.ycombinator.com/news
1. Open a bunch of tabs in the background quite quickly
1. Go to the tab switcher, note the titles updating in real time
1. Close the current tab - the next logical tab becomes current and the tab updates its state
1. Tap done and re-open the tab switcher. Note the tab state is now "viewed" (ie no blue dot)
1. Tap another tab and re-open the tab switcher. Note the tab state is now "viewed" (ie no blue dot) 
1. Confirm no memory leaks

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)