### PR TITLE
variants for serp and default onboarding to include themes

### DIFF
--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -233,6 +233,7 @@ class AtbIntegrationTests: XCTestCase {
     }
     
     private func skipOnboarding() {
+        waitForButtonThenTap("SKIP")
         waitForButtonThenTap("Continue")
     }
     

--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -20,10 +20,7 @@
 import Foundation
 
 public enum FeatureName: String {
-    
-    case onboardingSummary
-    case onboardingThemes
-    
+
     // Used for unit tests
     case dummy
     
@@ -34,11 +31,9 @@ public struct Variant {
     static let doNotAllocate = 0
     
     public static let defaultVariants: [Variant] = [
-        // Shared control group
-        Variant(name: "sc", weight: 1, features: [.onboardingSummary]),
-        
-        // Experiment 3
-        Variant(name: "mr", weight: 1, features: [.onboardingThemes, .onboardingSummary])
+        // SERP testing - check with Brad before removing
+        Variant(name: "sc", weight: 1, features: []),
+        Variant(name: "se", weight: 1, features: [])
     ]
     
     public let name: String

--- a/DuckDuckGo/OnboardingViewController.swift
+++ b/DuckDuckGo/OnboardingViewController.swift
@@ -22,8 +22,7 @@ import Core
 
 class OnboardingViewController: UIViewController, Onboarding {
 
-    // Use controller names based on the enabled features. If we somehow have an invalid variant default to the onboarding summary only.
-    var controllerNames = (DefaultVariantManager.init().currentVariant?.features ?? [ FeatureName.onboardingSummary ]).map({ $0.rawValue })
+    var controllerNames = ["onboardingThemes", "onboardingSummary"]
     
     @IBOutlet weak var header: UILabel!
     @IBOutlet weak var subheader: UILabel!


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1122209886952011/1122376970602163
Tech Design URL:
CC:

**Description**:

Set themes for the SERP and default onboarding to show themes then summary.

**Steps to test this PR**:
1. Install the app and ensure the variants are selected
1. Clean install the app and ensure the theme selection onboarding is shown, followed by the summary screen onboarding.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
