### PR TITLE
Show widget on force touch

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -24,7 +24,6 @@ import Core
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private struct ShortcutKey {
-        static let search = "com.duckduckgo.mobile.ios.newsearch"
         static let clipboard = "com.duckduckgo.mobile.ios.clipboard"
     }
     
@@ -146,9 +145,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem) {
         Logger.log(text: "Handling shortcut item: \(shortcutItem.type)")
         clearNavigationStack()
-        if shortcutItem.type ==  ShortcutKey.search {
-            mainViewController?.launchNewSearch()
-        }
         if shortcutItem.type ==  ShortcutKey.clipboard, let query = UIPasteboard.general.string {
             mainViewController?.loadQueryInNewTab(query)
         }

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -64,14 +64,6 @@
 	<array>
 		<dict>
 			<key>UIApplicationShortcutItemIconFile</key>
-			<string>SearchLoupe</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>Search</string>
-			<key>UIApplicationShortcutItemType</key>
-			<string>com.duckduckgo.mobile.ios.newsearch</string>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemIconFile</key>
 			<string>Clipboard</string>
 			<key>UIApplicationShortcutItemTitle</key>
 			<string>Paste from clipboard</string>
@@ -79,6 +71,8 @@
 			<string>com.duckduckgo.mobile.ios.clipboard</string>
 		</dict>
 	</array>
+	<key>UIApplicationShortcutWidget</key>
+	<string>com.duckduckgo.mobile.ios.QuickActionsTodayExtension</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/361428290920650/961597033219776/1108417444992794

**Description**:
Shows the widget and an "Add widget" button on force touch. Useful to have these options quickly available and helpful for widget discoverability.

**Steps to test this PR**:
1. Install the app
1. Force touch the icon and note that the widget is displayed
1. Tap the "Add Widget" button and note that the widget is added

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
