### PR TITLE
Improve Core Data stack

### DIFF
--- a/Core/DDGPersistenceContainer.swift
+++ b/Core/DDGPersistenceContainer.swift
@@ -60,13 +60,6 @@ public class DDGPersistenceContainer {
         return persistenceStoreCoordinator
     }
 
-    public func deleteAll(entities: [NSManagedObject]?) {
-        guard let entities = entities else { return }
-        for entity in entities {
-            managedObjectContext.delete(entity)
-        }
-    }
-
     public func save() -> Bool {
 
         do {

--- a/Core/DDGPersistenceContainer.swift
+++ b/Core/DDGPersistenceContainer.swift
@@ -27,12 +27,9 @@ public class DDGPersistenceContainer {
     public let persistenceStoreCoordinator: NSPersistentStoreCoordinator
     public let managedObjectContext: NSManagedObjectContext
 
-    public init?(name: String, concurrencyType: NSManagedObjectContextConcurrencyType = .privateQueueConcurrencyType) {
-        let mainBundle = Bundle.main
-        let coreBundle = Bundle(identifier: "com.duckduckgo.mobile.ios.Core")!
+    public init?(name: String, model: NSManagedObjectModel, concurrencyType: NSManagedObjectContextConcurrencyType = .privateQueueConcurrencyType) {
 
-        guard let managedObjectModel = NSManagedObjectModel.mergedModel(from: [mainBundle, coreBundle]) else { return nil }
-        self.managedObjectModel = managedObjectModel
+        self.managedObjectModel = model
 
         guard let persistenceStoreCoordinator =
             DDGPersistenceContainer.createPersistenceStoreCoordinator(name: name, model: managedObjectModel) else { return nil }

--- a/Core/DDGPersistenceContainer.swift
+++ b/Core/DDGPersistenceContainer.swift
@@ -39,12 +39,9 @@ public class DDGPersistenceContainer {
         managedObjectContext.persistentStoreCoordinator = persistenceStoreCoordinator
     }
 
-    private class func createPersistenceStoreCoordinator(name: String, model: NSManagedObjectModel) -> NSPersistentStoreCoordinator? {
-        let fileManager = FileManager.default
-        guard let docsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).last else { return nil }
-
-        let storeName = name + ".sqlite"
-        let storeURL = docsDir.appendingPathComponent(storeName)
+    private static func createPersistenceStoreCoordinator(name: String, model: NSManagedObjectModel) -> NSPersistentStoreCoordinator? {
+        guard let storeURL = storeURL(for: name) else { return nil }
+        
         let persistenceStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
         let options = [ NSMigratePersistentStoresAutomaticallyOption: true,
                         NSInferMappingModelAutomaticallyOption: true ]
@@ -55,6 +52,14 @@ public class DDGPersistenceContainer {
         }
 
         return persistenceStoreCoordinator
+    }
+    
+    public static func storeURL(for name: String) -> URL? {
+        let fileManager = FileManager.default
+        guard let docsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).last else { return nil }
+
+        let storeName = name + ".sqlite"
+        return docsDir.appendingPathComponent(storeName)
     }
 
     public func save() -> Bool {
@@ -68,5 +73,4 @@ public class DDGPersistenceContainer {
 
         return true
     }
-
 }

--- a/Core/Database.swift
+++ b/Core/Database.swift
@@ -1,0 +1,73 @@
+//
+//  Database.swift
+//  Core
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import CoreData
+
+public class Database {
+    
+    fileprivate struct Constants {
+        static let databaseGroupID = "group.com.duckduckgo.database"
+    }
+    
+    public static let shared = Database()
+
+    private let container: NSPersistentContainer
+    
+    init() {
+        let mainBundle = Bundle.main
+        let coreBundle = Bundle(identifier: "com.duckduckgo.mobile.ios.Core")!
+        
+        guard let managedObjectModel = NSManagedObjectModel.mergedModel(from: [mainBundle, coreBundle]) else { fatalError("No DB scheme found") }
+        
+        container = DDGPersistentContainer(name: "Database", managedObjectModel: managedObjectModel)
+        
+    }
+    
+    public func loadStore() {
+        let semaphore = DispatchSemaphore(value: 0)
+        container.loadPersistentStores { _, _ in semaphore.signal() }
+        semaphore.wait()
+    }
+    
+    public func makeContext(concurrencyType: NSManagedObjectContextConcurrencyType, name: String? = nil) -> NSManagedObjectContext {
+        
+        let context = NSManagedObjectContext(concurrencyType: concurrencyType)
+        context.persistentStoreCoordinator = container.persistentStoreCoordinator
+        context.name = name
+        return context
+    }
+}
+
+extension NSManagedObjectContext {
+    
+    public func deleteAll(entities: [NSManagedObject]?) {
+        guard let entities = entities else { return }
+        for entity in entities {
+            delete(entity)
+        }
+    }
+}
+
+private class DDGPersistentContainer: NSPersistentContainer {
+
+    override public class func defaultDirectoryURL() -> URL {
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Database.Constants.databaseGroupID)!
+    } 
+}

--- a/Core/HTTPSUpgradeStore.swift
+++ b/Core/HTTPSUpgradeStore.swift
@@ -114,7 +114,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
     
     private func deleteBloomFilterSpecification() {
         context.performAndWait {
-            context.deleteAll(entities: try? context.fetch(HTTPSStoredBloomFilterSpecification.fetchRequest()))
+            context.deleteAll(matching: HTTPSStoredBloomFilterSpecification.fetchRequest())
         }
     }
     
@@ -152,7 +152,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
     
     private func deleteWhitelist() {
         context.performAndWait {
-            context.deleteAll(entities: try? context.fetch(HTTPSWhitelistedDomain.fetchRequest()))
+            context.deleteAll(matching: HTTPSWhitelistedDomain.fetchRequest())
         }
     }
     

--- a/Core/HTTPSUpgradeStore.swift
+++ b/Core/HTTPSUpgradeStore.swift
@@ -108,7 +108,12 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
                 storedEntity.sha256 = specification.sha256
                 
             }
-            try? context.save()
+            
+            do {
+                try context.save()
+            } catch {
+                Pixel.fire(pixel: .dbSaveBloomFilterError, error: error)
+            }
         }
     }
     
