### PR TITLE
Always reveal bars on navigation

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -55,6 +55,8 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     private var startZoomScale: CGFloat = 0
     
     func attach(to scrollView: UIScrollView) {
+        detach()
+        
         scrollView.delegate = self
         
         observation = scrollView.observe(\.contentSize, options: .new) { [weak self] scrollView, _ in

--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -37,6 +37,8 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     struct Constants {
         static let dragThreshold: CGFloat = 30
         static let zoomThreshold: CGFloat = 0.1
+        
+        static let contentSizeKVOKey = "contentSize"
     }
 
     weak var delegate: BrowserChromeDelegate? {
@@ -46,10 +48,33 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     }
     
     private let animator = BarsAnimator()
+    
+    private var observation: NSKeyValueObservation?
 
     private var dragging = false
     private var startZoomScale: CGFloat = 0
     
+    func attach(to scrollView: UIScrollView) {
+        scrollView.delegate = self
+        
+        observation = scrollView.observe(\.contentSize, options: .new) { [weak self] scrollView, _ in
+            guard let strongSelf = self else { return }
+
+            strongSelf.scrollViewDidResizeContent(scrollView)
+        }
+    }
+    
+    func detach() {
+        observation?.invalidate()
+        observation = nil
+    }
+    
+    private func scrollViewDidResizeContent(_ scrollView: UIScrollView) {
+        if !canHideBars(for: scrollView) && animator.barsState != .revealed {
+            animator.revealBars(animated: true)
+        }
+    }
+        
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         guard !scrollView.isZooming else { return }
         

--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -58,9 +58,7 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
         scrollView.delegate = self
         
         observation = scrollView.observe(\.contentSize, options: .new) { [weak self] scrollView, _ in
-            guard let strongSelf = self else { return }
-
-            strongSelf.scrollViewDidResizeContent(scrollView)
+            self?.scrollViewDidResizeContent(scrollView)
         }
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -273,6 +273,8 @@ class MainViewController: UIViewController {
 
     fileprivate func attachHomeScreen() {
         findInPageView.isHidden = true
+        chromeManager.detach()
+        
         removeHomeScreen()
 
         let controller = HomeViewController.loadFromStoryboard()
@@ -377,7 +379,7 @@ class MainViewController: UIViewController {
         currentTab?.chromeDelegate = nil
         addToView(controller: tab)
         tab.progressWorker.progressBar = progressView
-        tab.webView.scrollView.delegate = chromeManager
+        chromeManager.attach(to: tab.webView.scrollView)
         tab.chromeDelegate = self
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -849,6 +849,7 @@ extension TabViewController: WKNavigationDelegate {
                 if let isDdg = self?.appUrls.isDuckDuckGoSearch(url: url), isDdg {
                     StatisticsLoader.shared.refreshSearchRetentionAtb()
                 }
+                self?.showBars()
                 self?.findInPage?.done()
             }
             decisionHandler(decision)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -849,7 +849,6 @@ extension TabViewController: WKNavigationDelegate {
                 if let isDdg = self?.appUrls.isDuckDuckGoSearch(url: url), isDdg {
                     StatisticsLoader.shared.refreshSearchRetentionAtb()
                 }
-                self?.showBars()
                 self?.findInPage?.done()
             }
             decisionHandler(decision)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/856498667309057/1145379614994849/1145481496542892
Tech Design URL:
CC:

**Description**:
Fix bars when on the Google News site.

**Steps to test this PR**:
1. Navigate to Google News.
2. Scroll down to hide bars.
3. Tap on a link -> bars should  appear.

1. Navigate to nytimes.com
2. Scroll to very bottom of the page so additional content is loaded.
3. Bars should remain hidden.

Also general smoke-tests of scrolling just in case.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
