### PR TITLE
Delete legacy https pixels

### DIFF
--- a/AtbIntegrationTests/AtbServerTests.swift
+++ b/AtbIntegrationTests/AtbServerTests.swift
@@ -101,8 +101,4 @@ class MockStatisticsStore: StatisticsStore {
     var searchRetentionAtb: String?
 
     var variant: String?
-        
-    var httpsUpgradesTotal = 0
-    
-    var httpsUpgradesFailures = 0
 }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -64,9 +64,6 @@ public enum PixelName: String {
     case autoClearTimingOptionExitOr30Mins = "macwhen_30"
     case autoClearTimingOptionExitOr60Mins = "macwhen_60"
 
-    case httpsUpgradeSiteError = "ehd"
-    case httpsUpgradeSiteSummary = "ehs"
-
     case browsingMenuOpened = "mb"
     case browsingMenuRefresh = "mb_rf"
     case browsingMenuNewTab = "mb_tb"
@@ -130,16 +127,6 @@ public enum PixelName: String {
 public class Pixel {
 
     private static let appUrls = AppUrls()
-    
-    public struct EhdParameters {
-        public static let url = "url"
-        public static let errorCode = "error_code"
-    }
-    
-    public struct EhsParameters {
-        public static let totalCount = "total"
-        public static let failureCount = "failures"
-    }
     
     private struct Constants {
         static let tablet = "tablet"

--- a/Core/StatisticsStore.swift
+++ b/Core/StatisticsStore.swift
@@ -27,9 +27,6 @@ public protocol StatisticsStore: class {
     var searchRetentionAtb: String? { get set }
     var appRetentionAtb: String? { get set }
     var variant: String? { get set }
-    
-    var httpsUpgradesTotal: Int { get set }
-    var httpsUpgradesFailures: Int { get set }
 }
 
 extension StatisticsStore {

--- a/Core/StatisticsUserDefaults.swift
+++ b/Core/StatisticsUserDefaults.swift
@@ -29,8 +29,6 @@ public class StatisticsUserDefaults: StatisticsStore {
         static let searchRetentionAtb = "com.duckduckgo.statistics.retentionatb.key"
         static let appRetentionAtb = "com.duckduckgo.statistics.appretentionatb.key"
         static let variant = "com.duckduckgo.statistics.variant.key"
-        static let httpsUpgradesTotal = "com.duckduckgo.statistics.httpsupgradestotal.key"
-        static let httpsUpgradesFailures = "com.duckduckgo.statistics.httpsupgradesfailures.key"
     }
 
     private var userDefaults: UserDefaults? {
@@ -91,24 +89,6 @@ public class StatisticsUserDefaults: StatisticsStore {
 
         set {
             userDefaults?.setValue(newValue, forKey: Keys.variant)
-        }
-    }
-    
-    public var httpsUpgradesTotal: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.httpsUpgradesTotal) ?? 0
-        }
-        set {
-            userDefaults?.set(newValue, forKey: Keys.httpsUpgradesTotal)
-        }
-    }
-    
-    public var httpsUpgradesFailures: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.httpsUpgradesFailures) ?? 0
-        }
-        set {
-            userDefaults?.set(newValue, forKey: Keys.httpsUpgradesFailures)
         }
     }
 }

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -24,19 +24,12 @@ public typealias AppConfigurationCompletion = (Bool) -> Void
 
 class AppConfigurationFetch {
     
-    private lazy var statisticsStore: StatisticsStore = StatisticsUserDefaults()
-
     func start(completion: AppConfigurationCompletion?) {
 
         DispatchQueue.global(qos: .background).async {
 
             var newData = false
             let semaphore = DispatchSemaphore(value: 0)
-            
-            self.sendHttpsSummaryPixel { newHttpsData in
-                newData = newData || newHttpsData
-                semaphore.signal()
-            }
 
             ContentBlockerLoader().start { newContentBlockingData in
                 newData = newData || newContentBlockingData
@@ -44,29 +37,7 @@ class AppConfigurationFetch {
             }
             
             semaphore.wait()
-            semaphore.wait()
             completion?(newData)
-        }
-    }
-    
-    private func sendHttpsSummaryPixel(completion: @escaping (Bool) -> Void) {
-            
-        if statisticsStore.httpsUpgradesTotal == 0 {
-            completion(false)
-            return
-        }
-        
-        let params = [
-            Pixel.EhsParameters.totalCount: "\(statisticsStore.httpsUpgradesTotal)",
-            Pixel.EhsParameters.failureCount: "\(statisticsStore.httpsUpgradesFailures)"
-        ]
-        
-        Pixel.fire(pixel: .httpsUpgradeSiteSummary, withAdditionalParameters: params) { error in
-            if error == nil {
-                self.statisticsStore.httpsUpgradesTotal = 0
-                self.statisticsStore.httpsUpgradesFailures = 0
-            }
-            completion(true)
         }
     }
 }

--- a/DuckDuckGoTests/MockStatisticsStore.swift
+++ b/DuckDuckGoTests/MockStatisticsStore.swift
@@ -31,7 +31,4 @@ class MockStatisticsStore: StatisticsStore {
     }
 
     var variant: String?
-    
-    var httpsUpgradesTotal = 0
-    var httpsUpgradesFailures = 0
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1127994182135076

**Description**:
Remove unused https pixels.

**Steps to test this PR**:
1. Run the app and watch traffic with Charles proxy on
1. Navigate to a few pages and then kill and restart the app
1. Note that a `ehs` pixel **does not** fire on startup sync (it previously did)
1. Using Charles proxy, blacklist duckduckgo.com
1. Navigate to http://duckduckgo.com (which will fail) and note that an `ehd` pixel does **not** fire (it previously did)
1. Remove Charles blacklist ;-)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
