### PR TITLE
Make atb test consistent and not affected by UI animation timings

### DIFF
--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -59,7 +59,7 @@ class AtbIntegrationTests: XCTestCase {
         Springboard.deleteMyApp()
         app.launch()
         skipOnboarding()
-
+        dismissAddToDockDialog()
     }
     
     override func tearDown() {
@@ -154,15 +154,26 @@ class AtbIntegrationTests: XCTestCase {
 
     }
     
+    private func dismissAddToDockDialog() {
+        let noThanksButton = app.buttons["No Thanks"]
+        guard noThanksButton.waitForExistence(timeout: 2) else {
+            fatalError("No 'add to dock' view present")
+        }
+        noThanksButton.tap()
+    }
+    
     private func search(forText text: String) {
-        if !app.searchFields["searchEntry"].exists {
-            let noThanksButton = app.buttons["No Thanks"]
-            _ = noThanksButton.waitForExistence(timeout: 2)
-            noThanksButton.tap()
+        let searchentrySearchField = app.searchFields["searchEntry"]
+        
+        if !searchentrySearchField.waitForExistence(timeout: 2) {
+            // Centered home screen variant
             app.collectionViews.otherElements["activateSearch"].tap()
+            
+            if !searchentrySearchField.waitForExistence(timeout: 2) {
+                fatalError("Search field could not be activated")
+            }
         }
         
-        let searchentrySearchField = app.searchFields["searchEntry"]
         searchentrySearchField.tap()
         
         let keyboard = app.keyboards.element

--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -172,9 +172,9 @@ class AtbIntegrationTests: XCTestCase {
             if !searchentrySearchField.waitForExistence(timeout: 2) {
                 fatalError("Search field could not be activated")
             }
+        } else {
+            searchentrySearchField.tap()
         }
-        
-        searchentrySearchField.tap()
         
         let keyboard = app.keyboards.element
         if keyboard.waitForExistence(timeout: 2) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/870033543252928

**Description**:
ATB tests flow can be affected by timing: sometimes 'add to dock' dialog was being dismissed, sometimes not. Before attempting any other tweaks, I'd like to make it work in a consistent way.

**Steps to test this PR**:
1. Run ATB tests for both centered search and regular variants.
2. Tests should pass.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)