### PR TITLE
Do not hide bars if content of the site won't fill the whole viewport

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -54,7 +54,12 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
         guard !scrollView.isZooming else { return }
         
         guard dragging else { return }
-        guard canHideBars(for: scrollView) else { return }
+        guard canHideBars(for: scrollView) else {
+            if animator.barsState != .revealed {
+                animator.revealBars(animated: true)
+            }
+            return
+        }
         
         let isInBottomBounceArea = scrollView.contentOffset.y > scrollView.contentOffsetYAtBottom
         guard isInBottomBounceArea == false else { return }

--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -105,9 +105,9 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
         }
     }
     
-    /// Bars should not be hidden in case ScrollView content is smaller than viewport.
+    /// Bars should not be hidden in case ScrollView content is smaller than full (with bars hidden) viewport.
     private func canHideBars(for scrollView: UIScrollView) -> Bool {
-        return scrollView.bounds.height < scrollView.contentSize.height
+        return scrollView.bounds.height + (delegate?.barsMaxHeight ?? 0) < scrollView.contentSize.height
     }
 
     func reset() {


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1103775464663252
Tech Design URL:
CC:

**Description**:
If website content is:
- larger than webview with bars in revealed state
- smaller than webview with bars in hidden state

There is an issue with bars hiding only partially. Fix is to adopt Safari's behavior and disallow hiding bars in such state. 

**Steps to test this PR**:
1. Open iPhone SE simulator.
2. Go to https://map.crossfit.com/
3. Check if scrolling works.

Also smoke-test scrolling in general.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)