### PR TITLE
handle link previews in iOS 13 (mainly to fix save images)

### DIFF
--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -91,7 +91,11 @@ private class Loader {
     }
 
     private func loadDocumentLevelScripts() {
-        load(scripts: [ .document, .findinpage ] )
+        if #available(iOS 13, *) {
+            load(scripts: [ .findinpage ] )
+        } else {
+            load(scripts: [ .document, .findinpage ] )
+        }
     }
 
     private func loadContentBlockingScripts() {

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -49,7 +49,6 @@ class TabManager {
         controller.attachWebView(configuration: configuration, andLoadUrl: url, consumeCookies: model.isEmpty)
         controller.delegate = delegate
         controller.loadViewIfNeeded()
-        decorate(tabController: controller, with: ThemeManager.shared.currentTheme)
         return controller
     }
 
@@ -171,27 +170,9 @@ class TabManager {
 extension TabManager: Themable {
     
     func decorate(with theme: Theme) {
-
         for tabController in tabControllerCache {
-            decorate(tabController: tabController, with: theme)
+            tabController.decorate(with: theme)
         }
     }
     
-    private func decorate(tabController controller: TabViewController,
-                          with theme: Theme) {
-        // This is done in a crude way: ideally tabController should implement
-        // 'Themable' protocol, but that would require moving Themable to 'Core'
-        // module.
-        controller.view.backgroundColor = theme.backgroundColor
-        controller.error?.backgroundColor = theme.backgroundColor
-        controller.errorHeader.textColor = theme.barTintColor
-        controller.errorMessage.textColor = theme.barTintColor
-        
-        switch theme.currentImageSet {
-        case .light:
-            controller.errorInfoImage?.image = UIImage(named: "ErrorInfoLight")
-        case .dark:
-            controller.errorInfoImage?.image = UIImage(named: "ErrorInfoDark")
-        }
-    }
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1037,7 +1037,9 @@ extension TabViewController {
         let config = UIContextMenuConfiguration(identifier: nil, previewProvider: {
             return self.buildPreview(for: url)
         }, actionProvider: { _ in
-            return self.buildLinkPreviewMenu(for: url)
+            let midX = self.view.frame.midX
+            let midY = self.view.frame.midY
+            return self.buildLinkPreviewMenu(for: url, atPoint: Point(x: Int(midX), y: Int(midY)))
         })
         
         completionHandler(config)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1023,46 +1023,6 @@ extension TabViewController: UIGestureRecognizerDelegate {
     
 }
 
-@available(iOS 13.0, *)
-extension TabViewController {
-    
-    func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
-                 completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
-    
-        guard let url = elementInfo.linkURL else {
-            completionHandler(nil)
-            return
-        }
-        
-        let config = UIContextMenuConfiguration(identifier: nil, previewProvider: {
-            return self.buildPreview(for: url)
-        }, actionProvider: { _ in
-            let midX = self.view.frame.midX
-            let midY = self.view.frame.midY
-            return self.buildLinkPreviewMenu(for: url, atPoint: Point(x: Int(midX), y: Int(midY)))
-        })
-        
-        completionHandler(config)
-    }
-    
-    func webView(_ webView: WKWebView, contextMenuForElement elementInfo: WKContextMenuElementInfo,
-                 willCommitWithAnimator animator: UIContextMenuInteractionCommitAnimating) {
-        guard let url = elementInfo.linkURL else { return }
-        load(url: url)
-    }
-        
-    func buildPreview(for url: URL) -> UIViewController? {
-        let tab = Tab(link: Link(title: nil, url: url))
-        let tabController = TabViewController.loadFromStoryboard(model: tab)
-        tabController.decorate(with: ThemeManager.shared.currentTheme)
-        let configuration = WKWebViewConfiguration.nonPersistent()
-        tabController.attachWebView(configuration: configuration, andLoadUrl: url, consumeCookies: false)
-        tabController.loadViewIfNeeded()
-        return tabController
-    }
-    
-}
-
 extension TabViewController: Themable {
 
     func decorate(with theme: Theme) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -176,8 +176,9 @@ class TabViewController: UIViewController {
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         
         if #available(iOS 13, *) {
-            attachLongPressHandler(webView: webView)
+            webView.allowsLinkPreview = true
         } else {
+            attachLongPressHandler(webView: webView)
             webView.allowsLinkPreview = false
         }
         

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -24,7 +24,7 @@ import SafariServices
 extension TabViewController {
 
     @available(iOS 13.0, *)
-    func buildLinkPreviewMenu(for url: URL) -> UIMenu {
+    func buildLinkPreviewMenu(for url: URL, atPoint point: Point) -> UIMenu {
         var items = [UIMenuElement]()
 
         items.append(UIAction(title: UserText.actionNewTabForUrl, image: UIImage(systemName: "rectangle.stack.badge.plus")) { [weak self] _ in
@@ -41,7 +41,7 @@ extension TabViewController {
             self?.onCopyAction(forUrl: url)
         })
         items.append(UIAction(title: UserText.actionShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
-             self?.onShareAction(forUrl: url, atPoint: nil)
+            self?.onShareAction(forUrl: url, atPoint: point)
         })
 
         return UIMenu(title: "", image: nil, identifier: nil, options: [], children: items)

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -115,7 +115,8 @@ extension TabViewController {
     static let excludedLongPressItems = [
         UIImage(systemName: "safari"),
         UIImage(systemName: "eyeglasses"),
-        nil // hide/show link previews
+        UIImage(systemName: "eye.fill"), //  hide/show link previews on some versions of ios
+        nil // hide/show link previews on some versions of ios
     ]
 
     func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -22,6 +22,30 @@ import Core
 import SafariServices
 
 extension TabViewController {
+
+    @available(iOS 13.0, *)
+    func buildLinkPreviewMenu(for url: URL) -> UIMenu {
+        var items = [UIMenuElement]()
+
+        items.append(UIAction(title: UserText.actionNewTabForUrl, image: UIImage(systemName: "rectangle.stack.badge.plus")) { [weak self] _ in
+            self?.onNewTabAction(url: url)
+        })
+        items.append(UIAction(title: UserText.actionNewBackgroundTabForUrl,
+                              image: UIImage(systemName: "rectangle.on.rectangle.angled")) { [weak self] _ in
+            self?.onBackgroundTabAction(url: url)
+        })
+        items.append(UIAction(title: UserText.actionReadingList, image: UIImage(systemName: "eyeglasses")) { [weak self] _ in
+            self?.onReadingAction(forUrl: url)
+        })
+        items.append(UIAction(title: UserText.actionCopy, image: UIImage(systemName: "doc.on.doc")) { [weak self] _ in
+            self?.onCopyAction(forUrl: url)
+        })
+        items.append(UIAction(title: UserText.actionShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+             self?.onShareAction(forUrl: url, atPoint: nil)
+        })
+
+        return UIMenu(title: "", image: nil, identifier: nil, options: [], children: items)
+    }
     
     func buildLongPressMenu(atPoint point: Point, forUrl url: URL) -> UIAlertController {
         let alert = UIAlertController(title: nil, message: makeMessage(from: url), preferredStyle: .actionSheet)
@@ -87,7 +111,7 @@ extension TabViewController {
         UIPasteboard.general.string = copyText
     }
     
-    private func onShareAction(forUrl url: URL, atPoint point: Point) {
+    private func onShareAction(forUrl url: URL, atPoint point: Point?) {
         Pixel.fire(pixel: .longPressMenuShareItem)
         guard let webView = webView else { return }
         presentShareSheet(withItems: [url], fromView: webView, atPoint: point)

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "action.title.bookmark" = "Bookmark";
 "action.title.newTab" = "New Tab";
 "action.title.newTabForUrl" = "Open in New Tab";
-"action.title.newBackgroundTabForUrl" = "Open in Background Tab";
+"action.title.newBackgroundTabForUrl" = "Open in Background";
 "action.title.forgetAll" = "Clear Tabs and Data";
 "action.title.forgetAllDone" = "Tabs and data cleared";
 "action.title.open" = "Open";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1144355399715969
Tech Design URL:
CC:

**Description**:

In iOS 13 our long press gesture appears to not work for images, as such users can't save them.  To enable this functionality again we have to handle link previews more generically.

This change shows a preview and our usual list of long press items for links.

For images iOS handles showing the preview and list of clickable items.

Note that "Open" has been dropped because tapping the preview opens the link.  We've also dropped Add To Reading List as it's not used very often and pushes people to Safari.

**Steps to test this PR**:
1. Search for something and then long press a link.
1. Check each menu item.
1. Check iPhone, iPad, Portrait, Landscape.
1. Check previewing images
1. Retest on iOS 12 or earlier - previous behaviour should still remain


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
