### PR TITLE
improve bad url and custom url scheme handling

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -106,9 +106,9 @@ public struct AppUrls {
         return URL(string: Url.feedback)!
     }
     
-    public func faviconUrl(forDomain domain: String) -> URL {
+    public func faviconUrl(forDomain domain: String) -> URL? {
         let urlString = String(format: Url.faviconService, domain)
-        return URL(string: urlString)!
+        return URL(string: urlString)
     }
 
     public var initialAtb: URL {

--- a/DuckDuckGo/BookmarksManager.swift
+++ b/DuckDuckGo/BookmarksManager.swift
@@ -171,7 +171,7 @@ fileprivate extension Link {
 
     func removeCachedFavicon() {
         guard let domain = url.host else { return }
-        let url = AppUrls().faviconUrl(forDomain: domain)
+        guard let url = AppUrls().faviconUrl(forDomain: domain) else { return }
         ImageCache(name: BookmarksManager.imageCacheName).removeImage(forKey: url.absoluteString)
     }
 

--- a/DuckDuckGo/FavoriteHomeCell.swift
+++ b/DuckDuckGo/FavoriteHomeCell.swift
@@ -106,8 +106,7 @@ class FavoriteHomeCell: UICollectionViewCell {
         
         iconBackground.backgroundColor = host.color
         
-        if let domain = link.url.host {
-            let resource = AppUrls().faviconUrl(forDomain: domain)
+        if let domain = link.url.host, let resource = AppUrls().faviconUrl(forDomain: domain) {
             iconImage.kf.setImage(with: resource,
                                   placeholder: nil,
                                   options: [

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -28,10 +28,7 @@ class TabViewController: UIViewController {
 // swiftlint:enable type_body_length
 
     private struct Constants {
-        static let unsupportedUrlErrorCode = -1002
-        static let urlCouldNotBeLoaded = 101
         static let frameLoadInterruptedErrorCode = 102
-        static let minimumProgress: CGFloat = 0.1
     }
 
     private struct UserAgent {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -929,12 +929,11 @@ extension TabViewController: WKNavigationDelegate {
     private func showErrorNow() {
         guard let error = lastError else { return }
         hideProgressIndicator()
-        
-        let code = (error as NSError).code
-        if  ![Constants.unsupportedUrlErrorCode, Constants.urlCouldNotBeLoaded].contains(code) {
+
+        if !((error as NSError).failedUrl?.isCustomURLScheme() ?? false) {
             showError(message: error.localizedDescription)
         }
-        
+
         webpageDidFailToLoad()
         checkForReloadOnError()
     }
@@ -1046,6 +1045,14 @@ extension TabViewController: Themable {
         }
     }
     
+}
+
+extension NSError {
+
+    var failedUrl: URL? {
+        return userInfo[NSURLErrorFailingURLErrorKey] as? URL
+    }
+
 }
 
 // swiftlint:enable file_length

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -53,11 +53,17 @@ class AppUrlsTests: XCTestCase {
         XCTAssertEqual("/t/ml_ios_formfactor", pixelUrl.path)
         XCTAssertEqual("x", pixelUrl.getParam(name: "atb"))
     }
-    
+
+    func testWhenDomainIsBadThenFaviconURLIsNil() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let faviconURL = testee.faviconUrl(forDomain: "Contains spaces because the website is broken")
+        XCTAssertNil(faviconURL)
+    }
+
     func testWhenFaviconUrlForDomainRequestedThenCorrectDomainIsCreated() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let faviconURL = testee.faviconUrl(forDomain: "example.com")
-        XCTAssertEqual("https://duckduckgo.com/ip3/example.com.ico", faviconURL.absoluteString)
+        XCTAssertEqual("https://duckduckgo.com/ip3/example.com.ico", faviconURL?.absoluteString)
     }
 
     func testBaseUrlDoesNotHaveSubDomain() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1147379879393388
Tech Design URL:
CC:

**Description**:

The favicon service would crash when we were passed a "bad" url from the WebView, so make that optional.

Additionally, our handling of custom URL schemes so we wouldn't show an error correctly when encountering bad URLs that had http/https prefixes.

**Steps to test this PR**:
1. Go to https://everydaycarry.com/posts/36124/roswell-carbon-fiber-wallet  then clean on "Read More"
* a new tab will open and show an error that we couldn't load the url 
* open the tab switcher, it should show the tab as an error

2. Go to https://falkirkrpg.org.uk/noxwall/custom.html and click on "Open in Chrome" - 
* the app shows the "open in another app" prompt

3. Go to https://falkirkrpg.org.uk/noxwall/custom.html and click on the "Spotify" link (which targets a blank tab)
* no new tab opens
* the app shows the "open in another app" prompt

4. Confirm open in new tab still works - go to https://falkirkrpg.org.uk/noxwall/frame.html and click on the link 
* should open in a new tab


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
