### PR TITLE
Matches weak retain of controller present in other renderers

### DIFF
--- a/DuckDuckGo/HomeViewSectionRenderers.swift
+++ b/DuckDuckGo/HomeViewSectionRenderers.swift
@@ -144,7 +144,7 @@ class HomeViewSectionRenderers: NSObject, UICollectionViewDataSource, UICollecti
         
     }
     
-    private let controller: HomeViewController
+    private weak var controller: HomeViewController!
     private var theme: Theme
     private var renderers = [HomeViewSectionRenderer]()
     


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

**Description**:
The strong reference to the `HomeViewController` from a `HomeViewSectionRenderers` causes tabs to be retained much longer than expected, if not perpetually. Other similar instances already use a `weak` reference, and this PR matches the pattern used elsewhere in the codebase including the implicit unwrap.

**Steps to test this PR**:
1. Checkout the current branch without this PR
2. Build, Run, and Profile the app using the Allocations tool in Instruments
3. Make 5 tabs going to any website, wipe them with the flames 
4. End profile
5. Filter by objects with 'DuckDuckGo' in them, notice at least 5 retained tabs 
6. Checkout this PR, repeat steps 2-4
7. Now, only a single tab should be retained as is expected after using the flames

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
