### PR TITLE
don't show tips when omnibar has focus

### DIFF
--- a/DuckDuckGo/BrowsingTips.swift
+++ b/DuckDuckGo/BrowsingTips.swift
@@ -22,9 +22,9 @@ import Core
 
 protocol BrowsingTipsDelegate: NSObjectProtocol {
     
-    func showPrivacyGradeTip()
+    func showPrivacyGradeTip(didShow: @escaping (Bool) -> Void)
     
-    func showFireButtonTip()
+    func showFireButtonTip(didShow: @escaping (Bool) -> Void)
     
 }
 
@@ -61,13 +61,17 @@ class BrowsingTips {
         switch tip {
             
         case .privacyGrade:
-            delegate?.showPrivacyGradeTip()
+            delegate?.showPrivacyGradeTip(didShow: didShow(shown:))
             
         case .fireButton:
-            delegate?.showFireButtonTip()
+            delegate?.showFireButtonTip(didShow: didShow(shown:))
             
         }
         
+    }
+ 
+    private func didShow(shown: Bool) {
+        guard shown else { return }
         storage.nextBrowsingTip += 1
     }
     

--- a/DuckDuckGo/BrowsingTips.swift
+++ b/DuckDuckGo/BrowsingTips.swift
@@ -61,16 +61,16 @@ class BrowsingTips {
         switch tip {
             
         case .privacyGrade:
-            delegate?.showPrivacyGradeTip(didShow: didShow(shown:))
+            delegate?.showPrivacyGradeTip(didShow: didShow)
             
         case .fireButton:
-            delegate?.showFireButtonTip(didShow: didShow(shown:))
+            delegate?.showFireButtonTip(didShow: didShow)
             
         }
         
     }
  