@@ -144,6 +149,7 @@ public class HTTPSUpgradePersistence: HTTPSUpgradeStore {
             do {
                 try context.save()
             } catch {
+                Pixel.fire(pixel: .dbSaveWhitelistError, error: error)
                 result = false
             }
         }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -155,6 +155,13 @@ public enum PixelName: String {
     case etagStoreOOSWithDisconnectMeFix = "m_d_dcf_oos"
     case etagStoreOOSWithEasylistFix = "m_d_elf_oos"
     
+    case dbMigrationError = "m_d_dbme"
+    case dbRemovalError = "m_d_dbre"
+    case dbDestroyError = "m_d_dbde"
+    case dbInitializationError = "m_d_dbie"
+    case dbSaveWhitelistError = "m_d_dbsw"
+    case dbSaveBloomFilterError = "m_d_dbsb"
+    
     case configurationFetchInfo = "m_d_cfgfetch"
     case brokenSiteReported = "m_bsr"
 }
@@ -203,6 +210,17 @@ public class Pixel {
         }
     }
     
+}
+
+extension Pixel {
+    
+    public static func fire(pixel: PixelName, error: Error) {
+        let nsError = error as NSError
+        
+        let params: [String: String?] = ["e": "\(nsError.code)", "d": nsError.domain]
+        
+        fire(pixel: pixel, withAdditionalParameters: params)
+    }
 }
 
 public class TimedPixel {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -294,6 +294,8 @@
 		983054442302E4F40017BED0 /* OnboardingNotificationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983054432302E4F40017BED0 /* OnboardingNotificationsViewController.swift */; };
 		9833FD7222BCE44C00E95CD8 /* debug-messaging-disabled.js in Resources */ = {isa = PBXBuildFile; fileRef = 9833FD7122BCE44C00E95CD8 /* debug-messaging-disabled.js */; };
 		9838059F2228208E00385F1A /* PositiveFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9838059E2228208E00385F1A /* PositiveFeedbackViewController.swift */; };
+		983EABB8236198F6003948D1 /* DatabaseMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983EABB7236198F6003948D1 /* DatabaseMigration.swift */; };
+		983EABBB236199C2003948D1 /* DatabaseMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983EABB923619986003948D1 /* DatabaseMigrationTests.swift */; };
 		9849942922B8FAF70019E4FA /* SiteRatingViewPerfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9849942822B8FAF70019E4FA /* SiteRatingViewPerfTests.swift */; };
 		9849942B22B8FFED0019E4FA /* PerformanceTestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9849942A22B8FFED0019E4FA /* PerformanceTestsHelper.swift */; };
 		9849942D22B9083A0019E4FA /* WebViewConfigurationPerfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9849942C22B9083A0019E4FA /* WebViewConfigurationPerfTests.swift */; };
@@ -882,6 +884,8 @@
 		983054432302E4F40017BED0 /* OnboardingNotificationsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingNotificationsViewController.swift; sourceTree = "<group>"; };
 		9833FD7122BCE44C00E95CD8 /* debug-messaging-disabled.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "debug-messaging-disabled.js"; sourceTree = "<group>"; };
 		9838059E2228208E00385F1A /* PositiveFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositiveFeedbackViewController.swift; sourceTree = "<group>"; };
+		983EABB7236198F6003948D1 /* DatabaseMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigration.swift; sourceTree = "<group>"; };
+		983EABB923619986003948D1 /* DatabaseMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigrationTests.swift; sourceTree = "<group>"; };
 		9846AA6622BD3BBF007DE48E /* InitHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitHelpers.swift; sourceTree = "<group>"; };
 		9849942822B8FAF70019E4FA /* SiteRatingViewPerfTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteRatingViewPerfTests.swift; sourceTree = "<group>"; };
 		9849942A22B8FFED0019E4FA /* PerformanceTestsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestsHelper.swift; sourceTree = "<group>"; };
@@ -2284,6 +2288,7 @@
 			children = (
 				F1134EC21F40E24600B73467 /* AppVersionExtensionTests.swift */,
 				85BA58561F34F61C00C6E8CA /* AppUserDefaultsTests.swift */,
+				983EABB923619986003948D1 /* DatabaseMigrationTests.swift */,
 			);
 			name = Application;
 			sourceTree = "<group>";
