### PR TITLE
test a centered search field only

### DIFF
--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -20,6 +20,7 @@
 import Foundation
 
 public enum FeatureName {
+    case centeredSearchHomeScreen
     case homeScreen
     case singleFavorite
     case additionalFavorites
@@ -34,9 +35,10 @@ public struct Variant {
         Variant(name: "sd", weight: 1, features: []),
         
         // Enhanced home page experiment
-        Variant(name: "mk", weight: 2, features: []),
-        Variant(name: "ml", weight: 1, features: [.homeScreen, .singleFavorite]),
-        Variant(name: "mm", weight: 1, features: [.homeScreen, .singleFavorite, .additionalFavorites])
+        Variant(name: "mk", weight: 1, features: []),
+        Variant(name: "ml", weight: 0, features: [.homeScreen, .singleFavorite]),
+        Variant(name: "mm", weight: 0, features: [.homeScreen, .singleFavorite, .additionalFavorites]),
+        Variant(name: "mn", weight: 1, features: [.centeredSearchHomeScreen])
     ]
     
     public let name: String
@@ -95,14 +97,15 @@ public class DefaultVariantManager: VariantManager {
             return
         }
         
-        if !isHomeThemeExperimentAndPad(variant) {
+        if !isHomeScreenExperimentAndPad(variant) {
             storage.variant = variant.name
             Logger.log(text: "newly assigned variant: \(currentVariant as Any)")
         }
     }
     
-    private func isHomeThemeExperimentAndPad(_ variant: Variant) -> Bool {
-        return !variant.name.starts(with: "s") && uiIdiom == .pad
+    private func isHomeScreenExperimentAndPad(_ variant: Variant) -> Bool {
+        return (variant.features.contains(.homeScreen) || variant.features.contains(.centeredSearchHomeScreen))
+            && uiIdiom == .pad
     }
     
     private func selectVariant() -> Variant? {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		85C9E5F821B4232A00460EBC /* HomePageConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C9E5F721B4232A00460EBC /* HomePageConfigurationTests.swift */; };
 		85CC936E203C402C00690089 /* SpeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CC936D203C402C00690089 /* SpeedTests.swift */; };
 		85CC9376203C42A500690089 /* speed_test_sites.json in Resources */ = {isa = PBXBuildFile; fileRef = 85CC9375203C42A500690089 /* speed_test_sites.json */; };
+		85CE790721E8A9F600607B91 /* EmptySectionRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CE790621E8A9F600607B91 /* EmptySectionRenderer.swift */; };
 		85F1C3C61F7A4C7500161346 /* easylist-cached.js in Resources */ = {isa = PBXBuildFile; fileRef = 85F1C3C31F7A4C7500161346 /* easylist-cached.js */; };
 		85F1C3C71F7A4C7500161346 /* easylist-parsing.js in Resources */ = {isa = PBXBuildFile; fileRef = 85F1C3C41F7A4C7500161346 /* easylist-parsing.js */; };
 		85F1C3C81F7A4C7500161346 /* messaging.js in Resources */ = {isa = PBXBuildFile; fileRef = 85F1C3C51F7A4C7500161346 /* messaging.js */; };
@@ -716,6 +717,7 @@
 		85CC936D203C402C00690089 /* SpeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTests.swift; sourceTree = "<group>"; };
 		85CC936F203C402C00690089 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		85CC9375203C42A500690089 /* speed_test_sites.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = speed_test_sites.json; sourceTree = "<group>"; };
+		85CE790621E8A9F600607B91 /* EmptySectionRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySectionRenderer.swift; sourceTree = "<group>"; };
 		85F1C3C31F7A4C7500161346 /* easylist-cached.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "easylist-cached.js"; sourceTree = "<group>"; };
 		85F1C3C41F7A4C7500161346 /* easylist-parsing.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "easylist-parsing.js"; sourceTree = "<group>"; };
 		85F1C3C51F7A4C7500161346 /* messaging.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = messaging.js; sourceTree = "<group>"; };
@@ -1428,6 +1430,7 @@
 				85374D3B21AC41E700FF5A1E /* FavoritesHomeViewSectionRenderer.swift */,
 				85374D3721AC419800FF5A1E /* NavigationSearchHomeViewSectionRenderer.swift */,
 				853C5F5C21C117A6001F7A05 /* PaddingSpaceHomeViewSectionRenderer.swift */,
