### PR TITLE
Add https upgrades summary pixel

### DIFF
--- a/AtbIntegrationTests/AtbServerTests.swift
+++ b/AtbIntegrationTests/AtbServerTests.swift
@@ -87,4 +87,7 @@ class MockStatisticsStore: StatisticsStore {
     
     var atbWithVariant: String?
     
+    var httpsUpgradesTotal = 0
+    
+    var httpsUpgradesFailures = 0
 }

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -40,9 +40,9 @@ public struct AppUrls {
         static let faviconService = "\(base)/ip3/%@.ico"
  
         static let staticBase = "https://staticcdn.duckduckgo.com"
-        static let httpsBloomFilter = "\(staticBase)/https/https-mobile-bloom.bin"
-        static let httpsBloomFilterSpec = "\(staticBase)/https/https-mobile-bloom-spec.json"
-        static let httpsWhitelist = "\(staticBase)/https/https-mobile-whitelist.json"
+        static let httpsBloomFilter = "\(staticBase)/https/https-mobile-bloom.bin?cache-version=1"
+        static let httpsBloomFilterSpec = "\(staticBase)/https/https-mobile-bloom-spec.json?cache-version=1"
+        static let httpsWhitelist = "\(staticBase)/https/https-mobile-whitelist.json?cache-version=1"
         
         static let pixelBase = ProcessInfo.processInfo.environment["PIXEL_BASE_URL", default: "https://improving.duckduckgo.com"]
         static let pixel = "\(pixelBase)/t/%@_ios_%@"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -48,9 +48,12 @@ public class Pixel {
 
     private static let appUrls = AppUrls()
     
-    public struct Parameters {
+    public struct EhdParameters {
         public static let url = "url"
         public static let errorCode = "error_code"
+    }
+    
+    public struct EhsParameters {
         public static let totalCount = "total"
         public static let failureCount = "failures"
     }

--- a/Core/StatisticsStore.swift
+++ b/Core/StatisticsStore.swift
@@ -25,7 +25,8 @@ public protocol StatisticsStore: class {
     var atb: String? { get set }
     var retentionAtb: String? { get set }
     var variant: String? { get set }
-
     var atbWithVariant: String? { get }
-
+    
+    var httpsUpgradesTotal: Int { get set }
+    var httpsUpgradesFailures: Int { get set }
 }

--- a/Core/StatisticsUserDefaults.swift
+++ b/Core/StatisticsUserDefaults.swift
@@ -27,6 +27,8 @@ public class StatisticsUserDefaults: StatisticsStore {
         static let atb = "com.duckduckgo.statistics.atb.key"
         static let retentionAtb = "com.duckduckgo.statistics.retentionatb.key"
         static let variant = "com.duckduckgo.statistics.variant.key"
+        static let httpsUpgradesTotal = "com.duckduckgo.statistics.httpsupgradestotal.key"
+        static let httpsUpgradesFailures = "com.duckduckgo.statistics.httpsupgradesfailures.key"
     }
 
     private var userDefaults: UserDefaults? {
@@ -73,5 +75,22 @@ public class StatisticsUserDefaults: StatisticsStore {
         guard let atb = atb else { return nil }
         return "\(atb)\(variant ?? "")"
     }
-
+    
+    public var httpsUpgradesTotal: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.httpsUpgradesTotal) ?? 0
+        }
+        set {
+            userDefaults?.set(newValue, forKey: Keys.httpsUpgradesTotal)
+        }
+    }
+    
+    public var httpsUpgradesFailures: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.httpsUpgradesFailures) ?? 0
+        }
+        set {
+            userDefaults?.set(newValue, forKey: Keys.httpsUpgradesFailures)
+        }
+    }
 }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -461,8 +461,8 @@ extension WebViewController: WKNavigationDelegate {
     
     private func reportHttpsUpgradeSiteError(url: URL, error: String) {
         let params = [
-            Pixel.Parameters.errorCode: error,
-            Pixel.Parameters.url: url.simpleUrl
+            Pixel.EhdParameters.errorCode: error,
+            Pixel.EhdParameters.url: url.simpleUrl
         ]
         Pixel.fire(pixel: .httpsUpgradeSiteError, withAdditionalParameters: params)
         statisticsStore.httpsUpgradesFailures += 1

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -357,7 +357,6 @@ extension WebViewController: WKNavigationDelegate {
         let error = error as NSError
         if let url = webView.url, isHttpsUpgradeSite(url: url) {
             reportHttpsUpgradeSiteError(url: url, error: "\(error.domain)_\(error.code)")
-            statisticsStore.httpsUpgradesFailures += 1
         }
         
         checkForReloadOnError()
@@ -466,6 +465,7 @@ extension WebViewController: WKNavigationDelegate {
             Pixel.Parameters.url: url.simpleUrl
         ]
         Pixel.fire(pixel: .httpsUpgradeSiteError, withAdditionalParameters: params)
+        statisticsStore.httpsUpgradesFailures += 1
     }
 }
 

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		839F46B620DD9D31003B8A66 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839F46B520DD9D31003B8A66 /* FeedbackViewController.swift */; };
 		83A23D6320DC330000051F39 /* Feedback.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83A23D6220DC330000051F39 /* Feedback.storyboard */; };
 		83B8BDAF20AB14A70076D6A1 /* APIHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */; };
