### PR TITLE
Safeguard renderers code by removing implicit unwrapping

### DIFF
--- a/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/CenteredSearchHomeViewSectionRenderer.swift
@@ -37,7 +37,7 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     
     private var overflowOffset: CGFloat = 0
     
-    private weak var controller: HomeViewController!
+    private weak var controller: HomeViewController?
     private weak var cell: CenteredSearchHomeCell?
 
     private var heightRatio: CGFloat {
@@ -76,8 +76,8 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
             fatalError("cell is not a CenteredSearchHomeCell")
         }
         cell.tapped = self.tapped
-        cell.targetSearchHeight = controller.chromeDelegate?.omniBar.editingBackground.frame.height ?? 0
-        cell.targetSearchRadius = controller.chromeDelegate?.omniBar.editingBackground.layer.cornerRadius ?? 0
+        cell.targetSearchHeight = controller?.chromeDelegate?.omniBar.editingBackground.frame.height ?? 0
+        cell.targetSearchRadius = controller?.chromeDelegate?.omniBar.editingBackground.layer.cornerRadius ?? 0
         self.cell = cell
         return cell
     }
@@ -93,7 +93,7 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
                         layout collectionViewLayout: UICollectionViewLayout,
                         referenceSizeForFooterInSection section: Int) -> CGSize? {
         
-        return CGSize(width: 1, height: controller.chromeDelegate?.omniBar.textFieldBottomSpacing ?? 0)
+        return CGSize(width: 1, height: controller?.chromeDelegate?.omniBar.textFieldBottomSpacing ?? 0)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -106,30 +106,34 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
 
         guard diff < offsetY else {
             // search bar is in the center
-            controller.searchHeaderTransition = 0.0
+            controller?.searchHeaderTransition = 0.0
             cell?.searchHeaderTransition = 0.0
             return
         }
         
         guard diff > 0 else {
             // search bar is in the navigation bar
-            controller.searchHeaderTransition = 1.0
+            controller?.searchHeaderTransition = 1.0
             cell?.searchHeaderTransition = 1.0
             return
         }
 
         // search bar is transitioning
         let percent = 1 - (diff / 46)
-        controller.searchHeaderTransition = percent
+        controller?.searchHeaderTransition = percent
         cell?.searchHeaderTransition = percent
     }
 
     func tapped(view: CenteredSearchHomeCell) {
         activateSearch()
-        controller.chromeDelegate?.omniBar.becomeFirstResponder()
+        controller?.chromeDelegate?.omniBar.becomeFirstResponder()
     }
     
     private func activateSearch() {
+        guard let controller = self.controller else {
+            return
+        }
+        
         var offset = controller.collectionView.contentOffset
         let omniBarBottomSpacing = controller.chromeDelegate?.omniBar.textFieldBottomSpacing ?? 0
         offset.y = (cell?.bounds.height ?? 0) + overflowOffset + omniBarBottomSpacing
@@ -138,7 +142,7 @@ class CenteredSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     }
     
     func omniBarCancelPressed() {
-        guard let indexPath = indexPath else { return }
+        guard let controller = self.controller, let indexPath = indexPath else { return }
         controller.collectionView.scrollToItem(at: indexPath, at: .top, animated: true)
         overflowOffset = controller.enableContentUnderflow()
     }

--- a/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -37,7 +37,7 @@ class FavoritesHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
     
     private lazy var bookmarksManager = BookmarksManager()
 
-    private weak var controller: (UIViewController & FavoritesHomeViewSectionRendererDelegate)!
+    private weak var controller: (UIViewController & FavoritesHomeViewSectionRendererDelegate)?
     
     private weak var reorderingCell: FavoriteHomeCell?
     
@@ -166,7 +166,7 @@ class FavoritesHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
             saveCompletion: { [weak self] newLink in
                 self?.updateFavorite(at: indexPath, in: collectionView, with: newLink)
             })
