### PR TITLE
Handle <a href target="_blank">

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -883,6 +883,11 @@ extension TabViewController: WKNavigationDelegate {
         }
         
         if shouldLoad(url: url, forDocument: documentUrl) {
+            if navigationAction.navigationType == .linkActivated && navigationAction.targetFrame == nil {
+                // Handle <a href target="_blank">
+                delegate?.tab(self, didRequestNewTabForUrl: url)
+                return .cancel
+            }
             return .allow
         }
         


### PR DESCRIPTION
Task/Issue URL: Issue #448
Tech Design URL: -
CC: @bwaresiak @subsymbolic @brindy 

**Description**:

A link in HTML (`<a href>`) can have a `target` attribute. When that attribute is either set to `_blank`, or set to a name that doesn't exist in the current browsing context, then the link should open in a new tab when tapped. This is the behaviour in Safari for iOS.

Currently, such links are opened in the same tab in this app.

This PR causes such links to be opened in a new tab.

**Implementation details**:

The `WKNavigationAction` object contains two `WKFrameInfo` properties: `sourceFrame` and `targetFrame`. When the link is meant to be opened in a specific frame, `targetFrame` is set to that frame (for e.g. if the link doesn't have a `target` attribute, `targetFrame` is the same as `sourceFrame`). When the link is meant to be opened in a new browsing context, `targetFrame` is set to nil ([docs](https://developer.apple.com/documentation/webkit/wknavigationaction/1401918-targetframe)). So, in that case, we can open the URL in a new tab.

**Alternatives considered**:

Another way to handle this would be in `webView(_:createWebViewWith:for:windowFeatures:)` ([docs](https://developer.apple.com/documentation/webkit/wkuidelegate/1536907-webview)). This is how `<a href target=“_blank”>` links are handled in Firefox for iOS.

However, doing that would cause multiple `WKWebView`s to share a single `WKWebViewConfiguration`, which is contrary to the way this app is architected. Instead, a separate configuration is created for each webView, and the configuration is not meant be shared across multiple webViews (or that’s my understanding).

**Steps to test this PR**:
 1. Open a page with HTML containing
     1. A `<a href target="_blank">` link
     2. A `<a href target="frame">` link, where "frame" is not the name of an iframe in the page.
Here's the test page I used: ([link](http://roopc.net/test/target.html)) ([HTML source](https://github.com/roop/roop.github.io/blob/master/test/target.html)).
 2. Tap on the link
 3. A new tab should open with the link URL

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)