### PR TITLE
separate cache for bookmark favicons

### DIFF
--- a/DuckDuckGo/BookmarkCell.swift
+++ b/DuckDuckGo/BookmarkCell.swift
@@ -24,6 +24,7 @@ import Kingfisher
 class BookmarkCell: UITableViewCell {
 
     static let reuseIdentifier = "BookmarkCell"
+    static let imageCacheName = "bookmarks"
 
     @IBOutlet weak var linkImage: UIImageView!
     @IBOutlet weak var title: UILabel!
@@ -57,7 +58,7 @@ class BookmarkCell: UITableViewCell {
                                   placeholder: placeholder,
                                   options: [
                                     .downloader(NotFoundCachingDownloader()),
-                                    .targetCache(ImageCache(name: "bookmarks"))
+                                    .targetCache(ImageCache(name: BookmarkCell.imageCacheName))
                                     ],
                                   progressBlock: nil,
                                   completionHandler: nil)

--- a/DuckDuckGo/BookmarkCell.swift
+++ b/DuckDuckGo/BookmarkCell.swift
@@ -52,9 +52,13 @@ class BookmarkCell: UITableViewCell {
 
         if let domain = domain {
             let faviconUrl = AppUrls().faviconUrl(forDomain: domain)
+
             linkImage.kf.setImage(with: faviconUrl,
                                   placeholder: placeholder,
-                                  options: [.downloader(NotFoundCachingDownloader())],
+                                  options: [
+                                    .downloader(NotFoundCachingDownloader()),
+                                    .targetCache(ImageCache(name: "bookmarks"))
+                                    ],
                                   progressBlock: nil,
                                   completionHandler: nil)
         }

--- a/DuckDuckGo/FavoriteHomeCell.swift
+++ b/DuckDuckGo/FavoriteHomeCell.swift
@@ -107,7 +107,8 @@ class FavoriteHomeCell: UICollectionViewCell {
             iconImage.kf.setImage(with: resource,
                                   placeholder: nil,
                                   options: [
-                                    .downloader(NotFoundCachingDownloader(name: "hello"))
+                                    .downloader(NotFoundCachingDownloader()),
+                                    .targetCache(ImageCache(name: BookmarkCell.imageCacheName))
                                     ],
                                   progressBlock: nil) { [weak self] image, error, _, _ in
                                     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 import WebKit
 import Core
 import Lottie
+import Kingfisher
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
@@ -931,6 +932,7 @@ extension MainViewController: AutoClearWorker {
     func forgetData() {
         findInPageView?.done()
         ServerTrustCache.shared.clear()
+        KingfisherManager.shared.cache.clearDiskCache()
         WebCacheManager.clear()
     }
     


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1128329641628046
Tech Design URL: 
CC:

**Description**:

Adds a cache for the bookmarks.  Clears the general cache when 🔥 executed.

**Steps to test this PR**:

1. Fresh install on simulator
1. Determine location of app install
1. Launch app
1. run `find .` from root app directory - note directories and files
1. Browse and open a new tabs and open the tab switcher
1. Add a few bookmarks and open the bookmarks manager
1. Run `find .` from root app directory - note directories and files
1. Press 🔥 
1. Run `find .` from root app directory - note directories and files - should return to clean state with "bookmarks" kingfisher cache still in place.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)