### PR TITLE
Fix crash when undoing

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -465,7 +465,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func displayAutocompleteSuggestions(forQuery query: String) {
-        if autocompleteController == nil && appSettings.autocomplete {
+        if autocompleteController == nil && appSettings.autocomplete && !query.isEmpty {
             let controller = AutocompleteViewController.loadFromStoryboard()
             controller.shouldOffsetY = allowContentUnderflow
             controller.delegate = self

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -179,6 +179,7 @@ class OmniBar: UIView {
 
     private func clear() {
         textField.text = nil
+        omniDelegate?.onOmniQueryUpdated("")
     }
 
     func refreshText(forUrl url: URL?) {

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -62,6 +62,11 @@ class OmniBar: UIView {
                                                              attributes: [.foregroundColor: theme.searchBarTextPlaceholderColor])
         textField.delegate = self
         
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(textDidChange),
+                                               name: UITextField.textDidChangeNotification,
+                                               object: textField)
+        
         if #available(iOS 11.0, *) {
             textField.textDragInteraction?.isEnabled = false
         }
@@ -78,6 +83,16 @@ class OmniBar: UIView {
     
     var textFieldBottomSpacing: CGFloat {
         return bounds.size.height - (searchContainer.frame.origin.y + searchContainer.frame.size.height)
+    }
+    
+    @objc func textDidChange() {
+        let newQuery = textField.text ?? ""
+        omniDelegate?.onOmniQueryUpdated(newQuery)
+        if newQuery.isEmpty {
+            refreshState(state.onTextClearedState)
+        } else {
+            refreshState(state.onTextEnteredState)
+        }
     }
 
     @objc func pasteAndGo(sender: UIMenuItem) {
@@ -274,15 +289,6 @@ extension OmniBar: UITextFieldDelegate {
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let oldQuery = textField.text else { return true }
-        guard let queryRange = oldQuery.range(from: range) else { return true }
-        let newQuery = oldQuery.replacingCharacters(in: queryRange, with: string)
-        omniDelegate?.onOmniQueryUpdated(newQuery)
-        if newQuery.isEmpty {
-            refreshState(state.onTextClearedState)
-        } else {
-            refreshState(state.onTextEnteredState)
-        }
         return true
     }
 

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -289,10 +289,6 @@ extension OmniBar: UITextFieldDelegate {
         }
     }
 
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        return true
-    }
-
     func textFieldDidEndEditing(_ textField: UITextField) {
         if let text = textField.text, text.isEmpty {
             omniDelegate?.onDismissed()

--- a/DuckDuckGo/OmniBarState.swift
+++ b/DuckDuckGo/OmniBarState.swift
@@ -61,7 +61,7 @@ struct HomeEmptyEditingState: OmniBarState {
 }
 
 struct HomeTextEditingState: OmniBarState {
-    var clearTextOnStart = true
+    var clearTextOnStart = false
     var showSearchLoupe = true
     let showSiteRating = false
     let showBackground = false

--- a/DuckDuckGoTests/OmniBarStateTests.swift
+++ b/DuckDuckGoTests/OmniBarStateTests.swift
@@ -83,9 +83,9 @@ class OmniBarStateTests: XCTestCase {
         XCTAssertTrue(testee.showSearchLoupe)
     }
 
-    func testWhenEnteringHomeTextEditingStateThenTextIsCleared() {
+    func testWhenEnteringHomeTextEditingStateThenTextIsNotCleared() {
         let testee = HomeTextEditingState()
-        XCTAssertTrue(testee.clearTextOnStart)
+        XCTAssertFalse(testee.clearTextOnStart)
     }
 
     func testWhenInHomeTextEditingStateThenEditingStartedMaintainsState() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1133035446878373
Tech Design URL:
CC:

**Description**:

- Fix for the crash.
- There was an inconsistency between how following scenarios were handled:
  - Clearing search bar by using backspace.
  - Clearing search by using clear button.

In one case autocomplete list has been cleared, in other not.


**Steps to test this PR**:

Crash scenario:
1. Open app on the iPad.
2. Write something in search field. Try undoing.

Also, please make sure there are no glitches on both home screen (in simple and centered search modes) and in browsing mode with regard to omni bar activity and state changes. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