-        controller.present(alert, animated: true, completion: nil)
+        controller?.present(alert, animated: true, completion: nil)
     }
     
     private func updateFavorite(at indexPath: IndexPath, in collectionView: UICollectionView, with link: Link) {
@@ -258,7 +258,7 @@ class FavoritesHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
         guard let link = bookmarksManager.favorite(atIndex: indexPath.row) else { return }
         Pixel.fire(pixel: .homeScreenFavouriteLaunched)
         UISelectionFeedbackGenerator().selectionChanged()
-        controller.favoritesRenderer(self, didSelect: link)
+        controller?.favoritesRenderer(self, didSelect: link)
     }
     
     private func addNewFavorite(in collectionView: UICollectionView, at indexPath: IndexPath) {
@@ -274,7 +274,7 @@ class FavoritesHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
                 Pixel.fire(pixel: .homeScreenAddFavoriteCancel)
             }
         )
-        controller.present(alert, animated: true, completion: nil)
+        controller?.present(alert, animated: true, completion: nil)
     }
     
     private func saveNewFavorite(_ link: Link, in collectionView: UICollectionView, at indexPath: IndexPath) {

--- a/DuckDuckGo/NavigationSearchHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/NavigationSearchHomeViewSectionRenderer.swift
@@ -32,7 +32,7 @@ class NavigationSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
         self.withOffset = withOffset
     }
     
-    weak var controller: HomeViewController!
+    weak var controller: HomeViewController?
     
     func install(into controller: HomeViewController) {
         self.controller = controller
@@ -47,7 +47,7 @@ class NavigationSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     }
     
     func openedAsNewTab() {
-        controller.chromeDelegate?.omniBar.becomeFirstResponder()
+        controller?.chromeDelegate?.omniBar.becomeFirstResponder()
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -92,11 +92,11 @@ class NavigationSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        controller.chromeDelegate?.omniBar.resignFirstResponder()
+        controller?.chromeDelegate?.omniBar.resignFirstResponder()
     }
     
     func launchNewSearch() {
-        controller.chromeDelegate?.omniBar.becomeFirstResponder()
+        controller?.chromeDelegate?.omniBar.becomeFirstResponder()
     }
     
 }

--- a/DuckDuckGo/PaddingSpaceHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/PaddingSpaceHomeViewSectionRenderer.swift
@@ -24,7 +24,7 @@ class PaddingSpaceHomeViewSectionRenderer: HomeViewSectionRenderer {
     lazy var bookmarksManager = BookmarksManager()
     
     var paddingHeight: CGFloat = 0
-    var controller: HomeViewController!
+    var controller: HomeViewController?
     
     private let withOffset: Bool
     
@@ -81,11 +81,11 @@ class PaddingSpaceHomeViewSectionRenderer: HomeViewSectionRenderer {
         let keyboardHeight = value.cgRectValue.height
         guard keyboardHeight > paddingHeight else { return }
         let height = keyboardHeight - 50 // roughly the navigation bar
-        controller.collectionView.contentInset = UIEdgeInsets(top: HomeCollectionView.Constants.topInset, left: 0, bottom: height, right: 0)
+        controller?.collectionView.contentInset = UIEdgeInsets(top: HomeCollectionView.Constants.topInset, left: 0, bottom: height, right: 0)
     }
     
     @objc func onKeyboardWillHide(notification: Notification) {
-        controller.collectionView.contentInset = UIEdgeInsets(top: HomeCollectionView.Constants.topInset, left: 0, bottom: 0, right: 0)
+        controller?.collectionView.contentInset = UIEdgeInsets(top: HomeCollectionView.Constants.topInset, left: 0, bottom: 0, right: 0)
     }
     
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1133259194884334
Tech Design URL:
CC:

**Description**:
Some async code execution (e.g. scrolling) could cause crashes by implicitly unwrapping weak variable that has already been nilled. 

**Steps to test this PR**:
Please test all three variants of the home screen and ensure these are not crashing and all functionality is working.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