+		83BE9BC3215D69C1009844D9 /* AppConfigurationFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BE9BC2215D69C1009844D9 /* AppConfigurationFetch.swift */; };
 		83C05D06212C77D80068712A /* BloomFilterWrapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C05D04212C74600068712A /* BloomFilterWrapperTest.swift */; };
 		83C389CC212D818500C11612 /* CommonCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8328AABA212ADAD100293140 /* CommonCrypto.framework */; };
 		83D306A41F6D500B00ED7CE2 /* tosdr.json in Resources */ = {isa = PBXBuildFile; fileRef = 83D306A31F6D500B00ED7CE2 /* tosdr.json */; };
@@ -478,6 +479,7 @@
 		839F46B520DD9D31003B8A66 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		83A23D6220DC330000051F39 /* Feedback.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Feedback.storyboard; sourceTree = "<group>"; };
 		83B8BDAD20AB0DA90076D6A1 /* APIHeadersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHeadersTests.swift; sourceTree = "<group>"; };
+		83BE9BC2215D69C1009844D9 /* AppConfigurationFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurationFetch.swift; sourceTree = "<group>"; };
 		83C05D04212C74600068712A /* BloomFilterWrapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloomFilterWrapperTest.swift; sourceTree = "<group>"; };
 		83D306A31F6D500B00ED7CE2 /* tosdr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tosdr.json; sourceTree = "<group>"; };
 		83D4A73620E1272F003A7A6D /* FeedbackModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackModel.swift; sourceTree = "<group>"; };
@@ -1973,6 +1975,7 @@
 				85BA58541F34F49E00C6E8CA /* AppUserDefaults.swift */,
 				85BA58591F3506AE00C6E8CA /* AppSettings.swift */,
 				F1134EC01F40DD9300B73467 /* AppVersionExtension.swift */,
+				83BE9BC2215D69C1009844D9 /* AppConfigurationFetch.swift */,
 			);
 			name = Application;
 			sourceTree = "<group>";
@@ -2708,6 +2711,7 @@
 				83D4A73720E1272F003A7A6D /* FeedbackModel.swift in Sources */,
 				85C37D861FA8BE7100CDE257 /* PrivacyProtectionOverviewController.swift in Sources */,
 				F1617C131E572E0300DEDCAF /* TabSwitcherViewController.swift in Sources */,
+				83BE9BC3215D69C1009844D9 /* AppConfigurationFetch.swift in Sources */,
 				F17922E01E71BB59006E3D97 /* AutocompleteViewControllerDelegate.swift in Sources */,
 				8565A33D1FC3B26E00239327 /* PrivacyProtectionFooterController.swift in Sources */,
 				8528AE7C212EF4A200D0BD74 /* AppRatingPrompt.swift in Sources */,

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -1,5 +1,5 @@
 //
-//  AppBackgroundFetch.swift
+//  AppConfigurationFetch.swift
 //  DuckDuckGo
 //
 //  Copyright © 2018 DuckDuckGo. All rights reserved.
@@ -37,14 +37,14 @@ class AppConfigurationFetch {
                 newData = newData || newHttpsData
                 semaphore.signal()
             }
-            semaphore.wait()
 
             ContentBlockerLoader().start { newContentBlockingData in
                 newData = newData || newContentBlockingData
                 semaphore.signal()
             }
-            semaphore.wait()
             
+            semaphore.wait()
+            semaphore.wait()
             completion?(newData)
         }
     }
