### PR TITLE
fix tracker blocking bug

### DIFF
--- a/Core/ContentBlockerStringCache.swift
+++ b/Core/ContentBlockerStringCache.swift
@@ -23,7 +23,7 @@ public class ContentBlockerStringCache {
 
     struct Constants {
         // bump the cache version if you know the cache should be invalidated on the next release
-        static let cacheVersion = 4
+        static let cacheVersion = 5
         static let cacheVersionKey = "com.duckduckgo.contentblockerstringcache.version"
     }
 

--- a/Core/DisconnectMeStore.swift
+++ b/Core/DisconnectMeStore.swift
@@ -89,7 +89,7 @@ public class DisconnectMeStore {
     }
 
     private func convertToInjectableJson(_ trackers: [String: DisconnectMeTracker]) throws -> String {
-        let simplifiedTrackers = trackers.mapValues({ $0.networkName })
+        let simplifiedTrackers = trackers.mapValues { $0.parentUrl?.host }
         let json = try JSONSerialization.data(withJSONObject: simplifiedTrackers, options: .prettyPrinted)
         if let jsonString = String(data: json, encoding: .utf8) {
             return jsonString

--- a/Core/SiteRating.swift
+++ b/Core/SiteRating.swift
@@ -37,7 +37,6 @@ public class SiteRating {
     }
 
     public let url: URL
-    public let protectionId: String
     public let httpsForced: Bool
     public let privacyPractice: PrivacyPractices.Practice
     public let isMajorTrackerNetwork: Bool
@@ -56,10 +55,9 @@ public class SiteRating {
                 httpsForced: Bool = false,
                 entityMapping: EntityMapping = EntityMapping(),
                 privacyPractices: PrivacyPractices = PrivacyPractices(),
-                prevalenceStore: PrevalenceStore = EmbeddedPrevalenceStore(),
-                protectionId: String = UUID.init().uuidString) {
+                prevalenceStore: PrevalenceStore = EmbeddedPrevalenceStore()) {
 
-        Logger.log(text: "new SiteRating(url: \(url), protectionId: \(protectionId))")
+        Logger.log(text: "new SiteRating(url: \(url), httpsForced: \(httpsForced))")
 
         if let host = url.host, let entity = entityMapping.findEntity(forHost: host) {
             self.grade.setParentEntity(named: entity, withPrevalence: prevalenceStore.prevalences[entity])
@@ -68,7 +66,6 @@ public class SiteRating {
             self.isMajorTrackerNetwork = false
         }
 
-        self.protectionId = protectionId
         self.url = url
         self.httpsForced = httpsForced
         self.prevalenceStore = prevalenceStore
@@ -82,7 +79,7 @@ public class SiteRating {
         self.grade.privacyScore = privacyPractice.score
         
     }
-
+    
     public var https: Bool {
         return url.isHttps()
     }
@@ -158,6 +155,10 @@ public class SiteRating {
 
     public var majorNetworkTrackersBlocked: [DetectedTracker: Int] {
         return trackersBlocked.filter(majorNetworkFilter)
+    }
+    
+    public func isFor(_ url: URL?) -> Bool {
+        return domain == url?.host
     }
 
     private func uniqueMajorTrackerNetworks(trackers: [DetectedTracker: Int]) -> Int {

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -46,8 +46,8 @@ extension WKWebViewConfiguration {
         return configuration
     }
 
-    public func loadScripts(with id: String, contentBlocking: Bool) {
-        Loader(id, userContentController, contentBlocking).load()
+    public func loadScripts(contentBlocking: Bool) {
+        Loader(userContentController, contentBlocking).load()
     }
 
 }
@@ -64,12 +64,10 @@ private class Loader {
     let cache = ContentBlockerStringCache()
     let javascriptLoader = JavascriptLoader()
 
-    let id: String
     let userContentController: WKUserContentController
     let contentBlocking: Bool
 
-    init(_ id: String, _ userContentController: WKUserContentController, _ contentBlocking: Bool) {
-        self.id = id
+    init(_ userContentController: WKUserContentController, _ contentBlocking: Bool) {
         self.userContentController = userContentController
         self.contentBlocking = contentBlocking
     }
@@ -91,7 +89,7 @@ private class Loader {
         let configuration = ContentBlockerConfigurationUserDefaults()
         let whitelist = configuration.domainWhitelist.toJsonLookupString()
         loadContentBlockerDependencyScripts()
-        loadBlockerData(with: whitelist, and: configuration.enabled, with: id)
+        loadBlockerData(with: whitelist, and: configuration.enabled)
         load(scripts: [ .disconnectme, .contentblocker ], forMainFrameOnly: false)
         load(scripts: [ .detection ], forMainFrameOnly: false)
     }
@@ -107,13 +105,12 @@ private class Loader {
         javascriptLoader.load(script: .tlds, withReplacements: [ "${tlds}": tlds.json ], into: userContentController, forMainFrameOnly: false)
     }
 
-    private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool, with id: String) {
+    private func loadBlockerData(with whitelist: String, and blockingEnabled: Bool) {
 
         let surrogates = loadSurrogateJson()
         let disconnectMeStore = DisconnectMeStore()
 
         javascriptLoader.load(script: .blockerData, withReplacements: [
-            "${protectionId}": id,
             "${blocking_enabled}": "\(blockingEnabled)",
             "${disconnectmeBanned}": disconnectMeStore.bannedTrackersJson,
             "${disconnectmeAllowed}": disconnectMeStore.allowedTrackersJson,

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -297,9 +297,9 @@ open class WebViewController: UIViewController {
         webView.isHidden = false
     }
 
-    open func reloadScripts(with protectionId: String) {
+    open func reloadScripts() {
         webView.configuration.userContentController.removeAllUserScripts()
-        webView.configuration.loadScripts(with: protectionId, contentBlocking: !isDuckDuckGoUrl())
+        webView.configuration.loadScripts(contentBlocking: !isDuckDuckGoUrl())
     }
 
     private func isDuckDuckGoUrl() -> Bool {

--- a/Core/blockerdata.js
+++ b/Core/blockerdata.js
@@ -19,7 +19,6 @@
 
 var duckduckgoBlockerData = {
 
-	protectionId: "${protectionId}",
     blockingEnabled: ${blocking_enabled},
 	disconnectmeBanned: ${disconnectmeBanned},
     disconnectmeAllowed: ${disconnectmeAllowed},

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -25,6 +25,7 @@ var duckduckgoContentBlocking = function() {
 	// private
 	function handleDetection(url, detectionMethod) {
 		if (isAssociatedFirstPartyDomain(url)) {
+			duckduckgoMessaging.log("first party url: " + url)
 			return null
 		}
 
@@ -37,6 +38,7 @@ var duckduckgoContentBlocking = function() {
 		}
 
 		if (currentDomainIsWhitelisted()) {
+			duckduckgoMessaging.log("domain whitelisted: " + url)
 			return {
 				method: detectionMethod,
 				block: false,
@@ -44,6 +46,7 @@ var duckduckgoContentBlocking = function() {
 			}
 		}
 
+		duckduckgoMessaging.log("blocking: " + url)
 		return {
 			method: detectionMethod,
 			block: true,
@@ -164,6 +167,7 @@ var duckduckgoContentBlocking = function() {
 	function getParentEntityUrl() {
 		var parentEntity = DisconnectMe.parentTracker(topLevelUrl)
 		if (parentEntity) {
+			duckduckgoMessaging.log("topLevelUrl: " + topLevelUrl.protocol + " parentEntity: " + JSON.stringify(parentEntity))
 			return new URL(topLevelUrl.protocol + parentEntity.parent)
 		}
 		return null
@@ -269,7 +273,6 @@ var duckduckgoContentBlocking = function() {
 		blockFunc(trackerUrl, result.block)
 
         duckduckgoMessaging.trackerDetected({
-        	protectionId: duckduckgoBlockerData.protectionId,
 	        url: trackerUrl,
 	        blocked: result.block,
 	        method: result.method,

--- a/Core/detection.js
+++ b/Core/detection.js
@@ -33,8 +33,12 @@
             type = event.target.nodeName
         }
 
+        duckduckgoMessaging.log("checking " + event.url + " (" + type + ")");
         duckduckgoContentBlocking.shouldBlock(event.url, type, function(url, block) {
-            if (!block) { return }
+            if (!block) { 
+                duckduckgoMessaging.log("don't block " + url);
+                return 
+            }
 
             duckduckgoMessaging.log("blocking beforeload")
             if (duckduckgoContentBlocking.loadSurrogate(event.url)) {                

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.10.1</string>
+	<string>7.10.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -29,7 +29,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -29,7 +29,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -125,10 +125,9 @@ class TabViewController: WebViewController {
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         guard let url = webView.url else { return }
 
-        if let siteRating = siteRating {
-            self.siteRating = SiteRating(url: url, httpsForced: httpsForced, protectionId: siteRating.protectionId)
-            updateSiteRating()
-        }
+        loadedURL = url
+        self.siteRating = SiteRating(url: url, httpsForced: httpsForced)
+        updateSiteRating()
     }
 
     private func resetNavigationBar() {
@@ -456,10 +455,9 @@ extension TabViewController: WKScriptMessageHandler {
         guard let dict = message.body as? [String: Any] else { return }
         guard let blocked = dict[TrackerDetectedKey.blocked] as? Bool else { return }
         guard let urlString = dict[TrackerDetectedKey.url] as? String else { return }
-        guard let protectionId = dict[TrackerDetectedKey.protectionId] as? String else { return }
-
-        guard protectionId == siteRating.protectionId else {
-            Logger.log(text: "protectionId check failed \(protectionId) != \(self.siteRating?.protectionId ?? "<none>")")
+        
+        guard siteRating.isFor(self.url) else {
+            Logger.log(text: "mismatching domain \(self.url as Any) vs \(siteRating.domain as Any)")
             return
         }
 
@@ -489,6 +487,7 @@ extension TabViewController: WebEventsDelegate {
         webView.configuration.userContentController.add(self, name: MessageHandlerNames.trackerDetected)
         webView.configuration.userContentController.add(self, name: MessageHandlerNames.cache)
         webView.configuration.userContentController.add(self, name: MessageHandlerNames.log)
+        reloadScripts()
     }
 
     func detached(webView: WKWebView) {
@@ -508,12 +507,9 @@ extension TabViewController: WebEventsDelegate {
 
         // if host and scheme are the same, use same protection id and don't inject scripts, otherwise, reset and reload
         if let siteRating = siteRating, siteRating.url.host == url?.host, siteRating.url.scheme == url?.scheme {
-            self.siteRating = SiteRating(url: siteRating.url, httpsForced: httpsForced, protectionId: siteRating.protectionId)
+            self.siteRating = SiteRating(url: siteRating.url, httpsForced: httpsForced)
         } else {
             resetSiteRating()
-            if let protectionId = siteRating?.protectionId {
-                reloadScripts(with: protectionId)
-            }
         }
 
         tabModel.link = link

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.10.1</string>
+	<string>7.10.2</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>7.10.1</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/TodayExtension/Info.plist
+++ b/TodayExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>7.10.1</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/TodayExtension/Info.plist
+++ b/TodayExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.10.1</string>
+	<string>7.10.2</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/872025706767190
Tech Design URL:
CC:

**Description**:

* remove protection id - compare current tab url with site rating url and only report trackers if they match
* inject scripts when web frame is created (otherwise they don't take effect quickly enough)
* fix bug where disconnect was injecting network name rather than parent url causing a javascript error which meant some trackers were missed
* add more useful javascript logging (will propagate to app, but not the javascript console and will not be logged in release builds)
* bump build number

**Steps to test this PR**:

1. Visit a range of URLs and ensure that trackers are being blocked as expected and that any JavaScript errors are not used by our scripts.
1. Ensure that the correct grade is applied to sites (for instance, navigating to and from DuckDuckGo.com which should always be an A)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
