### PR TITLE
Add 'Forget Tabs' option to Fire button on Tab Switcher screen

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		9887DC252354D2AA005C85F5 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9887DC242354D2AA005C85F5 /* Database.swift */; };
 		9888F77B2224980500C46159 /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9888F77A2224980500C46159 /* FeedbackViewController.swift */; };
 		988971A222C2DB95009DC1D6 /* StorageCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988971A122C2DB95009DC1D6 /* StorageCacheProvider.swift */; };
+		988F3DD3237DE8D900AEE34C /* ForgetDataAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988F3DD2237DE8D900AEE34C /* ForgetDataAlert.swift */; };
 		9896632422C56716007BE4FE /* EtagStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9896632322C56716007BE4FE /* EtagStorage.swift */; };
 		98982B3422F8D8E400578AC9 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98982B3322F8D8E400578AC9 /* Debounce.swift */; };
 		98999D5922FDA41500CBBE1B /* BasicAuthenticationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98999D5822FDA41500CBBE1B /* BasicAuthenticationAlert.swift */; };
@@ -914,6 +915,7 @@
 		9887DC242354D2AA005C85F5 /* Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database.swift; sourceTree = "<group>"; };
 		9888F77A2224980500C46159 /* FeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		988971A122C2DB95009DC1D6 /* StorageCacheProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCacheProvider.swift; sourceTree = "<group>"; };
+		988F3DD2237DE8D900AEE34C /* ForgetDataAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgetDataAlert.swift; sourceTree = "<group>"; };
 		9896632322C56716007BE4FE /* EtagStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EtagStorage.swift; sourceTree = "<group>"; };
 		98982B3322F8D8E400578AC9 /* Debounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debounce.swift; sourceTree = "<group>"; };
 		98999D5822FDA41500CBBE1B /* BasicAuthenticationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAuthenticationAlert.swift; sourceTree = "<group>"; };
@@ -2513,6 +2515,7 @@
 				851DFD86212C39D300D95F20 /* TabSwitcherButton.swift */,
 				8C4838B4221C8F7F008A6739 /* GestureToolbarButton.swift */,
 				9865DFF822A8220D00D27829 /* FavoritesOverlay.swift */,
+				988F3DD2237DE8D900AEE34C /* ForgetDataAlert.swift */,
 			);
 			name = Main;
 			sourceTree = "<group>";
@@ -3452,6 +3455,7 @@
 				8565A34B1FC8D96B00239327 /* LaunchTabNotification.swift in Sources */,
 				85A9C37720DD2DC200073340 /* AddToHomeRowCTAViewController.swift in Sources */,
 				980891A222369ADB00313A70 /* FeedbackUserText.swift in Sources */,
+				988F3DD3237DE8D900AEE34C /* ForgetDataAlert.swift in Sources */,
 				9817C9C321EF594700884F65 /* AutoClear.swift in Sources */,
 				85200FA81FBDE472001AF290 /* UIColorPrivacyProtectionExtension.swift in Sources */,
 				85EE7F572246685B000FE757 /* WebContainerViewController.swift in Sources */,

