### PR TITLE
Fix for lingering progress bar

### DIFF
--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -111,8 +111,7 @@ class ProgressView: UIView, CAAnimationDelegate {
     
     private func updateProgressMask(animated: Bool) {
         let runningAnimations = progressMask.animationKeys() ?? []
-        let progressRelatedAnimations = runningAnimations.filter({ $0 == Constants.progressAnimationKey || $0 == Constants.fadeOutAnimationKey
-        })
+        let progressRelatedAnimations = runningAnimations.filter({ $0 == Constants.progressAnimationKey || $0 == Constants.fadeOutAnimationKey })
         
         guard progressRelatedAnimations.isEmpty,
             currentProgress > visibleProgress else {

--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -110,9 +110,13 @@ class ProgressView: UIView, CAAnimationDelegate {
     }
     
     private func updateProgressMask(animated: Bool) {
-        guard (progressMask.animationKeys() ?? []).isEmpty,
+        let runningAnimations = progressMask.animationKeys() ?? []
+        let progressRelatedAnimations = runningAnimations.filter({ $0 == Constants.progressAnimationKey || $0 == Constants.fadeOutAnimationKey
+        })
+        
+        guard progressRelatedAnimations.isEmpty,
             currentProgress > visibleProgress else {
-            return
+                return
         }
         
         let progressFrame = calculateProgressMaskRect()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1121088491149044
Tech Design URL:
CC:

**Description**:
Fix for progress bar lingering in case search bar's disappear animation interferes with progress bar animations.

**Steps to test this PR**:
1. Load some webpage.
2. While loading but after the page appears, scroll so the bars disappear.
3. Progress bar should not get stuck or lingering.

Please repeat few times. :)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)