### PR TITLE
Fix auto clear glitch during application startup.

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -51,6 +51,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AtbAndVariantCleanup.cleanup()
         DefaultVariantManager().assignVariantIfNeeded()
         HomePageConfiguration.installNewUserFavorites()
+        
+        if !testing {
+            autoClear = AutoClear(worker: mainViewController!)
+            autoClear?.applicationDidLaunch()
+        }
 
         appIsLaunching = true
         return true
@@ -76,8 +81,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             beginAuthentication()
         }
         
-        autoClear = AutoClear(worker: mainViewController!)
-        autoClear?.applicationDidLaunch()
         AppConfigurationFetch().start(completion: nil)
         initialiseBackgroundFetch(application)
     }
@@ -88,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else {
             removeOverlay()
         }
-        autoClear?.applicationWillEnterForeground()
+        autoClear?.applicationWillMoveToForeground()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
@@ -105,6 +108,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         Logger.log(text: "App launched with url \(url.absoluteString)")
         clearNavigationStack()
+        autoClear?.applicationWillMoveToForeground()
+        
         if AppDeepLinks.isNewSearch(url: url) {
             mainViewController?.launchNewSearch()
         } else if AppDeepLinks.isQuickLink(url: url) {
@@ -187,6 +192,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem) {
         Logger.log(text: "Handling shortcut item: \(shortcutItem.type)")
         clearNavigationStack()
+        autoClear?.applicationWillMoveToForeground()
         if shortcutItem.type ==  ShortcutKey.clipboard, let query = UIPasteboard.general.string {
             mainViewController?.loadQueryInNewTab(query)
         }

--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -54,9 +54,12 @@ class AutoClear {
     }
     
     func applicationDidLaunch() {
-        guard isClearingEnabled else { return }
+        guard let settings = AutoClearSettingsModel(settings: appSettings) else { return }
         
-        clearData()
+        // Note: for startup, we clear only Data, as TabsModel is cleared on load
+        if settings.action.contains(.clearData) {
+            worker.forgetData()
+        }
     }
     
     /// Note: function is parametrised because of tests.
@@ -81,12 +84,12 @@ class AutoClear {
         }
     }
     
-    func applicationWillEnterForeground() {
+    func applicationWillMoveToForeground() {
         guard isClearingEnabled,
             let timestamp = timestamp,
             shouldClearData(elapsedTime: CACurrentMediaTime() - timestamp) else { return }
         
         clearData()
+        self.timestamp = nil
     }
-    
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -126,7 +126,14 @@ class MainViewController: UIViewController {
     }
 
     private func configureTabManager() {
-        let tabsModel = TabsModel.get() ?? TabsModel()
+        let tabsModel: TabsModel
+        let shouldClearTabsModelOnStartup = AutoClearSettingsModel(settings: appSettings) != nil
+        if shouldClearTabsModelOnStartup {
+            tabsModel = TabsModel()
+            tabsModel.save()
+        } else {
+            tabsModel = TabsModel.get() ?? TabsModel()
+        }
         tabManager = TabManager(model: tabsModel, delegate: self)
     }
 

--- a/DuckDuckGoTests/AutoClearTests.swift
+++ b/DuckDuckGoTests/AutoClearTests.swift
@@ -56,18 +56,7 @@ class AutoClearTests: XCTestCase {
         XCTAssertEqual(worker.forgetTabsInvocationCount, 0)
     }
     
-    func testWhenModeIsSetToCleanTabsThenTabsAreCleared() {
-        let appSettings = AppUserDefaults()
-        appSettings.autoClearAction = .clearTabs
-        appSettings.autoClearTiming = .termination
-        
-        logic.applicationDidLaunch()
-        
-        XCTAssertEqual(worker.forgetDataInvocationCount, 0)
-        XCTAssertEqual(worker.forgetTabsInvocationCount, 1)
-    }
-    
-    func testWhenModeIsSetToCleanTabsAndDataThenBothAreCleared() {
+    func testWhenModeIsSetToCleanTabsAndDataThenDataIsCleared() {
         let appSettings = AppUserDefaults()
         appSettings.autoClearAction = [.clearData, .clearTabs]
         appSettings.autoClearTiming = .termination
@@ -75,7 +64,9 @@ class AutoClearTests: XCTestCase {
         logic.applicationDidLaunch()
         
         XCTAssertEqual(worker.forgetDataInvocationCount, 1)
-        XCTAssertEqual(worker.forgetTabsInvocationCount, 1)
+        
+        // Tabs are cleared when loading TabsModel for the first time
+        XCTAssertEqual(worker.forgetTabsInvocationCount, 0)
     }
     
     func testWhenModeIsNotSetThenNothingIsCleared() {
@@ -94,7 +85,7 @@ class AutoClearTests: XCTestCase {
         appSettings.autoClearAction = .clearData
         appSettings.autoClearTiming = .termination
         
-        logic.applicationWillEnterForeground()
+        logic.applicationWillMoveToForeground()
         logic.applicationDidEnterBackground()
         
         XCTAssertEqual(worker.forgetDataInvocationCount, 0)
@@ -118,12 +109,12 @@ class AutoClearTests: XCTestCase {
             appSettings.autoClearTiming = timing
             
             logic.applicationDidEnterBackground(CACurrentMediaTime() - delay + 1)
-            logic.applicationWillEnterForeground()
+            logic.applicationWillMoveToForeground()
             
             XCTAssertEqual(worker.forgetDataInvocationCount, iterationCount)
             
             logic.applicationDidEnterBackground(CACurrentMediaTime() - delay - 1)
-            logic.applicationWillEnterForeground()
+            logic.applicationWillMoveToForeground()
             
             iterationCount += 1
             XCTAssertEqual(worker.forgetDataInvocationCount, iterationCount)


### PR DESCRIPTION
…el at all. This fixes possible UI glitch and improves startup performance.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1109324284489149

**Description**:
For centered search variant, in case auto clear feature is enabled there is a visible glitch when restarting the app. See attached video in asana task.

 
**Steps to test this PR**:
Centered search variant
1. Set up app with centered search variant.
2. Enable auto clear with 'on exit' trigger.
3. Load any page. Kill the app.
4. When starting, observe top of the screen - omni bar with website address should not appear.

"Regular" setup
1. Set up app w/o centered search variant.
2. Enable auto clear with 'on exit' trigger.
3. Load any page. Kill the app.
4. When starting, observe top of the screen - website address should not appear.


Also for both variants above:
1. Enable auto clear with 5 min inactivity trigger.
2. Load any page. Background the app.
3. Wait 5 minutes (or tweak AutoClear:shouldClearData(elapsedTime:) to always return true).
4. When starting, observe top of the screen - website address should not appear.



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)