### PR TITLE
remove sites visited

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -796,6 +796,7 @@
 		85CC936F203C402C00690089 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		85CC9375203C42A500690089 /* speed_test_sites.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = speed_test_sites.json; sourceTree = "<group>"; };
 		85CE790621E8A9F600607B91 /* EmptySectionRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySectionRenderer.swift; sourceTree = "<group>"; };
+		85D08E5722B3AB1C0085C93D /* NetworkLeaderboard 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "NetworkLeaderboard 2.xcdatamodel"; sourceTree = "<group>"; };
 		85E00178225E0D4E00877BF6 /* OnboardingSummaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSummaryViewController.swift; sourceTree = "<group>"; };
 		85E0017A225E0ED700877BF6 /* OnboardingThemesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingThemesViewController.swift; sourceTree = "<group>"; };
 		85EE7F54224667DD000FE757 /* WebContainer.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WebContainer.storyboard; sourceTree = "<group>"; };
@@ -4423,9 +4424,10 @@
 		85200FA21FBC607E001AF290 /* NetworkLeaderboard.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				85D08E5722B3AB1C0085C93D /* NetworkLeaderboard 2.xcdatamodel */,
 				85200FA31FBC607E001AF290 /* NetworkLeaderboard.xcdatamodel */,
 			);
-			currentVersion = 85200FA31FBC607E001AF290 /* NetworkLeaderboard.xcdatamodel */;
+			currentVersion = 85D08E5722B3AB1C0085C93D /* NetworkLeaderboard 2.xcdatamodel */;
 			path = NetworkLeaderboard.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/DuckDuckGo/NetworkLeaderboard.swift
+++ b/DuckDuckGo/NetworkLeaderboard.swift
@@ -56,7 +56,7 @@ class NetworkLeaderboard {
         _ = container.save()
     }
 