-    private func didShow(shown: Bool) {
+    private func didShow(_ shown: Bool) {
         guard shown else { return }
         storage.nextBrowsingTip += 1
     }

--- a/DuckDuckGo/HomeScreenTips.swift
+++ b/DuckDuckGo/HomeScreenTips.swift
@@ -22,9 +22,9 @@ import Core
 
 protocol HomeScreenTipsDelegate: NSObjectProtocol {
     
-    func showPrivateSearchTip()
+    func showPrivateSearchTip(didShow: @escaping (Bool) -> Void)
     
-    func showCustomizeTip()
+    func showCustomizeTip(didShow: @escaping (Bool) -> Void)
     
 }
 
@@ -60,13 +60,16 @@ class HomeScreenTips {
         switch tip {
             
         case .privateSearch:
-            delegate?.showPrivateSearchTip()
+            delegate?.showPrivateSearchTip(didShow: didShow(shown:))
             
         case .showCustomize:
-            delegate?.showCustomizeTip()
-            
+            delegate?.showCustomizeTip(didShow: didShow(shown:))
         }
         
+    }
+    
+    private func didShow(shown: Bool) {
+        guard shown else { return }
         storage.nextHomeScreenTip += 1
     }
     

--- a/DuckDuckGo/HomeScreenTips.swift
+++ b/DuckDuckGo/HomeScreenTips.swift
@@ -60,15 +60,15 @@ class HomeScreenTips {
         switch tip {
             
         case .privateSearch:
-            delegate?.showPrivateSearchTip(didShow: didShow(shown:))
+            delegate?.showPrivateSearchTip(didShow: didShow)
             
         case .showCustomize:
-            delegate?.showCustomizeTip(didShow: didShow(shown:))
+            delegate?.showCustomizeTip(didShow: didShow)
         }
         
     }
     
-    private func didShow(shown: Bool) {
+    private func didShow(_ shown: Bool) {
         guard shown else { return }
         storage.nextHomeScreenTip += 1
     }

--- a/DuckDuckGo/HomeViewController+HomeScreenDelegate.swift
+++ b/DuckDuckGo/HomeViewController+HomeScreenDelegate.swift
@@ -25,17 +25,9 @@ extension HomeViewController: HomeScreenTipsDelegate {
     func showPrivateSearchTip(didShow: @escaping (Bool) -> Void) {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self = self else {
-                didShow(false)
-                return
-            }
-            
-            guard !self.omniBarTextFieldHasFocus else {
-                didShow(false)
-                return
-            }
-            
-            guard let superView = self.parent?.view else {
+            guard let self = self,
+                !self.omniBarTextFieldHasFocus,
+                let superView = self.parent?.view else {
                 didShow(false)
                 return
             }
@@ -82,27 +74,11 @@ extension HomeViewController: HomeScreenTipsDelegate {
     func showCustomizeTip(didShow: @escaping (Bool) -> Void) {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self = self else {
-                didShow(false)
-                return
-            }
-            
-            guard !self.omniBarTextFieldHasFocus else {
-                didShow(false)
-                return
-            }
-
-            guard let omniBar = self.chromeDelegate?.omniBar else {
-                didShow(false)
-                return
-            }
-            
-            guard let settings = omniBar.settingsButton.imageView else {
-                didShow(false)
-                return
-            }
-            
-            guard let superView = self.parent?.view else {
+            guard let self = self,
+                !self.omniBarTextFieldHasFocus,
+                let omniBar = self.chromeDelegate?.omniBar,
+                let settings = omniBar.settingsButton.imageView,
+                let superView = self.parent?.view else {
                 didShow(false)
                 return
             }

--- a/DuckDuckGo/HomeViewController+HomeScreenDelegate.swift
+++ b/DuckDuckGo/HomeViewController+HomeScreenDelegate.swift
@@ -22,11 +22,23 @@ import EasyTipView
 
 extension HomeViewController: HomeScreenTipsDelegate {
     
-    func showPrivateSearchTip() {
+    func showPrivateSearchTip(didShow: @escaping (Bool) -> Void) {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let superView = self?.parent?.view else { return }
-            guard let self = self else { return }
+            guard let self = self else {
+                didShow(false)
+                return
+            }
+            
+            guard !self.omniBarTextFieldHasFocus else {
+                didShow(false)
+                return
+            }
+            
+            guard let superView = self.parent?.view else {
+                didShow(false)
+                return
+            }
             
             let view: UIView!
             if self.isCenteredSearch {
@@ -35,7 +47,10 @@ extension HomeViewController: HomeScreenTipsDelegate {
                 view = self.chromeDelegate?.omniBar
             }
             
-            guard view != nil else { return }
+            guard view != nil else {
+                didShow(false)
+                return
+            }
             
             var preferences = EasyTipView.globalPreferences
             preferences.positioning.bubbleVInset = 8
@@ -45,11 +60,16 @@ extension HomeViewController: HomeScreenTipsDelegate {
                                   icon: icon,
                                   preferences: preferences)
             tip.show(animated: true, forView: view, withinSuperview: superView)
+            didShow(true)
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 tip.handleGlobalTouch()
             }
         }
         
+    }
+    
+    private var omniBarTextFieldHasFocus: Bool {
+        return self.chromeDelegate?.omniBar.textField.isFirstResponder ?? false
     }
     
     private var isCenteredSearch: Bool {
@@ -59,12 +79,33 @@ extension HomeViewController: HomeScreenTipsDelegate {
         })
     }
     
-    func showCustomizeTip() {
+    func showCustomizeTip(didShow: @escaping (Bool) -> Void) {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let omniBar = self?.chromeDelegate?.omniBar else { return }
-            guard let settings = omniBar.settingsButton.imageView else { return }
-            guard let superView = self?.parent?.view else { return }
+            guard let self = self else {
+                didShow(false)
+                return
+            }
+            
+            guard !self.omniBarTextFieldHasFocus else {
+                didShow(false)
+                return
+            }
+
+            guard let omniBar = self.chromeDelegate?.omniBar else {
+                didShow(false)
+                return
+            }
+            
+            guard let settings = omniBar.settingsButton.imageView else {
+                didShow(false)
+                return
+            }
+            
+            guard let superView = self.parent?.view else {
+                didShow(false)
+                return
+            }
 
             var preferences = EasyTipView.globalPreferences
             preferences.positioning.bubbleHInset = 8
@@ -75,6 +116,7 @@ extension HomeViewController: HomeScreenTipsDelegate {
                                   preferences: preferences)
 
             tip.show(animated: true, forView: settings, withinSuperview: superView)
+            didShow(true)
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 tip.handleGlobalTouch()
             }

--- a/DuckDuckGo/TabViewCell.swift
+++ b/DuckDuckGo/TabViewCell.swift
@@ -54,7 +54,7 @@ class TabViewCell: UICollectionViewCell {
     @IBOutlet weak var unread: UIView!
 
     func update(withTab tab: Tab) {
-        accessibilityElements = [ title, link, removeButton, unread ]
+        accessibilityElements = [ title as Any, removeButton as Any ]
         
         removeTabObserver()
         tab.addObserver(self)

--- a/DuckDuckGo/TabViewController+BrowsingTipsDelegate.swift
+++ b/DuckDuckGo/TabViewController+BrowsingTipsDelegate.swift
@@ -24,27 +24,11 @@ extension TabViewController: BrowsingTipsDelegate {
     func showPrivacyGradeTip(didShow: @escaping (Bool) -> Void) {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self = self else {
-                didShow(false)
-                return
-            }
-            
-            guard !self.omniBarTextFieldHasFocus else {
-                didShow(false)
-                return
-            }
-            
-            guard let omniBar = self.chromeDelegate?.omniBar else {
-                didShow(false)
-                return
-            }
-            
-            guard let grade = omniBar.siteRatingView else {
-                didShow(false)
-                return
-            }
-            
-            guard let superView = self.parent?.view else {
+            guard let self = self,
+                !self.omniBarTextFieldHasFocus,
+                let omniBar = self.chromeDelegate?.omniBar,
+                let grade = omniBar.siteRatingView,
+                let superView = self.parent?.view else {
                 didShow(false)
                 return
             }
@@ -71,26 +55,11 @@ extension TabViewController: BrowsingTipsDelegate {
     func showFireButtonTip(didShow: @escaping (Bool) -> Void) {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self = self else {
-                didShow(false)
-                return
-            }
-            
-            guard !self.omniBarTextFieldHasFocus else {
-                didShow(false)
-                return
-            }
-            
-            guard let mainViewController = self.parent as? MainViewController else {
-                didShow(false)
-                return
-            }
-            
-            guard let button = mainViewController.fireButton else {
-                didShow(false)
-                return
-            }
-            guard let superView = self.parent?.view else {
+            guard let self = self,
+                !self.omniBarTextFieldHasFocus,
+                let mainViewController = self.parent as? MainViewController,
+                let button = mainViewController.fireButton,
+                let superView = self.parent?.view else {
                 didShow(false)
                 return
             }

--- a/DuckDuckGo/TabViewController+BrowsingTipsDelegate.swift
+++ b/DuckDuckGo/TabViewController+BrowsingTipsDelegate.swift
@@ -21,14 +21,35 @@ import EasyTipView
 
 extension TabViewController: BrowsingTipsDelegate {
     
-    func showPrivacyGradeTip() {
+    func showPrivacyGradeTip(didShow: @escaping (Bool) -> Void) {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let omniBar = self?.chromeDelegate?.omniBar else { return }
-            guard let grade = omniBar.siteRatingView else { return }
-            guard let superView = self?.parent?.view else { return }
+            guard let self = self else {
+                didShow(false)
+                return
+            }
+            
+            guard !self.omniBarTextFieldHasFocus else {
+                didShow(false)
+                return
+            }
+            
+            guard let omniBar = self.chromeDelegate?.omniBar else {
+                didShow(false)
+                return
+            }
+            
+            guard let grade = omniBar.siteRatingView else {
+                didShow(false)
+                return
+            }
+            
+            guard let superView = self.parent?.view else {
+                didShow(false)
+                return
+            }
 
-            self?.delegate?.showBars()
+            self.delegate?.showBars()
 
             var preferences = EasyTipView.globalPreferences
             preferences.positioning.bubbleHInset = 8
@@ -39,6 +60,7 @@ extension TabViewController: BrowsingTipsDelegate {
                                   preferences: preferences)
 
             tip.show(animated: true, forView: grade, withinSuperview: superView)
+            didShow(true)
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 tip.handleGlobalTouch()
             }
@@ -46,14 +68,34 @@ extension TabViewController: BrowsingTipsDelegate {
 
     }
     
-    func showFireButtonTip() {
+    func showFireButtonTip(didShow: @escaping (Bool) -> Void) {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let mainViewController = self?.parent as? MainViewController else { return }
-            guard let button = mainViewController.fireButton else { return }
-            guard let superView = self?.parent?.view else { return }
+            guard let self = self else {
+                didShow(false)
+                return
+            }
             
-            self?.delegate?.showBars()
+            guard !self.omniBarTextFieldHasFocus else {
+                didShow(false)
+                return
+            }
+            
+            guard let mainViewController = self.parent as? MainViewController else {
+                didShow(false)
+                return
+            }
+            
+            guard let button = mainViewController.fireButton else {
+                didShow(false)
+                return
+            }
+            guard let superView = self.parent?.view else {
+                didShow(false)
+                return
+            }
+            
+            self.delegate?.showBars()
             
             var preferences = EasyTipView.globalPreferences
             preferences.positioning.bubbleHInset = 8
@@ -63,10 +105,15 @@ extension TabViewController: BrowsingTipsDelegate {
                                   icon: icon,
                                   preferences: preferences)
             tip.show(forItem: button, withinSuperView: superView)            
+            didShow(true)
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 tip.handleGlobalTouch()
             }
         }
     }
-        
+    
+    private var omniBarTextFieldHasFocus: Bool {
+        return self.chromeDelegate?.omniBar.textField.isFirstResponder ?? false
+    }
+
 }

--- a/DuckDuckGoTests/BrowsingTipsTests.swift
+++ b/DuckDuckGoTests/BrowsingTipsTests.swift
@@ -35,6 +35,21 @@ class BrowsingTipsTests: XCTestCase {
     // swiftlint:enable weak_delegate
     var storage = MockContextualTipsStorage()
 
+    func testWhenNotShownThenNextTipIsUnchanged() {
+        
+        storage.isEnabled = true
+        delegate.shown = false
+        
+        let tips = BrowsingTips(delegate: delegate, storage: storage)
+        XCTAssertNotNil(tips)
+        
+        tips?.onFinishedLoading(url: URLs.example, error: false)
+        XCTAssertEqual(1, delegate.showPrivacyGradeTipCounter)
+        XCTAssertEqual(0, delegate.showFireButtonTipCounter)
+        
+        XCTAssertEqual(0, storage.nextBrowsingTip)
+    }
+
     func testWhenFeatureNotEnabledThenInstanciationFails() {
         
         let tips = BrowsingTips(delegate: delegate, storage: storage)
@@ -72,18 +87,22 @@ class BrowsingTipsTests: XCTestCase {
         let tips = BrowsingTips(delegate: delegate, storage: storage)
         XCTAssertEqual(0, delegate.showPrivacyGradeTipCounter)
         XCTAssertEqual(0, delegate.showFireButtonTipCounter)
-        
+        XCTAssertEqual(0, storage.nextBrowsingTip)
+
         tips?.onFinishedLoading(url: URLs.example, error: false)
         XCTAssertEqual(0, delegate.showFireButtonTipCounter)
         XCTAssertEqual(1, delegate.showPrivacyGradeTipCounter)
-        
+        XCTAssertEqual(1, storage.nextBrowsingTip)
+
         tips?.onFinishedLoading(url: URLs.example, error: false)
         XCTAssertEqual(1, delegate.showFireButtonTipCounter)
         XCTAssertEqual(1, delegate.showPrivacyGradeTipCounter)
-        
+        XCTAssertEqual(2, storage.nextBrowsingTip)
+
         tips?.onFinishedLoading(url: URLs.example, error: false)
         XCTAssertEqual(1, delegate.showFireButtonTipCounter)
         XCTAssertEqual(1, delegate.showPrivacyGradeTipCounter)
+        XCTAssertEqual(2, storage.nextBrowsingTip)
     }
     
     func testWhenTipsDisabledLaterThenTriggerDoesNothing() {
@@ -103,15 +122,18 @@ class BrowsingTipsTests: XCTestCase {
 
 class MockBrowsingTipsDelegate: NSObject, BrowsingTipsDelegate {
     
+    var shown = true
     var showPrivacyGradeTipCounter = 0
     var showFireButtonTipCounter = 0
     
-    func showPrivacyGradeTip() {
+    func showPrivacyGradeTip(didShow: (Bool) -> Void) {
         showPrivacyGradeTipCounter += 1
+        didShow(shown)
     }
     
-    func showFireButtonTip() {
+    func showFireButtonTip(didShow: (Bool) -> Void) {
         showFireButtonTipCounter += 1
+        didShow(shown)
     }
     
 }

--- a/DuckDuckGoTests/HomeScreenTipsTests.swift
+++ b/DuckDuckGoTests/HomeScreenTipsTests.swift
@@ -30,6 +30,22 @@ class HomeScreenTipsTests: XCTestCase {
     var storage = MockContextualTipsStorage()
     var tutorialSettings = MockTutorialSettings()
 
+    func testWhenNotShownThenNextTipIsUnchanged() {
+
+        storage.isEnabled = true
+        tutorialSettings.hasSeenOnboarding = true
+        delegate.shown = false
+        
+        let tips = HomeScreenTips(delegate: delegate, tutorialSettings: tutorialSettings, storage: storage)
+        XCTAssertNotNil(tips)
+
+        tips?.trigger()
+        XCTAssertEqual(1, delegate.showPrivateSearchTipCounter)
+        XCTAssertEqual(0, delegate.showCustomizeTipCounter)
+
+        XCTAssertEqual(0, storage.nextHomeScreenTip)
+    }
+    
     func testWhenFeatureEnabledButOnboardingNotShownThenTriggerDoesNothing() {
 
         let tips = HomeScreenTips(delegate: delegate, tutorialSettings: tutorialSettings, storage: storage)
@@ -55,38 +71,44 @@ class HomeScreenTipsTests: XCTestCase {
         tutorialSettings.hasSeenOnboarding = true
 
         let tips = HomeScreenTips(delegate: delegate, tutorialSettings: tutorialSettings, storage: storage)
-
         XCTAssertNotNil(tips)
 
         XCTAssertEqual(0, delegate.showCustomizeTipCounter)
         XCTAssertEqual(0, delegate.showPrivateSearchTipCounter)
+        XCTAssertEqual(0, storage.nextHomeScreenTip)
 
         tips?.trigger()
         XCTAssertEqual(0, delegate.showCustomizeTipCounter)
         XCTAssertEqual(1, delegate.showPrivateSearchTipCounter)
+        XCTAssertEqual(1, storage.nextHomeScreenTip)
 
         tips?.trigger()
         XCTAssertEqual(1, delegate.showCustomizeTipCounter)
         XCTAssertEqual(1, delegate.showPrivateSearchTipCounter)
+        XCTAssertEqual(2, storage.nextHomeScreenTip)
 
         tips?.trigger()
         XCTAssertEqual(1, delegate.showCustomizeTipCounter)
         XCTAssertEqual(1, delegate.showPrivateSearchTipCounter)
+        XCTAssertEqual(2, storage.nextHomeScreenTip)
     }
     
 }
 
 class MockHomeScreenTipsDelegate: NSObject, HomeScreenTipsDelegate {
 
+    var shown = true
     var showPrivateSearchTipCounter = 0
     var showCustomizeTipCounter = 0
     
-    func showPrivateSearchTip() {
+    func showPrivateSearchTip(didShow: (Bool) -> Void) {
         showPrivateSearchTipCounter += 1
+        didShow(shown)
     }
     
-    func showCustomizeTip() {
+    func showCustomizeTip(didShow: (Bool) -> Void) {
         showCustomizeTipCounter += 1
+        didShow(shown)
     }
     
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/461563361318156/1116986626461595
Tech Design URL:
CC:

**Description**:

Prevents tips being shown if the omni bar has focus, reducing the confusion about where the tip is pointing. 

**Steps to test this PR**:
1. Clean install
1. As soon as the home screen shows give the omnibar focus (you have < 0.5 seconds) - the tip should not show
1. Trigger the home screen again (e.g. open and close bookmarks)
1. Tip will show
1. Check for both home screen tips
1. Repeat for the browsing tips

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
