### PR TITLE
delete favicons when removed from bookmarks or favorites

### DIFF
--- a/DuckDuckGo/BookmarkCell.swift
+++ b/DuckDuckGo/BookmarkCell.swift
@@ -24,7 +24,6 @@ import Kingfisher
 class BookmarkCell: UITableViewCell {
 
     static let reuseIdentifier = "BookmarkCell"
-    static let imageCacheName = "bookmarks"
 
     @IBOutlet weak var linkImage: UIImageView!
     @IBOutlet weak var title: UILabel!
@@ -58,7 +57,7 @@ class BookmarkCell: UITableViewCell {
                                   placeholder: placeholder,
                                   options: [
                                     .downloader(NotFoundCachingDownloader()),
-                                    .targetCache(ImageCache(name: BookmarkCell.imageCacheName))
+                                    .targetCache(ImageCache(name: BookmarksManager.imageCacheName))
                                     ],
                                   progressBlock: nil,
                                   completionHandler: nil)

--- a/DuckDuckGo/BookmarksManager.swift
+++ b/DuckDuckGo/BookmarksManager.swift
@@ -18,8 +18,11 @@
 //
 
 import Core
+import Kingfisher
 
 class BookmarksManager {
+
+    static let imageCacheName = "bookmarks"
 
     private var dataStore: BookmarkStore
 
@@ -105,12 +108,14 @@ class BookmarksManager {
 
     func deleteBookmark(at index: Int) {
         var bookmarks = dataStore.bookmarks
+        bookmarks[index].removeCachedFavicon()
         bookmarks.remove(at: index)
         dataStore.bookmarks = bookmarks
     }
 
     func deleteFavorite(at index: Int) {
         var favorites = dataStore.favorites
+        favorites[index].removeCachedFavicon()
         favorites.remove(at: index)
         dataStore.favorites = favorites
     }
@@ -160,4 +165,14 @@ class BookmarksManager {
         }
     }
     
+}
+
+fileprivate extension Link {
+
+    func removeCachedFavicon() {
+        guard let domain = url.host else { return }
+        let url = AppUrls().faviconUrl(forDomain: domain)
+        ImageCache(name: BookmarksManager.imageCacheName).removeImage(forKey: url.absoluteString)
+    }
+
 }

--- a/DuckDuckGo/FavoriteHomeCell.swift
+++ b/DuckDuckGo/FavoriteHomeCell.swift
@@ -108,7 +108,7 @@ class FavoriteHomeCell: UICollectionViewCell {
                                   placeholder: nil,
                                   options: [
                                     .downloader(NotFoundCachingDownloader()),
-                                    .targetCache(ImageCache(name: BookmarkCell.imageCacheName))
+                                    .targetCache(ImageCache(name: BookmarksManager.imageCacheName))
                                     ],
                                   progressBlock: nil) { [weak self] image, error, _, _ in
                                     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1128329641628046
Tech Design URL:
CC:

**Description**:

Removes the favicon associated with a bookmark or favourite when it is deleted.  This might delete favicons for remaining bookmarks, but that's ok, they will be re downloaded.

**Steps to test this PR**:
1. Add a bookmark, check the cache
1. Delete the bookmark, check the cache

1. Add a favourite, check the cache
1. Delete the favourite, check the cache

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
