### PR TITLE
Fix video auth bypass

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -124,7 +124,7 @@ public class Pixel {
             .addParams(params)
         
         Alamofire.request(url, headers: headers).validate(statusCode: 200..<300).response { response in
-            Logger.log(items: "Pixel fired \(pixel.rawValue) \(response)")
+            Logger.log(items: "Pixel fired \(pixel.rawValue)")
             onComplete(response.error)
         }
     }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -74,8 +74,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if privacyStore.authenticationEnabled {
             displayAuthenticationWindow()
             beginAuthentication()
-        } else {
-            removeOverlay()
         }
         
         autoClear = AutoClear(worker: mainViewController!)
@@ -87,6 +85,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillEnterForeground(_ application: UIApplication) {
         if privacyStore.authenticationEnabled {
             beginAuthentication()
+        } else {
+            removeOverlay()
         }
         autoClear?.applicationWillEnterForeground()
     }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -64,6 +64,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         startOnboardingFlowIfNotSeenBefore()
         
         if appIsLaunching {
+            appIsLaunching = false
             onApplicationLaunch(application)
         }
     }
@@ -78,8 +79,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         autoClear?.applicationDidLaunch()
         AppConfigurationFetch().start(completion: nil)
         initialiseBackgroundFetch(application)
-        
-        appIsLaunching = false
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -70,9 +70,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func onApplicationLaunch(_ application: UIApplication) {
+       
         if privacyStore.authenticationEnabled {
             displayAuthenticationWindow()
             beginAuthentication()
+        } else {
+            removeOverlay()
         }
         
         autoClear = AutoClear(worker: mainViewController!)

--- a/DuckDuckGo/AuthenticationViewController.swift
+++ b/DuckDuckGo/AuthenticationViewController.swift
@@ -43,7 +43,6 @@ class AuthenticationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         hideUnlockInstructions()
-        
         applyTheme(ThemeManager.shared.currentTheme)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/944767190704272

**Description**:
Fix issue where video can show aboce authentications screen

**Steps to test this PR**:
1. Launch app
1. Go to settings and turn on "Application Lock"
1. Visit Vimeo https://vimeo.com/watch
1. Play a viceo and make it full screen
1. Background the app for 5 seconds
1. Launch the app again

Previous behavior: Video was visible above lock screen but under dialog
New behavior: Video is now completely hidden behind lock screen and dialog

Note: the video will continue to play when the app is backgrounded. Whether this is desirable behavior or not is another question and goes beyond the scope of this task.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