--- a/DuckDuckGo/ForgetDataAlert.swift
+++ b/DuckDuckGo/ForgetDataAlert.swift
@@ -1,0 +1,43 @@
+//
+//  ForgetDataAlert.swift
+//  DuckDuckGo
+//
+//  Copyright © 2019 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+class ForgetDataAlert {
+    
+    static func buildAlert(forgetTabsHandler: @escaping () -> Void,
+                           forgetTabsAndDataHandler: @escaping () -> Void) -> UIAlertController {
+        
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alert.overrideUserInterfaceStyle()
+        
+        let forgetTabsAction = UIAlertAction(title: UserText.actionForgetTabs, style: .destructive) { _ in
+            forgetTabsHandler()
+        }
+        
+        let forgetTabsAndDataAction = UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { _ in
+            forgetTabsAndDataHandler()
+        }
+        
+        alert.addAction(forgetTabsAction)
+        alert.addAction(forgetTabsAndDataAction)
+        alert.addAction(UIAlertAction(title: UserText.actionCancel, style: .cancel))
+        return alert
+    }
+}

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -297,11 +297,13 @@ class MainViewController: UIViewController {
 
     @IBAction func onFirePressed() {
         Pixel.fire(pixel: .forgetAllPressedBrowsing)
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.overrideUserInterfaceStyle()
-        alert.addAction(forgetTabsAction())
-        alert.addAction(forgetAllAction())
-        alert.addAction(UIAlertAction(title: UserText.actionCancel, style: .cancel))
+        
+        let alert = ForgetDataAlert.buildAlert(forgetTabsHandler: { [weak self] in
+            self?.forgetTabsWithAnimation {}
+        }, forgetTabsAndDataHandler: { [weak self] in
+            self?.forgetAllWithAnimation {}
+        })
+        
         present(controller: alert, fromView: toolbar)
     }
     
@@ -509,20 +511,6 @@ class MainViewController: UIViewController {
         currentTab?.launchBrowsingMenu()
     }
     
-    private func forgetTabsAction() -> UIAlertAction {
-        let action = UIAlertAction(title: UserText.actionForgetTabs, style: .destructive) { [weak self] _ in
-            self?.forgetTabsWithAnimation {}
-        }
-        return action
-    }
-
-    private func forgetAllAction() -> UIAlertAction {
-        let action = UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] _ in
-            self?.forgetAllWithAnimation {}
-        }
-        return action
-    }
-
     fileprivate func launchReportBrokenSite() {
         performSegue(withIdentifier: "ReportBrokenSite", sender: self)
     }
@@ -922,6 +910,12 @@ extension MainViewController: TabSwitcherDelegate {
     func closeTab(_ tab: Tab) {
         guard let index = tabManager.model.indexOf(tab: tab) else { return }
         remove(tabAt: index)
+    }
+    
+    func tabSwitcherDidRequestForgetTabs(tabSwitcher: TabSwitcherViewController) {
+        forgetTabsWithAnimation {
+            tabSwitcher.dismiss(animated: false, completion: nil)
+        }
     }
 
     func tabSwitcherDidRequestForgetAll(tabSwitcher: TabSwitcherViewController) {

--- a/DuckDuckGo/TabSwitcherDelegate.swift
+++ b/DuckDuckGo/TabSwitcherDelegate.swift
@@ -27,6 +27,7 @@ protocol TabSwitcherDelegate: class {
 
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, didRemoveTab tab: Tab)
 
+    func tabSwitcherDidRequestForgetTabs(tabSwitcher: TabSwitcherViewController)
     func tabSwitcherDidRequestForgetAll(tabSwitcher: TabSwitcherViewController)
     
     func tabSwitcherDidAppear(_ tabSwitcher: TabSwitcherViewController)

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -167,13 +167,18 @@ class TabSwitcherViewController: UIViewController {
 
     @IBAction func onFirePressed() {
         Pixel.fire(pixel: .forgetAllPressedTabSwitching)
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.overrideUserInterfaceStyle()
-        alert.addAction(UIAlertAction(title: UserText.actionForgetAll, style: .destructive) { [weak self] _ in
+        
+        let alert = ForgetDataAlert.buildAlert(forgetTabsHandler: { [weak self] in
+            self?.forgetTabs()
+        }, forgetTabsAndDataHandler: { [weak self] in
             self?.forgetAll()
         })
-        alert.addAction(UIAlertAction(title: UserText.actionCancel, style: .cancel))
+        
         present(controller: alert, fromView: toolbar)
+    }
+    
+    private func forgetTabs() {
+        self.delegate.tabSwitcherDidRequestForgetTabs(tabSwitcher: self)
     }
 
     private func forgetAll() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/856498667309057/1149667590460481/1149644742695411
Tech Design URL:
CC:

**Description**:
Forget Tabs option is missing when pressing Fire button on Tabs switcher.

**Steps to test this PR**:
- Test fire button on Home screen.
- Test fire button on Tab Switcher screen.
- Check if pixels are fired as required.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
