### PR TITLE
fix crash in on boarding

### DIFF
--- a/BookmarksTodayExtension/Info.plist
+++ b/BookmarksTodayExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.18.2</string>
+	<string>7.18.3</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.18.2</string>
+	<string>7.18.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/DuckDuckGo/OnboardingViewController.swift
+++ b/DuckDuckGo/OnboardingViewController.swift
@@ -22,7 +22,8 @@ import Core
 
 class OnboardingViewController: UIViewController, Onboarding {
 
-    var controllerNames = DefaultVariantManager.init().currentVariant?.features.map({ $0.rawValue }) ?? []
+    // Use controller names based on the enabled features. If we somehow have an invalid variant default to the onboarding summary only.
+    var controllerNames = (DefaultVariantManager.init().currentVariant?.features ?? [ FeatureName.onboardingSummary ]).map({ $0.rawValue })
     
     @IBOutlet weak var header: UILabel!
     @IBOutlet weak var subheader: UILabel!

--- a/QuickActionsTodayExtension/Info.plist
+++ b/QuickActionsTodayExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.18.2</string>
+	<string>7.18.3</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.18.2</string>
+	<string>7.18.3</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: n/a 
Tech Design URL:
CC:

**Description**:

Fixes a crash in onboarding when user has an old / invalid variant.

**Steps to test this PR**:
1. Set the VARIANT environment variant to a known good one (e.g. `sc` or `mr`) and run the app
1. Without completing onboarding close the app
1. Set the VARIANT environment variable to something else (e.g. mt) and run the app - it should show the the onboarding summary, previously it would crash.
1. Comment out the variants and repeat the test.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
