### PR TITLE
Fix toggle responding to old global setting when off

### DIFF
--- a/Core/ContentBlockerConfigurationStore.swift
+++ b/Core/ContentBlockerConfigurationStore.swift
@@ -27,8 +27,6 @@ public protocol ContentBlockerConfigurationStore: class {
 
     var domainWhitelist: Set<String> { get }
 
-    var enabled: Bool { get set }
-
     func whitelisted(domain: String) -> Bool
 
     func addToWhitelist(domain: String)
@@ -36,5 +34,4 @@ public protocol ContentBlockerConfigurationStore: class {
     func removeFromWhitelist(domain: String)
 
     func protecting(domain: String?) -> Bool
-
 }

--- a/Core/ContentBlockerConfigurationUserDefaults.swift
+++ b/Core/ContentBlockerConfigurationUserDefaults.swift
@@ -23,7 +23,6 @@ import SafariServices
 public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfigurationStore {
 
     private struct Keys {
-        static let enabled = "com.duckduckgo.contentblocker.enabled"
         static let whitelistedDomains = "com.duckduckgo.contentblocker.whitelist"
         static let trackerList = "com.duckduckgo.trackerList"
     }
@@ -36,17 +35,6 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
 
     private var userDefaults: UserDefaults? {
         return UserDefaults(suiteName: suiteName)
-    }
-
-    public var enabled: Bool {
-        get {
-            guard let userDefaults = userDefaults else { return true }
-            return userDefaults.bool(forKey: Keys.enabled, defaultValue: true)
-        }
-        set(newValue) {
-            userDefaults?.set(newValue, forKey: Keys.enabled)
-            onStoreChanged()
-        }
     }
 
     public private(set) var domainWhitelist: Set<String> {
@@ -79,8 +67,8 @@ public class ContentBlockerConfigurationUserDefaults: ContentBlockerConfiguratio
     }
 
     public func protecting(domain: String?) -> Bool {
-        guard let domain = domain else { return enabled }
-        return enabled && !whitelisted(domain: domain)
+        guard let domain = domain else { return true }
+        return !whitelisted(domain: domain)
     }
 
     private func onStoreChanged() {

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -157,12 +157,11 @@ private class Loader {
     private func loadBlockerData() {
 
         let surrogates = loadSurrogateJson(storageCache.surrogateStore)
-        let blockingEnabled = storageCache.configuration.enabled
         let whitelist = storageCache.configuration.domainWhitelist.toJsonLookupString()
         let disconnectMeStore = storageCache.disconnectMeStore
 
         javascriptLoader.load(script: .blockerData, withReplacements: [
-            "${blocking_enabled}": "\(blockingEnabled)",
+            "${blocking_enabled}": "true",
             "${disconnectmeBanned}": disconnectMeStore.bannedTrackersJson,
             "${disconnectmeAllowed}": disconnectMeStore.allowedTrackersJson,
             "${whitelist}": whitelist,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -3891,7 +3891,7 @@
 				INFOPLIST_FILE = BookmarksTodayExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).BookmarksTodayExtension";
@@ -3921,7 +3921,7 @@
 				INFOPLIST_FILE = BookmarksTodayExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).BookmarksTodayExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3974,7 +3974,7 @@
 				INFOPLIST_FILE = QuickActionsTodayExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).QuickActionsTodayExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3998,7 +3998,7 @@
 				INFOPLIST_FILE = QuickActionsTodayExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).QuickActionsTodayExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -4021,7 +4021,7 @@
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -4044,7 +4044,7 @@
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -4214,7 +4214,7 @@
 				INFOPLIST_FILE = DuckDuckGo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4237,7 +4237,7 @@
 				INFOPLIST_FILE = DuckDuckGo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 7.31.0;
+				MARKETING_VERSION = 7.31.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/DuckDuckGo/PrivacyProtectionFooter.storyboard
+++ b/DuckDuckGo/PrivacyProtectionFooter.storyboard
@@ -117,7 +117,7 @@
                                         <rect key="frame" x="0.0" y="32" width="320" height="88"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="rO0-0v-ngG">
-                                                <rect key="frame" x="38" y="50" width="244" height="28"/>
+                                                <rect key="frame" x="38" y="52" width="244" height="28"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sk1-FS-KoR" customClass="TrackerNetworkPillView" customModule="DuckDuckGo" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="76" height="28"/>
@@ -233,13 +233,13 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TRACKER NETWORK TOP OFFENDERS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4AA-Ma-AG6">
-                                                <rect key="frame" x="0.0" y="20" width="320" height="12"/>
+                                                <rect key="frame" x="0.0" y="20" width="320" height="14"/>
                                                 <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="12"/>
                                                 <color key="textColor" red="0.46666666670000001" green="0.46666666670000001" blue="0.46666666670000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Arrow Forward" translatesAutoresizingMaskIntoConstraints="NO" id="5NM-vg-MQe">
-                                                <rect key="frame" x="290" y="36" width="10" height="16"/>
+                                                <rect key="frame" x="280" y="28" width="20" height="32"/>
                                             </imageView>
                                         </subviews>
                                         <constraints>
@@ -258,19 +258,19 @@
                                         <rect key="frame" x="0.0" y="16" width="320" height="120"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Network Leaderboard No Stats" translatesAutoresizingMaskIntoConstraints="NO" id="gPE-Br-bJP">
-                                                <rect key="frame" x="110.99999999999999" y="8" width="98.000000000000043" height="48"/>
+                                                <rect key="frame" x="62" y="8" width="196" height="48"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="48" id="LPU-2C-SJH"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TRACKER NETWORK TOP OFFENDERS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zHx-Qp-lvj">
-                                                <rect key="frame" x="0.0" y="72" width="320" height="12"/>
+                                                <rect key="frame" x="0.0" y="72" width="320" height="14"/>
                                                 <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="12"/>
                                                 <color key="textColor" red="0.46666666670000001" green="0.46666666670000001" blue="0.46666666670000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqv-VR-7we">
-                                                <rect key="frame" x="0.0" y="92" width="320" height="36"/>
+                                                <rect key="frame" x="0.0" y="94" width="320" height="42"/>
                                                 <attributedString key="attributedText">
                                                     <fragment>
                                                         <string key="content">We're still collecting data to show how

--- a/DuckDuckGo/PrivacyProtectionHeader.storyboard
+++ b/DuckDuckGo/PrivacyProtectionHeader.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sXL-hA-WaJ">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sXL-hA-WaJ">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -68,31 +66,12 @@
                         <outlet property="gradeImage" destination="dBn-cZ-MJt" id="Z7T-Zf-d3Z"/>
                         <outlet property="privacyGradeLabel" destination="Crm-QC-kK1" id="5yT-x9-zPM"/>
                         <outlet property="protectionDisabledLabel" destination="5P7-G9-cPW" id="Bvt-gA-lB6"/>
-                        <outlet property="protectionPausedLabel" destination="FIb-U7-6ri" id="OSX-AR-JMb"/>
                         <outlet property="protectionUpgraded" destination="7Tq-7h-2gl" id="Iw5-On-CMy"/>
                         <outlet property="siteTitleLabel" destination="QfX-2n-ECb" id="AfE-dA-5MY"/>
                         <outlet property="stackView" destination="tQB-uB-beX" id="Z2Y-MY-GIg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Zc9-vm-Nx4" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <view contentMode="scaleToFill" id="FIb-U7-6ri">
-                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PRIVACY PROTECTION PAUSED" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="176.5" translatesAutoresizingMaskIntoConstraints="NO" id="6rE-Jv-hAU" userLabel="PRIVACY PROTECTION PAUSED">
-                            <rect key="frame" x="32" y="64" width="176.5" height="12"/>
-                            <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="12"/>
-                            <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="6rE-Jv-hAU" firstAttribute="centerX" secondItem="pm5-tB-ODh" secondAttribute="centerX" id="6c6-cY-Zr4"/>
-                        <constraint firstItem="6rE-Jv-hAU" firstAttribute="centerY" secondItem="pm5-tB-ODh" secondAttribute="centerY" constant="6" id="7g2-wz-miv"/>
-                    </constraints>
-                    <viewLayoutGuide key="safeArea" id="pm5-tB-ODh"/>
-                </view>
                 <view contentMode="scaleToFill" id="Crm-QC-kK1">
                     <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -115,8 +94,8 @@
                     <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PRIVACY PROTECTION DISABLED" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="187.5" translatesAutoresizingMaskIntoConstraints="NO" id="oMQ-8E-39A">
-                            <rect key="frame" x="26.5" y="64" width="187.5" height="12"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SITE PROTECTION DISABLED" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="187.5" translatesAutoresizingMaskIntoConstraints="NO" id="oMQ-8E-39A">
+                            <rect key="frame" x="39" y="64" width="162.5" height="12"/>
                             <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="12"/>
                             <color key="textColor" red="0.57647058819999997" green="0.57647058819999997" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>

--- a/DuckDuckGo/PrivacyProtectionHeaderController.swift
+++ b/DuckDuckGo/PrivacyProtectionHeaderController.swift
@@ -46,7 +46,6 @@ class PrivacyProtectionHeaderController: UIViewController {
     @IBOutlet weak var gradeImage: UIImageView!
     @IBOutlet weak var siteTitleLabel: UILabel!
     @IBOutlet weak var privacyGradeLabel: UIView!
-    @IBOutlet weak var protectionPausedLabel: UIView!
     @IBOutlet weak var protectionDisabledLabel: UIView!
     @IBOutlet weak var protectionUpgraded: ProtectionUpgradedView!
 
@@ -68,19 +67,15 @@ class PrivacyProtectionHeaderController: UIViewController {
         siteTitleLabel.text = siteRating.domain
 
         privacyGradeLabel.removeFromSuperview()
-        protectionPausedLabel.removeFromSuperview()
         protectionDisabledLabel.removeFromSuperview()
         protectionUpgraded.removeFromSuperview()
         
         stackView.removeArrangedSubview(privacyGradeLabel)
-        stackView.removeArrangedSubview(protectionPausedLabel)
         stackView.removeArrangedSubview(protectionDisabledLabel)
         stackView.removeArrangedSubview(protectionUpgraded)
 
-        if !contentBlockerConfiguration.enabled {
+        if contentBlockerConfiguration.domainWhitelist.contains(siteRating.domain ?? "") {
             stackView.addArrangedSubview(protectionDisabledLabel)
-        } else if contentBlockerConfiguration.domainWhitelist.contains(siteRating.domain ?? "") {
-            stackView.addArrangedSubview(protectionPausedLabel)
         } else if siteRating.scores.enhanced != siteRating.scores.site {
             protectionUpgraded.update(with: siteRating)
             stackView.addArrangedSubview(protectionUpgraded)

--- a/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
+++ b/DuckDuckGo/SiteRatingPrivacyProtectionExtension.swift
@@ -92,8 +92,8 @@ extension SiteRating {
     }
     
     func protecting(_ contentBlocker: ContentBlockerConfigurationStore) -> Bool {
-        guard let domain = domain else { return contentBlocker.enabled }
-        return contentBlocker.enabled && !contentBlocker.domainWhitelist.contains(domain)
+        guard let domain = domain else { return true }
+        return !contentBlocker.domainWhitelist.contains(domain)
     }
     
     static let gradeImages: [Grade.Grading: UIImage] = [

--- a/DuckDuckGoTests/ContentBlockerUserDefaultsTests.swift
+++ b/DuckDuckGoTests/ContentBlockerUserDefaultsTests.swift
@@ -35,23 +35,6 @@ class ContentBlockerUserDefaultsTests: XCTestCase {
         testee = ContentBlockerConfigurationUserDefaults(suiteName: Constants.userDefaultsSuit)
     }
 
-    func testWhenInitialisedThenEnableIsTrue() {
-        XCTAssertTrue(testee.enabled)
-    }
-
-    func testWhenBlockingDisabledThenDisabledIsTrue() {
-        testee.enabled = false
-        XCTAssertFalse(testee.enabled)
-    }
-
-    func testWhenBlockingEnabledThenEnabledIsTrue() {
-        // default value is true so start be setting to false to ensure test is accurate
-        testee.enabled = false
-
-        testee.enabled = true
-        XCTAssertTrue(testee.enabled)
-    }
-
     func testWhenNothingInWhitelistThenWhitelistedIsFalse() {
         XCTAssertFalse(testee.whitelisted(domain: Constants.domain))
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/361428290920652/1147715495103851

**Description**:
Fixes issue where if toggle was switched off pre-migration that setting was still honoured.

**Steps to test this PR**:
1. Run tag 7.30.0.0 of the app and switch the privacy toggle off
1. Run this version of the app
1. Visit cnn.com and ensure it is blocked and trackers show up correctly
1. Switch the tracker toggle off, ensure that trackers are no longer blocked

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
