### PR TITLE
Remove CI test retry as it is extending build time

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,7 +32,6 @@ workflows:
     - xcode-test@1.18.17:
         inputs:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/xcode-atb-test-results-${BITRISE_SCHEME}.html"
-        - should_retry_test_on_fail: 'yes'
         - scheme: AtbIntegrationTests
     - deploy-to-bitrise-io@1.3.18: {}
     - cache-push@2.0.5: {}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/276630244458377/823983167962557

**Description**:
Remove retry config for integration tests as it seems to be extending the build time without fixing the issue. We will try and make these tests more reliable.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
