### PR TITLE
Add application to user agent

### DIFF
--- a/Core/APIHeaders.swift
+++ b/Core/APIHeaders.swift
@@ -29,7 +29,7 @@ public class APIHeaders {
 
     private let appVersion: AppVersion
 
-    public init(appVersion: AppVersion = AppVersion()) {
+    public init(appVersion: AppVersion = AppVersion.shared) {
         self.appVersion = appVersion
     }
 

--- a/Core/AppVersion.swift
+++ b/Core/AppVersion.swift
@@ -28,6 +28,8 @@ public struct AppVersion {
         static let versionNumber = "CFBundleShortVersionString"
     }
 
+    public static let shared = AppVersion()
+    
     private let bundle: InfoBundle
 
     public init(bundle: InfoBundle = Bundle.main) {

--- a/Core/AppVersion.swift
+++ b/Core/AppVersion.swift
@@ -41,6 +41,10 @@ public struct AppVersion {
     public var identifier: String {
         return bundle.object(forInfoDictionaryKey: Keys.identifier) as? String ?? ""
     }
+    
+    public var majorVersionNumber: String {
+        return String(versionNumber.split(separator: ".").first ?? "")
+    }
 
     public var versionNumber: String {
         return bundle.object(forInfoDictionaryKey: Keys.versionNumber) as? String ?? ""

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -21,6 +21,10 @@ import WebKit
 
 extension WKWebViewConfiguration {
 
+    public static var ddgNameForUserAgent: String {
+        return "DuckDuckGo/\(AppVersion.shared.majorVersionNumber)"
+    }
+    
     public static func persistent() -> WKWebViewConfiguration {
         return configuration(persistsData: true)
     }
@@ -28,7 +32,7 @@ extension WKWebViewConfiguration {
     public static func nonPersistent() -> WKWebViewConfiguration {
         return configuration(persistsData: false)
     }
-
+    
     private static func configuration(persistsData: Bool) -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         if !persistsData {
@@ -38,7 +42,7 @@ extension WKWebViewConfiguration {
             configuration.dataDetectorTypes = [.link, .phoneNumber]
         }
 
-        configuration.applicationNameForUserAgent = "DuckDuckGo/\(AppVersion().majorVersionNumber)"
+        configuration.applicationNameForUserAgent = WKWebViewConfiguration.ddgNameForUserAgent
         configuration.allowsAirPlayForMediaPlayback = true
         configuration.allowsInlineMediaPlayback = true
         configuration.allowsPictureInPictureMediaPlayback = true

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -42,7 +42,8 @@ extension WKWebViewConfiguration {
             configuration.dataDetectorTypes = [.link, .phoneNumber]
         }
 
-        configuration.applicationNameForUserAgent = WKWebViewConfiguration.ddgNameForUserAgent
+        let defaultNameForUserAgent = configuration.applicationNameForUserAgent ?? ""
+        configuration.applicationNameForUserAgent = "\(defaultNameForUserAgent) \(WKWebViewConfiguration.ddgNameForUserAgent)"
         configuration.allowsAirPlayForMediaPlayback = true
         configuration.allowsInlineMediaPlayback = true
         configuration.allowsPictureInPictureMediaPlayback = true

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -38,6 +38,7 @@ extension WKWebViewConfiguration {
             configuration.dataDetectorTypes = [.link, .phoneNumber]
         }
 
+        configuration.applicationNameForUserAgent = "DuckDuckGo/\(AppVersion().majorVersionNumber)"
         configuration.allowsAirPlayForMediaPlayback = true
         configuration.allowsInlineMediaPlayback = true
         configuration.allowsPictureInPictureMediaPlayback = true

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 		F194FAED1F14E2B3009B4DF8 /* UIFontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194FAEC1F14E2B3009B4DF8 /* UIFontExtension.swift */; };
 		F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194FAFA1F14E622009B4DF8 /* UIFontExtensionTests.swift */; };
 		F198D78E1E39762C0088DA8A /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198D78D1E39762C0088DA8A /* StringExtensionTests.swift */; };
-		F198D7981E3A45D90088DA8A /* WKWebViewExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198D7971E3A45D90088DA8A /* WKWebViewExtensionTests.swift */; };
+		F198D7981E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198D7971E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift */; };
 		F1A169F31F3B2A8A00BE3E3B /* FlamesAnimation.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F1A169F21F3B2A8A00BE3E3B /* FlamesAnimation.xcassets */; };
 		F1A5683A1E70F98E0081082E /* AutocompleteRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A568391E70F98E0081082E /* AutocompleteRequest.swift */; };
 		F1A886781F29394E0096251E /* WebCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A886771F29394E0096251E /* WebCacheManager.swift */; };
