### PR TITLE
hide atb modals

### DIFF
--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -42,6 +42,10 @@ extension WKWebViewConfiguration {
             configuration.dataDetectorTypes = [.link, .phoneNumber]
         }
 
+        if #available(iOS 11, *) {
+            configuration.installHideAtbModals()
+        }
+
         let defaultNameForUserAgent = configuration.applicationNameForUserAgent ?? ""
         configuration.applicationNameForUserAgent = "\(defaultNameForUserAgent) \(WKWebViewConfiguration.ddgNameForUserAgent)"
         configuration.allowsAirPlayForMediaPlayback = true
@@ -50,6 +54,29 @@ extension WKWebViewConfiguration {
         configuration.ignoresViewportScaleLimits = true
 
         return configuration
+    }
+
+    @available(iOS 11, *)
+    private func installHideAtbModals() {
+        guard let store = WKContentRuleListStore.default() else { return }
+        let rules = """
+        [
+          {
+            "trigger": {
+              "url-filter": ".*",
+              "if-domain": ["*duckduckgo.com"]
+            },
+            "action": {
+              "type": "css-display-none",
+              "selector": ".ddg-extension-hide"
+            }
+          }
+        ]
+        """
+        store.compileContentRuleList(forIdentifier: "hide-extension-css", encodedContentRuleList: rules) { rulesList, _ in
+            guard let rulesList = rulesList else { return }
+            self.userContentController.add(rulesList)
+        }
     }
 
     public func loadScripts(storageCache: StorageCache, contentBlockingEnabled: Bool) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1141661062607805/1145027585067786
Tech Design URL:
CC:

**Description**:

Hides `ddg-extension-hide` css class to let the FE know not to show the ATB modals.

Note that there is a bug in the FE just now so this doesn't actually work at the moment, but it will once that is fixed. See below for how to test.

**Steps to test this PR**:
1.  Go to duckduckgo.com 
1. Request desktop mode (probably optional)
1. Debug the web view
1. Run the following command in the console `DDG.extension.isInstalled()` - it should return `true`

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
