### PR TITLE
fix the alignment of the fire button on the tool bar

### DIFF
--- a/DuckDuckGo/TabSwitcherButton.swift
+++ b/DuckDuckGo/TabSwitcherButton.swift
@@ -107,7 +107,7 @@ class TabSwitcherButton: UIView {
     }
     
     convenience init() {
-        self.init(frame: CGRect(x: 0, y: 0, width: 34, height: 44))
+        self.init(frame: CGRect(x: 0, y: 0, width: 29, height: 44))
     }
     
     required init(coder aDecoder: NSCoder) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/867363975659092
Tech Design URL:
CC:

**Description**:

Fixes the alignment of the fire button by resizing the tab switcher button.

**Steps to test this PR**:
1. Open tab switcher and click done - the fire button should appear to remain stationary
1. Ensure that the tab switcher button is still tappable 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