+				85CE790621E8A9F600607B91 /* EmptySectionRenderer.swift */,
 			);
 			name = Renderers;
 			sourceTree = "<group>";
@@ -3058,6 +3061,7 @@
 				85200F911FBA38E2001AF290 /* PrivacyProtectionScoreCardController.swift in Sources */,
 				F16390821E648B7A005B4550 /* HomeViewController.swift in Sources */,
 				98F3A1DA217B37200011A0D4 /* LightTheme.swift in Sources */,
+				85CE790721E8A9F600607B91 /* EmptySectionRenderer.swift in Sources */,
 				85BA585A1F3506AE00C6E8CA /* AppSettings.swift in Sources */,
 				F17922E21E71CD67006E3D97 /* NoSuggestionsTableViewCell.swift in Sources */,
 				85200F931FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift in Sources */,

--- a/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
@@ -27,12 +27,24 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
         static let searchCenterOffset: CGFloat = 50
         static let scrollUpAdjustment: CGFloat = 46
         
+        static let fixedSearchCenterOffset: CGFloat = -62
+        
+    }
+    
+    private var searchCenterOffset: CGFloat {
+        return fixed && isPortrait ? Constants.fixedSearchCenterOffset : Constants.searchCenterOffset
     }
     
     private weak var controller: HomeViewController!
     private weak var cell: CenteredSearchHomeCell?
 
     private var indexPath: IndexPath?
+    
+    private let fixed: Bool
+    
+    init(fixed: Bool = false) {
+        self.fixed = fixed
+    }
     
     func install(into controller: HomeViewController) {
         self.controller = controller
@@ -41,9 +53,10 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
                                                selector: #selector(CenteredSearchHomeViewSectionRenderer.rotated),
                                                name: UIDevice.orientationDidChangeNotification,
                                                object: nil)
-        
-        controller.allowContentUnderflow()
 
+        controller.collectionView.isScrollEnabled = !fixed
+
+        controller.allowContentUnderflow()
         controller.searchHeaderTransition = 0.0
         cell?.searchHeaderTransition = 0.0
 
@@ -72,18 +85,18 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath)
         -> CGSize {
-            let height = (collectionView.frame.height / 2) - Constants.searchCenterOffset
+            let height = (collectionView.frame.height / 2) - searchCenterOffset
             let width = collectionView.frame.width - (HomeViewSectionRenderers.Constants.sideInsets * 2)
             return CGSize(width: width, height: height)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let offsetY: CGFloat = Constants.searchCenterOffset + Constants.scrollUpAdjustment
+        let offsetY: CGFloat = Constants.scrollUpAdjustment
         
-        let targetHeight = (scrollView.frame.height / 2) - offsetY
+        let targetHeight = (scrollView.frame.height / 2) - searchCenterOffset
         let y = scrollView.contentOffset.y
 
-        let diff = targetHeight - y
+        let diff = targetHeight - y - offsetY
 
         guard diff < offsetY else {
             // search bar is in the center
@@ -100,7 +113,7 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
         }
 
         // search bar is transitioning
-        let percent = 1 - (diff / offsetY)
+        let percent = 1 - (diff / 46)
         controller.searchHeaderTransition = percent
         cell?.searchHeaderTransition = percent
     }

--- a/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
@@ -27,7 +27,7 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
         static let searchCenterOffset: CGFloat = 50
         static let scrollUpAdjustment: CGFloat = 46
         
-        static let fixedSearchCenterOffset: CGFloat = -62
+        static let fixedSearchCenterOffset: CGFloat = 30
         
     }
     

--- a/DuckDuckGo/EmptySectionRenderer.swift
+++ b/DuckDuckGo/EmptySectionRenderer.swift
@@ -1,0 +1,52 @@
+//
+//  EmptySectionRenderer.swift
+//  DuckDuckGo
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+class EmptySectionRenderer: HomeViewSectionRenderer {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return collectionView.dequeueReusableCell(withReuseIdentifier: "space", for: indexPath)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 1, height: collectionView.frame.size.height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        referenceSizeForHeaderInSection section: Int) -> CGSize? {
+        
+        return CGSize(width: 1, height: 39)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        referenceSizeForFooterInSection section: Int) -> CGSize? {
+        
+        return CGSize(width: 1, height: 10)
+    }
+    
+}

