### PR TITLE
improve tracker url counts

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -658,7 +658,7 @@ extension TabViewController: WKScriptMessageHandler {
             return
         }
 
-        let url = URL(string: urlString)
+        let url = URL(string: urlString.trimWhitespace())
         var networkName: String?
         var category: String?
         if let domain = url?.host {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1136473077054069/1136473310598184
Tech Design URL:
CC:

**Description**:

On imdb mobile page Privacy Protection displays 2 trackers, but Network Leaderboard contains only one entry with trackers count set to 1.

Reason
There is one tracker URL reported that is not bumping the counts as expected:

"https://aax-eu.amazon-adsystem.com/x/getadi?pj=%7B%22prid%22%3A%220101cae2eeb1d778196c3171588e516c25afba611beb1f74fe19e178e6946623f461%22%7D&pk=%5B%22p%3Dtop%22%2C%22p%3Dt%22%2C%22c%3D0%22%2C%22pi%3Dhomepage%22%2C%22ua%3D1%22%5D&src=401&c=100&sz=320x50&ec=0&u=https%3A%2F%2Fm.imdb.com%2F&slot=TOP_AD&site=m.imdb.com&pt=homepage&rnd=047278089276 "

Notice ' ' (space) at the end of url

**Steps to test this PR**:

1. Check URL is counted on imdb mobile page
1. Check tracker counts are otherwise unaffected across devices / sites


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