-    func pageVisited() {
+    func incrementPagesLoaded() {
         if let pageStats = pageStats {
             let count = (pageStats.pagesLoaded ?? 0).intValue
             pageStats.pagesLoaded = NSNumber(value: count + 1)
@@ -64,7 +64,7 @@ class NetworkLeaderboard {
         }
     }
     
-    func pageHasTrackers() {
+    func incrementPagesWithTrackers() {
         if let pageStats = pageStats {
             let count = (pageStats.pagesWithTrackers ?? 0).intValue
             pageStats.pagesWithTrackers = NSNumber(value: count + 1)

--- a/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/.xccurrentversion
+++ b/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>NetworkLeaderboard 2.xcdatamodel</string>
+</dict>
+</plist>

--- a/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/NetworkLeaderboard 2.xcdatamodel/contents
+++ b/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/NetworkLeaderboard 2.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18F132" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="1">
+    <entity name="PPTrackerNetwork" representedClassName="PPTrackerNetwork" syncable="YES" codeGenerationType="class">
+        <attribute name="detectedOnCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="PPTrackerNetwork" positionX="-45" positionY="18" width="128" height="75"/>
+    </elements>
+</model>

--- a/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/NetworkLeaderboard 2.xcdatamodel/contents
+++ b/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/NetworkLeaderboard 2.xcdatamodel/contents
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18F132" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="1">
+    <entity name="PPPageStats" representedClassName="PPPageStats" syncable="YES" codeGenerationType="class">
+        <attribute name="pagesLoaded" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pagesWithTrackers" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
     <entity name="PPTrackerNetwork" representedClassName="PPTrackerNetwork" syncable="YES" codeGenerationType="class">
         <attribute name="detectedOnCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
         <element name="PPTrackerNetwork" positionX="-45" positionY="18" width="128" height="75"/>
+        <element name="PPPageStats" positionX="-45" positionY="36" width="128" height="90"/>
     </elements>
 </model>

--- a/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/NetworkLeaderboard.xcdatamodel/contents
+++ b/DuckDuckGo/NetworkLeaderboard.xcdatamodeld/NetworkLeaderboard.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13533" systemVersion="16G1036" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="1">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18F132" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="1">
     <entity name="PPTrackerNetwork" representedClassName="PPTrackerNetwork" syncable="YES" codeGenerationType="class">
         <attribute name="detectedOnCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" attributeType="String" syncable="YES"/>
@@ -10,7 +10,7 @@
         <relationship name="networksDetected" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PPTrackerNetwork" inverseName="detectedOn" inverseEntity="PPTrackerNetwork" syncable="YES"/>
     </entity>
     <elements>
-        <element name="PPVisitedSite" positionX="-225" positionY="-144" width="128" height="73"/>
         <element name="PPTrackerNetwork" positionX="-45" positionY="18" width="128" height="88"/>
+        <element name="PPVisitedSite" positionX="-225" positionY="-144" width="128" height="73"/>
     </elements>
 </model>

--- a/DuckDuckGo/PrivacyProtectionFooterController.swift
+++ b/DuckDuckGo/PrivacyProtectionFooterController.swift
@@ -89,10 +89,10 @@ class TrackerNetworkLeaderboardView: UIView {
         scoresView.isHidden = !shouldShow
 
         if shouldShow {
-            let sitesVisited = leaderboard.sitesVisited()
-            firstPill.update(network: networksDetected[0], sitesVisited: sitesVisited)
-            secondPill.update(network: networksDetected[1], sitesVisited: sitesVisited)
-            thirdPill.update(network: networksDetected[2], sitesVisited: sitesVisited)
+            let pagesVisited = leaderboard.pagesVisited()
+            firstPill.update(network: networksDetected[0], pagesVisited: pagesVisited)
+            secondPill.update(network: networksDetected[1], pagesVisited: pagesVisited)
+            thirdPill.update(network: networksDetected[2], pagesVisited: pagesVisited)
         }
     }
 
@@ -107,8 +107,8 @@ class TrackerNetworkPillView: UIView {
         layer.cornerRadius = frame.size.height / 2
     }
 
-    func update(network: PPTrackerNetwork, sitesVisited: Int) {
-        let percent = 100 * Int(truncating: network.detectedOnCount ?? 0) / sitesVisited
+    func update(network: PPTrackerNetwork, pagesVisited: Int) {
+        let percent = 100 * Int(truncating: network.detectedOnCount ?? 0) / pagesVisited
         let percentText = "\(percent)%"
         let image = network.image
 

--- a/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
+++ b/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
@@ -39,7 +39,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
 
     let leaderboard = NetworkLeaderboard.shared
     var networksDetected = [PPTrackerNetwork]()
-    var sitesVisited = 0
+    var pagesVisited = 0
     var drama = true
 
     override func viewDidLoad() {
@@ -90,7 +90,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
     }
 
     private func initLeaderboard() {
-        sitesVisited = leaderboard.sitesVisited()
+        pagesVisited = leaderboard.pagesVisited()
         networksDetected = leaderboard.networksDetected()
     }
 
@@ -108,7 +108,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
         let dateText = dateFormatter.string(from: date)
 
         let detectedOn = networksDetected.count == 0 ? 0 : Int(truncating: networksDetected[0].detectedOnCount ?? 0)
-        let percent = sitesVisited == 0 ? 0 : 100 * detectedOn / sitesVisited
+        let percent = pagesVisited == 0 ? 0 : 100 * detectedOn / pagesVisited
         let percentText = "\(percent)%"
         let message = UserText.ppNetworkLeaderboard.format(arguments: percentText, dateText)
 
@@ -179,7 +179,7 @@ extension PrivacyProtectionNetworkLeaderboardController: UITableViewDataSource {
         }
 
         let network = networksDetected[indexPath.row]
-        let percent = drama ? 0 : 100 * Int(truncating: network.detectedOnCount!) / sitesVisited
+        let percent = drama ? 0 : 100 * Int(truncating: network.detectedOnCount!) / pagesVisited
 
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "Cell") as? PrivacyProtectionNetworkLeaderboardCell else {
             fatalError("Failed to dequeue cell as PrivacyProtectionNetworkLeaderboardCell")

--- a/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
+++ b/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
@@ -40,6 +40,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
     let leaderboard = NetworkLeaderboard.shared
     var networksDetected = [PPTrackerNetwork]()
     var pagesVisited = 0
+    var pagesWithTrackers = 0
     var drama = true
 
     override func viewDidLoad() {
@@ -91,6 +92,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
 
     private func initLeaderboard() {
         pagesVisited = leaderboard.pagesVisited()
+        pagesWithTrackers = leaderboard.pagesWithTrackers()
         networksDetected = leaderboard.networksDetected()
     }
 
@@ -107,8 +109,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
         let date = leaderboard.startDate ?? Date()
         let dateText = dateFormatter.string(from: date)
 
-        let detectedOn = networksDetected.count == 0 ? 0 : Int(truncating: networksDetected[0].detectedOnCount ?? 0)
-        let percent = pagesVisited == 0 ? 0 : 100 * detectedOn / pagesVisited
+        let percent = pagesVisited == 0 ? 0 : 100 * pagesWithTrackers / pagesVisited
         let percentText = "\(percent)%"
         let message = UserText.ppNetworkLeaderboard.format(arguments: percentText, dateText)
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -618,7 +618,7 @@ extension TabViewController: WKScriptMessageHandler {
         onSiteRatingChanged()
         
         if !pageHasTrackers {
-            NetworkLeaderboard.shared.incrementPagesLoaded()
+            NetworkLeaderboard.shared.incrementPagesWithTrackers()
             pageHasTrackers = true
         }
         

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -618,7 +618,7 @@ extension TabViewController: WKScriptMessageHandler {
         onSiteRatingChanged()
         
         if !pageHasTrackers {
-            NetworkLeaderboard.shared.pageHasTrackers()
+            NetworkLeaderboard.shared.incrementPagesLoaded()
             pageHasTrackers = true
         }
         
@@ -670,7 +670,7 @@ extension TabViewController: WKNavigationDelegate {
 
         trackerNetworksDetectedOnPage.removeAll()
         pageHasTrackers = false
-        NetworkLeaderboard.shared.pageVisited()
+        NetworkLeaderboard.shared.incrementPagesLoaded()
         
         if #available(iOS 10.3, *) {
             appRatingPrompt.registerUsage()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -72,7 +72,7 @@ class TabViewController: UIViewController {
     private var shouldReloadOnError = false
     private var failingUrls = Set<String>()
     
-    private var pageNetworkNames = Set<String>()
+    private var trackerNetworksDetectedOnPage = Set<String>()
     private var pageHasTrackers = false
     
     private var tearDownCount = 0
@@ -623,8 +623,8 @@ extension TabViewController: WKScriptMessageHandler {
         }
         
         if let networkName = networkName,
-            !pageNetworkNames.contains(networkName) {
-            pageNetworkNames.insert(networkName)
+            !trackerNetworksDetectedOnPage.contains(networkName) {
+            trackerNetworksDetectedOnPage.insert(networkName)
             NetworkLeaderboard.shared.incrementCount(forNetworkNamed: networkName)
         }
 
@@ -668,7 +668,7 @@ extension TabViewController: WKNavigationDelegate {
         delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
 
-        pageNetworkNames.removeAll()
+        trackerNetworksDetectedOnPage.removeAll()
         pageHasTrackers = false
         NetworkLeaderboard.shared.pageVisited()
         

--- a/DuckDuckGoTests/NetworkLeaderboardTests.swift
+++ b/DuckDuckGoTests/NetworkLeaderboardTests.swift
@@ -41,7 +41,7 @@ class NetworkLeaderboardTests: XCTestCase {
     func testWhenPagesWithTrackersCalledThenCorrectNumberIsReturned() {
         let leaderboard = NetworkLeaderboard()
         for _ in 0 ..< 15 {
-            leaderboard.pageHasTrackers()
+            leaderboard.incrementPagesWithTrackers()
         }
         XCTAssertEqual(15, leaderboard.pagesWithTrackers())
     }
@@ -54,7 +54,7 @@ class NetworkLeaderboardTests: XCTestCase {
         }
 
         for _ in 0 ..< 30 {
-            leaderboard.pageVisited()
+            leaderboard.incrementPagesLoaded()
         }
         
         XCTAssertEqual(30, leaderboard.pagesVisited())
@@ -81,7 +81,7 @@ class NetworkLeaderboardTests: XCTestCase {
 
     func testWhenFirstSiteVisitedStartDateIsSet() {
         let leaderboard = NetworkLeaderboard()
-        leaderboard.pageVisited()
+        leaderboard.incrementPagesLoaded()
         XCTAssertNotNil(leaderboard.startDate)
     }
 

--- a/DuckDuckGoTests/NetworkLeaderboardTests.swift
+++ b/DuckDuckGoTests/NetworkLeaderboardTests.swift
@@ -26,17 +26,38 @@ class NetworkLeaderboardTests: XCTestCase {
     override func setUp() {
         NetworkLeaderboard().reset()
     }
+    
+    func testWhenFirstAccessingLeaderboardThenItHasAStartDateOfToday() {
+        let leaderboard = NetworkLeaderboard()
+        guard let startDate = leaderboard.startDate else {
+            XCTFail("No start date on leaderboard")
+            return
+        }
+
+        let calendar = Calendar.current
+        XCTAssertTrue(calendar.isDateInToday(startDate))
+    }
+    
+    func testWhenPagesWithTrackersCalledThenCorrectNumberIsReturned() {
+        let leaderboard = NetworkLeaderboard()
+        for _ in 0 ..< 15 {
+            leaderboard.pageHasTrackers()
+        }
+        XCTAssertEqual(15, leaderboard.pagesWithTrackers())
+    }
 
     func testWhenEnoughPagesVisitedAndEnoughNetworksDetectedThenShouldShow() {
         let leaderboard = NetworkLeaderboard()
-        
-        for _ in 0 ..< 11 {
-            for i in 0 ..< 3 {
-                leaderboard.incrementCount(forNetworkNamed: "google\(i).com")
-            }
+
+        for i in 0 ..< 3 {
+            leaderboard.incrementCount(forNetworkNamed: "google\(i).com")
+        }
+
+        for _ in 0 ..< 30 {
+            leaderboard.pageVisited()
         }
         
-        XCTAssertEqual(33, leaderboard.pagesVisited())
+        XCTAssertEqual(30, leaderboard.pagesVisited())
         XCTAssertEqual(3, leaderboard.networksDetected().count)
         XCTAssertTrue(leaderboard.shouldShow())
     }
@@ -62,19 +83,6 @@ class NetworkLeaderboardTests: XCTestCase {
         let leaderboard = NetworkLeaderboard()
         leaderboard.pageVisited()
         XCTAssertNotNil(leaderboard.startDate)
-    }
-
-    func testWhenNoSitesVisitedStartDateIsNil() {
-        let leaderboard = NetworkLeaderboard()
-        XCTAssertNil(leaderboard.startDate)
-    }
-
-    func testWhenSitesVisitedTotalSitesVistedReturnsCorrectNumber() {
-        let leaderboard = NetworkLeaderboard()
-        leaderboard.incrementCount(forNetworkNamed: "Network 1")
-        leaderboard.incrementCount(forNetworkNamed: "Network 2")
-        leaderboard.incrementCount(forNetworkNamed: "Network 1")
-        XCTAssertEqual(3, leaderboard.pagesVisited())
     }
 
     func testWhenSitesVisitedNetworksDetectedReturnsThemInOrderOfCountDescending() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1127123170200347/1127123994394223
Tech Design URL:
CC:

**Description**:

Create v2 of the Network Leaderboard Model and remove the sites visited entity.

**Steps to test this PR**:

**Migration:**

1. Check out and install from develop
1. Run the app until the leaderboard is visible
1. Check out this branch and install
1. The app should automatically migrate to the new model (the numbers on the leaderboard may change)
1. Check table has been dropped:
    1. Determine the simulator location by filtering the output in Xcode for "devices".  You should end up with a path like `/Users/brindy/Library/Developer/CoreSimulator/Devices/D1D645CF-39F4-4A82-8E70-781D81B5E403/`
    1. cd into `Containers/Data/Application` and then find the sqlite files for the app using `find . | grep sql`
    1. there maybe several, check each one to ensure the visited sites table has been removed:
        1. `sqlite3 -readonly <path to file>`
        1. in the sqlite prompt execute the `.tables` command
        1. it will list the tables. Before the migration there would have been a table called `ZPPVISITEDSITE`. Ensure this is not present.

**Clean Install:**

1. Perform a fresh install
2. Run the app until the leaderboard is visible
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
