### PR TITLE
fix protection and whitelist toggle

### DIFF
--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -65,18 +65,18 @@ private class Loader {
     let javascriptLoader = JavascriptLoader()
 
     let userContentController: WKUserContentController
-    let contentBlocking: Bool
+    let injectContentBlockingScripts: Bool
 
-    init(_ userContentController: WKUserContentController, _ contentBlocking: Bool) {
+    init(_ userContentController: WKUserContentController, _ injectContentBlockingScripts: Bool) {
         self.userContentController = userContentController
-        self.contentBlocking = contentBlocking
+        self.injectContentBlockingScripts = injectContentBlockingScripts
     }
 
     func load() {
         Logger.log(text: "Loading scripts")
         loadDocumentLevelScripts()
 
-        if contentBlocking {
+        if injectContentBlockingScripts {
             loadContentBlockingScripts()
         }
     }

--- a/Core/WebViewController.swift
+++ b/Core/WebViewController.swift
@@ -227,7 +227,7 @@ open class WebViewController: UIViewController {
     private func checkForReloadOnError() {
         guard shouldReloadOnError else { return }
         shouldReloadOnError = false
-        reload()
+        reload(scripts: false)
     }
 
     private func shouldReissueSearch(for url: URL) -> Bool {
@@ -250,7 +250,10 @@ open class WebViewController: UIViewController {
         }
     }
 
-    public func reload() {
+    public func reload(scripts: Bool) {
+        if scripts {
+            reloadScripts()
+        }
         updateUserAgent()
         webView.reload()
     }
@@ -304,7 +307,7 @@ open class WebViewController: UIViewController {
         webView.isHidden = false
     }
 
-    open func reloadScripts() {
+    public func reloadScripts() {
         webView.configuration.userContentController.removeAllUserScripts()
         webView.configuration.loadScripts(contentBlocking: !isDuckDuckGoUrl())
     }

--- a/DuckDuckGo/PrivacyProtectionController.swift
+++ b/DuckDuckGo/PrivacyProtectionController.swift
@@ -24,7 +24,7 @@ protocol PrivacyProtectionDelegate: class {
 
     func omniBarTextTapped()
 
-    func reload()
+    func reload(scripts: Bool)
 
 }
 
@@ -149,7 +149,7 @@ extension PrivacyProtectionController: PrivacyProtectionErrorDelegate {
         DispatchQueue.main.async {
             if newData {
                 controller.dismiss(animated: true)
-                self.delegate?.reload()
+                self.delegate?.reload(scripts: true)
             } else {
                 controller.resetTryAgain()
             }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -156,7 +156,7 @@ class TabManager {
 
     func invalidateCache(forController controller: TabViewController) {
         if current === controller {
-            current?.reload()
+            current?.reload(scripts: false)
         } else {
             removeFromCache(controller)
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -122,10 +122,7 @@ class TabViewController: WebViewController {
     }
 
     @objc func onContentBlockerConfigurationChanged() {
-        // defer it for 0.2s so that the privacy protection UI can update instantly, otherwise this causes a visible delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            self.webView?.reload()
-        }
+        reload(scripts: true)
     }
 
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
@@ -212,7 +209,7 @@ class TabViewController: WebViewController {
             if isDesktop {
                 self?.load(url: url.toDesktopUrl())
             } else {
-                self?.reload()
+                self?.reload(scripts: false)
             }
         }
     }
@@ -224,10 +221,9 @@ class TabViewController: WebViewController {
         let title = whitelisted ? UserText.actionRemoveFromWhitelist : UserText.actionAddToWhitelist
         let operation = whitelisted ? whitelistManager.remove : whitelistManager.add
 
-        return UIAlertAction(title: title, style: .default) { [weak self] (_) in
+        return UIAlertAction(title: title, style: .default) { _ in
             Pixel.fire(pixel: .browsingMenuWhitelist)
             operation(domain)
-            self?.reload()
         }
 
     }
@@ -255,7 +251,7 @@ class TabViewController: WebViewController {
                     strongSelf.load(url: url)
                 }
             } else {
-                strongSelf.reload()
+                strongSelf.reload(scripts: false)
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->
 
Task/Issue URL: https://app.asana.com/0/392891325557410/687064381433120
Tech Design URL:
CC:

**Description**:

Fixes a bug where protection wouldn't toggle until after the forget all functionality had been used.  ie forces the scripts to be reloaded.

**Steps to test this PR**:
1. Go to a site with blockers,  observe in Xcode blocked "blocked = 0" messages
1. Toggle whitelist,  observe in Xcode blocked "blocked = 1" messages
1. Toggle whitelist,  observe in Xcode blocked "blocked = 0" messages
1. Toggle privacy protection in the dashboard,  observe in Xcode blocked "blocked = 0" messages
1. Toggle privacy protection in the dashboard,  observe in Xcode blocked "blocked = 1" messages

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
