### PR TITLE
support updateVersion in the atb response

### DIFF
--- a/AtbIntegrationTests/AtbServerTests.swift
+++ b/AtbIntegrationTests/AtbServerTests.swift
@@ -86,6 +86,38 @@ class AtbServerTests: XCTestCase {
         XCTAssertNotEqual(store.atb, store.searchRetentionAtb)
     }
 
+    func testWhenAtbIsOldThenCohortIsGeneralizedForAppRetention() {
+
+        store.atb = "v117-2"
+        store.appRetentionAtb = "v117-2"
+
+        let waitForCompletion = expectation(description: "wait for completion")
+        loader.refreshAppRetentionAtb {
+            waitForCompletion.fulfill()
+        }
+
+        wait(for: [waitForCompletion], timeout: 5.0)
+
+        XCTAssertNotNil(store.appRetentionAtb)
+        XCTAssertEqual(store.atb, "v117-1")
+    }
+
+    func testWhenAtbIsOldThenCohortIsGeneralizedForSearchRetention() {
+
+        store.atb = "v117-2"
+        store.searchRetentionAtb = "v117-2"
+
+        let waitForCompletion = expectation(description: "wait for completion")
+        loader.refreshSearchRetentionAtb {
+            waitForCompletion.fulfill()
+        }
+
+        wait(for: [waitForCompletion], timeout: 5.0)
+
+        XCTAssertNotNil(store.searchRetentionAtb)
+        XCTAssertEqual(store.atb, "v117-1")
+    }
+
 }
 
 class MockStatisticsStore: StatisticsStore {

--- a/Core/Atb.swift
+++ b/Core/Atb.swift
@@ -22,5 +22,6 @@ import Foundation
 public struct Atb: Decodable {
 
     let version: String
+    let updateVersion: String?
 
 }

--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -88,6 +88,7 @@ public class StatisticsLoader {
             }
             if let data = response?.data, let atb  = try? self.parser.convert(fromJsonData: data) {
                 self.statisticsStore.searchRetentionAtb = atb.version
+                self.storeUpdateVersionIfPresent(atb)
             }
             completion()
         }
@@ -108,8 +109,15 @@ public class StatisticsLoader {
             }
             if let data = response?.data, let atb  = try? self.parser.convert(fromJsonData: data) {
                 self.statisticsStore.appRetentionAtb = atb.version
+                self.storeUpdateVersionIfPresent(atb)
             }
             completion()
+        }
+    }
+
+    public func storeUpdateVersionIfPresent(_ atb: Atb) {
+        if let updateVersion = atb.updateVersion {
+            statisticsStore.atb = updateVersion
         }
     }
 }

--- a/DuckDuckGoTests/AtbParserTests.swift
+++ b/DuckDuckGoTests/AtbParserTests.swift
@@ -54,4 +54,10 @@ class AtbParserTests: XCTestCase {
         XCTAssertEqual(result?.version, "v77-5")
     }
 
+    func testWhenJsonContainsUpdateVersionThenResultContainsUpdateVersion() {
+        let validJson = data.fromJsonFile("MockFiles/atb-with-update.json")
+        let result = try? testee.convert(fromJsonData: validJson)
+        XCTAssertEqual(result?.updateVersion, "v20-1")
+    }
+
 }

--- a/DuckDuckGoTests/MockFiles/atb-with-update.json
+++ b/DuckDuckGoTests/MockFiles/atb-with-update.json
@@ -1,0 +1,7 @@
+{
+    "majorVersion": 77,
+    "for_more_info": "https://duck.co/help/privacy/atb",
+    "version": "v77-5",
+    "minorVersion": 5,
+    "updateVersion": "v20-1"
+}

--- a/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -37,6 +37,38 @@ class StatisticsLoaderTests: XCTestCase {
         super.tearDown()
     }
 
