### PR TITLE
Make simulator in `./run-tests.sh` configurable.

### DIFF
--- a/run_atb_tests.sh
+++ b/run_atb_tests.sh
@@ -1,3 +1,3 @@
-carthage bootstrap --platform iOS --cache-builds;
-xcrun simctl uninstall booted com.duckduckgo.mobile.ios;
-xcodebuild test -quiet -project DuckDuckGo.xcodeproj -scheme AtbIntegrationTests CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 6s';
+#!/usr/bin/env bash
+
+DDG_TEST_SCHEME='AtbIntegrationTests' ./run_tests.sh

--- a/run_site_report.sh
+++ b/run_site_report.sh
@@ -1,3 +1,3 @@
-carthage bootstrap --platform iOS --cache-builds;
-xcrun simctl uninstall booted com.duckduckgo.mobile.ios;
-xcodebuild test -project DuckDuckGo.xcodeproj -scheme TopSitesReport CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 6s';
+#!/usr/bin/env bash
+
+DDG_TEST_SCHEME='TopSitesReport' ./run_tests.sh

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,8 @@
+#!/usr/bin/env bash
+
+SIM_NAME=${DDG_SIMULATOR:-'iPhone 6s'}
+SCHEME=${DDG_TEST_SCHEME:-'DuckDuckGo'}
+
 carthage bootstrap --platform iOS --cache-builds;
 xcrun simctl uninstall booted com.duckduckgo.mobile.ios;
-xcodebuild test -quiet -project DuckDuckGo.xcodeproj -scheme DuckDuckGo CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 6s';
+xcodebuild test -quiet -project DuckDuckGo.xcodeproj -scheme $SCHEME CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination "platform=iOS Simulator,name=$SIM_NAME";

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SIM_NAME=${DDG_SIMULATOR:-'iPhone 6s'}
+SIM_NAME=${DDG_SIMULATOR:-'iPhone 8'}
 SCHEME=${DDG_TEST_SCHEME:-'DuckDuckGo'}
 
 carthage bootstrap --platform iOS --cache-builds;


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
It's a very minor change, so I just decided to go with a PR, but I can open an issue if needed.

👋 
I've checked out the repository and tried to run tests on it and it turns out I don't have iPhone 6s simulator anymore. So, instead of installing this simulator or patching the script, I decided to slightly improve DX of the first time usage by making test scripts follow an environment variable.

Basically, each script now accepts `DDG_SIMULATOR=<SimulatorName>` env variable, and if it isn't set it defaults back to the original iPhone 6s.

Also, I DRY-ed scripts a bit.

Potential improvements:
- document these parameters somewhere;
- add auto-detection of a test device from a whitelist (improve DX even further);
- leave only one parametrized `./run-tests.sh` and remove other shell scripts.

Feel free to just close this PR is that isn't a direction you want to follow.

**Steps to test this PR**:
1. Run `DDG_SIMULATOR='iPhone 8' ./run_tests.sh`
1. Run `DDG_SIMULATOR='iPhone 8' ./run_atb_tests.sh`
1. Run `DDG_SIMULATOR='iPhone 8' ./run_site_report.sh`

All the tests should run using iPhone 8 simulator.