@@ -2488,6 +2493,7 @@
 				83BE9BC2215D69C1009844D9 /* AppConfigurationFetch.swift */,
 				853C5F6021C277C7001F7A05 /* global.swift */,
 				850250B220D803F4002199C7 /* AtbAndVariantCleanup.swift */,
+				983EABB7236198F6003948D1 /* DatabaseMigration.swift */,
 			);
 			name = Application;
 			sourceTree = "<group>";
@@ -3466,6 +3472,7 @@
 				F103076B1E800DC30059FEC7 /* BookmarksManager.swift in Sources */,
 				851DFD87212C39D300D95F20 /* TabSwitcherButton.swift in Sources */,
 				8505836A219F424500ED4EDB /* UIAlertControllerExtension.swift in Sources */,
+				983EABB8236198F6003948D1 /* DatabaseMigration.swift in Sources */,
 				F1AE54E81F0425FC00D9A700 /* AuthenticationViewController.swift in Sources */,
 				F103073B1E7C91330059FEC7 /* BookmarksDataSource.swift in Sources */,
 				85200FA61FBCCD58001AF290 /* PrivacyProtectionNetworkLeaderboardController.swift in Sources */,
@@ -3542,6 +3549,7 @@
 				85081A031FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift in Sources */,
 				8341D807212D5E8D000514C2 /* HashExtensionTest.swift in Sources */,
 				85C271E41FD04ACD007216B4 /* HTTPSUpgradeParserTests.swift in Sources */,
+				983EABBB236199C2003948D1 /* DatabaseMigrationTests.swift in Sources */,
 				F143C2CC1E4A4B9100CFDE3A /* AppVersionTests.swift in Sources */,
 				85F1E9B31FB7C59C00A75AC1 /* DisplayableCertificateExtensionTests.swift in Sources */,
 				F189AED71F18F6DE001EBAE1 /* TabTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		987E7FB922D914B200AD30A1 /* PrivacyReportCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987E7FB822D914B200AD30A1 /* PrivacyReportCell.swift */; };
 		987E7FBB22DA8E1100AD30A1 /* PrivacyReportFooterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987E7FBA22DA8E1100AD30A1 /* PrivacyReportFooterCell.swift */; };
 		9881439C23326DC200573F7C /* ThemeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9881439B23326DC200573F7C /* ThemeSettingsViewController.swift */; };
+		9887DC252354D2AA005C85F5 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9887DC242354D2AA005C85F5 /* Database.swift */; };
 		9888F77B2224980500C46159 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9888F77A2224980500C46159 /* FeedbackViewController.swift */; };
 		988971A222C2DB95009DC1D6 /* StorageCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988971A122C2DB95009DC1D6 /* StorageCacheProvider.swift */; };
 		9896632422C56716007BE4FE /* EtagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9896632322C56716007BE4FE /* EtagStorage.swift */; };
@@ -903,6 +904,7 @@
 		987E7FB822D914B200AD30A1 /* PrivacyReportCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyReportCell.swift; sourceTree = "<group>"; };
 		987E7FBA22DA8E1100AD30A1 /* PrivacyReportFooterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyReportFooterCell.swift; sourceTree = "<group>"; };
 		9881439B23326DC200573F7C /* ThemeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsViewController.swift; sourceTree = "<group>"; };
+		9887DC242354D2AA005C85F5 /* Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database.swift; sourceTree = "<group>"; };
 		9888F77A2224980500C46159 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		988971A122C2DB95009DC1D6 /* StorageCacheProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCacheProvider.swift; sourceTree = "<group>"; };
 		9896632322C56716007BE4FE /* EtagStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtagStorage.swift; sourceTree = "<group>"; };
@@ -2165,6 +2167,7 @@
 				8328AAB6212A3DF200293140 /* BloomFilterWrapper.h */,
 				8328AAB7212A3DF200293140 /* BloomFilterWrapper.mm */,
 				8328AAAE212A3AE900293140 /* HashExtension.swift */,
+				9887DC242354D2AA005C85F5 /* Database.swift */,
 				85200FA01FBC5BB5001AF290 /* DDGPersistenceContainer.swift */,
 				F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */,
 				F1134ED91F40FC3F00B73467 /* InfoBundle.swift */,
@@ -3702,6 +3705,7 @@
 				859C5FBD214972E400E2A43D /* Grade.swift in Sources */,
 				F10E522D1E946F8800CE1253 /* NSAttributedStringExtension.swift in Sources */,
 				988971A222C2DB95009DC1D6 /* StorageCacheProvider.swift in Sources */,