+    func testWhenSearchRefreshHasSuccessfulUpdateAtbRequestThenSearchRetentionAtbUpdated() {
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.searchRetentionAtb = "retentionatb"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: "Successful atb updates retention store")
+        testee.refreshSearchRetentionAtb {
+            XCTAssertEqual(self.mockStatisticsStore.atb, "v20-1")
+            XCTAssertEqual(self.mockStatisticsStore.searchRetentionAtb, "v77-5")
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testWhenAppRefreshHasSuccessfulUpdateAtbRequestThenAppRetentionAtbUpdated() {
+
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.appRetentionAtb = "retentionatb"
+        loadSuccessfulUpdateAtbStub()
+
+        let expect = expectation(description: "Successful atb updates retention store")
+        testee.refreshAppRetentionAtb {
+            XCTAssertEqual(self.mockStatisticsStore.atb, "v20-1")
+            XCTAssertEqual(self.mockStatisticsStore.appRetentionAtb, "v77-5")
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
     func testWhenLoadHasSuccessfulAtbAndExtiRequestsThenStoreUpdatedWithVariant() {
 
         loadSuccessfulAtbStub()
@@ -72,7 +104,7 @@ class StatisticsLoaderTests: XCTestCase {
         loadSuccessfulAtbStub()
         loadUnsuccessfulExiStub()
 
-        let expect = expectation(description: "Unsuccessfult exti does not update store")
+        let expect = expectation(description: "Unsuccessful exti does not update store")
         testee.load {
             XCTAssertFalse(self.mockStatisticsStore.hasInstallStatistics)
             XCTAssertNil(self.mockStatisticsStore.atb)
@@ -88,7 +120,7 @@ class StatisticsLoaderTests: XCTestCase {
         mockStatisticsStore.searchRetentionAtb = "retentionatb"
         loadSuccessfulAtbStub()
 
-        let expect = expectation(description: "Successfult atb updates retention store")
+        let expect = expectation(description: "Successful atb updates retention store")
         testee.refreshSearchRetentionAtb {
             XCTAssertEqual(self.mockStatisticsStore.atb, "atb")
             XCTAssertEqual(self.mockStatisticsStore.searchRetentionAtb, "v77-5")
@@ -104,7 +136,7 @@ class StatisticsLoaderTests: XCTestCase {
         mockStatisticsStore.appRetentionAtb = "retentionatb"
         loadSuccessfulAtbStub()
         
-        let expect = expectation(description: "Successfult atb updates retention store")
+        let expect = expectation(description: "Successful atb updates retention store")
         testee.refreshAppRetentionAtb {
             XCTAssertEqual(self.mockStatisticsStore.atb, "atb")
             XCTAssertEqual(self.mockStatisticsStore.appRetentionAtb, "v77-5")
@@ -119,7 +151,7 @@ class StatisticsLoaderTests: XCTestCase {
         mockStatisticsStore.searchRetentionAtb = "retentionAtb"
         loadUnsuccessfulAtbStub()
 
-        let expect = expectation(description: "Unsuccessfult atb does not update store")
+        let expect = expectation(description: "Unsuccessful atb does not update store")
         testee.refreshSearchRetentionAtb {
             XCTAssertEqual(self.mockStatisticsStore.atb, "atb")
             XCTAssertEqual(self.mockStatisticsStore.searchRetentionAtb, "retentionAtb")
@@ -134,7 +166,7 @@ class StatisticsLoaderTests: XCTestCase {
         mockStatisticsStore.appRetentionAtb = "retentionAtb"
         loadUnsuccessfulAtbStub()
         
-        let expect = expectation(description: "Unsuccessfult atb does not update store")
+        let expect = expectation(description: "Unsuccessful atb does not update store")
         testee.refreshAppRetentionAtb {
             XCTAssertEqual(self.mockStatisticsStore.atb, "atb")
             XCTAssertEqual(self.mockStatisticsStore.appRetentionAtb, "retentionAtb")
@@ -147,6 +179,13 @@ class StatisticsLoaderTests: XCTestCase {
     func loadSuccessfulAtbStub() {
         stub(condition: isHost(appUrls.initialAtb.host!)) { _ in
             let path = OHPathForFile("MockFiles/atb.json", type(of: self))!
+            return fixture(filePath: path, status: 200, headers: nil)
+        }
+    }
+
+    func loadSuccessfulUpdateAtbStub() {
+        stub(condition: isHost(appUrls.initialAtb.host!)) { _ in
+            let path = OHPathForFile("MockFiles/atb-with-update.json", type(of: self))!
             return fixture(filePath: path, status: 200, headers: nil)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1114152243888973
Tech Design URL: 
CC: 

**Description**:

When the `udpateVersion` property is available in the atb.js response then it is stored as the main atb version.

**Steps to test this PR**:

With Charles proxy running and a breakpoint for atb.js
1. clean install
1. edit the `atb.js` response to set the atb version to something old
1. perform a search, observe the `updateVersion` in the response
1. subsequent `set_atb` calls should use the new cohort for the atb

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
