### PR TITLE
Fire pixel on https upgrade failures

### DIFF
--- a/Core/HTTPSUpgradeStore.swift
+++ b/Core/HTTPSUpgradeStore.swift
@@ -100,10 +100,14 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
             let entityName = String(describing: HTTPSStoredBloomFilterSpecification.self)
             let context = container.managedObjectContext
             
-            if let storedEntity = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context) as? HTTPSStoredBloomFilterSpecification {
+            if let storedEntity = NSEntityDescription.insertNewObject(
+                forEntityName: entityName,
+                into: context) as? HTTPSStoredBloomFilterSpecification {
+                
                 storedEntity.totalEntries = Int64(specification.totalEntries)
                 storedEntity.errorRate = specification.errorRate
                 storedEntity.sha256 = specification.sha256
+                
             }
             _ = container.save()
         }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -50,7 +50,6 @@ public class Pixel {
     public struct Parameters {
         static let url = "url"
         static let errorCode = "error_code"
-        static let statusCode = "status_code"
     }
     
     private struct Constants {

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -40,17 +40,22 @@ public enum PixelName: String {
     case longPressMenuCopyItem = "mlp_c"
     case longPressMenuShareItem = "mlp_s"
 
+    case httpsUpgradeSiteError = "ehd"
 }
 
 public class Pixel {
 
     private static let appUrls = AppUrls()
     
+    public struct Parameters {
+        static let url = "url"
+        static let errorCode = "error_code"
+        static let statusCode = "status_code"
+    }
+    
     private struct Constants {
-        
         static let tablet = "tablet"
         static let phone = "phone"
-        
     }
     
     private init() {
@@ -58,12 +63,18 @@ public class Pixel {
     
     public static func fire(pixel: PixelName,
                             forDeviceType deviceType: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+                            withAdditionalParameters params: [String: String?] = [:],
                             withHeaders headers: HTTPHeaders = APIHeaders().defaultHeaders) {
+        
         let formFactor = deviceType == .pad ? Constants.tablet : Constants.phone
-        Alamofire.request(appUrls.pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor),
-                          headers: headers).response { data in
+        let url = appUrls
+            .pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor)
+            .addParams(params)
+        
+        Alamofire.request(url, headers: headers).response { data in
             Logger.log(items: "Fire pixel \(pixel.rawValue) \(data)")
         }
+    
     }
     
 }

--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -33,6 +33,16 @@ extension URL {
     enum Host: String {
         case localhost
     }
+    
+    public var simpleUrl: String {
+        var string = ""
+        if let scheme = scheme {
+            string = "\(scheme)://"
+        }
+        string += host ?? ""
+        string += path
+        return string
+    }
 
     public func getParam(name: String) -> String? {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }
@@ -52,10 +62,10 @@ extension URL {
         return components.url ?? self
     }
 
-    public func addParams(_ params: [URLQueryItem]) -> URL {
+    public func addParams(_ params: [String: String?]) -> URL {
         var url = self
         for param in params {
-            url = url.addParam(name: param.name, value: param.value)
+            url = url.addParam(name: param.key, value: param.value)
         }
         return url
     }

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.1</string>
+	<string>7.9.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -38,6 +38,22 @@ class PixelTests: XCTestCase {
 
     }
     
+    func testWhenPixelIsFiredWithAdditionalParametersThenParametersAdded() {
+        let expectation = XCTestExpectation()
+        let params = ["param1": "value1", "param2": "value2"]
+        
+        stub(condition: isHost(host) && isPath("/t/ml_ios_phone")) { request -> OHHTTPStubsResponse in
+            XCTAssertEqual("value1", request.url?.getParam(name: "param1"))
+            XCTAssertEqual("value2", request.url?.getParam(name: "param2"))
+            expectation.fulfill()
+            return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .phone, withAdditionalParameters: params)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
     func testWhenAppLaunchPixelIsFiredFromPhoneThenCorrectURLRequestIsMade() {
         let expectation = XCTestExpectation()
         

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -20,11 +20,36 @@
 import XCTest
 
 class URLExtensionTests: XCTestCase {
-
+    
+    func testWhenUriContainsDomainThenSimpleUrlIsEqual() {
+        let url = "http://example.com"
+        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
+    }
+    
+    func testWhenUriCotnainsSubdomainThenSimpleUrlIsEqual() {
+        let url = "http://subdomain.example.com"
+        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
+    }
+    
+    func testWhenUriContainsPathThenSimpleUrlIsEqual() {
+        let url = "http://example.com/about"
+        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
+    }
+    
+    func whenUriContainsUsernameThenSimpleUrlOmitsThis() {
+        let url = "http://user@example.com"
+        XCTAssertEqual("http://example.com", URL(string: url)!.simpleUrl)
+    }
+    
+    func testWhenUriContainsParametersThenSimpleUrlOmitsThese() {
+        let url = "http://example.com?search=54"
+        XCTAssertEqual("http://example.com", URL(string: url)!.simpleUrl)
+    }
+    
     func testWhenURLHasLongTLDItStillIsConsideredValid() {
         XCTAssertTrue(URL.isWebUrl(text: "https://blah.accountants"))
     }
-
+    
     func testWhenUserIsPresentThenIsWebUrlIsFalse() {
         XCTAssertFalse(URL.isWebUrl(text: "http://example.com@sample.com"))
     }

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -26,8 +26,13 @@ class URLExtensionTests: XCTestCase {
         XCTAssertEqual(url, URL(string: url)!.simpleUrl)
     }
     
-    func testWhenUriCotnainsSubdomainThenSimpleUrlIsEqual() {
+    func testWhenUriContainsSubdomainThenSimpleUrlIsEqual() {
         let url = "http://subdomain.example.com"
+        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
+    }
+    
+    func testWhenUriMissingSchemeThenSimpleUrlIsEqual() {
+        let url = "example.com"
         XCTAssertEqual(url, URL(string: url)!.simpleUrl)
     }
     
@@ -36,7 +41,7 @@ class URLExtensionTests: XCTestCase {
         XCTAssertEqual(url, URL(string: url)!.simpleUrl)
     }
     
-    func whenUriContainsUsernameThenSimpleUrlOmitsThis() {
+    func testWhenUriContainsUsernameThenSimpleUrlOmitsThis() {
         let url = "http://user@example.com"
         XCTAssertEqual("http://example.com", URL(string: url)!.simpleUrl)
     }

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.0</string>
+	<string>7.9.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/TodayExtension/Info.plist
+++ b/TodayExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.0</string>
+	<string>7.9.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/fastlane/metadata/default/release_notes.txt
+++ b/fastlane/metadata/default/release_notes.txt
@@ -1,1 +1,1 @@
-In this release we've fixed a bug that made it difficult to open the tab switcher and also improved what is displayed in the tab switcher.
+In this release we've added optimizations to our HTTPS upgrading solution.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/832602107339144/f
Tech Design URL: N/A however spec was discussed in https://app.asana.com/0/56420494107937/832602107339145/f

**Description**:
Fire pixel on https upgrade failures to allow bad data to be removed from lists

**Steps to test this PR**:
1. Go to a broken https upgrade site ensure that the new ehd pixel is fired.
It may be easier to got to `HTTPSUpgrade.swift` and return true from the ` isInUpgradeList` method. Then visit https://badssl.com and tap on the "expired" link.

1. Ensure that existing pixels fire as normal


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
