### PR TITLE
Add broken site pixel

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -145,6 +145,17 @@ public enum PixelName: String {
     case etagStoreOOSWithEasylistFix = "m_d_elf_oos"
     
     case configurationFetchInfo = "m_d_cfgfetch"
+    case brokenSiteReported = "m_bsr"
+}
+
+public struct PixelParameters {
+    static let url = "url"
+    static let duration = "dur"
+    static let test = "test"
+}
+
+public struct PixelValues {
+    static let test = "1"
 }
 
 public class Pixel {
@@ -167,7 +178,7 @@ public class Pixel {
         
         var newParams = params
         if isDebugBuild {
-            newParams["test"] = "1"
+            newParams[PixelParameters.test] = PixelValues.test
         }
         
         let formFactor = deviceType == .pad ? Constants.tablet : Constants.phone
@@ -195,7 +206,7 @@ public class TimedPixel {
     
     public func fire(_ fireDate: Date = Date()) {
         let duration = String(fireDate.timeIntervalSince(date))
-        Pixel.fire(pixel: pixel, withAdditionalParameters: ["dur": duration])
+        Pixel.fire(pixel: pixel, withAdditionalParameters: [PixelParameters.duration: duration])
     }
     
 }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -149,8 +149,8 @@ public enum PixelName: String {
 }
 
 public struct PixelParameters {
-    static let url = "url"
-    static let duration = "dur"
+    public static let url = "url"
+    public static let duration = "dur"
     static let test = "test"
 }
 

--- a/DuckDuckGo/SiteFeedbackModel.swift
+++ b/DuckDuckGo/SiteFeedbackModel.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import Core
 
 struct SiteFeedbackModel {
 
@@ -44,7 +45,7 @@ struct SiteFeedbackModel {
 
     public func submit() {
         guard canSubmit() else { return }
-
+        Pixel.fire(pixel: .brokenSiteReported, withAdditionalParameters: [PixelParameters.url: url!])
         feedbackSender.submitBrokenSite(url: url!, message: message!)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1137628760317279
Grafana: https://grafana.duckduckgo.com/d/sawhWhOWk/mobile-sre

**Description**:
Add a simple pixel to the broken site reports so we can visualize these in Grafana and add alerts should the numbers unexpectedly rise.

**Steps to test this PR**:
1. Run the app and browse to a site
1. Tap the browser settings button and select "Report Broken Site"
1. Enter "test.com" for the url and "TEST" in the comment section
1. Submit the report and ensure the "m_bsr" pixel fires, checking Kibana https://kibana.duckduckgo.com/goto/5de1d263245cdf6769d9afe7d074326c
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
