### PR TITLE
Auto clear data fixes

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -107,7 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         Logger.log(text: "App launched with url \(url.absoluteString)")
-        clearNavigationStack()
+        mainViewController?.clearNavigationStack()
         autoClear?.applicationWillMoveToForeground()
         
         if AppDeepLinks.isNewSearch(url: url) {
@@ -191,7 +191,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem) {
         Logger.log(text: "Handling shortcut item: \(shortcutItem.type)")
-        clearNavigationStack()
+        mainViewController?.clearNavigationStack()
         autoClear?.applicationWillMoveToForeground()
         if shortcutItem.type ==  ShortcutKey.clipboard, let query = UIPasteboard.general.string {
             mainViewController?.loadQueryInNewTab(query)
@@ -200,13 +200,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private var mainViewController: MainViewController? {
         return window?.rootViewController as? MainViewController
-    }
-
-    private func clearNavigationStack() {
-        if let presented = mainViewController?.presentedViewController {
-            presented.dismiss(animated: false) { [weak self] in
-                self?.clearNavigationStack()
-            }
-        }
     }
 }

--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -63,7 +63,7 @@ class AutoClear {
     }
     
     /// Note: function is parametrised because of tests.
-    func applicationDidEnterBackground(_ time: TimeInterval = CACurrentMediaTime()) {
+    func applicationDidEnterBackground(_ time: TimeInterval = Date().timeIntervalSince1970) {
         timestamp = time
     }
     
@@ -87,7 +87,7 @@ class AutoClear {
     func applicationWillMoveToForeground() {
         guard isClearingEnabled,
             let timestamp = timestamp,
-            shouldClearData(elapsedTime: CACurrentMediaTime() - timestamp) else { return }
+            shouldClearData(elapsedTime: Date().timeIntervalSince1970 - timestamp) else { return }
         
         clearData()
         self.timestamp = nil

--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -22,6 +22,7 @@ import UIKit
 
 protocol AutoClearWorker {
     
+    func clearNavigationStack()
     func forgetData()
     func forgetTabs()
 }
@@ -89,6 +90,7 @@ class AutoClear {
             let timestamp = timestamp,
             shouldClearData(elapsedTime: Date().timeIntervalSince1970 - timestamp) else { return }
         
+        worker.clearNavigationStack()
         clearData()
         self.timestamp = nil
     }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -694,6 +694,14 @@ extension MainViewController: TabSwitcherButtonDelegate {
 
 extension MainViewController: AutoClearWorker {
     
+    func clearNavigationStack() {
+        if let presented = presentedViewController {
+            presented.dismiss(animated: false) { [weak self] in
+                self?.clearNavigationStack()
+            }
+        }
+    }
+    
     func forgetTabs() {
         tabManager.removeAll()
         showBars()

--- a/DuckDuckGoTests/AutoClearTests.swift
+++ b/DuckDuckGoTests/AutoClearTests.swift
@@ -25,8 +25,13 @@ class AutoClearTests: XCTestCase {
     
     class MockWorker: AutoClearWorker {
         
+        var clearNavigationStackInvocationCount = 0
         var forgetDataInvocationCount = 0
         var forgetTabsInvocationCount = 0
+        
+        func clearNavigationStack() {
+            clearNavigationStackInvocationCount += 1
+        }
         
         func forgetData() {
             forgetDataInvocationCount += 1
@@ -88,6 +93,7 @@ class AutoClearTests: XCTestCase {
         logic.applicationWillMoveToForeground()
         logic.applicationDidEnterBackground()
         
+        XCTAssertEqual(worker.clearNavigationStackInvocationCount, 0)
         XCTAssertEqual(worker.forgetDataInvocationCount, 0)
         
         logic.applicationDidLaunch()
@@ -95,7 +101,7 @@ class AutoClearTests: XCTestCase {
         XCTAssertEqual(worker.forgetDataInvocationCount, 1)
     }
     
-    func testWhenDesiredTimingIsSetThenDataIsClearedOnceThimeHasElapsed() {
+    func testWhenDesiredTimingIsSetThenDataIsClearedOnceTimeHasElapsed() {
         let appSettings = AppUserDefaults()
         appSettings.autoClearAction = .clearData
         
@@ -108,15 +114,17 @@ class AutoClearTests: XCTestCase {
         for (timing, delay) in cases {
             appSettings.autoClearTiming = timing
             
-            logic.applicationDidEnterBackground(CACurrentMediaTime() - delay + 1)
+            logic.applicationDidEnterBackground(Date().timeIntervalSince1970 - delay + 1)
             logic.applicationWillMoveToForeground()
             
+            XCTAssertEqual(worker.clearNavigationStackInvocationCount, iterationCount)
             XCTAssertEqual(worker.forgetDataInvocationCount, iterationCount)
             
-            logic.applicationDidEnterBackground(CACurrentMediaTime() - delay - 1)
+            logic.applicationDidEnterBackground(Date().timeIntervalSince1970 - delay - 1)
             logic.applicationWillMoveToForeground()
             
             iterationCount += 1
+            XCTAssertEqual(worker.clearNavigationStackInvocationCount, iterationCount)
             XCTAssertEqual(worker.forgetDataInvocationCount, iterationCount)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1110603288604188

**Description**:
Fixes two issues around auto clear feature:
- Problem with calculating time spent in the background.
- Issue with Tabs screen possibly showing old state in case it was open while moving back to the app.

**Steps to test this PR**:
Timer:
1. Enable auto clear data feature with inactivity timer.
2. Ensure data is cleared after specified time.

Regression:
1. Enable auto clear data feature without inactivity timer.
2. Ensure data is cleared after killing the app.

Tabs view.
1. Enable auto clear data feature with inactivity timer.
2. Open tabs view.
3. Put app to the background. Wait.
4. When moving back to the app, in case auto clear has been invoked, then only home screen should be visible.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
