### PR TITLE
Reveal bars when scrolling below bottom of the web page

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -86,9 +86,6 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
             return
         }
         
-        let isInBottomBounceArea = scrollView.contentOffset.y > scrollView.contentOffsetYAtBottom
-        guard isInBottomBounceArea == false else { return }
-
         animator.didScroll(in: scrollView)
     }
     
@@ -177,6 +174,11 @@ private class BarsAnimator {
     }
     
     func didScroll(in scrollView: UIScrollView) {
+        let isInBottomBounceArea = scrollView.contentOffset.y > scrollView.contentOffsetYAtBottom
+        guard isInBottomBounceArea == false else {
+            scrollingInBottomBounceArea(in: scrollView)
+            return
+        }
         
         switch barsState {
         case .revealed:
@@ -188,6 +190,12 @@ private class BarsAnimator {
         case .hidden:
             hiddenAndScrolling(in: scrollView)
             
+        }
+    }
+    
+    private func scrollingInBottomBounceArea(in scrollView: UIScrollView) {
+        if barsState == .hidden {
+            delegate?.setBarsHidden(false, animated: true)
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/iOS/issues/495
CC: @bwaresiak

**Description**:
Changed behavior of BarsAnimator to reveal navigation bar and toolbar when the user 'rubberbands' the web page beyond its lower bound. 

**Steps to test this PR**:
1. Load a web page higher than a screen's height.
2. Scroll down and let the bars hide automatically.
3. After reaching the bottom, let go of the screen and scroll down again (this is a similar interaction required by Mobile Safari to reveal bars).
4. Top and bottom bars should appear automatically.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
