### PR TITLE
add pixel for forget all pressed

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -24,7 +24,8 @@ public enum PixelName: String {
     
     case appLaunch = "ml"
 
-    case forgetAllPressed = "mf_p"
+    case forgetAllPressedBrowsing = "mf_bp"
+    case forgetAllPressedTabSwitching = "mf_tp"
     case forgetAllExecuted = "mf"
     
     case privacyDashboardOpened = "mp"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -23,6 +23,8 @@ import Alamofire
 public enum PixelName: String {
     
     case appLaunch = "ml"
+
+    case forgetAllPressed = "mf_p"
     case forgetAllExecuted = "mf"
     
     case privacyDashboardOpened = "mp"

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -296,6 +296,7 @@ class MainViewController: UIViewController {
     }
 
     @IBAction func onFirePressed() {
+        Pixel.fire(pixel: .forgetAllPressed)
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.overrideUserInterfaceStyle()
         alert.addAction(forgetAllAction())

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -296,7 +296,7 @@ class MainViewController: UIViewController {
     }
 
     @IBAction func onFirePressed() {
-        Pixel.fire(pixel: .forgetAllPressed)
+        Pixel.fire(pixel: .forgetAllPressedBrowsing)
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.overrideUserInterfaceStyle()
         alert.addAction(forgetAllAction())

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -166,6 +166,7 @@ class TabSwitcherViewController: UIViewController {
     }
 
     @IBAction func onFirePressed() {
+        Pixel.fire(pixel: .forgetAllPressedTabSwitching)
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.overrideUserInterfaceStyle()
         alert.addAction(UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] _ in


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1146815623648367
Tech Design URL:
CC:

**Description**:

Add a pixel for fire button presses so they can be compared with launches.

**Steps to test this PR**:
1. From the browser/home screen tap the fire button, `mf.bp` pixel should fire.
1. From the browser/home screen tap the fire button, `mf.tp` pixel should fire.
1. Check Grafana 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
