### PR TITLE
Fix bug in Forget All

### DIFF
--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -148,10 +148,10 @@ class TabManager {
     }
 
     func removeAll() {
+        model.clearAll()
         for controller in tabControllerCache {
             removeFromCache(controller)
         }
-        model.clearAll()
         save()
     }
 

--- a/DuckDuckGo/TabsModel.swift
+++ b/DuckDuckGo/TabsModel.swift
@@ -107,12 +107,11 @@ public class TabsModel: NSObject, NSCoding {
     }
 
     func indexOf(tab: Tab) -> Int? {
-        return tabs.enumerated().first(where: { $1 === tab  })?.offset
+        return tabs.firstIndex { $0 === tab }        
     }
 
     func clearAll() {
-        for tab in tabs {
-            remove(tab: tab)
-        }
+        tabs.removeAll()
+        currentIndex = nil
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1126785482737439

**Description**:
Current tab might've been refreshed unnecessarily while cleaning up tabs.

**Steps to test this PR**:
1. Open some tabs.
2. Press fire button.
3. Ensure WebView is not refreshed.

Also to check:
1. Individual tab removal.
2. Auto clear data/tabs functionality.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
