### PR TITLE
Harden flaky atb integration tests

### DIFF
--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -84,7 +84,8 @@ class AtbIntegrationTests: XCTestCase {
     }
     
     func testWhenAppIsInstalledThenExitIsCalledAndInitialAtbIsRetrieved() throws {
-        assertRequestCount(count: 3)
+        assertSearchRequestCount(count: 0)
+        assertStatisticsRequestCount(count: 3)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
@@ -93,9 +94,10 @@ class AtbIntegrationTests: XCTestCase {
     func testWhenSearchPerformedThenAtbIsAddedToRequest() throws {
         search(forText: "oranges")
 
-        assertRequestCount(count: 5)
+        assertSearchRequestCount(count: 1)
         assertSearch(text: "oranges", atb: Constants.initialAtb)
 
+        assertStatisticsRequestCount(count: 4)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
@@ -108,10 +110,11 @@ class AtbIntegrationTests: XCTestCase {
         search(forText: "lemons")
         search(forText: "pears")
 
-        assertRequestCount(count: 7)
+        assertSearchRequestCount(count: 2)
         assertSearch(text: "lemons", atb: Constants.initialAtb)
         assertSearch(text: "pears", atb: Constants.initialAtb)
 
+        assertStatisticsRequestCount(count: 5)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
@@ -122,9 +125,10 @@ class AtbIntegrationTests: XCTestCase {
     func testWhenUserEntersSearchDirectlyThenAtbIsAddedToRequest() {
         search(forText: "http://localhost:8080?q=beagles")
         
-        assertRequestCount(count: 5)
+        assertSearchRequestCount(count: 1)
         assertSearch(text: "beagles", atb: Constants.initialAtb)
 
+        assertStatisticsRequestCount(count: 4)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
@@ -137,7 +141,8 @@ class AtbIntegrationTests: XCTestCase {
         backgroundRelaunch() // this launch gets new atb
         backgroundRelaunch() // this launch sends it
 
-        assertRequestCount(count: 5)
+        assertSearchRequestCount(count: 0)
+        assertStatisticsRequestCount(count: 5)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
@@ -153,8 +158,8 @@ class AtbIntegrationTests: XCTestCase {
         }
     }
     
-    func assertRequestCount(count: Int) {
-        XCTAssertEqual(count, statisticsRequests.count + searchRequests.count)
+    func assertStatisticsRequestCount(count: Int) {
+        XCTAssertEqual(count, statisticsRequests.count)
     }
     
     func assertExti() {
@@ -172,6 +177,10 @@ class AtbIntegrationTests: XCTestCase {
         XCTAssertEqual(expectedSetAtb, httpRequest.queryParam(Constants.setAtbParam))
         XCTAssertEqual(expectedType, httpRequest.queryParam(Constants.activityType))
         XCTAssertEqual("1", httpRequest.queryParam(Constants.devmode))
+    }
+    
+    func assertSearchRequestCount(count: Int) {
+        XCTAssertEqual(count, searchRequests.count)
     }
     
     func assertSearch(text: String, atb: String) {

--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -94,36 +94,40 @@ class AtbIntegrationTests: XCTestCase {
         search(forText: "oranges")
 
         assertRequestCount(count: 5)
+        assertSearch(text: "oranges", atb: Constants.initialAtb)
+
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
-        assertSearch(text: "oranges", atb: Constants.initialAtb)
     }
 
     func testWhenUserSearchesWithOldAtbThenAtbIsUpdated() {
         atbToSet = Constants.searchRetentionAtb
+
         search(forText: "lemons")
         search(forText: "pears")
 
         assertRequestCount(count: 7)
+        assertSearch(text: "lemons", atb: Constants.initialAtb)
+        assertSearch(text: "pears", atb: Constants.initialAtb)
+
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
-        assertSearch(text: "lemons", atb: Constants.initialAtb)
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
-        assertSearch(text: "pears", atb: Constants.initialAtb)
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.searchRetentionAtb, expectedType: nil)
     }
     
     func testWhenUserEntersSearchDirectlyThenAtbIsAddedToRequest() {
         search(forText: "http://localhost:8080?q=beagles")
-
+        
         assertRequestCount(count: 5)
+        assertSearch(text: "beagles", atb: Constants.initialAtb)
+
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
-        assertSearch(text: "beagles", atb: Constants.initialAtb)
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
     }
     

--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -36,20 +36,20 @@ class AtbIntegrationTests: XCTestCase {
         static let activityType = "at"
     }
     
-    enum RequestType {
+    enum StatisticsRequestType {
         case atb
         case exti
-        case search
     }
     
-    struct Request {
-        let type: RequestType
+    struct StatisticsRequest {
+        let type: StatisticsRequestType
         let httpRequest: HttpRequest
     }
     
     let app = XCUIApplication()
     let server = HttpServer()
-    var requests = [Request]()
+    var statisticsRequests = [StatisticsRequest]()
+    var searchRequests = [HttpRequest]()
     var atbToSet = Constants.initialAtb
     
     override func setUp() {
@@ -79,7 +79,8 @@ class AtbIntegrationTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         server.stop()
-        requests.removeAll()
+        statisticsRequests.removeAll()
+        searchRequests.removeAll()
     }
     
     func testWhenAppIsInstalledThenExitIsCalledAndInitialAtbIsRetrieved() throws {
@@ -109,21 +110,21 @@ class AtbIntegrationTests: XCTestCase {
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
-        assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
         assertSearch(text: "lemons", atb: Constants.initialAtb)
-        assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.searchRetentionAtb, expectedType: nil)
+        assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
         assertSearch(text: "pears", atb: Constants.initialAtb)
+        assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.searchRetentionAtb, expectedType: nil)
     }
     
     func testWhenUserEntersSearchDirectlyThenAtbIsAddedToRequest() {
         search(forText: "http://localhost:8080?q=beagles")
-    
+
         assertRequestCount(count: 5)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
         assertExti()
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
-        assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
         assertSearch(text: "beagles", atb: Constants.initialAtb)
+        assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: nil)
     }
     
     func testWhenAppLaunchedAgainThenAppAtbIsUpdated() {
@@ -149,18 +150,18 @@ class AtbIntegrationTests: XCTestCase {
     }
     
     func assertRequestCount(count: Int) {
-        XCTAssertEqual(count, requests.count)
+        XCTAssertEqual(count, statisticsRequests.count + searchRequests.count)
     }
     
     func assertExti() {
-        let request = requests.removeFirst()
-        XCTAssertEqual(RequestType.exti, request.type)
+        let request = statisticsRequests.removeFirst()
+        XCTAssertEqual(StatisticsRequestType.exti, request.type)
         XCTAssertEqual(Constants.initialAtb, request.httpRequest.queryParam(Constants.atbParam))
     }
     
     func assertAtb(expectedAtb: String? = nil, expectedSetAtb: String? = nil, expectedType: String? = nil) {
-        let request = requests.removeFirst()
-        XCTAssertEqual(RequestType.atb, request.type)
+        let request = statisticsRequests.removeFirst()
+        XCTAssertEqual(StatisticsRequestType.atb, request.type)
         
         let httpRequest = request.httpRequest
         XCTAssertEqual(expectedAtb, httpRequest.queryParam(Constants.atbParam))
@@ -170,12 +171,10 @@ class AtbIntegrationTests: XCTestCase {
     }
     
     func assertSearch(text: String, atb: String) {
-        let request = requests.removeFirst()
-        XCTAssertEqual(RequestType.search, request.type)
+        let request = searchRequests.removeFirst()
 
-        let httpRequest = request.httpRequest
-        XCTAssertEqual(text, httpRequest.queryParam("q"))
-        XCTAssertEqual(atb, httpRequest.queryParam(Constants.atbParam))
+        XCTAssertEqual(text, request.queryParam("q"))
+        XCTAssertEqual(atb, request.queryParam(Constants.atbParam))
     }
     
     private func dismissAddToDockDialog() {
@@ -212,17 +211,17 @@ class AtbIntegrationTests: XCTestCase {
     private func addRequestHandlers() {
         
         server["/"] = {
-            self.requests.append(Request(type: RequestType.search, httpRequest: $0))
+            self.searchRequests.append($0)
             return .accepted
         }
         
         server["/exti/"] = {
-            self.requests.append(Request(type: RequestType.exti, httpRequest: $0))
+            self.statisticsRequests.append(StatisticsRequest(type: StatisticsRequestType.exti, httpRequest: $0))
             return .accepted
         }
         
         server["/atb.js"] = {
-            self.requests.append(Request(type: RequestType.atb, httpRequest: $0))
+            self.statisticsRequests.append(StatisticsRequest(type: StatisticsRequestType.atb, httpRequest: $0))
             return .ok(.json([
                 "version": self.atbToSet
             ] as AnyObject))

--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -128,8 +128,9 @@ class AtbIntegrationTests: XCTestCase {
     
     func testWhenAppLaunchedAgainThenAppAtbIsUpdated() {
         atbToSet = Constants.appRetentionAtb
-        app.launch() // this launch gets new atb
-        app.launch() // this launch sends it
+        
+        backgroundRelaunch() // this launch gets new atb
+        backgroundRelaunch() // this launch sends it
 
         assertRequestCount(count: 5)
         assertAtb(expectedAtb: nil, expectedSetAtb: nil, expectedType: nil)
@@ -137,6 +138,14 @@ class AtbIntegrationTests: XCTestCase {
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.initialAtb, expectedType: "app_use")
         assertAtb(expectedAtb: Constants.initialAtb, expectedSetAtb: Constants.appRetentionAtb, expectedType: "app_use")
+    }
+    
+    func backgroundRelaunch() {
+        XCUIDevice().press(.home)
+        app.activate()
+        if !app.searchFields["searchEntry"].waitForExistence(timeout: Constants.defaultTimeout) {
+            fatalError("Can not find search field. Has the app launched?")
+        }
     }
     
     func assertRequestCount(count: Int) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1109730748569886

**Description**:
Harden flaky atb integrations tests:
- now backgrounding rather than killing app (which causes issues)
- separating statistics request and search request queues as the atb and search requests are fired at the same time so order is non-deterministic. We still keep all the statistics (atb and exti together) as order there is defined and important.

**Steps to test this PR**:
1. Check CI to ensure tests are passing there
1. Also, run the tests locally and make sure they pass!

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
