### PR TITLE
Introduce debounce to autocomplete

### DIFF
--- a/Core/Debounce.swift
+++ b/Core/Debounce.swift
@@ -1,0 +1,39 @@
+//
+//  Debounce.swift
+//  DuckDuckGo
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public class Debounce {
+    
+    private let queue: DispatchQueue
+    private let interval: TimeInterval
+    
+    private var currentWorkItem = DispatchWorkItem(block: {})
+    
+    public init(queue: DispatchQueue, seconds: TimeInterval) {
+        self.queue = queue
+        self.interval = seconds
+    }
+    
+    public func schedule(_ block: @escaping (() -> Void)) {
+        currentWorkItem.cancel()
+        currentWorkItem = DispatchWorkItem(block: { block() })
+        queue.asyncAfter(deadline: .now() + interval, execute: currentWorkItem)
+    }
+}

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 		9888F77B2224980500C46159 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9888F77A2224980500C46159 /* FeedbackViewController.swift */; };
 		988971A222C2DB95009DC1D6 /* StorageCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988971A122C2DB95009DC1D6 /* StorageCacheProvider.swift */; };
 		9896632422C56716007BE4FE /* EtagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9896632322C56716007BE4FE /* EtagStorage.swift */; };
+		98982B3422F8D8E400578AC9 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98982B3322F8D8E400578AC9 /* Debounce.swift */; };
 		989B337522D7EF2100437824 /* EmptyCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989B337422D7EF2100437824 /* EmptyCollectionReusableView.swift */; };
 		989B337722D88C9B00437824 /* PrivacyProtectionHomeViewSectionRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989B337622D88C9B00437824 /* PrivacyProtectionHomeViewSectionRenderer.swift */; };
 		989DF82922C628F80077AA55 /* ContentBlockerLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989DF82822C628F80077AA55 /* ContentBlockerLoaderTests.swift */; };
@@ -900,6 +901,7 @@
 		9888F77A2224980500C46159 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		988971A122C2DB95009DC1D6 /* StorageCacheProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCacheProvider.swift; sourceTree = "<group>"; };
 		9896632322C56716007BE4FE /* EtagStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtagStorage.swift; sourceTree = "<group>"; };
+		98982B3322F8D8E400578AC9 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		989B337422D7EF2100437824 /* EmptyCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCollectionReusableView.swift; sourceTree = "<group>"; };
 		989B337622D88C9B00437824 /* PrivacyProtectionHomeViewSectionRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyProtectionHomeViewSectionRenderer.swift; sourceTree = "<group>"; };
 		989DF82822C628F80077AA55 /* ContentBlockerLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerLoaderTests.swift; sourceTree = "<group>"; };
@@ -2166,6 +2168,7 @@
 				85372446220DD103009D09CD /* UIKeyCommandExtension.swift */,
 				F143C3251E4A9A0E00CFDE3A /* URLExtension.swift */,
 				F1075C911E9EF827006BE8A8 /* UserDefaultsExtension.swift */,
+				98982B3322F8D8E400578AC9 /* Debounce.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -3633,6 +3636,7 @@
 				85A53ECA200D1FA20010D13F /* SurrogateStore.swift in Sources */,
 				F1134EB31F40AD2500B73467 /* Atb.swift in Sources */,
 				8328AAB9212A3DF200293140 /* BloomFilterWrapper.mm in Sources */,
+				98982B3422F8D8E400578AC9 /* Debounce.swift in Sources */,
 				F143C3291E4A9A0E00CFDE3A /* URLExtension.swift in Sources */,
 				F143C3271E4A9A0E00CFDE3A /* Logger.swift in Sources */,
 				85267D29215273F500A0CE28 /* EntityMappingStore.swift in Sources */,

--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -21,6 +21,10 @@ import UIKit
 import Core
 
 class AutocompleteViewController: UIViewController {
+    
+    struct Constants {
+        static let debounceDelay = 0.3
+    }
 
     weak var delegate: AutocompleteViewControllerDelegate?
 
@@ -34,6 +38,8 @@ class AutocompleteViewController: UIViewController {
     fileprivate var selectedItem = -1
 
     private var hidesBarsOnSwipeDefault = true
+    
+    private let debounce = Debounce(queue: .main, seconds: Constants.debounceDelay)
 
     @IBOutlet weak var tableView: UITableView!
     var shouldOffsetY = false
@@ -88,7 +94,9 @@ class AutocompleteViewController: UIViewController {
         self.query = query
         selectedItem = -1
         cancelInFlightRequests()
-        requestSuggestions(query: query)
+        debounce.schedule { [weak self] in
+            self?.requestSuggestions(query: query)
+        }
     }
 
     @IBAction func onPlusButtonPressed(_ button: UIButton) {
@@ -99,6 +107,7 @@ class AutocompleteViewController: UIViewController {
     private func cancelInFlightRequests() {
         if let inFlightRequest = lastRequest {
             inFlightRequest.cancel()
+            lastRequest = nil
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1134392822512027

**Description**:
Added debounce to autocomplete in order to avoid `HTTPProtocol::shouldAttemptOriginLoad()` crashes on iOS 12

**Steps to test this PR**:
Ensure that Autocomplete work as expected.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