+				9887DC252354D2AA005C85F5 /* Database.swift in Sources */,
 				F143C3171E4A99D200CFDE3A /* AppUrls.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -42,8 +42,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        Database.shared.loadStore()
-        
         testing = ProcessInfo().arguments.contains("testing")
         if testing {
             window?.rootViewController = UIStoryboard.init(name: "LaunchScreen", bundle: nil).instantiateInitialViewController()

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -41,12 +41,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        Database.shared.loadStore()
+        
         testing = ProcessInfo().arguments.contains("testing")
         if testing {
             window?.rootViewController = UIStoryboard.init(name: "LaunchScreen", bundle: nil).instantiateInitialViewController()
             return true
         }
-
+        
         EasyTipView.updateGlobalPreferences()
         HTTPSUpgrade.shared.loadDataAsync()
         

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -44,8 +44,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         testing = ProcessInfo().arguments.contains("testing")
         if testing {
+            Database.shared.loadStore { _ in }
             window?.rootViewController = UIStoryboard.init(name: "LaunchScreen", bundle: nil).instantiateInitialViewController()
             return true
+        }
+        
+        Database.shared.loadStore { context in
+            DatabaseMigration.migrate(to: context)
         }
         
         EasyTipView.updateGlobalPreferences()

--- a/DuckDuckGo/AppRatingPrompt.swift
+++ b/DuckDuckGo/AppRatingPrompt.swift
@@ -71,7 +71,7 @@ class AppRatingPromptCoreDataStorage: AppRatingPromptStorage {
         
         set {
             entity().lastAccess = newValue
-            _ = persistence.save()
+            try? context.save() 
         }
     }
     
@@ -82,7 +82,7 @@ class AppRatingPromptCoreDataStorage: AppRatingPromptStorage {
         
         set {
             entity().uniqueAccessDays = Int64(newValue)
-            _ = persistence.save()
+            try? context.save()
         }
     }
     
@@ -93,22 +93,22 @@ class AppRatingPromptCoreDataStorage: AppRatingPromptStorage {
         
         set {
             entity().lastShown = newValue
-            _ = persistence.save()
+            try? context.save()
         }
     }
     
-    let persistence: DDGPersistenceContainer = DDGPersistenceContainer(name: "AppRatingPrompt", concurrencyType: .mainQueueConcurrencyType)!
+    let context: NSManagedObjectContext = Database.shared.makeContext(concurrencyType: .mainQueueConcurrencyType, name: "AppRatingPrompt")
     
     public init() { }
     
     func entity() -> AppRatingPromptEntity {
         let fetchRequest: NSFetchRequest<AppRatingPromptEntity> = AppRatingPromptEntity.fetchRequest()
         
-        guard let results = try? persistence.managedObjectContext.fetch(fetchRequest) else {
+        guard let results = try? context.fetch(fetchRequest) else {
             fatalError("Error fetching AppRatingPromptEntity")
         }
         
-        return results.first ?? AppRatingPromptEntity(context: persistence.managedObjectContext)
+        return results.first ?? AppRatingPromptEntity(context: context)
     }
     
 }

--- a/DuckDuckGo/DatabaseMigration.swift
+++ b/DuckDuckGo/DatabaseMigration.swift
@@ -24,62 +24,45 @@ import Core
 class DatabaseMigration {
 
     static func migrate(to context: NSManagedObjectContext) {
-        
         let group = DispatchGroup()
-        
         group.enter()
-        migrate(db: "AppRatingPrompt",
-                to: context,
+        migrate(db: "AppRatingPrompt", to: context,
                 with: { (source: AppRatingPromptEntity, destination: AppRatingPromptEntity) in
             destination.lastAccess = source.lastAccess
             destination.lastShown = source.lastShown
             destination.uniqueAccessDays = source.uniqueAccessDays
-        }, completion: {
-            group.leave()
-        })
+        }, completion: { group.leave() })
         
         group.enter()
-        migrate(db: "NetworkLeaderboard",
-                to: context,
+        migrate(db: "NetworkLeaderboard", to: context,
                 with: { (source: PPTrackerNetwork, destination: PPTrackerNetwork) in
             destination.detectedOnCount = source.detectedOnCount
             destination.trackersCount = source.trackersCount
             destination.name = source.name
-        }, completion: {
-            group.leave()
-        })
+        }, completion: { group.leave() })
         
         group.enter()
-        migrate(db: "NetworkLeaderboard",
-                to: context,
+        migrate(db: "NetworkLeaderboard", to: context,
                 with: { (source: PPPageStats, destination: PPPageStats) in
             destination.httpsUpgrades = source.httpsUpgrades
             destination.pagesLoaded = source.pagesLoaded
             destination.pagesWithTrackers = source.pagesWithTrackers
             destination.startDate = source.startDate
-        }, completion: {
-            group.leave()
-        })
+        }, completion: { group.leave() })
         
         group.enter()
-        migrate(db: "HTTPSUpgrade",
-                to: context,
+        migrate(db: "HTTPSUpgrade", to: context,
                 with: { (source: HTTPSStoredBloomFilterSpecification, destination: HTTPSStoredBloomFilterSpecification) in
             destination.errorRate = source.errorRate
             destination.totalEntries = source.totalEntries
             destination.sha256 = source.sha256
-        }, completion: {
-            group.leave()
-        })
+        }, completion: { group.leave() })
         
         group.enter()
-        migrate(db: "HTTPSUpgrade",
-                to: context,
+        migrate(db: "HTTPSUpgrade", to: context,
                 with: { (source: HTTPSWhitelistedDomain, destination: HTTPSWhitelistedDomain) in
             destination.domain = source.domain
-        }, completion: {
-            group.leave()
-        })
+        }, completion: { group.leave() })
         
         group.wait()
     }

--- a/DuckDuckGo/DatabaseMigration.swift
+++ b/DuckDuckGo/DatabaseMigration.swift
@@ -128,6 +128,7 @@ class DatabaseMigration {
             do {
                 try stack.persistenceStoreCoordinator.remove(store)
             } catch {
+                Pixel.fire(pixel: .dbRemovalError, error: error)
                 Logger.log(text: "Error removing store: \(error.localizedDescription)")
             }
         }
@@ -153,6 +154,7 @@ class DatabaseMigration {
             do {
                 try destination.save()
             } catch {
+                Pixel.fire(pixel: .dbMigrationError, error: error)
                 completion(false)
                 return
             }
@@ -192,6 +194,7 @@ class DatabaseMigration {
             let shmURL = URL(fileURLWithPath: storeURL.path.appending("-shm"))
             try FileManager.default.removeItem(at: shmURL)
         } catch {
+            Pixel.fire(pixel: .dbDestroyError, error: error)
             Logger.log(text: "Error destroying store: \(error.localizedDescription)")
         }
     }

--- a/DuckDuckGo/DatabaseMigration.swift
+++ b/DuckDuckGo/DatabaseMigration.swift
@@ -161,9 +161,7 @@ class DatabaseMigration {
         }
 
         source.deleteAll(entities: existingEntities)
-        do {
-            try source.save()
-        } catch {}
+        try? source.save()
         
         completion(true)
     }

--- a/DuckDuckGo/DatabaseMigration.swift
+++ b/DuckDuckGo/DatabaseMigration.swift
@@ -1,0 +1,136 @@
+//
+//  DatabaseMigration.swift
+//  DuckDuckGo
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import CoreData
+import Core
+
+class DatabaseMigration {
+
+    static func migrate(to context: NSManagedObjectContext) {
+        
+        let group = DispatchGroup()
+        
+        group.enter()
+        migrate(db: "AppRatingPrompt", to: context, with: { (existing: AppRatingPromptEntity, new: AppRatingPromptEntity) in
+            existing.lastAccess = new.lastAccess
+            existing.lastShown = new.lastShown
+            existing.uniqueAccessDays = new.uniqueAccessDays
+        }, completion: {
+            group.leave()
+        })
+        
+        group.enter()
+        migrate(db: "NetworkLeaderboard", to: context, with: { (existing: PPTrackerNetwork, new: PPTrackerNetwork) in
+            existing.detectedOnCount = new.detectedOnCount
+            existing.trackersCount = new.trackersCount
+            existing.name = new.name
+        }, completion: {
+            group.leave()
+        })
+        
+        group.enter()
+        migrate(db: "NetworkLeaderboard", to: context, with: { (existing: PPPageStats, new: PPPageStats) in
+            existing.httpsUpgrades = new.httpsUpgrades
+            existing.pagesLoaded = new.pagesLoaded
+            existing.pagesWithTrackers = new.pagesWithTrackers
+            existing.startDate = new.startDate
+        }, completion: {
+            group.leave()
+        })
+        
+        group.enter()
+        migrate(db: "HTTPSUpgrade", to: context, with: { (existing: HTTPSStoredBloomFilterSpecification, new: HTTPSStoredBloomFilterSpecification) in
+            existing.errorRate = new.errorRate
+            existing.totalEntries = new.totalEntries
+            existing.sha256 = new.sha256
+        }, completion: {
+            group.leave()
+        })
+        
+        group.enter()
+        migrate(db: "HTTPSUpgrade", to: context, with: { (existing: HTTPSWhitelistedDomain, new: HTTPSWhitelistedDomain) in
+            existing.domain = new.domain
+        }, completion: {
+            group.leave()
+        })
+        
+        group.wait()
+    }
+    
+    static func migrate<T: NSManagedObject>(db name: String,
+                                            to destination: NSManagedObjectContext,
+                                            with logic: @escaping (T, T) -> Void,
+                                            completion: @escaping () -> Void) {
+        let oldStack = DDGPersistenceContainer(name: name,
+                                               model: destination.persistentStoreCoordinator!.managedObjectModel,
+                                               concurrencyType: .privateQueueConcurrencyType)
+        guard let stack = oldStack else {
+            completion()
+            return
+        }
+        
+        stack.managedObjectContext.performAndWait {
+            self.migrate(from: stack.managedObjectContext,
+                         to: destination,
+                         with: logic,
+                         completion: completion)
+        }
+    }
+    
+    static func migrate<T: NSManagedObject>(from source: NSManagedObjectContext,
+                                            to destination: NSManagedObjectContext,
+                                            with logic: (_ source: T, _ dest: T) -> Void,
+                                            completion: () -> Void) {
+        let fetchRequest = T.fetchRequest()
+        
+        guard let existingEntities = try? source.fetch(fetchRequest) as? [T] else {
+            completion()
+            return
+        }
+        
+        if let count = try? destination.count(for: fetchRequest), count == 0 {
+            for existingEntity in existingEntities {
+                let newEntity = T(context: destination)
+                logic(existingEntity, newEntity)
+            }
+            
+            do {
+                try destination.save()
+            } catch {
+                completion()
+                return
+            }
+        }
+
+        source.deleteAll(entities: existingEntities)
+        do {
+            try source.save()
+        } catch {}
+        
+        completion()
+    }
+}
+
+private class MigrationPersistentContainer: NSPersistentContainer {
+
+    override public class func defaultDirectoryURL() -> URL {
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last!
+    }
+}

--- a/DuckDuckGo/DatabaseMigration.swift
+++ b/DuckDuckGo/DatabaseMigration.swift
@@ -28,45 +28,55 @@ class DatabaseMigration {
         let group = DispatchGroup()
         
         group.enter()
-        migrate(db: "AppRatingPrompt", to: context, with: { (existing: AppRatingPromptEntity, new: AppRatingPromptEntity) in
-            existing.lastAccess = new.lastAccess
-            existing.lastShown = new.lastShown
-            existing.uniqueAccessDays = new.uniqueAccessDays
+        migrate(db: "AppRatingPrompt",
+                to: context,
+                with: { (source: AppRatingPromptEntity, destination: AppRatingPromptEntity) in
+            destination.lastAccess = source.lastAccess
+            destination.lastShown = source.lastShown
+            destination.uniqueAccessDays = source.uniqueAccessDays
         }, completion: {
             group.leave()
         })
         
         group.enter()
-        migrate(db: "NetworkLeaderboard", to: context, with: { (existing: PPTrackerNetwork, new: PPTrackerNetwork) in
-            existing.detectedOnCount = new.detectedOnCount
-            existing.trackersCount = new.trackersCount
-            existing.name = new.name
+        migrate(db: "NetworkLeaderboard",
+                to: context,
+                with: { (source: PPTrackerNetwork, destination: PPTrackerNetwork) in
+            destination.detectedOnCount = source.detectedOnCount
+            destination.trackersCount = source.trackersCount
+            destination.name = source.name
         }, completion: {
             group.leave()
         })
         
         group.enter()
-        migrate(db: "NetworkLeaderboard", to: context, with: { (existing: PPPageStats, new: PPPageStats) in
-            existing.httpsUpgrades = new.httpsUpgrades
-            existing.pagesLoaded = new.pagesLoaded
-            existing.pagesWithTrackers = new.pagesWithTrackers
-            existing.startDate = new.startDate
+        migrate(db: "NetworkLeaderboard",
+                to: context,
+                with: { (source: PPPageStats, destination: PPPageStats) in
+            destination.httpsUpgrades = source.httpsUpgrades
+            destination.pagesLoaded = source.pagesLoaded
+            destination.pagesWithTrackers = source.pagesWithTrackers
+            destination.startDate = source.startDate
         }, completion: {
             group.leave()
         })
         
         group.enter()
-        migrate(db: "HTTPSUpgrade", to: context, with: { (existing: HTTPSStoredBloomFilterSpecification, new: HTTPSStoredBloomFilterSpecification) in
-            existing.errorRate = new.errorRate
-            existing.totalEntries = new.totalEntries
-            existing.sha256 = new.sha256
+        migrate(db: "HTTPSUpgrade",
+                to: context,
+                with: { (source: HTTPSStoredBloomFilterSpecification, destination: HTTPSStoredBloomFilterSpecification) in
+            destination.errorRate = source.errorRate
+            destination.totalEntries = source.totalEntries
+            destination.sha256 = source.sha256
         }, completion: {
             group.leave()
         })
         
         group.enter()
-        migrate(db: "HTTPSUpgrade", to: context, with: { (existing: HTTPSWhitelistedDomain, new: HTTPSWhitelistedDomain) in
-            existing.domain = new.domain
+        migrate(db: "HTTPSUpgrade",
+                to: context,
+                with: { (source: HTTPSWhitelistedDomain, destination: HTTPSWhitelistedDomain) in
+            destination.domain = source.domain
         }, completion: {
             group.leave()
         })
@@ -76,7 +86,7 @@ class DatabaseMigration {
     
     static func migrate<T: NSManagedObject>(db name: String,
                                             to destination: NSManagedObjectContext,
-                                            with logic: @escaping (T, T) -> Void,
+                                            with logic: @escaping (_ source: T, _ dest: T) -> Void,
                                             completion: @escaping () -> Void) {
         let oldStack = DDGPersistenceContainer(name: name,
                                                model: destination.persistentStoreCoordinator!.managedObjectModel,

--- a/DuckDuckGo/DuckDuckGo.entitlements
+++ b/DuckDuckGo/DuckDuckGo.entitlements
@@ -7,6 +7,7 @@
 		<string>group.com.duckduckgo.bookmarks</string>
 		<string>group.com.duckduckgo.contentblocker</string>
 		<string>group.com.duckduckgo.statistics</string>
+		<string>group.com.duckduckgo.database</string>
 	</array>
 </dict>
 </plist>

--- a/DuckDuckGo/NetworkLeaderboard.swift
+++ b/DuckDuckGo/NetworkLeaderboard.swift
@@ -32,7 +32,7 @@ class NetworkLeaderboard {
 
     }
 
-    private lazy var container = DDGPersistenceContainer(name: "NetworkLeaderboard", concurrencyType: .mainQueueConcurrencyType)!
+    private lazy var context = Database.shared.makeContext(concurrencyType: .mainQueueConcurrencyType, name: "NetworkLeaderboard")
 
     var startDate: Date? {
         return pageStats?.startDate
@@ -40,7 +40,7 @@ class NetworkLeaderboard {
     
     private var pageStats: PPPageStats? {
         let request: NSFetchRequest<PPPageStats> = PPPageStats.fetchRequest()
-        return try? container.managedObjectContext.fetch(request).first
+        return try? context.fetch(request).first
     }
     
     init() {
@@ -50,39 +50,39 @@ class NetworkLeaderboard {
     }
     
     func reset() {
-        container.deleteAll(entities: try? container.managedObjectContext.fetch(PPTrackerNetwork.fetchRequest()))
-        container.deleteAll(entities: try? container.managedObjectContext.fetch(PPPageStats.fetchRequest()))
+        context.deleteAll(entities: try? context.fetch(PPTrackerNetwork.fetchRequest()))
+        context.deleteAll(entities: try? context.fetch(PPPageStats.fetchRequest()))
         createNewPageStatsEntity()
-        _ = container.save()
+        try? context.save()
     }
 
     func incrementPagesLoaded() {
         if let pageStats = pageStats {
             pageStats.pagesLoaded += 1
-            _ = container.save()
+            try? context.save()
         }
     }
     
     func incrementPagesWithTrackers() {
         if let pageStats = pageStats {
             pageStats.pagesWithTrackers += 1
-            _ = container.save()
+            try? context.save()
         }
     }
     
     func incrementHttpsUpgrades() {
         if let pageStats = pageStats {
             pageStats.httpsUpgrades += 1
-            _ = container.save()
+            try? context.save()
         }
     }
     
     private func createNewPageStatsEntity() {
-        let managedObject = NSEntityDescription.insertNewObject(forEntityName: EntityNames.pageStats, into: container.managedObjectContext)
+        let managedObject = NSEntityDescription.insertNewObject(forEntityName: EntityNames.pageStats, into: context)
         guard let stats = managedObject as? PPPageStats else { return }
         stats.startDate = Date()
         stats.pagesLoaded = 0
-        _ = container.save()
+        try? context.save()
     }
     
     func pagesVisited() -> Int {
@@ -100,7 +100,7 @@ class NetworkLeaderboard {
     func networksDetected() -> [PPTrackerNetwork] {
         let request: NSFetchRequest<PPTrackerNetwork> = PPTrackerNetwork.fetchRequest()
         request.sortDescriptors = [ NSSortDescriptor(key: "detectedOnCount", ascending: false) ]
-        guard let results = try? container.managedObjectContext.fetch(request) else { return [] }
+        guard let results = try? context.fetch(request) else { return [] }
         return results
     }
 
@@ -115,7 +115,7 @@ class NetworkLeaderboard {
             return
         }
         network.detectedOnCount += 1
-        _ = container.save()
+        try? context.save()
     }
     
     func incrementTrackersCount(forNetworkNamed networkName: String) {
@@ -124,21 +124,21 @@ class NetworkLeaderboard {
             return
         }
         network.trackersCount += 1
-        _ = container.save()
+        try? context.save()
     }
     
     private func createNewNetworkEntity(named networkName: String) {
-        let managedObject = NSEntityDescription.insertNewObject(forEntityName: EntityNames.trackerNetwork, into: container.managedObjectContext)
+        let managedObject = NSEntityDescription.insertNewObject(forEntityName: EntityNames.trackerNetwork, into: context)
         guard let trackerNetwork = managedObject as? PPTrackerNetwork else { return }
         trackerNetwork.name = networkName
         trackerNetwork.detectedOnCount = 1
-        _ = container.save()
+        try? context.save()
     }
 
     private func findNetwork(byName network: String) -> PPTrackerNetwork? {
         let request: NSFetchRequest<PPTrackerNetwork> = PPTrackerNetwork.fetchRequest()
         request.predicate = NSPredicate(format: "name LIKE %@", network)
-        guard let results = try? container.managedObjectContext.fetch(request) else { return nil }
+        guard let results = try? context.fetch(request) else { return nil }
         return results.first
     }
 

--- a/DuckDuckGo/NetworkLeaderboard.swift
+++ b/DuckDuckGo/NetworkLeaderboard.swift
@@ -50,8 +50,8 @@ class NetworkLeaderboard {
     }
     
     func reset() {
-        context.deleteAll(entities: try? context.fetch(PPTrackerNetwork.fetchRequest()))
-        context.deleteAll(entities: try? context.fetch(PPPageStats.fetchRequest()))
+        context.deleteAll(matching: PPTrackerNetwork.fetchRequest())
+        context.deleteAll(matching: PPPageStats.fetchRequest())
         createNewPageStatsEntity()
         try? context.save()
     }

--- a/DuckDuckGoTests/AppRatingPromptStorageTests.swift
+++ b/DuckDuckGoTests/AppRatingPromptStorageTests.swift
@@ -52,8 +52,8 @@ class AppRatingPromptStorageTests: XCTestCase {
 
     private func reset() {
         let storage = AppRatingPromptCoreDataStorage()
-        storage.persistence.managedObjectContext.delete(storage.entity())
-        try? storage.persistence.managedObjectContext.save()
+        storage.context.delete(storage.entity())
+        try? storage.context.save()
     }
     
 }

--- a/DuckDuckGoTests/DatabaseMigrationTests.swift
+++ b/DuckDuckGoTests/DatabaseMigrationTests.swift
@@ -78,7 +78,7 @@ class DatabaseMigrationTests: XCTestCase {
                                   with: { (source: PPTrackerNetwork, dest: PPTrackerNetwork) in
                                     dest.name = source.name
         },
-                                  completion: { migrated.fulfill() })
+                                  completion: { _ in migrated.fulfill() })
         
         result = (try? destination.fetch(PPTrackerNetwork.fetchRequest())) ?? []
         XCTAssert(result.count == 2)
@@ -113,7 +113,7 @@ class DatabaseMigrationTests: XCTestCase {
                                   with: { (source: PPTrackerNetwork, dest: PPTrackerNetwork) in
                                     dest.name = source.name
         },
-                                  completion: { migrated.fulfill() })
+                                  completion: { _ in migrated.fulfill() })
         
         result = (try? destination.fetch(PPTrackerNetwork.fetchRequest())) ?? []
         XCTAssert(result.count == 2)

--- a/DuckDuckGoTests/DatabaseMigrationTests.swift
+++ b/DuckDuckGoTests/DatabaseMigrationTests.swift
@@ -1,0 +1,129 @@
+//
+//  DatabaseMigrationTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import CoreData
+@testable import Core
+@testable import DuckDuckGo
+
+class DatabaseMigrationTests: XCTestCase {
+    
+    let sourceDB = Database(name: "Source", model: Database.shared.model)
+
+    override func setUp() {
+        sourceDB.loadStore()
+        
+        cleanup(database: Database.shared)
+        cleanup(database: sourceDB)
+    }
+    
+    override func tearDown() {
+        cleanup(database: Database.shared)
+        cleanup(database: sourceDB)
+    }
+    
+    private func cleanup(database: Database) {
+        let context = database.makeContext(concurrencyType: .mainQueueConcurrencyType)
+        context.deleteAll(entityDescriptions: [PPTrackerNetwork.entity(),
+                                               PPPageStats.entity()])
+        try? context.save()
+    }
+    
+    private func populate(context: NSManagedObjectContext) {
+        let tn1 = PPTrackerNetwork(context: context)
+        tn1.name = "1"
+        let tn2 = PPTrackerNetwork(context: context)
+        tn2.name = "2"
+        
+        _ = PPPageStats(context: context)
+        
+        do {
+            try context.save()
+        } catch {
+            XCTFail("Could not save context: \(error.localizedDescription)")
+        }
+    }
+    
+    func testWhenDestinationIsEmptyThenMigrateAndClean() {
+        let destination = Database.shared.makeContext(concurrencyType: .mainQueueConcurrencyType)
+        let source = sourceDB.makeContext(concurrencyType: .mainQueueConcurrencyType)
+        
+        populate(context: source)
+        
+        var result = (try? destination.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.isEmpty)
+        
+        result = (try? source.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.count == 2)
+        
+        let migrated = expectation(description: "Migration finished")
+        DatabaseMigration.migrate(from: source,
+                                  to: destination,
+                                  with: { (source: PPTrackerNetwork, dest: PPTrackerNetwork) in
+                                    dest.name = source.name
+        },
+                                  completion: { migrated.fulfill() })
+        
+        result = (try? destination.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.count == 2)
+        XCTAssert(destination.hasChanges == false)
+        
+        result = (try? source.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.isEmpty)
+        XCTAssert(source.hasChanges == false)
+        
+        wait(for: [migrated], timeout: 1)
+    }
+    
+    func testWhenDestinationIsNotEmptyThenSkipAndClean() {
+        let destination = Database.shared.makeContext(concurrencyType: .mainQueueConcurrencyType)
+        let source = sourceDB.makeContext(concurrencyType: .mainQueueConcurrencyType)
+        
+        populate(context: source)
+        populate(context: destination)
+        
+        var result: [PPTrackerNetwork] = (try? destination.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.count == 2)
+        
+        // Update name here, this change should be unsaved after migration
+        result.last?.name = "Updated"
+        
+        result = (try? source.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.count == 2)
+        
+        let migrated = expectation(description: "Migration finished")
+        DatabaseMigration.migrate(from: source,
+                                  to: destination,
+                                  with: { (source: PPTrackerNetwork, dest: PPTrackerNetwork) in
+                                    dest.name = source.name
+        },
+                                  completion: { migrated.fulfill() })
+        
+        result = (try? destination.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.count == 2)
+        XCTAssert(destination.hasChanges)
+        let modified = destination.updatedObjects.first(where: { ($0 as? PPTrackerNetwork)?.name == "Updated"})
+        XCTAssertNotNil(modified)
+        
+        result = (try? source.fetch(PPTrackerNetwork.fetchRequest())) ?? []
+        XCTAssert(result.isEmpty)
+        
+        wait(for: [migrated], timeout: 1)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1143203875833530
Tech Design URL:
CC:

**Description**:
Make Core Data stack a shared instance, migrate to NSPersistentContainer

**Steps to test this PR**:

"Multiple NSEntityDescriptions claim the NSManagedObject subclass" error should no longer be printed in console.

Migration (iOS 10 - iOS 13): 
- Ensure everything is being migrated properly.
- After migration old DBs should be removed.
- Re-launching should not do any work related to migration if old DBs are cleared.
- Failed migration (interrupted) should resume.

Pixels:
- Replace app container with malformed DB - pixel should be fired. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
