### PR TITLE
Remove domain label from the leaderboard

### DIFF
--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -728,7 +728,13 @@
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Hero Leaderboard On" translatesAutoresizingMaskIntoConstraints="NO" id="HGe-jW-qhx">
                                             <rect key="frame" x="177" y="20" width="60" height="55"/>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TRACKER NETWORK LEADERBOARD" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y3q-u7-IeX" userLabel="Mixed Encryption Label">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Top Offenders" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPS-SD-65t">
+                                            <rect key="frame" x="40" y="86" width="334" height="20"/>
+                                            <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="20"/>
+                                            <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TRACKER NETWORK FREQUENCY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y3q-u7-IeX" userLabel="Mixed Encryption Label">
                                             <rect key="frame" x="20" y="112" width="374" height="12"/>
                                             <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="12"/>
                                             <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
@@ -790,15 +796,18 @@
                                         <constraint firstItem="Y3q-u7-IeX" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" constant="-40" id="4ky-h3-4Hu"/>
                                         <constraint firstItem="4ye-uJ-wqw" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="BVe-K7-7L5"/>
                                         <constraint firstItem="2vQ-S5-Xxv" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" id="CUn-bm-XRn"/>
+                                        <constraint firstItem="IPS-SD-65t" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" constant="-80" id="GGd-LH-Oo9"/>
                                         <constraint firstItem="4ye-uJ-wqw" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" id="HsO-hc-aBG"/>
                                         <constraint firstItem="Y3q-u7-IeX" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="OZB-Xz-T7R"/>
                                         <constraint firstItem="HGe-jW-qhx" firstAttribute="top" secondItem="UAf-eb-tA7" secondAttribute="top" constant="20" id="PcO-KV-Iw4"/>
                                         <constraint firstItem="2vQ-S5-Xxv" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="ST8-Fr-SiZ"/>
                                         <constraint firstItem="HGe-jW-qhx" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="bIe-DI-dgG"/>
                                         <constraint firstItem="2vQ-S5-Xxv" firstAttribute="top" secondItem="4ye-uJ-wqw" secondAttribute="bottom" id="gEe-2D-nwE"/>
+                                        <constraint firstItem="IPS-SD-65t" firstAttribute="top" secondItem="HGe-jW-qhx" secondAttribute="bottom" constant="11" id="kRE-k1-1n2"/>
                                         <constraint firstAttribute="bottom" secondItem="2vQ-S5-Xxv" secondAttribute="bottom" id="nkd-F5-2YP"/>
                                         <constraint firstItem="Ict-Tf-vBn" firstAttribute="leading" secondItem="UAf-eb-tA7" secondAttribute="leading" constant="20" id="pDB-lj-mmP"/>
-                                        <constraint firstItem="Y3q-u7-IeX" firstAttribute="top" secondItem="HGe-jW-qhx" secondAttribute="bottom" constant="40.33" id="ptn-4m-rYU"/>
+                                        <constraint firstItem="Y3q-u7-IeX" firstAttribute="top" secondItem="IPS-SD-65t" secondAttribute="bottom" constant="6" id="ptn-4m-rYU"/>
+                                        <constraint firstItem="IPS-SD-65t" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="r7g-88-2oT"/>
                                         <constraint firstItem="4ye-uJ-wqw" firstAttribute="top" secondItem="UAf-eb-tA7" secondAttribute="top" id="wZV-UM-8oh"/>
                                         <constraint firstItem="Ict-Tf-vBn" firstAttribute="top" secondItem="UAf-eb-tA7" secondAttribute="top" constant="20" id="wdt-rA-eO2"/>
                                     </constraints>

--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -728,12 +728,6 @@
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Hero Leaderboard On" translatesAutoresizingMaskIntoConstraints="NO" id="HGe-jW-qhx">
                                             <rect key="frame" x="177" y="20" width="60" height="55"/>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="www.example.com" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPS-SD-65t">
-                                            <rect key="frame" x="40" y="86" width="334" height="20"/>
-                                            <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="20"/>
-                                            <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TRACKER NETWORK LEADERBOARD" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y3q-u7-IeX" userLabel="Mixed Encryption Label">
                                             <rect key="frame" x="20" y="112" width="374" height="12"/>
                                             <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="12"/>
@@ -796,18 +790,15 @@
                                         <constraint firstItem="Y3q-u7-IeX" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" constant="-40" id="4ky-h3-4Hu"/>
                                         <constraint firstItem="4ye-uJ-wqw" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="BVe-K7-7L5"/>
                                         <constraint firstItem="2vQ-S5-Xxv" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" id="CUn-bm-XRn"/>