@@ -57,8 +57,8 @@ class AppConfigurationFetch {
         }
         
         let params = [
-            Pixel.Parameters.totalCount: "\(statisticsStore.httpsUpgradesTotal)",
-            Pixel.Parameters.failureCount: "\(statisticsStore.httpsUpgradesFailures)"
+            Pixel.EhsParameters.totalCount: "\(statisticsStore.httpsUpgradesTotal)",
+            Pixel.EhsParameters.failureCount: "\(statisticsStore.httpsUpgradesFailures)"
         ]
         
         Pixel.fire(pixel: .httpsUpgradeSiteSummary, withAdditionalParameters: params) { error in

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -1,0 +1,72 @@
+//
+//  AppBackgroundFetch.swift
+//  DuckDuckGo
+//
+//  Copyright © 2018 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+
+public typealias AppConfigurationCompletion = (Bool) -> Void
+
+class AppConfigurationFetch {
+    
+    private lazy var statisticsStore: StatisticsStore = StatisticsUserDefaults()
+
+    func start(completion: AppConfigurationCompletion?) {
+
+        DispatchQueue.global(qos: .background).async {
+
+            var newData = false
+            let semaphore = DispatchSemaphore(value: 0)
+            
+            self.sendHttpsSummaryPixel { newHttpsData in
+                newData = newData || newHttpsData
+                semaphore.signal()
+            }
+            semaphore.wait()
+
+            ContentBlockerLoader().start { newContentBlockingData in
+                newData = newData || newContentBlockingData
+                semaphore.signal()
+            }
+            semaphore.wait()
+            
+            completion?(newData)
+        }
+    }
+    
+    private func sendHttpsSummaryPixel(completion: @escaping (Bool) -> Void) {
+            
+        if statisticsStore.httpsUpgradesTotal == 0 {
+            completion(false)
+            return
+        }
+        
+        let params = [
+            Pixel.Parameters.totalCount: "\(statisticsStore.httpsUpgradesTotal)",
+            Pixel.Parameters.failureCount: "\(statisticsStore.httpsUpgradesFailures)"
+        ]
+        
+        Pixel.fire(pixel: .httpsUpgradeSiteSummary, withAdditionalParameters: params) { error in
+            if error == nil {
+                self.statisticsStore.httpsUpgradesTotal = 0
+                self.statisticsStore.httpsUpgradesFailures = 0
+            }
+            completion(true)
+        }
+    }
+}

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var authWindow: UIWindow?
     var window: UIWindow?
 
-    private lazy var bookmarkStore: BookmarkUserDefaults = BookmarkUserDefaults()
+    private lazy var bookmarkStore: BookmarkStore = BookmarkUserDefaults()
 
     // MARK: lifecycle
 
@@ -62,7 +62,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         startOnboardingFlowIfNotSeenBefore()
         if appIsLaunching {
             appIsLaunching = false
-            ContentBlockerLoader().start(completion: nil)
+            AppConfigurationFetch().start(completion: nil)
             displayAuthenticationWindow()
             beginAuthentication()
             initialiseBackgroundFetch(application)
@@ -97,10 +97,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Logger.log(items: #function)
 
-        ContentBlockerLoader().start { newData in
+        AppConfigurationFetch().start { newData in
             completionHandler(newData ? .newData : .noData)
         }
-
     }
 
     // MARK: private

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.2</string>
+	<string>7.9.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/DuckDuckGoTests/MockStatisticsStore.swift
+++ b/DuckDuckGoTests/MockStatisticsStore.swift
@@ -29,7 +29,8 @@ class MockStatisticsStore: StatisticsStore {
     }
 
     var variant: String?
-
     var atbWithVariant: String?
-
+    
+    var httpsUpgradesTotal = 0
+    var httpsUpgradesFailures = 0
 }

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -93,4 +93,34 @@ class PixelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testWhenPixelFiresSuccessfullyThenCompletesWithNoError() {
+        let expectation = XCTestExpectation()
+        
+        stub(condition: isHost(host)) { _ -> OHHTTPStubsResponse in
+            return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .phone) { error in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testWhenPixelFiresUnsuccessfullyThenCompletesWithError() {
+        let expectation = XCTestExpectation()
+        
+        stub(condition: isHost(host)) { _ -> OHHTTPStubsResponse in
+            return OHHTTPStubsResponse(data: Data(), statusCode: 404, headers: nil)
+        }
+        
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .phone) { error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+
 }

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.2</string>
+	<string>7.9.3</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/TodayExtension/Info.plist
+++ b/TodayExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.2</string>
+	<string>7.9.3</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/839627367764302
Tech Design URL: N/A however spec was discussed in https://app.asana.com/0/361428290920652/832602107339150

**Description**:
- Add a summary `ehs` pixel to determine https failures versus successes

**Steps to test this PR**:
1. Go to a broken https upgrade site ensure that the new ehd pixel is fired.
It may be easier to got to `HTTPSUpgrade.swift` and return true from the ` isInUpgradeList` method. Then visit https://badssl.com and tap on the "expired" link.
1. Navigate to a few sites successfully
1. Stop and relaunch the app ensure that the `ehs` summary pixel is fired on sync showing the count of failed versus total https sites in our upgrade list
1. Ensure that other app pixels continue to fire as normal
1. Ensure the app suncs as normal

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