@@ -1029,7 +1029,7 @@
 		F194FAFA1F14E622009B4DF8 /* UIFontExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtensionTests.swift; sourceTree = "<group>"; };
 		F197EA3B1E6885F20029BDC1 /* TextFieldWithInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextFieldWithInsets.swift; path = ../Core/TextFieldWithInsets.swift; sourceTree = "<group>"; };
 		F198D78D1E39762C0088DA8A /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
-		F198D7971E3A45D90088DA8A /* WKWebViewExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WKWebViewExtensionTests.swift; sourceTree = "<group>"; };
+		F198D7971E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WKWebViewConfigurationExtensionTests.swift; sourceTree = "<group>"; };
 		F1A169F21F3B2A8A00BE3E3B /* FlamesAnimation.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = FlamesAnimation.xcassets; sourceTree = "<group>"; };
 		F1A568391E70F98E0081082E /* AutocompleteRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteRequest.swift; sourceTree = "<group>"; };
 		F1A886771F29394E0096251E /* WebCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebCacheManager.swift; sourceTree = "<group>"; };
@@ -2405,7 +2405,7 @@
 		F198D7961E3A45C00088DA8A /* Web */ = {
 			isa = PBXGroup;
 			children = (
-				F198D7971E3A45D90088DA8A /* WKWebViewExtensionTests.swift */,
+				F198D7971E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift */,
 				85A1B3B320C6D07100C18F15 /* CookieStorageTests.swift */,
 			);
 			name = Web;
@@ -3578,7 +3578,7 @@
 				F1D477C91F2139410031ED49 /* OmniBarStateTests.swift in Sources */,
 				85FAAE66214EFE59006AD5DA /* EmbeddedPrevalenceStoreTests.swift in Sources */,
 				85F1E9B71FB7C81C00A75AC1 /* NativeDisplayableCertificateBuilderDriverTests.swift in Sources */,
-				F198D7981E3A45D90088DA8A /* WKWebViewExtensionTests.swift in Sources */,
+				F198D7981E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift in Sources */,
 				851B12AB22259DDE004781BC /* MockContextualTipsStorage.swift in Sources */,
 				8364F7131F961E5E00562989 /* DisconnectMeStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,

--- a/DuckDuckGo/FeedbackSender.swift
+++ b/DuckDuckGo/FeedbackSender.swift
@@ -52,7 +52,7 @@ struct FeedbackSubmitter: FeedbackSender {
     private let statisticsStore: StatisticsStore
     private let versionProvider: AppVersion
 
-    init(statisticsStore: StatisticsStore = StatisticsUserDefaults(), versionProvider: AppVersion = AppVersion()) {
+    init(statisticsStore: StatisticsStore = StatisticsUserDefaults(), versionProvider: AppVersion = AppVersion.shared) {
         self.statisticsStore = statisticsStore
         self.versionProvider = versionProvider
     }

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -37,7 +37,7 @@ class SettingsViewController: UITableViewController {
     
     weak var homePageSettingsDelegate: HomePageSettingsDelegate?
 
-    private lazy var versionProvider: AppVersion = AppVersion()
+    private lazy var versionProvider: AppVersion = AppVersion.shared
     fileprivate lazy var privacyStore = PrivacyUserDefaults()
     fileprivate lazy var appSettings = AppDependencyProvider.shared.appSettings
     fileprivate lazy var variantManager = AppDependencyProvider.shared.variantManager

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -35,8 +35,8 @@ class TabViewController: UIViewController {
     }
 
     private struct UserAgent {
-        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 " +
-            WKWebViewConfiguration.ddgNameForUserAgent
+        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0  Safari/605.1.15" +
+                             WKWebViewConfiguration.ddgNameForUserAgent
     }
     
     @IBOutlet private(set) weak var error: UIView!

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -35,7 +35,8 @@ class TabViewController: UIViewController {
     }
 
     private struct UserAgent {
-        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15"
+        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 " +
+            WKWebViewConfiguration.ddgNameForUserAgent
     }
     
     @IBOutlet private(set) weak var error: UIView!

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -35,7 +35,7 @@ class TabViewController: UIViewController {
     }
 
     private struct UserAgent {
-        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0  Safari/605.1.15 " +
+        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15 " +
                              WKWebViewConfiguration.ddgNameForUserAgent
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -35,7 +35,7 @@ class TabViewController: UIViewController {
     }
 
     private struct UserAgent {
-        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0  Safari/605.1.15" +
+        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0  Safari/605.1.15 " +
                              WKWebViewConfiguration.ddgNameForUserAgent
     }
     

--- a/DuckDuckGoTests/AppVersionTests.swift
+++ b/DuckDuckGoTests/AppVersionTests.swift
@@ -42,7 +42,7 @@ class AppVersionTests: XCTestCase {
         XCTAssertEqual(Constants.name, testee.name)
     }
 
-    func testMAajorNumber() {
+    func testMajorNumber() {
         mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
         XCTAssertEqual("2", testee.majorVersionNumber)
     }

--- a/DuckDuckGoTests/AppVersionTests.swift
+++ b/DuckDuckGoTests/AppVersionTests.swift
@@ -42,6 +42,11 @@ class AppVersionTests: XCTestCase {
         XCTAssertEqual(Constants.name, testee.name)
     }
 
+    func testMAajorNumber() {
+        mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
+        XCTAssertEqual("2", testee.majorVersionNumber)
+    }
+    
     func testVersionNumber() {
         mockBundle.add(name: AppVersion.Keys.versionNumber, value: Constants.version)
         XCTAssertEqual(Constants.version, testee.versionNumber)

--- a/DuckDuckGoTests/WKWebViewConfigurationExtensionTests.swift
+++ b/DuckDuckGoTests/WKWebViewConfigurationExtensionTests.swift
@@ -21,17 +21,21 @@ import XCTest
 import WebKit
 
 class WKWebViewConfigurationExtensionTests: XCTestCase {
-
+    
     func testWhenWebViewCreatedWithNonPersistenceThenDataStoreIsNonPersistent() {
         let configuration = WKWebViewConfiguration.nonPersistent()
         let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertFalse(webView.configuration.websiteDataStore.isPersistent)
     }
-
+    
     func testWhenWebViewCreatedWithPersistenceThenDataStoreIsPersistent() {
         let configuration = WKWebViewConfiguration.persistent()
         let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertTrue(webView.configuration.websiteDataStore.isPersistent)
+    }
+    
+    func testWhenDddgNameForUserAgentRequestedThenNameAndVersionAreCorrect() {
+        XCTAssertEqual("DuckDuckGo/7", WKWebViewConfiguration.ddgNameForUserAgent)
     }
     
     func testWhenPersistantConfigurationCreatedThenApplicationForUserAgentIsSet() {

--- a/DuckDuckGoTests/WKWebViewConfigurationExtensionTests.swift
+++ b/DuckDuckGoTests/WKWebViewConfigurationExtensionTests.swift
@@ -40,11 +40,11 @@ class WKWebViewConfigurationExtensionTests: XCTestCase {
     
     func testWhenPersistantConfigurationCreatedThenApplicationForUserAgentIsSet() {
         let configuration = WKWebViewConfiguration.persistent()
-        XCTAssertEqual("DuckDuckGo/7", configuration.applicationNameForUserAgent)
+        XCTAssertTrue(configuration.applicationNameForUserAgent?.hasSuffix("DuckDuckGo/7") ?? false)
     }
     
     func testWhenNonPersistantConfigurationCreatedThenApplicationForUserAgentIsSet() {
         let configuration = WKWebViewConfiguration.nonPersistent()
-        XCTAssertEqual("DuckDuckGo/7", configuration.applicationNameForUserAgent)
+        XCTAssertTrue(configuration.applicationNameForUserAgent?.hasSuffix("DuckDuckGo/7") ?? false)
     }
 }

--- a/DuckDuckGoTests/WKWebViewConfigurationExtensionTests.swift
+++ b/DuckDuckGoTests/WKWebViewConfigurationExtensionTests.swift
@@ -1,5 +1,5 @@
 //
-//  WKWebViewExtensionTests.swift
+//  WKWebViewConfigurationExtensionTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2017 DuckDuckGo. All rights reserved.
@@ -20,7 +20,7 @@
 import XCTest
 import WebKit
 
-class WKWebViewExtensionTests: XCTestCase {
+class WKWebViewConfigurationExtensionTests: XCTestCase {
 
     func testWhenWebViewCreatedWithNonPersistenceThenDataStoreIsNonPersistent() {
         let configuration = WKWebViewConfiguration.nonPersistent()
@@ -33,5 +33,14 @@ class WKWebViewExtensionTests: XCTestCase {
         let webView = WKWebView(frame: CGRect(), configuration: configuration)
         XCTAssertTrue(webView.configuration.websiteDataStore.isPersistent)
     }
-
+    
+    func testWhenPersistantConfigurationCreatedThenApplicationForUserAgentIsSet() {
+        let configuration = WKWebViewConfiguration.persistent()
+        XCTAssertEqual("DuckDuckGo/7", configuration.applicationNameForUserAgent)
+    }
+    
+    func testWhenNonPersistantConfigurationCreatedThenApplicationForUserAgentIsSet() {
+        let configuration = WKWebViewConfiguration.nonPersistent()
+        XCTAssertEqual("DuckDuckGo/7", configuration.applicationNameForUserAgent)
+    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1136878908228408
Tech Design URL: N/A

**Description**:
Append application to user agent following RFC and the format of other browsers.

**Steps to test this PR**:
1. Run the app
1. Search for "what is my user agent"
1. Note the Instant Answer displaying our UA shows the suffix as "DuckDuckGo/7"
1. Visit https://github.com/duckduckgo/iOS and note that the mobile version of the site is showing
1. From the menu select, "Request Desktop Site" and note the desktop site is loaded
1. Now  search for "what is my user agent" again
1. Note that the desktop UA suffix also shows as "DuckDuckGo/7"

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
