### PR TITLE
New Feature - quick sharing bookmark from bookmarks screen..

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -88,6 +88,7 @@ public enum PixelName: String {
     case homeScreenDeleteFavorite = "mh_df"
     case homeScreenFavoriteMoved = "mh_fm"
     
+    case bookmarkShare = "bm_sh"
 }
 
 public class Pixel {

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -88,7 +88,6 @@ public enum PixelName: String {
     case homeScreenDeleteFavorite = "mh_df"
     case homeScreenFavoriteMoved = "mh_fm"
     
-    case bookmarkShare = "bm_sh"
 }
 
 public class Pixel {

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -53,13 +53,12 @@ class BookmarksViewController: UITableViewController {
     
     @available(iOS 11.0, *)
     override func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let shareContextualAction = UIContextualAction.init(style: .normal, title: "Share") { (_, _, completionHandler) in
-            Logger.log(text: "share action")
+        let shareContextualAction = UIContextualAction(style: .normal, title: UserText.actionShare) { (_, _, completionHandler) in
             self.showShareSheet(for: indexPath)
             completionHandler(true)
         }
-        shareContextualAction.backgroundColor = UIColor.ppGreen
-        return UISwipeActionsConfiguration.init(actions: [shareContextualAction])
+        shareContextualAction.backgroundColor = UIColor.cornflowerBlue
+        return UISwipeActionsConfiguration(actions: [shareContextualAction])
     }
 
     private func addAplicationActiveObserver() {
@@ -131,7 +130,7 @@ class BookmarksViewController: UITableViewController {
     }
     
     fileprivate func showShareSheet(for indexPath: IndexPath) {
-        Pixel.fire(pixel: .browsingMenuShare)
+
         if let link = dataSource.link(at: indexPath) {
             let appUrls: AppUrls = AppUrls()
             let url = appUrls.removeATBAndSource(fromUrl: link.url)

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -50,6 +50,17 @@ class BookmarksViewController: UITableViewController {
             selectLink(link)
         }
     }
+    
+    @available(iOS 11.0, *)
+    override func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let shareContextualAction = UIContextualAction.init(style: .normal, title: "Share") { (_, _, completionHandler) in
+            Logger.log(text: "share action")
+            self.showShareSheet(for: indexPath)
+            completionHandler(true)
+        }
+        shareContextualAction.backgroundColor = UIColor.ppGreen
+        return UISwipeActionsConfiguration.init(actions: [shareContextualAction])
+    }
 
     private func addAplicationActiveObserver() {
         NotificationCenter.default.addObserver(self,
@@ -117,6 +128,17 @@ class BookmarksViewController: UITableViewController {
             }
         )
         present(alert, animated: true)
+    }
+    
+    fileprivate func showShareSheet(for indexPath: IndexPath) {
+        Pixel.fire(pixel: .browsingMenuShare)
+        if let link = dataSource.link(at: indexPath) {
+            let appUrls: AppUrls = AppUrls()
+            let url = appUrls.removeATBAndSource(fromUrl: link.url)
+            presentShareSheet(withItems: [ url, link ], fromView: self.view)
+        } else {
+            Logger.log(text: "Invalid share link found")
+        }
     }
 
     fileprivate func selectLink(_ link: Link) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->
**Description**:
Ability to share a bookmark on swipe from left to right in bookmarks screen.
This feature supports only in iOS 11.0 and above.
Added corresponding new pixel identifier called "bm_sh" (bookmark share)

**Steps to test this PR**:
1. On iOS 11 and above supported device, open bookmarks screen by pressing bookmarks icon on home screen tab bar
1. Now swipe left to right on a bookmark results share sheet appears.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
