### PR TITLE
Fire pixel if Etag store is out od sync with disconnect me or easylist

### DIFF
--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -77,9 +77,15 @@ public class ContentBlockerLoader {
     
     fileprivate func requestDisconnectMe(_ contentBlockerRequest: ContentBlockerRequest, _ semaphore: DispatchSemaphore) {
         contentBlockerRequest.request(.disconnectMe) { data, isCached in
-            if let data = data, !isCached {
-                self.newDataItems += 1
-                try? self.disconnectStore.persist(data: data)
+            if let data = data {
+                if isCached {
+                    if self.disconnectStore.hasData == false {
+                        Pixel.fire(pixel: .etagStoreOOSWithDisconnectMe)
+                    }
+                } else {
+                    self.newDataItems += 1
+                    try? self.disconnectStore.persist(data: data)
+                }
             }
             semaphore.signal()
         }
@@ -87,9 +93,15 @@ public class ContentBlockerLoader {
     
     fileprivate func requestTrackerWhitelist(_ contentBlockerRequest: ContentBlockerRequest, _ semaphore: DispatchSemaphore) {
         contentBlockerRequest.request(.trackersWhitelist) { data, isCached in
-            if let data = data, !isCached {
-                self.newDataItems += 1
-                self.easylistStore.persistEasylistWhitelist(data: data)
+            if let data = data {
+                if isCached {
+                    if self.easylistStore.hasData == false {
+                        Pixel.fire(pixel: .etagStoreOOSWithEasylist)
+                    }
+                } else {
+                    self.newDataItems += 1
+                    self.easylistStore.persistEasylistWhitelist(data: data)
+                }
             }
             semaphore.signal()
         }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -131,8 +131,8 @@ public enum PixelName: String {
     case feedbackNegativePerformanceVideo = "mfbs_negative_performance_video"
     case feedbackNegativePerformanceOther = "mfbs_negative_performance_other"
     
-    case etagStoreOOSWithDisconnectMe = "mdebug_etag_disconnect_oos"
-    case etagStoreOOSWithEasylist = "mdebug_etag_easylist_oos"
+    case etagStoreOOSWithDisconnectMe = "m_dbg_dc_oos"
+    case etagStoreOOSWithEasylist = "m_dbg_el_oos"
 }
 
 public class Pixel {

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -131,6 +131,8 @@ public enum PixelName: String {
     case feedbackNegativePerformanceVideo = "mfbs_negative_performance_video"
     case feedbackNegativePerformanceOther = "mfbs_negative_performance_other"
     
+    case etagStoreOOSWithDisconnectMe = "mdebug_etag_disconnect_oos"
+    case etagStoreOOSWithEasylist = "mdebug_etag_easylist_oos"
 }
 
 public class Pixel {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1128480535457420
Tech Design URL:
CC:

**Description**:
Test for possible bug related to etag store being out od sync with disconnect me or easylist.

**Steps to test this PR**:

Regular scenario:
1. Run the app.
2. Make sure that pixel is not fired when initially downloading the content blocker data, nor after restart.

Broken store scenario:
1. Tweak the code so disconnect me is not stored.
2. Run the app to populate etag.
3. Restart the app -> pixel should fire. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
