### PR TITLE
exclude ipad from control group for the experiment

### DIFF
--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -104,8 +104,7 @@ public class DefaultVariantManager: VariantManager {
     }
     
     private func isHomeScreenExperimentAndPad(_ variant: Variant) -> Bool {
-        return (variant.features.contains(.homeScreen) || variant.features.contains(.centeredSearchHomeScreen))
-            && uiIdiom == .pad
+        return ["mk", "ml", "mm", "mn"].contains(variant.name) && uiIdiom == .pad
     }
     
     private func selectVariant() -> Variant? {

--- a/DuckDuckGoTests/EnhancedHomePageVariantManagerTests.swift
+++ b/DuckDuckGoTests/EnhancedHomePageVariantManagerTests.swift
@@ -22,6 +22,26 @@ import XCTest
 
 class EnhancedHomePageVariantManagerTests: XCTestCase {
     
+    func testWhenControlGroupAndNotOnPadThenVariantNotSelected() {
+        let mockStatisticsStore = MockStatisticsStore()
+        let mockRng = MockVariantRNG(returnValue: 2)
+        
+        let variantManager = DefaultVariantManager(storage: mockStatisticsStore, rng: mockRng, uiIdiom: .phone)
+        variantManager.assignVariantIfNeeded()
+        
+        XCTAssertEqual("mk", variantManager.currentVariant?.name)
+    }
+
+    func testWhenControlGroupAndOnPadThenVariantIsNotSelected() {
+        let mockStatisticsStore = MockStatisticsStore()
+        let mockRng = MockVariantRNG(returnValue: 2)
+        
+        let variantManager = DefaultVariantManager(storage: mockStatisticsStore, rng: mockRng, uiIdiom: .pad)
+        variantManager.assignVariantIfNeeded()
+        
+        XCTAssertNil(variantManager.currentVariant)
+    }
+    
     func testWhenSerpVariantAndOnPadThenVariantIsSelected() {
         
         let mockStatisticsStore = MockStatisticsStore()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1108308588639096
Tech Design URL:
CC:

**Description**:

Ensures that iPad is not included in any experimental group for the home screen experiment.

**Steps to test this PR**:

1. Using iPad simulator ensure that no home screen variant is selected, including the control group.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)