### PR TITLE
Remove path from https reports

### DIFF
--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -33,16 +33,6 @@ extension URL {
     enum Host: String {
         case localhost
     }
-    
-    public var simpleUrl: String {
-        var string = ""
-        if let scheme = scheme {
-            string = "\(scheme)://"
-        }
-        string += host ?? ""
-        string += path
-        return string
-    }
 
     public func getParam(name: String) -> String? {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -460,9 +460,10 @@ extension WebViewController: WKNavigationDelegate {
     }
     
     private func reportHttpsUpgradeSiteError(url: URL, error: String) {
+        guard let host = url.host else { return }
         let params = [
             Pixel.EhdParameters.errorCode: error,
-            Pixel.EhdParameters.url: "https://\(url.host ?? "")"
+            Pixel.EhdParameters.url: "https://\(host)"
         ]
         Pixel.fire(pixel: .httpsUpgradeSiteError, withAdditionalParameters: params)
         statisticsStore.httpsUpgradesFailures += 1

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -462,7 +462,7 @@ extension WebViewController: WKNavigationDelegate {
     private func reportHttpsUpgradeSiteError(url: URL, error: String) {
         let params = [
             Pixel.EhdParameters.errorCode: error,
-            Pixel.EhdParameters.url: url.simpleUrl
+            Pixel.EhdParameters.url: "https://\(url.host ?? "")"
         ]
         Pixel.fire(pixel: .httpsUpgradeSiteError, withAdditionalParameters: params)
         statisticsStore.httpsUpgradesFailures += 1

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -21,36 +21,6 @@ import XCTest
 
 class URLExtensionTests: XCTestCase {
     
-    func testWhenUriContainsDomainThenSimpleUrlIsEqual() {
-        let url = "http://example.com"
-        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
-    }
-    
-    func testWhenUriContainsSubdomainThenSimpleUrlIsEqual() {
-        let url = "http://subdomain.example.com"
-        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
-    }
-    
-    func testWhenUriMissingSchemeThenSimpleUrlIsEqual() {
-        let url = "example.com"
-        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
-    }
-    
-    func testWhenUriContainsPathThenSimpleUrlIsEqual() {
-        let url = "http://example.com/about"
-        XCTAssertEqual(url, URL(string: url)!.simpleUrl)
-    }
-    
-    func testWhenUriContainsUsernameThenSimpleUrlOmitsThis() {
-        let url = "http://user@example.com"
-        XCTAssertEqual("http://example.com", URL(string: url)!.simpleUrl)
-    }
-    
-    func testWhenUriContainsParametersThenSimpleUrlOmitsThese() {
-        let url = "http://example.com?search=54"
-        XCTAssertEqual("http://example.com", URL(string: url)!.simpleUrl)
-    }
-    
     func testWhenURLHasLongTLDItStillIsConsideredValid() {
         XCTAssertTrue(URL.isWebUrl(text: "https://blah.accountants"))
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/859498148695195

**Description**:
- Remove path from https reports
- Remove simpleUrl extension method based on previous team conversations that it is not needed

**Steps to test this PR**:
1. Update the `HTTPSUpgrade.isInUpgradeList` method to always return true.
1. Launch the app and watch traffic. Charles proxy can be a useful tool for this.
1. Visit https://expired.badssl.com/abcd
1. Note the EHD pixel fires with a url of https://expired.badssl.com (now omitting the "abcd" path section)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
