### PR TITLE
Improved progress bar

### DIFF
--- a/Core/UIColorExtension.swift
+++ b/Core/UIColorExtension.swift
@@ -77,6 +77,18 @@ extension UIColor {
         return UIColor(red: 103.0 / 255.0, green: 143.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0)
     }
     
+    public static var cornflowerDark: UIColor {
+        return UIColor(red: 80.0 / 255.0, green: 120.0 / 255.0, blue: 233.0 / 255.0, alpha: 1.0)
+    }
+    
+    public static var skyBlue: UIColor {
+        return UIColor(red: 66.0 / 255.0, green: 191.0 / 255.0, blue: 254.0 / 255.0, alpha: 1.0)
+    }
+    
+    public static var skyBlueLight: UIColor {
+        return UIColor(red: 120.0 / 255.0, green: 210.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0)
+    }
+    
     public static var nearlyWhiteLight: UIColor {
         return UIColor(red: 250.0 / 255.0, green: 250.0 / 255.0, blue: 250.0 / 255.0, alpha: 1.0)
     }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -288,11 +288,13 @@
 		981FED712202519C008488D7 /* BlankSnapshot.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 981FED702202519C008488D7 /* BlankSnapshot.storyboard */; };
 		981FED7422046017008488D7 /* AutoClearTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981FED7322046017008488D7 /* AutoClearTests.swift */; };
 		981FED76220464EF008488D7 /* AutoClearSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981FED75220464EF008488D7 /* AutoClearSettingsModel.swift */; };
+		9820EAF522613CD30089094D /* WebProgressWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9820EAF422613CD30089094D /* WebProgressWorker.swift */; };
 		9820FF502244FECC008D4782 /* UIScrollViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9820FF4F2244FECC008D4782 /* UIScrollViewExtension.swift */; };
 		982C87C42255559A00919035 /* UITableViewCellExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982C87C32255559A00919035 /* UITableViewCellExtension.swift */; };
 		982E5630222C3D5B008D861B /* FeedbackPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982E562F222C3D5B008D861B /* FeedbackPickerViewController.swift */; };
 		9838059F2228208E00385F1A /* PositiveFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9838059E2228208E00385F1A /* PositiveFeedbackViewController.swift */; };
 		984D60B2222A1284003B9E3B /* FeedbackFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984D60B1222A1284003B9E3B /* FeedbackFormViewController.swift */; };
+		985892522260B1B200EEB31B /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985892512260B1B200EEB31B /* ProgressView.swift */; };
 		9874F9EE2187AFCE00CAF33D /* Themable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9874F9ED2187AFCE00CAF33D /* Themable.swift */; };
 		9888F77B2224980500C46159 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9888F77A2224980500C46159 /* FeedbackViewController.swift */; };
 		98B31290218CCB2200E54DE1 /* MockDependencyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B3128F218CCB2200E54DE1 /* MockDependencyProvider.swift */; };
@@ -840,12 +842,14 @@
 		981FED702202519C008488D7 /* BlankSnapshot.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BlankSnapshot.storyboard; sourceTree = "<group>"; };
 		981FED7322046017008488D7 /* AutoClearTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoClearTests.swift; sourceTree = "<group>"; };
 		981FED75220464EF008488D7 /* AutoClearSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoClearSettingsModel.swift; sourceTree = "<group>"; };
+		9820EAF422613CD30089094D /* WebProgressWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebProgressWorker.swift; sourceTree = "<group>"; };
 		9820FF4F2244FECC008D4782 /* UIScrollViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewExtension.swift; sourceTree = "<group>"; };
 		982C87C32255559A00919035 /* UITableViewCellExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewCellExtension.swift; sourceTree = "<group>"; };
 		982E562D222C39F8008D861B /* Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		982E562F222C3D5B008D861B /* FeedbackPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackPickerViewController.swift; sourceTree = "<group>"; };
 		9838059E2228208E00385F1A /* PositiveFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositiveFeedbackViewController.swift; sourceTree = "<group>"; };
 		984D60B1222A1284003B9E3B /* FeedbackFormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackFormViewController.swift; sourceTree = "<group>"; };
+		985892512260B1B200EEB31B /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
 		9874F9ED2187AFCE00CAF33D /* Themable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Themable.swift; sourceTree = "<group>"; };
 		9888F77A2224980500C46159 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		98B3128F218CCB2200E54DE1 /* MockDependencyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDependencyProvider.swift; sourceTree = "<group>"; };
@@ -1988,6 +1992,7 @@
 				8563A0371F8E54F100F04442 /* Tab.storyboard */,
 				F1386BA31E6846C40062FC3C /* TabDelegate.swift */,
 				F159BDA31F0BDB5A00B4A01D /* TabViewController.swift */,
+				9820EAF422613CD30089094D /* WebProgressWorker.swift */,
 				83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */,
 				83004E872193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift */,
 				8C47244F2217A14B004C9B2D /* TabViewControllerLongPressBookmarkExtension.swift */,
@@ -2426,6 +2431,7 @@
 				857D1DCA22401DB900833940 /* NotFoundCachingImageDownloader.swift */,
 				F1D796F11E7C0EE00019D451 /* PartiallyRoundedRectangleView.swift */,
 				F1D934021E610DCE00A6F0D6 /* Point.swift */,
+				985892512260B1B200EEB31B /* ProgressView.swift */,
 				F143C32B1E4A9A4800CFDE3A /* RoundedRectangleView.swift */,
 				F143C3451E4AA32D00CFDE3A /* SearchBarExtension.swift */,
 				F197EA3B1E6885F20029BDC1 /* TextFieldWithInsets.swift */,
