### PR TITLE
[Database] updates groupID to use 'groupIdPrefix'

### DIFF
--- a/Core/Database.swift
+++ b/Core/Database.swift
@@ -23,7 +23,7 @@ import CoreData
 public class Database {
     
     fileprivate struct Constants {
-        static let databaseGroupID = "group.com.duckduckgo.database"
+        static let databaseGroupID = "\(Global.groupIdPrefix).database"
         
         static let databaseName = "Database"
     }
@@ -107,6 +107,7 @@ extension NSManagedObjectContext {
 private class DDGPersistentContainer: NSPersistentContainer {
 
     override public class func defaultDirectoryURL() -> URL {
+        
         return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Database.Constants.databaseGroupID)!
     } 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/iOS/issues/530

**Description**:
After following the `README` instructions for external developers, `DDGPersistentContainer.defaultDirectoryURL` returned `nil`, which cause
the app to crash upon launch.

I used `Global.groupIdPrefix` within `Database.Constants.databaseGroupID`, 
similar to how `BookmarkUserDefaults.bookmarks`, et. al., does it, and the
app launched successfully.

**Steps to test this PR**:
1. Follow the instructions for external devs in the `README`
2. Build & launch the app, confirming that it does not crash.

**Known Issues**:
None.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
