### PR TITLE
remove atb and source params when sharing searches

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -190,4 +190,10 @@ public struct AppUrls {
         url = url.addParam(name: Param.atb, value: statisticsStore.atbWithVariant ?? "")
         return url
     }
+    
+    public func removeATBAndSource(fromUrl url: URL) -> URL {
+        guard isDuckDuckGoSearch(url: url) else { return url }
+        return url.removeParam(name: Param.atb).removeParam(name: Param.source)
+    }
+
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -343,10 +343,11 @@ class TabViewController: WebViewController {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] _ in
             Pixel.fire(pixel: .browsingMenuShare)
             guard let menu = self?.chromeDelegate?.omniBar.menuButton else { return }
-            self?.presentShareSheet(withItems: [ link.url, link ], fromView: menu)
+            guard let url = self?.appUrls.removeATBAndSource(fromUrl: link.url) else { return }
+            self?.presentShareSheet(withItems: [ url, link ], fromView: menu)
         }
     }
-
+    
     private func shareAction(forUrl url: URL, atPoint point: Point) -> UIAlertAction {
         return UIAlertAction(title: UserText.actionShare, style: .default) { [weak self] _ in
             Pixel.fire(pixel: .longPressMenuShareItem)

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -29,6 +29,21 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
+    func testWhenRemoveATBAndSourceFromSearchUrlThenUrlIsUnchanged() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let searchUrl = testee.searchUrl(text: "example")
+        let result = testee.removeATBAndSource(fromUrl: searchUrl)
+        XCTAssertNil(result.getParam(name: "atb"))
+        XCTAssertNil(result.getParam(name: "t"))
+    }
+
+    func testWhenRemoveATBAndSourceFromNonSearchUrlThenUrlIsUnchanged() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let example = "https://duckduckgo.com?atb=x&t=y"
+        let result = testee.removeATBAndSource(fromUrl: URL(string: example)!)
+        XCTAssertEqual(example, result.absoluteString)
+    }
+    
     func testWhenPixelUrlRequestThenCorrectURLIsReturned() {
         mockStatisticsStore.atbWithVariant = "x"
         let testee = AppUrls(statisticsStore: mockStatisticsStore)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/898065300990902/898545282117893 
Tech Design URL:
CC:

**Description**:

Removes atb and source params when sharing searches.

**Steps to test this PR**:
1. Perform a search and use the browsing menu to share the URL.  Copy it and paste it in to Safari - should be no ATB or source parameters.
1. Perform a search and use the browsing menu to share the URL. Choose "add bookmark" - displayed url should be unaffected.
1. Share other non-search links - URLs should be unaffected.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)