@@ -3290,6 +3296,7 @@
 				85058368219C49E000ED4EDB /* HomeViewSectionRenderers.swift in Sources */,
 				85F1E9B01FB7BF3900A75AC1 /* NativeDisplayableCertificateBuilderDriver.swift in Sources */,
 				85BD869F1FAA0E1100252411 /* PrivacyProtectionInfoDisplaying.swift in Sources */,
+				9820EAF522613CD30089094D /* WebProgressWorker.swift in Sources */,
 				F1C4A70E1E57725800A6CA1B /* OmniBar.swift in Sources */,
 				8565A3431FC5995900239327 /* PrivacyProtectionTrackerNetworksController.swift in Sources */,
 				F130D73A1E5776C500C45811 /* OmniBarDelegate.swift in Sources */,
@@ -3315,6 +3322,7 @@
 				F16390821E648B7A005B4550 /* HomeViewController.swift in Sources */,
 				98F3A1DA217B37200011A0D4 /* LightTheme.swift in Sources */,
 				85CE790721E8A9F600607B91 /* EmptySectionRenderer.swift in Sources */,
+				985892522260B1B200EEB31B /* ProgressView.swift in Sources */,
 				85BA585A1F3506AE00C6E8CA /* AppSettings.swift in Sources */,
 				F17922E21E71CD67006E3D97 /* NoSuggestionsTableViewCell.swift in Sources */,
 				85200F931FBA3BA4001AF290 /* PrivacyProtectionHeaderController.swift in Sources */,

--- a/DuckDuckGo/Base.lproj/Main.storyboard
+++ b/DuckDuckGo/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="C1X-Zd-UbA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="C1X-Zd-UbA">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -45,6 +45,13 @@
                                 <color key="backgroundColor" red="0.0" green="0.56031829119999998" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="52" id="XOq-1B-9oE"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kFG-OX-YkL" customClass="ProgressView" customModule="DuckDuckGo" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="69" width="320" height="3"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="3" id="ysF-8z-Vg0"/>
                                 </constraints>
                             </view>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Krm-hA-s9u">
@@ -220,11 +227,14 @@
                             <constraint firstItem="iiL-6e-jxs" firstAttribute="width" secondItem="Vxt-xD-aBt" secondAttribute="width" id="CfL-Ud-UIC"/>
                             <constraint firstItem="uBn-Md-Q2c" firstAttribute="bottom" secondItem="yPc-P1-sCk" secondAttribute="bottom" constant="100" id="FWX-GD-c7o"/>
                             <constraint firstItem="iiL-6e-jxs" firstAttribute="centerX" secondItem="uBn-Md-Q2c" secondAttribute="centerX" id="GYY-82-9YX"/>
+                            <constraint firstItem="kFG-OX-YkL" firstAttribute="width" secondItem="nQT-PV-ULm" secondAttribute="width" id="HdJ-g2-Ov8"/>
+                            <constraint firstItem="kFG-OX-YkL" firstAttribute="bottom" secondItem="nQT-PV-ULm" secondAttribute="bottom" id="LiF-mb-9zs"/>
                             <constraint firstItem="Krm-hA-s9u" firstAttribute="top" secondItem="Ylj-oJ-fqD" secondAttribute="bottom" id="N6y-rD-Nne"/>
                             <constraint firstItem="lJT-0B-l2J" firstAttribute="width" secondItem="Vxt-xD-aBt" secondAttribute="width" id="NuH-hE-pWg"/>
                             <constraint firstItem="lJT-0B-l2J" firstAttribute="top" secondItem="nQT-PV-ULm" secondAttribute="bottom" id="P7O-RF-g4h"/>
                             <constraint firstItem="Ylj-oJ-fqD" firstAttribute="leading" secondItem="Vxt-xD-aBt" secondAttribute="leading" id="Piz-bL-YZd"/>
                             <constraint firstItem="Krm-hA-s9u" firstAttribute="bottom" secondItem="uBn-Md-Q2c" secondAttribute="bottom" id="UsQ-i7-pjr"/>
+                            <constraint firstItem="kFG-OX-YkL" firstAttribute="leading" secondItem="nQT-PV-ULm" secondAttribute="leading" id="W6d-u9-zZQ"/>
                             <constraint firstItem="lJT-0B-l2J" firstAttribute="centerX" secondItem="uBn-Md-Q2c" secondAttribute="centerX" id="d7x-EX-84Q"/>
                             <constraint firstAttribute="top" secondItem="iiL-6e-jxs" secondAttribute="top" id="ea4-zN-0Co"/>
                             <constraint firstItem="Ylj-oJ-fqD" firstAttribute="top" secondItem="lJT-0B-l2J" secondAttribute="bottom" id="h5k-Sy-jb2"/>
@@ -256,6 +266,7 @@
                         <outlet property="notificationContainer" destination="lJT-0B-l2J" id="mM8-Jf-tfY"/>
                         <outlet property="notificationContainerHeight" destination="g5u-N0-iSI" id="QUq-JS-Eqd"/>
                         <outlet property="notificationContainerTop" destination="P7O-RF-g4h" id="4qK-Ti-ONY"/>
+                        <outlet property="progressView" destination="kFG-OX-YkL" id="aTf-Ch-ha9"/>
                         <outlet property="statusBarBackground" destination="iiL-6e-jxs" id="a4O-jb-Wke"/>
                         <outlet property="tabsButton" destination="K7o-WL-SC5" id="K5w-s3-8x3"/>
                         <outlet property="toolbar" destination="Krm-hA-s9u" id="JHv-PZ-ILs"/>

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -30,6 +30,8 @@ class MainViewController: UIViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return ThemeManager.shared.currentTheme.statusBarStyle
     }
