### PR TITLE
centered search fixes for iPad

### DIFF
--- a/DuckDuckGo/CenteredSearchHomeCell.swift
+++ b/DuckDuckGo/CenteredSearchHomeCell.swift
@@ -50,8 +50,7 @@ class CenteredSearchHomeCell: UICollectionViewCell {
     var defaultSearchRadius: CGFloat!
 
     var defaultSearchBackgroundMargin: CGFloat {
-        // this only gives two distinct states unlike device orientation which can be unknown and flat
-        return isPortrait ? 0 : (frame.width - Constants.searchWidth) / 2
+        return isPortrait && !isPad ? 0 : (frame.width - Constants.searchWidth) / 2
     }
     
     var searchHeaderTransition: CGFloat = 0.0 {

--- a/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
@@ -64,7 +64,12 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     }
     
     @objc func rotated() {
-        scrollViewDidScroll(controller.collectionView)
+        controller.collectionView.invalidateIntrinsicContentSize()
+        controller.collectionView.collectionViewLayout.invalidateLayout()
+        
+        DispatchQueue.main.async {
+            self.scrollViewDidScroll(self.controller.collectionView)
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/DuckDuckGo/global.swift
+++ b/DuckDuckGo/global.swift
@@ -25,3 +25,8 @@ import UIKit
 var isPortrait: Bool {
     return UIApplication.shared.statusBarOrientation.isPortrait
 }
+
+/// Shortcut to `UIDevice.current.userInterfaceIdiom == .pad`
+var isPad: Bool {
+    return UIDevice.current.userInterfaceIdiom == .pad
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1110935224550058
Tech Design URL:
CC:

**Description**:

Even though it's disabled for iPad now, it won't be when we eventually roll it out.

There's currently a bug on iPad where the centred search doesn't show properly for two reasons:
1) For some reason on iPad the size of the collection view gets messed up on rotation
2) The search field has no width constraint specific to iPad so it has an inconsistent layout when rotating

**Steps to test this PR**:
1. Edit VariantManager to select one of the centred search variants
1. Launch on iPad 
1. Rotate device and ensure view looks the same and scrolls as expected
1. Launch on iPhone and ensure behaviour looks unchanged

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
