### PR TITLE
add permissions plist entry for face id

### DIFF
--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -49,6 +49,8 @@
 	<string>Allows you to save images to your device</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Allows you to upload photographs and videos</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Allows you unlock the app using Face ID</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>proximanova-light.otf</string>

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -50,7 +50,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Allows you to upload photographs and videos</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Allows you unlock the app using Face ID</string>
+	<string>Allows you to unlock using Face ID</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>proximanova-light.otf</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/846764864649334
Tech Design URL:
CC:

**Description**:

Fixes a chunk of feedback reporting that Face ID has stopped working.

**Steps to test this PR**:

1. On a device with Face ID - enable the application lock
1. switch to a different app
1. launch DuckDuckGo - should be prompted to allow access to Face ID
1. Deny access - should prompt for pin code
1. Repeat and allow access - should prompt for Face ID

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)