### PR TITLE
Attempt to fix ETag crashes 

### DIFF
--- a/Core/APIRequest.swift
+++ b/Core/APIRequest.swift
@@ -24,6 +24,8 @@ public typealias APIRequestCompletion = (APIRequest.Response?, Error?) -> Void
 
 public class APIRequest {
     
+    private static let callbackQueue = DispatchQueue(label: "APIRequest callback queue", qos: .utility)
+    
     public struct Response {
         
         var data: Data?
@@ -41,7 +43,7 @@ public class APIRequest {
         
         return Alamofire.request(url, method: method, parameters: parameters, headers: APIHeaders().defaultHeaders)
             .validate(statusCode: 200..<300)
-            .responseData(queue: DispatchQueue.global(qos: .utility)) { response in
+            .responseData(queue: callbackQueue) { response in
                 
                 Logger.log(text: "Request for \(url) completed with response code: \(String(describing: response.response?.statusCode))")
                 Logger.log(text: " and headers \(String(describing: response.response?.allHeaderFields))")


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/890456148190619
Tech Design URL:
CC:

**Description**:
ETag crashes (despite being really rare) are the most frequent ones. See asana task for details about investigation.

**Steps to test this PR**:
1. Install and open the app.
2. Check whether initial requests are processed properly and content blocking info is available.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)