-                                        <constraint firstItem="IPS-SD-65t" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" constant="-80" id="GGd-LH-Oo9"/>
                                         <constraint firstItem="4ye-uJ-wqw" firstAttribute="width" secondItem="UAf-eb-tA7" secondAttribute="width" id="HsO-hc-aBG"/>
                                         <constraint firstItem="Y3q-u7-IeX" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="OZB-Xz-T7R"/>
                                         <constraint firstItem="HGe-jW-qhx" firstAttribute="top" secondItem="UAf-eb-tA7" secondAttribute="top" constant="20" id="PcO-KV-Iw4"/>
                                         <constraint firstItem="2vQ-S5-Xxv" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="ST8-Fr-SiZ"/>
                                         <constraint firstItem="HGe-jW-qhx" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="bIe-DI-dgG"/>
                                         <constraint firstItem="2vQ-S5-Xxv" firstAttribute="top" secondItem="4ye-uJ-wqw" secondAttribute="bottom" id="gEe-2D-nwE"/>
-                                        <constraint firstItem="IPS-SD-65t" firstAttribute="top" secondItem="HGe-jW-qhx" secondAttribute="bottom" constant="11" id="kRE-k1-1n2"/>
                                         <constraint firstAttribute="bottom" secondItem="2vQ-S5-Xxv" secondAttribute="bottom" id="nkd-F5-2YP"/>
                                         <constraint firstItem="Ict-Tf-vBn" firstAttribute="leading" secondItem="UAf-eb-tA7" secondAttribute="leading" constant="20" id="pDB-lj-mmP"/>
-                                        <constraint firstItem="Y3q-u7-IeX" firstAttribute="top" secondItem="IPS-SD-65t" secondAttribute="bottom" constant="6" id="ptn-4m-rYU"/>
-                                        <constraint firstItem="IPS-SD-65t" firstAttribute="centerX" secondItem="UAf-eb-tA7" secondAttribute="centerX" id="r7g-88-2oT"/>
+                                        <constraint firstItem="Y3q-u7-IeX" firstAttribute="top" secondItem="HGe-jW-qhx" secondAttribute="bottom" constant="40.33" id="ptn-4m-rYU"/>
                                         <constraint firstItem="4ye-uJ-wqw" firstAttribute="top" secondItem="UAf-eb-tA7" secondAttribute="top" id="wZV-UM-8oh"/>
                                         <constraint firstItem="Ict-Tf-vBn" firstAttribute="top" secondItem="UAf-eb-tA7" secondAttribute="top" constant="20" id="wdt-rA-eO2"/>
                                     </constraints>
@@ -976,7 +967,6 @@
                         <viewLayoutGuide key="safeArea" id="s83-RN-jpp"/>
                     </view>
                     <connections>
-                        <outlet property="domainLabel" destination="IPS-SD-65t" id="acs-Qv-veN"/>
                         <outlet property="heroIconImage" destination="HGe-jW-qhx" id="fHi-CA-OCI"/>
                         <outlet property="hoveringResetContainer" destination="nFB-0r-HZW" id="hZ6-ca-wPv"/>
                         <outlet property="hoveringView" destination="zKA-e0-nkA" id="GE0-aa-qKX"/>

--- a/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
+++ b/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
@@ -49,7 +49,6 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
         
         initHeroIcon()
         initResetButton()
-        initDomainLabel()
         initDrama()
         update()
 
@@ -131,10 +130,6 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
         let paragaphStyle = NSMutableParagraphStyle()
         paragaphStyle.lineHeightMultiple = 1.375
         return paragaphStyle
-    }
-
-    private func initDomainLabel() {
-        domainLabel.text = siteRating.domain
     }
 
     private func initResetButton() {


### PR DESCRIPTION
The trackers listed in the leaderbaord may not be related to the current domain. Showing domain label may cause misleadings. This patch remove the domain label and related constrains, a new constrain is added to keep the any other things in their original position.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:

This is the original layout of the tracker leaderboard, when I am browsing https://duckduckgo.com:
<img width="535" alt="screen shot 2018-10-16 at 11 17 15 pm" src="https://user-images.githubusercontent.com/3814422/47029720-cf6f0e80-d19e-11e8-9513-78880f5c9e1b.png">
We can see that there are many trackers listed under the domain, however, we all know that duckduckgo has no relationship to these trackers, and the trackers are the statical data from my browsing history.

In order to clarify that these trackers may not be related to what I am browsing, I propose removing the domain label from the tracker leaderboard.

<img width="535" alt="screen shot 2018-10-16 at 11 53 18 pm" src="https://user-images.githubusercontent.com/3814422/47030062-7d7ab880-d19f-11e8-90f2-cc03a8386b4f.png">

FYI, The value 40.33 of the constrain is the origin vertical distance between the image **PP Hero Leaderboard On** and the text **TRACKER NETWORK LEADERBOARD**.

**Steps to test this PR**:
1. Install duckduckgo app
1. Browser with duckduckgo app until there is something in the leaderboard
1. Visit any website, such as https://duckduckgo.com
1. Go to tracker leaderboard, and the domain name of the site we are visiting is not shown in the leaderboard


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
