### PR TITLE
allow JS to open windows

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -836,6 +836,10 @@ extension MainViewController: HomeControllerDelegate {
 
 extension MainViewController: TabDelegate {
 
+    func tabDidClose(_ tab: TabViewController) {
+        closeTab(tab.tabModel)
+    }
+
     func tabLoadingStateDidChange(tab: TabViewController) {
         findInPageView.done()
         

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -42,4 +42,6 @@ protocol TabDelegate: class {
 
     func showBars()
 
+    func tabDidClose(_ tab: TabViewController)
+
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -955,7 +955,13 @@ extension TabViewController: WKUIDelegate {
                         createWebViewWith configuration: WKWebViewConfiguration,
                         for navigationAction: WKNavigationAction,
                         windowFeatures: WKWindowFeatures) -> WKWebView? {
-        webView.load(navigationAction.request)
+            
+        if let url = navigationAction.request.url {
+            delegate?.tab(self, didRequestNewTabForUrl: url, animated: true)
+        } else {
+            webView.load(navigationAction.request)
+        }
+        
         return nil
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -855,6 +855,10 @@ extension TabViewController: WKNavigationDelegate {
             decisionHandler(decision)
         }
     }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        delegate?.tabDidClose(self)
+    }
     
     private func decidePolicyFor(navigationAction: WKNavigationAction, completion: @escaping (WKNavigationActionPolicy) -> Void) {
         let allowPolicy = determineAllowPolicy()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1150230163112681
Tech Design URL:
CC:

**Description**:

Allow window.open from JS

**Steps to test this PR**:
1. Visit https://www.w3schools.com/code/tryit.asp?filename=G8SKXWB6508R
1. Both the link and button should open new windows
1. Visit https://falkirkrpg.org.uk/noxwall/framespam.html
* Opening the page opens no new tabs
* Clicking the button opens 10 additional tabs

**Open/Close flow**:
1. Visit https://falkirkrpg.org.uk/noxwall/open.html
1. Click the button, a new tab will open showing https://falkirkrpg.org.uk/noxwall/close.html
1. Click the close button, the tab should close
1. Go directly to https://falkirkrpg.org.uk/noxwall/close.html in a new tab
1. Click the button - it should do nothing


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
