### PR TITLE
Fix Favorites overlay animation

### DIFF
--- a/DuckDuckGo/FavoritesOverlay.swift
+++ b/DuckDuckGo/FavoritesOverlay.swift
@@ -62,6 +62,7 @@ class FavoritesOverlay: UIViewController {
         
         delegate = controller
         collectionView.reloadData()
+        collectionView.layoutIfNeeded()
     }
     
     private func registerForKeyboardNotifications() {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -421,14 +421,14 @@ class MainViewController: UIViewController {
         
         let controller = FavoritesOverlay()
         controller.install(into: self)
-        controller.view.alpha = 0
+//        controller.view.alpha = 0
         addChild(controller)
         containerView.addSubview(controller.view)
         controller.didMove(toParent: self)
         
-        UIView.animate(withDuration: 0.2) {
-            controller.view.alpha = 1
-        }
+//        UIView.animate(withDuration: 0.2) {
+//            controller.view.alpha = 1
+//        }
         favoritesOverlay = controller
     }
     
@@ -697,13 +697,17 @@ extension MainViewController: OmniBarDelegate {
         autocompleteController?.keyboardEscape()
         homeController?.omniBarCancelPressed()
     }
+    
+    func onTextFieldWillBeginEditing(_ omniBar: OmniBar) {
+        guard homeController == nil else { return }
+        
+        displayFavoritesOverlay()
+    }
 
     func onTextFieldDidBeginEditing(_ omniBar: OmniBar) {
-        if let homeController = homeController {
-            homeController.launchNewSearch()
-        } else {
-            displayFavoritesOverlay()
-        }
+        guard let homeController = homeController else { return }
+        
+        homeController.launchNewSearch()
     }
     
     func onRefreshPressed() {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -421,14 +421,14 @@ class MainViewController: UIViewController {
         
         let controller = FavoritesOverlay()
         controller.install(into: self)
-//        controller.view.alpha = 0
+        controller.view.alpha = 0
         addChild(controller)
         containerView.addSubview(controller.view)
         controller.didMove(toParent: self)
         
-//        UIView.animate(withDuration: 0.2) {
-//            controller.view.alpha = 1
-//        }
+        UIView.animate(withDuration: 0.2) {
+            controller.view.alpha = 1
+        }
         favoritesOverlay = controller
     }
     

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -255,6 +255,11 @@ class OmniBar: UIView {
 }
 
 extension OmniBar: UITextFieldDelegate {
+    
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        omniDelegate?.onTextFieldWillBeginEditing(self)
+        return true
+    }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         DispatchQueue.main.async {

--- a/DuckDuckGo/OmniBarDelegate.swift
+++ b/DuckDuckGo/OmniBarDelegate.swift
@@ -39,6 +39,8 @@ protocol OmniBarDelegate: class {
 
     func onRefreshPressed()
     
+    func onTextFieldWillBeginEditing(_ omniBar: OmniBar)
+    
     func onTextFieldDidBeginEditing(_ omniBar: OmniBar)
 
 }
@@ -74,6 +76,10 @@ extension OmniBarDelegate {
     }
     
     func onCancelPressed() {
+        
+    }
+    
+    func onTextFieldWillBeginEditing(_ omniBar: OmniBar) {
         
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1127120102379332

**Description**:
Sometimes Favorites Overlay is displayed with what seem to be a lag - it appears after the keyboard is animated in. Please se related task for details about the fix.

**Steps to test this PR**:
According to my experience it is best to test that on an iPad device.

1. Navigate to some page.
2. Tap on URL so Overlay is being shown.
3. Observe whether animation works OK.

Also please double check regressions scenarios:
1. Tapping URL on empty home screen.
2. Canceling & re-entering overlay.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