+    
+    @IBOutlet weak var progressView: ProgressView!
 
     @IBOutlet weak var customNavigationBar: UIView!
     @IBOutlet weak var containerView: UIView!
@@ -346,8 +348,10 @@ class MainViewController: UIViewController {
     private func addToView(tab: TabViewController) {
         removeHomeScreen()
         updateFindInPage()
+        currentTab?.progressWorker.progressBar = nil
         currentTab?.chromeDelegate = nil
         addToView(controller: tab)
+        tab.progressWorker.progressBar = progressView
         tab.webView.scrollView.delegate = chromeManager
         tab.chromeDelegate = self
     }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -248,6 +248,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func attachHomeScreen() {
+        progressView.hide()
         findInPageView.isHidden = true
         removeHomeScreen()
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -248,7 +248,6 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func attachHomeScreen() {
-        progressView.hide()
         findInPageView.isHidden = true
         removeHomeScreen()
 

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -174,11 +174,19 @@ class ProgressView: UIView, CAAnimationDelegate {
     
     func hide(animated: Bool = false) {
         if animated {
+            CATransaction.begin()
             let animation = CABasicAnimation(keyPath: "opacity")
             animation.fromValue = 1
             animation.toValue = 0
             animation.duration = 0.4
             progressMask.add(animation, forKey: Constants.fadeOutAnimationKey)
+            CATransaction.setCompletionBlock {
+                self.stopGradientAnimation()
+            }
+            CATransaction.commit()
+        } else {
+            progressMask.removeAllAnimations()
+            stopGradientAnimation()
         }
         
         CATransaction.begin()

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -94,6 +94,9 @@ class ProgressView: UIView, CAAnimationDelegate {
     func increaseProgress(to progress: CGFloat, animated: Bool = false) {
         guard progress > currentProgress else { return }
         currentProgress = progress
+        
+        // Workaround for the issue, when iOS removes all animations automatically (e.g. when putting app to the background)
+        startGradientAnimation()
         updateProgressMask(animated: animated)
     }
     

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -1,0 +1,173 @@
+//
+//  ProgressView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+class ProgressView: UIView {
+    
+    private struct Constants {
+        static let gradientAnimationKey = "animateGradient"
+    }
+    
+    private var progressLayer = CAGradientLayer()
+    private var progressMask = CALayer()
+    
+    private var currentProgress: CGFloat = 0.0
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureLayers()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        configureLayers()
+    }
+    
+    func configureLayers() {
+        var progressFrame = bounds
+        progressFrame.size.width *= 0.5
+        
+        progressMask.frame = progressFrame
+        
+        if #available(iOS 11.0, *) {
+            progressMask.cornerRadius = 2
+            progressMask.maskedCorners = [.layerMaxXMaxYCorner, .layerMaxXMinYCorner]
+        }
+        
+        progressMask.backgroundColor = UIColor.white.cgColor
+        
+        progressLayer.anchorPoint = .zero
+        progressLayer.frame = bounds
+        progressLayer.mask = progressMask
+        
+        var colors = [CGColor]()
+        var locations = [NSNumber]()
+        for i in 0...6 {
+            colors.append(UIColor.cornflowerBlue.cgColor)
+            colors.append(UIColor.skyBlueLight.cgColor)
+            
+            let location = 0.2 * Double(i)
+            locations.append(NSNumber(value: location - 0.1))
+            locations.append(NSNumber(value: location))
+        }
+        
+        progressLayer.colors = colors
+        progressLayer.locations = locations
+        progressLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        progressLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        layer.insertSublayer(progressLayer, at: 0)
+    }
+    
+    override func awakeFromNib() {
+        self.backgroundColor = .clear
+    }
+    
+    func updateProgress(_ progress: CGFloat, animated: Bool = false) {
+        print("---> p: \(progress)")
+        
+        currentProgress = progress
+        updateProgressMask(animated: animated)
+    }
+    
+    private func updateProgressMask(animated: Bool) {
+        var progressFrame = bounds
+        progressFrame.size.width *= currentProgress
+        
+        let duration: TimeInterval
+        if animated == false {
+            duration = 0
+        } else if currentProgress > 1 - CGFloat.ulpOfOne {
+            duration = 0.3
+        } else {
+            duration = 1
+            progressFrame.size.width *= 0.5
+        }
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(duration)
+        self.progressMask.frame = progressFrame
+        CATransaction.commit()
+        CATransaction.flush()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        progressLayer.frame = bounds
+        updateProgressMask(animated: false)
+    }
+    
+    private func startGradientAnimation() {
+        
+        let animation = CABasicAnimation(keyPath: "locations")
+        
+        var fromLocations = [NSNumber]()
+        var toLocations: [NSNumber] = [-0.2, -0.1]
+        for i in 0...6 {
+            let location = 0.2 * Double(i)
+            fromLocations.append(NSNumber(value: location - 0.1))
+            fromLocations.append(NSNumber(value: location))
+            
+            toLocations.append(NSNumber(value: location - 0.1))
+            toLocations.append(NSNumber(value: location))
+        }
+        toLocations = toLocations.dropLast(2)
+        
+//        animation.fromValue =  fromLocations
+        animation.toValue = toLocations
+        animation.duration = 0.4
+        animation.isRemovedOnCompletion = true
+        animation.repeatCount = .greatestFiniteMagnitude
+        self.progressLayer.add(animation, forKey: Constants.gradientAnimationKey)
+    }
+    
+    private func stopGradientAnimation() {
+        self.progressLayer.removeAnimation(forKey: Constants.gradientAnimationKey)
+    }
+    
+    func hide() {
+        stopGradientAnimation()
+        currentProgress = 0
+        
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.4)
+        var frame = progressMask.frame
+        frame.origin.x += frame.size.width
+        progressMask.frame = frame
+        CATransaction.commit()
+    }
+    
+    func show() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        var frame = progressMask.frame
+        frame.origin.x = 0
+        frame.size.width = 0
+        progressMask.frame = frame
+        CATransaction.commit()
+        CATransaction.flush()
+        startGradientAnimation()
+    }
+    
+    var isVisible: Bool {
+        return alpha > 0
+    }
+}

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -85,10 +85,7 @@ class ProgressView: UIView, CAAnimationDelegate {
         
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        var frame = progressMask.frame
-        frame.origin.x = 0
-        frame.size.width = 0
-        progressMask.frame = frame
+        progressMask.bounds = calculateProgressMaskRect()
         progressMask.opacity = 1
         CATransaction.commit()
         CATransaction.flush()

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -123,7 +123,7 @@ class ProgressView: UIView, CAAnimationDelegate {
         visibleProgress = currentProgress
         
         let duration: TimeInterval
-        if animated == false {
+        if !animated {
             duration = 0
         } else if currentProgress > 1 - CGFloat.ulpOfOne {
             duration = 0.2
@@ -183,9 +183,7 @@ class ProgressView: UIView, CAAnimationDelegate {
             animation.toValue = 0
             animation.duration = 0.4
             progressMask.add(animation, forKey: Constants.fadeOutAnimationKey)
-            CATransaction.setCompletionBlock {
-                self.stopGradientAnimation()
-            }
+            CATransaction.setCompletionBlock(stopGradientAnimation)
             CATransaction.commit()
         } else {
             progressMask.removeAllAnimations()

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -26,6 +26,8 @@ class ProgressView: UIView, CAAnimationDelegate {
         static let gradientAnimationKey = "animateGradient"
         static let progressAnimationKey = "animateProgress"
         static let fadeOutAnimationKey = "animateFadeOut"
+        
+        static let completionThreshold = 1 - CGFloat.ulpOfOne
     }
     
     private var progressLayer = CAGradientLayer()
@@ -125,7 +127,7 @@ class ProgressView: UIView, CAAnimationDelegate {
         let duration: TimeInterval
         if !animated {
             duration = 0
-        } else if currentProgress > 1 - CGFloat.ulpOfOne {
+        } else if currentProgress > Constants.completionThreshold {
             duration = 0.2
         } else {
             duration = 0.6
@@ -146,7 +148,7 @@ class ProgressView: UIView, CAAnimationDelegate {
     }
     
     func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
-        if visibleProgress > 1 - CGFloat.ulpOfOne {
+        if visibleProgress > Constants.completionThreshold {
             hide(animated: true)
         } else {
             updateProgressMask(animated: true)

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -19,16 +19,22 @@
 
 import UIKit
 
-class ProgressView: UIView {
+@IBDesignable
+class ProgressView: UIView, CAAnimationDelegate {
     
     private struct Constants {
         static let gradientAnimationKey = "animateGradient"
+        static let progressAnimationKey = "animateProgress"
+        static let fadeOutAnimationKey = "animateFadeOut"
     }
     
     private var progressLayer = CAGradientLayer()
     private var progressMask = CALayer()
     
+    // Actual progress
     private var currentProgress: CGFloat = 0.0
+    // Progress used to calculate last animation
+    private var visibleProgress: CGFloat = 0.0
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -43,131 +49,154 @@ class ProgressView: UIView {
     }
     
     func configureLayers() {
+        backgroundColor = .clear
+        
         var progressFrame = bounds
-        progressFrame.size.width *= 0.5
+        progressFrame.size.width = 0
         
+        progressMask.anchorPoint = .zero
         progressMask.frame = progressFrame
-        
         if #available(iOS 11.0, *) {
             progressMask.cornerRadius = 2
             progressMask.maskedCorners = [.layerMaxXMaxYCorner, .layerMaxXMinYCorner]
         }
-        
         progressMask.backgroundColor = UIColor.white.cgColor
         
-        progressLayer.anchorPoint = .zero
         progressLayer.frame = bounds
+        progressLayer.anchorPoint = .zero
         progressLayer.mask = progressMask
         
         var colors = [CGColor]()
-        var locations = [NSNumber]()
-        for i in 0...6 {
+        for _ in 0...6 {
             colors.append(UIColor.cornflowerBlue.cgColor)
             colors.append(UIColor.skyBlueLight.cgColor)
-            
-            let location = 0.2 * Double(i)
-            locations.append(NSNumber(value: location - 0.1))
-            locations.append(NSNumber(value: location))
         }
         
         progressLayer.colors = colors
-        progressLayer.locations = locations
+        progressLayer.locations = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3]
         progressLayer.startPoint = CGPoint(x: 0, y: 0.5)
         progressLayer.endPoint = CGPoint(x: 1, y: 0.5)
         layer.insertSublayer(progressLayer, at: 0)
     }
     
-    override func awakeFromNib() {
-        self.backgroundColor = .clear
-    }
-    
-    func updateProgress(_ progress: CGFloat, animated: Bool = false) {
-        print("---> p: \(progress)")
-        
-        currentProgress = progress
-        updateProgressMask(animated: animated)
-    }
-    
-    private func updateProgressMask(animated: Bool) {
-        var progressFrame = bounds
-        progressFrame.size.width *= currentProgress
-        
-        let duration: TimeInterval
-        if animated == false {
-            duration = 0
-        } else if currentProgress > 1 - CGFloat.ulpOfOne {
-            duration = 0.3
-        } else {
-            duration = 1
-            progressFrame.size.width *= 0.5
-        }
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(duration)
-        self.progressMask.frame = progressFrame
-        CATransaction.commit()
-        CATransaction.flush()
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        progressLayer.frame = bounds
-        updateProgressMask(animated: false)
-    }
-    
-    private func startGradientAnimation() {
-        
-        let animation = CABasicAnimation(keyPath: "locations")
-        
-        var fromLocations = [NSNumber]()
-        var toLocations: [NSNumber] = [-0.2, -0.1]
-        for i in 0...6 {
-            let location = 0.2 * Double(i)
-            fromLocations.append(NSNumber(value: location - 0.1))
-            fromLocations.append(NSNumber(value: location))
-            
-            toLocations.append(NSNumber(value: location - 0.1))
-            toLocations.append(NSNumber(value: location))
-        }
-        toLocations = toLocations.dropLast(2)
-        
-//        animation.fromValue =  fromLocations
-        animation.toValue = toLocations
-        animation.duration = 0.4
-        animation.isRemovedOnCompletion = true
-        animation.repeatCount = .greatestFiniteMagnitude
-        self.progressLayer.add(animation, forKey: Constants.gradientAnimationKey)
-    }
-    
-    private func stopGradientAnimation() {
-        self.progressLayer.removeAnimation(forKey: Constants.gradientAnimationKey)
-    }
-    
-    func hide() {
-        stopGradientAnimation()
-        currentProgress = 0
-        
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(0.4)
-        var frame = progressMask.frame
-        frame.origin.x += frame.size.width
-        progressMask.frame = frame
-        CATransaction.commit()
-    }
-    
     func show() {
+        currentProgress = 0
+        visibleProgress = 0
+        
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         var frame = progressMask.frame
         frame.origin.x = 0
         frame.size.width = 0
         progressMask.frame = frame
+        progressMask.opacity = 1
         CATransaction.commit()
         CATransaction.flush()
+        
         startGradientAnimation()
     }
     
-    var isVisible: Bool {
-        return alpha > 0
+    func increaseProgress(to progress: CGFloat, animated: Bool = false) {
+        currentProgress = progress
+        updateProgressMask(animated: animated)
+    }
+    
+    func finishAndHide() {
+        increaseProgress(to: 1, animated: true)
+    }
+    
+    private func calculateProgressMaskRect() -> CGRect {
+        guard currentProgress < 1  else {
+            return bounds
+        }
+        var progressRect = bounds
+        progressRect.size.width *= currentProgress * 0.5
+        return progressRect
+    }
+    
+    private func updateProgressMask(animated: Bool) {
+        guard progressMask.animation(forKey: Constants.progressAnimationKey) == nil,
+            currentProgress > visibleProgress else {
+            return
+        }
+        
+        let progressFrame = calculateProgressMaskRect()
+        visibleProgress = currentProgress
+        
+        let duration: TimeInterval
+        if animated == false {
+            duration = 0
+        } else if currentProgress > 1 - CGFloat.ulpOfOne {
+            duration = 0.2
+        } else {
+            duration = 0.6
+        }
+        
+        let animation = CABasicAnimation(keyPath: "bounds")
+        animation.fromValue = progressMask.bounds
+        animation.toValue = progressFrame
+        animation.duration = duration
+        animation.isRemovedOnCompletion = true
+        animation.delegate = self
+        
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        progressMask.bounds = progressFrame
+        CATransaction.commit()
+        
+        progressMask.add(animation, forKey: Constants.progressAnimationKey)
+    }
+    
+    func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
+        if visibleProgress > 1 - CGFloat.ulpOfOne {
+            hideAndReset()
+        } else {
+            updateProgressMask(animated: true)
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        progressLayer.frame = bounds
+        progressMask.frame = calculateProgressMaskRect()
+        progressMask.removeAnimation(forKey: Constants.progressAnimationKey)
+    }
+    
+    private func startGradientAnimation() {
+        let animation = CABasicAnimation(keyPath: "locations")
+        animation.toValue = [-0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1]
+        animation.duration = 0.4
+        animation.repeatCount = .greatestFiniteMagnitude
+        progressLayer.add(animation, forKey: Constants.gradientAnimationKey)
+    }
+    
+    private func stopGradientAnimation() {
+        progressLayer.removeAnimation(forKey: Constants.gradientAnimationKey)
+    }
+    
+    private func hideAndReset() {
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 1
+        animation.toValue = 0
+        animation.duration = 0.4
+        
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        progressMask.opacity = 0
+        CATransaction.commit()
+        
+        progressMask.add(animation, forKey: Constants.fadeOutAnimationKey)
+        
+        visibleProgress = 0
+        currentProgress = 0
+    }
+    
+    // MARK: IB
+    override func prepareForInterfaceBuilder() {
+        var progressFrame = bounds
+        progressFrame.size.width = 0
+        
+        progressMask.frame = progressFrame
     }
 }

--- a/DuckDuckGo/Tab.storyboard
+++ b/DuckDuckGo/Tab.storyboard
@@ -108,21 +108,11 @@
                                     <constraint firstItem="09V-cw-B4O" firstAttribute="centerY" secondItem="Kd4-Oi-JP2" secondAttribute="centerY" id="xtF-Qe-4A7"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5O-6E-vLF" customClass="ProgressView" customModule="DuckDuckGo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="17" width="768" height="6"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="6" id="s6j-Xo-V7O"/>
-                                </constraints>
-                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.1333333333" green="0.1333333333" blue="0.1333333333" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="centerY" secondItem="t0t-53-xVf" secondAttribute="centerY" id="3qe-NM-ikO"/>
-                            <constraint firstItem="d5O-6E-vLF" firstAttribute="leading" secondItem="t0t-53-xVf" secondAttribute="leading" id="4K2-Uj-zU1"/>
-                            <constraint firstItem="d5O-6E-vLF" firstAttribute="top" secondItem="ypz-s2-KJB" secondAttribute="bottom" constant="-3" id="Ke1-ii-OeP"/>
-                            <constraint firstItem="t0t-53-xVf" firstAttribute="trailing" secondItem="d5O-6E-vLF" secondAttribute="trailing" id="Rnp-ZL-s0a"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="width" secondItem="Sgm-Wo-lho" secondAttribute="width" id="WgD-oO-Ds7"/>
                             <constraint firstItem="ypz-s2-KJB" firstAttribute="top" secondItem="cfL-5d-Vrt" secondAttribute="bottom" constant="-80" id="Zyh-vQ-fMz"/>
                             <constraint firstAttribute="trailing" secondItem="ypz-s2-KJB" secondAttribute="trailing" id="bXU-Fx-c7D"/>
@@ -144,7 +134,6 @@
                         <outlet property="errorHeader" destination="6P7-7R-riV" id="IkB-Tc-Eat"/>
                         <outlet property="errorInfoImage" destination="TUO-E3-s7Q" id="ngN-8S-PwR"/>
                         <outlet property="errorMessage" destination="Cjw-mk-QL3" id="b1N-1W-IGs"/>
-                        <outlet property="progressBar" destination="d5O-6E-vLF" id="fl9-Fl-Hp5"/>
                         <outlet property="showBarsTapGestureRecogniser" destination="Y72-bH-DMy" id="SAY-KX-OEJ"/>
                         <outlet property="webViewContainer" destination="3yc-Gh-Vqe" id="kNL-fm-49U"/>
                         <segue destination="5Os-y0-IaV" kind="popoverPresentation" identifier="PrivacyProtectionTablet" popoverAnchorView="ypz-s2-KJB" id="nKl-8K-k03">

--- a/DuckDuckGo/Tab.storyboard
+++ b/DuckDuckGo/Tab.storyboard
@@ -42,11 +42,6 @@
                                     <constraint firstAttribute="height" constant="80" id="xhL-Yb-2Uf"/>
                                 </constraints>
                             </view>
-                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="cf7-Ja-fUU">
-                                <rect key="frame" x="0.0" y="20" width="768" height="2"/>
-                                <color key="progressTintColor" red="0.40392156862745099" green="0.5607843137254902" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <color key="trackTintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </progressView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kd4-Oi-JP2">
                                 <rect key="frame" x="0.0" y="338.5" width="768" height="367"/>
                                 <subviews>
@@ -113,19 +108,26 @@
                                     <constraint firstItem="09V-cw-B4O" firstAttribute="centerY" secondItem="Kd4-Oi-JP2" secondAttribute="centerY" id="xtF-Qe-4A7"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5O-6E-vLF" customClass="ProgressView" customModule="DuckDuckGo" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="17" width="768" height="6"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="6" id="s6j-Xo-V7O"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.1333333333" green="0.1333333333" blue="0.1333333333" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="t0t-53-xVf" firstAttribute="trailing" secondItem="cf7-Ja-fUU" secondAttribute="trailing" id="2jX-5z-Ssu"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="centerY" secondItem="t0t-53-xVf" secondAttribute="centerY" id="3qe-NM-ikO"/>
-                            <constraint firstItem="cf7-Ja-fUU" firstAttribute="leading" secondItem="t0t-53-xVf" secondAttribute="leading" id="Vfx-ef-Qp5"/>
+                            <constraint firstItem="d5O-6E-vLF" firstAttribute="leading" secondItem="t0t-53-xVf" secondAttribute="leading" id="4K2-Uj-zU1"/>
+                            <constraint firstItem="d5O-6E-vLF" firstAttribute="top" secondItem="ypz-s2-KJB" secondAttribute="bottom" constant="-3" id="Ke1-ii-OeP"/>
+                            <constraint firstItem="t0t-53-xVf" firstAttribute="trailing" secondItem="d5O-6E-vLF" secondAttribute="trailing" id="Rnp-ZL-s0a"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="width" secondItem="Sgm-Wo-lho" secondAttribute="width" id="WgD-oO-Ds7"/>
                             <constraint firstItem="ypz-s2-KJB" firstAttribute="top" secondItem="cfL-5d-Vrt" secondAttribute="bottom" constant="-80" id="Zyh-vQ-fMz"/>
                             <constraint firstAttribute="trailing" secondItem="ypz-s2-KJB" secondAttribute="trailing" id="bXU-Fx-c7D"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="centerX" secondItem="t0t-53-xVf" secondAttribute="centerX" id="oFL-Ft-NQV"/>
                             <constraint firstItem="ypz-s2-KJB" firstAttribute="leading" secondItem="Sgm-Wo-lho" secondAttribute="leading" id="ugB-DM-Oye"/>
-                            <constraint firstItem="cf7-Ja-fUU" firstAttribute="top" secondItem="ypz-s2-KJB" secondAttribute="bottom" id="xwr-1D-cel"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="t0t-53-xVf"/>
                         <connections>
@@ -142,7 +144,7 @@
                         <outlet property="errorHeader" destination="6P7-7R-riV" id="IkB-Tc-Eat"/>
                         <outlet property="errorInfoImage" destination="TUO-E3-s7Q" id="ngN-8S-PwR"/>
                         <outlet property="errorMessage" destination="Cjw-mk-QL3" id="b1N-1W-IGs"/>
-                        <outlet property="progressBar" destination="cf7-Ja-fUU" id="3z8-Dr-WFy"/>
+                        <outlet property="progressBar" destination="d5O-6E-vLF" id="fl9-Fl-Hp5"/>
                         <outlet property="showBarsTapGestureRecogniser" destination="Y72-bH-DMy" id="SAY-KX-OEJ"/>
                         <outlet property="webViewContainer" destination="3yc-Gh-Vqe" id="kNL-fm-49U"/>
                         <segue destination="5Os-y0-IaV" kind="popoverPresentation" identifier="PrivacyProtectionTablet" popoverAnchorView="ypz-s2-KJB" id="nKl-8K-k03">

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -629,14 +629,12 @@ extension TabViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView,
                  didReceive challenge: URLAuthenticationChallenge,
                  completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        print("===> \(#function) url: \(webView.url)")
         completionHandler(.performDefaultHandling, nil)
         guard let serverTrust = challenge.protectionSpace.serverTrust else { return }
         ServerTrustCache.shared.put(serverTrust: serverTrust, forDomain: challenge.protectionSpace.host)
     }
     
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-        print("===> \(#function) url: \(webView.url)")
         url = webView.url
         let httpsForced = tld.domain(lastUpgradedDomain) == tld.domain(webView.url?.host)
         onWebpageDidStartLoading(httpsForced: httpsForced)
@@ -647,7 +645,6 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     private func onWebpageDidStartLoading(httpsForced: Bool) {
-        print("===> \(#function) url: \(webView.url)")
         Logger.log(items: "webpageLoading started:", Date().timeIntervalSince1970)
         self.httpsForced = httpsForced
         delegate?.showBars()
@@ -680,12 +677,10 @@ extension TabViewController: WKNavigationDelegate {
                  decidePolicyFor navigationResponse: WKNavigationResponse,
                  decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
         decisionHandler(.allow)
-        print("===> \(#function) url: \(webView.url)")
         url = webView.url
     }
     
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        print("===> \(#function) url: \(webView.url)")
         lastError = nil
         shouldReloadOnError = false
         hideErrorMessage()
@@ -693,7 +688,6 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        print("===> \(#function) url: \(webView.url)")
         hideProgressIndicator()
         onWebpageDidFinishLoading()
     }
@@ -709,7 +703,6 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        print("===> \(#function) url: \(webView.url)")
         hideProgressIndicator()
         webpageDidFailToLoad()
         
@@ -733,7 +726,6 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        print("===> \(#function) url: \(webView.url)")
         hideProgressIndicator()
         lastError = error
         let error = error as NSError
@@ -756,7 +748,6 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
-        print("===> \(#function) url: \(webView.url)")
         guard let url = webView.url else { return }
         self.url = url
         self.siteRating = SiteRating(url: url, httpsForced: httpsForced)
@@ -766,7 +757,6 @@ extension TabViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        print("===> \(#function) url: \(webView.url)")
         let decision = decidePolicyFor(navigationAction: navigationAction)
         
         if let url = navigationAction.request.url,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -38,7 +38,6 @@ class TabViewController: UIViewController {
         static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15"
     }
     
-    @IBOutlet weak var progressBar: ProgressView!
     let progressWorker = WebProgressWorker()
     
     @IBOutlet private(set) weak var error: UIView!
@@ -141,9 +140,6 @@ class TabViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         addContentBlockerConfigurationObserver()
-        
-        progressWorker.progressBar = progressBar
-        progressBar.alpha = 0
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -219,7 +215,6 @@ class TabViewController: UIViewController {
         }
         
         if url != nil {
-            progressBar.increaseProgress(to: Constants.minimumProgress)
             delegate?.tabLoadingStateDidChange(tab: self)
             onWebpageDidStartLoading(httpsForced: false)
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -494,6 +494,7 @@ class TabViewController: UIViewController {
     }
 
     func dismiss() {
+        progressWorker.progressBar = nil
         chromeDelegate = nil
         webView.scrollView.delegate = nil
         willMove(toParent: nil)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -38,8 +38,6 @@ class TabViewController: UIViewController {
         static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15"
     }
     
-    let progressWorker = WebProgressWorker()
-    
     @IBOutlet private(set) weak var error: UIView!
     @IBOutlet private(set) weak var errorInfoImage: UIImageView!
     @IBOutlet private(set) weak var errorHeader: UILabel!
@@ -52,6 +50,8 @@ class TabViewController: UIViewController {
     weak var delegate: TabDelegate?
     weak var chromeDelegate: BrowserChromeDelegate?
     var findInPage: FindInPage?
+    
+    let progressWorker = WebProgressWorker()
 
     private(set) var webView: WKWebView!
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -219,7 +219,7 @@ class TabViewController: UIViewController {
         }
         
         if url != nil {
-            progressBar.updateProgress(Constants.minimumProgress)
+            progressBar.increaseProgress(to: Constants.minimumProgress)
             delegate?.tabLoadingStateDidChange(tab: self)
             onWebpageDidStartLoading(httpsForced: false)
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -629,6 +629,7 @@ extension TabViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView,
                  didReceive challenge: URLAuthenticationChallenge,
                  completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        
         completionHandler(.performDefaultHandling, nil)
         guard let serverTrust = challenge.protectionSpace.serverTrust else { return }
         ServerTrustCache.shared.put(serverTrust: serverTrust, forDomain: challenge.protectionSpace.host)
@@ -757,6 +758,7 @@ extension TabViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        
         let decision = decidePolicyFor(navigationAction: navigationAction)
         
         if let url = navigationAction.request.url,

--- a/DuckDuckGo/WebProgressWorker.swift
+++ b/DuckDuckGo/WebProgressWorker.swift
@@ -1,0 +1,55 @@
+//
+//  WebProgressWorker.swift
+//  DuckDuckGo
+//
+//  Created by Bartek on 12/04/2019.
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+
+import UIKit
+
+class WebProgressWorker {
+    
+    private struct Constants {
+        static let initialProgress: CGFloat = 0.1
+    }
+    
+    weak var progressBar: ProgressView?
+    
+    private var isLoading = false
+    private var currentProgress: CGFloat = 0.0
+    
+    func didStartLoading() {
+        guard let progressBar = progressBar,
+            isLoading == false else {
+                print("===> FAILED START")
+                return
+        }
+        
+        print("===> START")
+        isLoading = true
+        progressBar.show()
+        self.progressBar?.updateProgress(Constants.initialProgress, animated: true)
+    }
+    
+    func progressDidChange(_ progress: Double) {
+        guard isLoading else {
+            print("==> FAILED update to \(progress)")
+            return
+        }
+        
+        let progress = CGFloat(progress)
+        guard progress > currentProgress else { return }
+        currentProgress = progress
+        
+        self.progressBar?.updateProgress(progress, animated: true)
+    }
+    
+    func didFinishLoading() {
+        guard isLoading else { return }
+        isLoading = false
+        print("===> FINISH")
+        self.progressBar?.hide()
+        self.currentProgress = 0
+    }
+}

--- a/DuckDuckGo/WebProgressWorker.swift
+++ b/DuckDuckGo/WebProgressWorker.swift
@@ -20,36 +20,27 @@ class WebProgressWorker {
     private var currentProgress: CGFloat = 0.0
     
     func didStartLoading() {
-        guard let progressBar = progressBar,
-            isLoading == false else {
-                print("===> FAILED START")
-                return
-        }
-        
-        print("===> START")
+        guard isLoading == false else { return }
+
         isLoading = true
-        progressBar.show()
-        self.progressBar?.updateProgress(Constants.initialProgress, animated: true)
+        progressBar?.show()
+        progressBar?.increaseProgress(to: Constants.initialProgress, animated: true)
     }
     
     func progressDidChange(_ progress: Double) {
-        guard isLoading else {
-            print("==> FAILED update to \(progress)")
-            return
-        }
+        guard isLoading else { return }
         
         let progress = CGFloat(progress)
         guard progress > currentProgress else { return }
         currentProgress = progress
         
-        self.progressBar?.updateProgress(progress, animated: true)
+        progressBar?.increaseProgress(to: progress, animated: true)
     }
     
     func didFinishLoading() {
         guard isLoading else { return }
         isLoading = false
-        print("===> FINISH")
-        self.progressBar?.hide()
-        self.currentProgress = 0
+        progressBar?.finishAndHide()
+        currentProgress = 0
     }
 }

--- a/DuckDuckGo/WebProgressWorker.swift
+++ b/DuckDuckGo/WebProgressWorker.swift
@@ -2,8 +2,19 @@
 //  WebProgressWorker.swift
 //  DuckDuckGo
 //
-//  Created by Bartek on 12/04/2019.
 //  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import UIKit

--- a/DuckDuckGo/WebProgressWorker.swift
+++ b/DuckDuckGo/WebProgressWorker.swift
@@ -26,7 +26,9 @@ class WebProgressWorker {
     }
     
     weak var progressBar: ProgressView? {
-        didSet {
+        didSet(oldValue) {
+            oldValue?.hide()
+            
             if isLoading {
                 self.progressBar?.show(initialProgress: currentProgress)
             } else {

--- a/DuckDuckGo/WebProgressWorker.swift
+++ b/DuckDuckGo/WebProgressWorker.swift
@@ -25,7 +25,15 @@ class WebProgressWorker {
         static let initialProgress: CGFloat = 0.1
     }
     
-    weak var progressBar: ProgressView?
+    weak var progressBar: ProgressView? {
+        didSet {
+            if isLoading {
+                self.progressBar?.show(initialProgress: currentProgress)
+            } else {
+                self.progressBar?.hide()
+            }
+        }
+    }
     
     private var isLoading = false
     private var currentProgress: CGFloat = 0.0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/856498667320406/1117573875936431
Tech Design URL:
CC:

**Description**:
Improvements to progress bar:
- It is now moved above Omni Bar.
- Smooth animation on update.
- Gradient animation for 'filled' part of the progress bar.

**Steps to test this PR**:
Regular scenario:
1. Open new tab.
2. Start loading webpage.
3. Look out for any glitches/issues around progress bar.

**Redirect**:
1. Open new tab.
2. Navigate to page that redirects to another domain, e.g. bbc.co.uk
3. Look out for any glitches/issues around progress bar.

**Navigating across tabs**:
1. Open new tab.
2. Navigate to page that loads slowly.
3. Open another tab, load another web page there.
4. Progress bar should reflect actual progres when switching between tabs.

**Clearing data**:
1. Open new tab.
2. Navigate to page that loads slowly.
3. Use fire button to clear data.
4. Progress bar should disappear.

**Gradient animation checks**:
1. Open new tab.
2. Navigate to page that loads slowly.
3. Open privacy protection dashboard, then close it OR put app to the background, then move back to it.
4. If visible, progress bar gradient should be animating.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)