### PR TITLE
Update progress bar colors for Dark Theme

### DIFF
--- a/Core/UIColorExtension.swift
+++ b/Core/UIColorExtension.swift
@@ -89,6 +89,22 @@ extension UIColor {
         return UIColor(red: 120.0 / 255.0, green: 210.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0)
     }
     
+    public static var salmonLight: UIColor {
+        return UIColor(red: 255.0 / 255.0, green: 120.0 / 255.0, blue: 130.0 / 255.0, alpha: 1.0)
+    }
+    
+    public static var salmonDark: UIColor {
+        return UIColor(red: 250.0 / 255.0, green: 70.0 / 255.0, blue: 80.0 / 255.0, alpha: 1.0)
+    }
+    
+    public static var orangeLight: UIColor {
+        return UIColor(red: 255.0 / 255.0, green: 135.0 / 255.0, blue: 20.0 / 255.0, alpha: 1.0)
+    }
+    
+    public static var orangeDark: UIColor {
+        return UIColor(red: 245.0 / 255.0, green: 90.0 / 255.0, blue: 70.0 / 255.0, alpha: 1.0)
+    }
+    
     public static var nearlyWhiteLight: UIColor {
         return UIColor(red: 250.0 / 255.0, green: 250.0 / 255.0, blue: 250.0 / 255.0, alpha: 1.0)
     }

--- a/Core/UIColorExtension.swift
+++ b/Core/UIColorExtension.swift
@@ -89,20 +89,12 @@ extension UIColor {
         return UIColor(red: 120.0 / 255.0, green: 210.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0)
     }
     
-    public static var salmonLight: UIColor {
-        return UIColor(red: 255.0 / 255.0, green: 120.0 / 255.0, blue: 130.0 / 255.0, alpha: 1.0)
-    }
-    
-    public static var salmonDark: UIColor {
-        return UIColor(red: 250.0 / 255.0, green: 70.0 / 255.0, blue: 80.0 / 255.0, alpha: 1.0)
+    public static var orange: UIColor {
+        return UIColor(red: 222.0 / 255.0, green: 88.0 / 255.0, blue: 51.0 / 255.0, alpha: 1.0)
     }
     
     public static var orangeLight: UIColor {
-        return UIColor(red: 255.0 / 255.0, green: 135.0 / 255.0, blue: 20.0 / 255.0, alpha: 1.0)
-    }
-    
-    public static var orangeDark: UIColor {
-        return UIColor(red: 245.0 / 255.0, green: 90.0 / 255.0, blue: 70.0 / 255.0, alpha: 1.0)
+        return UIColor(red: 255.0 / 255.0, green: 135.0 / 255.0, blue: 75.0 / 255.0, alpha: 1.0)
     }
     
     public static var nearlyWhiteLight: UIColor {

--- a/DuckDuckGo/DarkTheme.swift
+++ b/DuckDuckGo/DarkTheme.swift
@@ -43,8 +43,8 @@ struct DarkTheme: Theme {
     var searchBarBorderColor = UIColor.darkGreyish
     var searchBarClearTextIconColor = UIColor.greyish2
     
-    var progressBarGradientDarkColor = UIColor.salmonDark
-    var progressBarGradientLightColor = UIColor.salmonLight
+    var progressBarGradientDarkColor = UIColor.orange
+    var progressBarGradientLightColor = UIColor.orangeLight
     
     var autocompleteCellAccessoryColor = UIColor.lightMercury
 

--- a/DuckDuckGo/DarkTheme.swift
+++ b/DuckDuckGo/DarkTheme.swift
@@ -43,6 +43,9 @@ struct DarkTheme: Theme {
     var searchBarBorderColor = UIColor.darkGreyish
     var searchBarClearTextIconColor = UIColor.greyish2
     
+    var progressBarGradientDarkColor = UIColor.salmonDark
+    var progressBarGradientLightColor = UIColor.salmonLight
+    
     var autocompleteCellAccessoryColor = UIColor.lightMercury
 
     var tableCellBackgroundColor = UIColor.nearlyBlackLight

--- a/DuckDuckGo/LightTheme.swift
+++ b/DuckDuckGo/LightTheme.swift
@@ -42,6 +42,9 @@ struct LightTheme: Theme {
     var searchBarTextDeemphasisColor = UIColor.greyish3
     var searchBarBorderColor = UIColor.lightGreyish
     var searchBarClearTextIconColor = UIColor.greyish2
+    
+    var progressBarGradientDarkColor = UIColor.cornflowerBlue
+    var progressBarGradientLightColor = UIColor.skyBlueLight
 
     var autocompleteCellAccessoryColor = UIColor.darkGreyish
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -896,6 +896,7 @@ extension MainViewController: Themable {
         customNavigationBar?.tintColor = theme.barTintColor
         
         omniBar?.decorate(with: theme)
+        progressView?.decorate(with: theme)
         
         toolbar?.barTintColor = theme.barBackgroundColor
         toolbar?.tintColor = theme.barTintColor

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -47,6 +47,7 @@ class ProgressView: UIView, CAAnimationDelegate {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         
+        decorate(with: ThemeManager.shared.currentTheme)
         configureLayers()
     }
     
@@ -64,13 +65,6 @@ class ProgressView: UIView, CAAnimationDelegate {
         progressLayer.anchorPoint = .zero
         progressLayer.mask = progressMask
         
-        var colors = [CGColor]()
-        for _ in 0...6 {
-            colors.append(UIColor.cornflowerBlue.cgColor)
-            colors.append(UIColor.skyBlueLight.cgColor)
-        }
-        
-        progressLayer.colors = colors
         progressLayer.locations = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3]
         progressLayer.startPoint = CGPoint(x: 0, y: 0.5)
         progressLayer.endPoint = CGPoint(x: 1, y: 0.5)
@@ -201,5 +195,18 @@ class ProgressView: UIView, CAAnimationDelegate {
     // MARK: IB
     override func prepareForInterfaceBuilder() {
         backgroundColor = .cornflowerBlue
+    }
+}
+
+extension ProgressView: Themable {
+    
+    func decorate(with theme: Theme) {
+        var colors = [CGColor]()
+        for _ in 0...6 {
+            colors.append(theme.progressBarGradientDarkColor.cgColor)
+            colors.append(theme.progressBarGradientLightColor.cgColor)
+        }
+        
+        progressLayer.colors = colors
     }
 }

--- a/DuckDuckGo/Theme.swift
+++ b/DuckDuckGo/Theme.swift
@@ -50,6 +50,9 @@ protocol Theme {
     var searchBarBorderColor: UIColor { get }
     var searchBarClearTextIconColor: UIColor { get }
     
+    var progressBarGradientDarkColor: UIColor { get }
+    var progressBarGradientLightColor: UIColor { get }
+    
     var autocompleteCellAccessoryColor: UIColor { get }
     
     var tableCellBackgroundColor: UIColor { get }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1121042699076194
Tech Design URL:
CC:

**Description**:
Update progress bar gradient colors to variations of orange color when in Dark Theme.

**Steps to test this PR**:
Clean start #1
1. Open app in Light Theme.
2. Load webpage -> progress bar should be blue.

Clean start #2
1. Open app in Dark Theme.
2. Load webpage -> progress bar should be orange.

Interactive update
1. Open app in Light Theme.
2. Start loading webpage.
3. Change theme to Dark.
4. Progress bar color should change to orange.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)