--- a/DuckDuckGo/HomeCollectionView.swift
+++ b/DuckDuckGo/HomeCollectionView.swift
@@ -55,6 +55,10 @@ class HomeCollectionView: UICollectionView {
             case .favorites:
                 renderers.install(renderer: FavoritesHomeViewSectionRenderer())
                 renderers.install(renderer: PaddingSpaceHomeViewSectionRenderer())
+                
+            case .fixedCenteredSearch:
+                renderers.install(renderer: CenteredSearchHomeViewSectionRenderer(fixed: true))
+                renderers.install(renderer: EmptySectionRenderer())
             }
         }
         

--- a/DuckDuckGo/HomePageConfiguration.swift
+++ b/DuckDuckGo/HomePageConfiguration.swift
@@ -25,21 +25,31 @@ class HomePageConfiguration {
     enum Component {
         case navigationBarSearch
         case centeredSearch
+        case fixedCenteredSearch
         case favorites
     }
     
     let variantManager: VariantManager
     
     var components: [Component] {
-        guard let currentVariant = variantManager.currentVariant,
-                currentVariant.features.contains(.homeScreen) else {
+        guard let currentVariant = variantManager.currentVariant else {
             return [ .navigationBarSearch ]
         }
+
+        if currentVariant.features.contains(.homeScreen) {
+            return [
+                .centeredSearch,
+                .favorites
+            ]
+        }
         
-        return [
-            .centeredSearch,
-            .favorites
-        ]
+        if currentVariant.features.contains(.centeredSearchHomeScreen) {
+            return [
+                .fixedCenteredSearch
+            ]
+        }
+        
+        return [ .navigationBarSearch ]
     }
     
     init(variantManager: VariantManager = DefaultVariantManager()) {
@@ -87,7 +97,8 @@ class HomePageConfiguration {
             return
         }
         
-        guard currentVariant.features.contains(.homeScreen) else {
+        let homeScreen = currentVariant.features.contains(.homeScreen) || currentVariant.features.contains(.centeredSearchHomeScreen)
+        guard homeScreen else {
             Logger.log(text: "no home screen in variant, not configuring omnibar")
             return
         }

--- a/DuckDuckGoTests/EnhancedHomePageVariantManagerTests.swift
+++ b/DuckDuckGoTests/EnhancedHomePageVariantManagerTests.swift
@@ -47,7 +47,7 @@ class EnhancedHomePageVariantManagerTests: XCTestCase {
     func testWhenEnhancedHomePageVariantAndNotOnPadThenVariantIsSelected() {
         
         let mockStatisticsStore = MockStatisticsStore()
-        let mockRng = MockVariantRNG(returnValue: Variant.defaultVariants.count)
+        let mockRng = MockVariantRNG(returnValue: 3)
         
         let variantManager = DefaultVariantManager(storage: mockStatisticsStore, rng: mockRng, uiIdiom: .phone)
         variantManager.assignVariantIfNeeded()

--- a/DuckDuckGoTests/EnhancedHomePageVariantManagerTests.swift
+++ b/DuckDuckGoTests/EnhancedHomePageVariantManagerTests.swift
@@ -65,5 +65,21 @@ class EnhancedHomePageVariantManagerTests: XCTestCase {
         
         XCTAssertNil(mockStatisticsStore.variant)
     }
+
+    func testWhenAssigningVariantThenOnHoldVariantsAreNotSelected() {
+
+        for i in 0 ..< Variant.defaultVariants.count {
+
+            let mockStatisticsStore = MockStatisticsStore()
+            let mockRng = MockVariantRNG(returnValue: i)
+
+            let variantManager = DefaultVariantManager(storage: mockStatisticsStore, rng: mockRng, uiIdiom: .pad)
+            variantManager.assignVariantIfNeeded()
+
+            XCTAssertNotEqual("ml", variantManager.currentVariant?.name)
+            XCTAssertNotEqual("mm", variantManager.currentVariant?.name)
+        }
+
+    }
     
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/973376906566548
Tech Design URL:
CC:

**Description**:

Changes the home screen experiment to just test the center search.

Leaves the other experiments in place but reduces their chance of allocation to zero.

Note, apart from the positioning which may change by a few points, this is basically code complete and ready to review.

**Steps to test this PR**:

Updates
1. Install an old version and get favourites
1. Update to new version and check you still see favorites, etc

New Installs
1. Fresh install, ensure you only get the control, SERP or centred search variant.

Functionality
1. Ensure user cannot scroll
2. Ensure tapping the search and cancel still work as expected

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
