### PR TITLE
fix glitch when editing long URLs in address bar

### DIFF
--- a/BookmarksTodayExtension/Info.plist
+++ b/BookmarksTodayExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.17.1</string>
+	<string>7.17.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.17.1</string>
+	<string>7.17.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -124,7 +124,7 @@ class MainViewController: UIViewController {
         }
 
         findInPageBottomLayoutConstraint.constant = 0
-        animateForKeyboard(userInfo: userInfo)
+        animateForKeyboard(userInfo: userInfo, y: view.frame.height)
     }
     
     /// Based on https://stackoverflow.com/a/46117073/73479
@@ -148,17 +148,18 @@ class MainViewController: UIViewController {
 
         findInPageBottomLayoutConstraint.constant = height
         currentTab?.webView.scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: height, right: 0)
-        animateForKeyboard(userInfo: userInfo)
+        animateForKeyboard(userInfo: userInfo, y: view.frame.height - height)
     }
     
-    private func animateForKeyboard(userInfo: [AnyHashable: Any]) {
+    private func animateForKeyboard(userInfo: [AnyHashable: Any], y: CGFloat) {
         let duration: TimeInterval = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
         let animationCurveRawNSN = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber
         let animationCurveRaw = animationCurveRawNSN?.uintValue ?? UIView.AnimationOptions.curveEaseInOut.rawValue
         let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
-        
+
+        let frame = self.findInPageView.frame
         UIView.animate(withDuration: duration, delay: 0, options: animationCurve, animations: {
-            self.view.layoutIfNeeded()
+            self.findInPageView.frame = CGRect(x: 0, y: y - frame.height, width: frame.width, height: frame.height)
         }, completion: nil)
 
     }

--- a/QuickActionsTodayExtension/Info.plist
+++ b/QuickActionsTodayExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.17.1</string>
+	<string>7.17.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.17.1</string>
+	<string>7.17.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/fastlane/metadata/default/release_notes.txt
+++ b/fastlane/metadata/default/release_notes.txt
@@ -1,5 +1,1 @@
-• You can now choose how the home page looks by choosing from the options in settings.
-• You can now long press the bookmark icon to add the current page as a bookmark.
-• You can now add all open tabs as bookmarks by tapping the icon in the tab switcher.
-• You can now share bookmarks by swiping the bookmark to the right.
-• Fixes and improvements.
+• Fixes glitch when editing long URLs in the address bar.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/413877547933097/1115530951548071
Tech Design URL:
CC:

**Description**:

Fixes glitch when editing long URLs in the address bar

**Steps to test this PR**:
1. Experience glitch by going to cnn.com and tapping a link.  If it extends beyond the end of the address bar then tapping the address will show the text slide in from the right.
1. Test the glitch has gone with this code.
1. Test that Find in Page still behaves as expected.
1. Finally, do some exploratory testing to ensure no regression.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
