### PR TITLE
Update log statement to display milliseconds

### DIFF
--- a/Core/HTTPSUpgrade.swift
+++ b/Core/HTTPSUpgrade.swift
@@ -21,6 +21,10 @@ import Foundation
 
 public class HTTPSUpgrade {
     
+    private struct Constants {
+        static let millisecondsPerSecond = 1000.0
+    }
+    
     public static let shared = HTTPSUpgrade()
     
     private let dataReloadLock = NSLock()
@@ -55,10 +59,10 @@ public class HTTPSUpgrade {
         waitForAnyReloadsToComplete()
         
         guard let bloomFilter = bloomFilter else { return false }
-        let startTime = Date().timeIntervalSince1970
+        let startTimeMs = Date().timeIntervalSince1970 * Constants.millisecondsPerSecond
         let result = bloomFilter.contains(host)
-        let endTime = Date().timeIntervalSince1970
-        Logger.log(text: "Site \(host) \(result ? "can" : "cannot") be upgraded. Lookup took \(endTime - startTime)ms")
+        let endTimeMs = Date().timeIntervalSince1970 * Constants.millisecondsPerSecond
+        Logger.log(text: "Site \(host) \(result ? "can" : "cannot") be upgraded. Lookup took \(endTimeMs - startTimeMs)ms")
         
         return result
     }

--- a/Core/HTTPSUpgrade.swift
+++ b/Core/HTTPSUpgrade.swift
@@ -59,10 +59,11 @@ public class HTTPSUpgrade {
         waitForAnyReloadsToComplete()
         
         guard let bloomFilter = bloomFilter else { return false }
-        let startTimeMs = Date().timeIntervalSince1970 * Constants.millisecondsPerSecond
+        
+        let startTime = Date()
         let result = bloomFilter.contains(host)
-        let endTimeMs = Date().timeIntervalSince1970 * Constants.millisecondsPerSecond
-        Logger.log(text: "Site \(host) \(result ? "can" : "cannot") be upgraded. Lookup took \(endTimeMs - startTimeMs)ms")
+        let lookupTimeMs = abs(startTime.timeIntervalSinceNow) * Constants.millisecondsPerSecond
+        Logger.log(text: "Site \(host) \(result ? "can" : "cannot") be upgraded. Lookup took \(lookupTimeMs)ms")
         
         return result
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/914681888297007
Tech Design URL: N/A, this is a tiny PR

**Description**:
A small tweak to fix an incorrect log statement that was displaying seconds rather than milliseconds. I was doing some investigation into bloom timing and noticed it so fixed it but this is not urgent, it can be reviewed whenever time allows.

**Steps to test this PR**:
1. Check that the code change makes sense
1. Visit example.com and make sure everything still runs fine and the "Site example.com can be upgraded. Lookup took ..ms" log statement appears in the console

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)