### PR TITLE
Show existing CTA on first open

### DIFF
--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -276,14 +276,19 @@ class Springboard {
             icon.press(forDuration: 1.3)
             
             let rearrangeButton = springboard.buttons["Rearrange Apps"]
-            _ = rearrangeButton.waitForExistence(timeout: AtbIntegrationTests.Constants.defaultTimeout)
-            rearrangeButton.tap()
-            
-            sleep(1)
-            // Tap the little "X" button at approximately where it is. The X is not exposed directly
+            if rearrangeButton.waitForExistence(timeout: 2) {
+                rearrangeButton.tap()
+                
+                sleep(1)
+                // Tap the little "X" button at approximately where it is. The X is not exposed directly
 
-            springboard.coordinate(withNormalizedOffset: CGVector(dx: (iconFrame.minX + 3) / springboardFrame.maxX,
-                                                                  dy: (iconFrame.minY + 3) / springboardFrame.maxY)).tap()
+                springboard.coordinate(withNormalizedOffset: CGVector(dx: (iconFrame.minX + 3) / springboardFrame.maxX,
+                                                                      dy: (iconFrame.minY + 3) / springboardFrame.maxY)).tap()
+            } else {
+                // Buttons have been rearranged for iOS 13.1+ version
+                let deleteButton = springboard.buttons["Delete App"]
+                deleteButton.tap()
+            }
             
             let deleteButton = springboard.alerts.buttons["Delete"]
             _ = deleteButton.waitForExistence(timeout: AtbIntegrationTests.Constants.defaultTimeout)

--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -39,7 +39,9 @@ public struct Variant {
         Variant(name: "se", weight: doNotAllocate, features: []),
         
         Variant(name: "mv", weight: 1, features: []),
-        Variant(name: "mf", weight: 1, features: [.firstOpenCTA])
+        Variant(name: "mf", weight: 1, features: [.firstOpenCTA]),
+        
+        Variant(name: "mp", weight: doNotAllocate, features: [ .privacyOnHomeScreen ])
     ]
     
     public let name: String

--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -24,6 +24,8 @@ public enum FeatureName: String {
     // Used for unit tests
     case dummy
     
+    case firstOpenCTA
+    
     case privacyOnHomeScreen
 }
 
@@ -33,10 +35,11 @@ public struct Variant {
     
     public static let defaultVariants: [Variant] = [
         // SERP testing
-        Variant(name: "sc", weight: 1, features: []),
-        Variant(name: "se", weight: 1, features: []),
+        Variant(name: "sc", weight: doNotAllocate, features: []),
+        Variant(name: "se", weight: doNotAllocate, features: []),
         
-        Variant(name: "mp", weight: doNotAllocate, features: [ .privacyOnHomeScreen ])
+        Variant(name: "mv", weight: 1, features: []),
+        Variant(name: "mf", weight: 1, features: [.firstOpenCTA])
     ]
     
     public let name: String

--- a/DuckDuckGo/HomeRowCTA.swift
+++ b/DuckDuckGo/HomeRowCTA.swift
@@ -42,16 +42,16 @@ class HomeRowCTA {
         self.statistics = statistics
     }
 
-    func shouldShow(currentDate: Date = Date()) -> Bool {
-        guard tutorialSettings.hasSeenOnboarding else {
-            return false
-        }
-
-        if tipsStorage.isEnabled && tipsStorage.nextHomeScreenTip < HomeScreenTips.Tips.allCases.count {
+    func shouldShow(currentDate: Date = Date(), variantManager: VariantManager = DefaultVariantManager()) -> Bool {
+        guard !storage.dismissed, tutorialSettings.hasSeenOnboarding else {
             return false
         }
         
-        if storage.dismissed {
+        if variantManager.isSupported(feature: .firstOpenCTA) {
+            return true
+        }
+        
+        if tipsStorage.isEnabled && tipsStorage.nextHomeScreenTip < HomeScreenTips.Tips.allCases.count {
             return false
         }
         

--- a/DuckDuckGo/HomeScreenTips.swift
+++ b/DuckDuckGo/HomeScreenTips.swift
@@ -52,9 +52,10 @@ class HomeScreenTips {
         self.storage = storage
     }
     
-    func trigger() {
+    func trigger(variantManager: VariantManager = DefaultVariantManager()) {
         guard storage.isEnabled else { return }
         guard tutorialSettings.hasSeenOnboarding else { return }
+        if variantManager.isSupported(feature: .firstOpenCTA), !UserDefaultsHomeRowCTAStorage().dismissed { return }
         guard let tip = Tips(rawValue: storage.nextHomeScreenTip) else { return }
         
         switch tip {

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -136,8 +136,14 @@ class HomeViewController: UIViewController {
         collectionView.reloadData()
     }
 
-    func resetHomeRowCTAAnimations() {
-        hideHomeRowCTA()
+    func resetHomeRowCTAAnimations(variantManager: VariantManager = DefaultVariantManager()) {
+        if variantManager.isSupported(feature: .firstOpenCTA) {
+            if HomeRowCTA().shouldShow() {
+                showHomeRowCTA()
+            }
+        } else {
+            hideHomeRowCTA()
+        }
     }
 
     @IBAction func hideKeyboard() {

--- a/DuckDuckGo/Onboarding.swift
+++ b/DuckDuckGo/Onboarding.swift
@@ -105,7 +105,6 @@ extension MainViewController: OnboardingDelegate {
         markOnboardingSeen()
         controller.modalTransitionStyle = .crossDissolve
         controller.dismiss(animated: true)
-    
         homeController?.resetHomeRowCTAAnimations()
     }
     

--- a/DuckDuckGo/Onboarding.swift
+++ b/DuckDuckGo/Onboarding.swift
@@ -105,6 +105,7 @@ extension MainViewController: OnboardingDelegate {
         markOnboardingSeen()
         controller.modalTransitionStyle = .crossDissolve
         controller.dismiss(animated: true)
+    
         homeController?.resetHomeRowCTAAnimations()
     }
     

--- a/DuckDuckGoTests/HomeRowCTATests.swift
+++ b/DuckDuckGoTests/HomeRowCTATests.swift
@@ -50,7 +50,7 @@ class HomeRowCTATests: XCTestCase {
         XCTAssertTrue(feature.shouldShow())
     }
     
-    func testWhenContextualOnboardingFeatureEnabledAndNotAllHomeScreenTipsShownThenDontShowCTA() {
+    func testWhenNotAllHomeScreenTipsShownThenDontShowCTA() {
         statistics.installDate = Date.distantPast
         tutorialSettings.hasSeenOnboarding = true
         tipsStorage.nextHomeScreenTip = 0
@@ -58,7 +58,20 @@ class HomeRowCTATests: XCTestCase {
         
         let feature = HomeRowCTA(storage: storage, tipsStorage: tipsStorage, tutorialSettings: tutorialSettings, statistics: statistics)
         
-        XCTAssertFalse(feature.shouldShow())
+        let variantManager = MockVariantManager(isSupportedReturns: false, currentVariant: nil)
+        XCTAssertFalse(feature.shouldShow(variantManager: variantManager))
+    }
+    
+    func testWhenNotAllHomeScreenTipsShownAndDay0CTAEnabledThenDontShowCTA() {
+        statistics.installDate = Date.distantPast
+        tutorialSettings.hasSeenOnboarding = true
+        tipsStorage.nextHomeScreenTip = 0
+        tipsStorage.isEnabled = true
+        
+        let feature = HomeRowCTA(storage: storage, tipsStorage: tipsStorage, tutorialSettings: tutorialSettings, statistics: statistics)
+        
+        let variantManager = MockVariantManager(isSupportedReturns: true, currentVariant: nil)
+        XCTAssert(feature.shouldShow(variantManager: variantManager))
     }
 
     func testWhenDismissedThenDismissedStateStored() {
@@ -101,7 +114,21 @@ class HomeRowCTATests: XCTestCase {
         
         let feature = HomeRowCTA(storage: storage, tipsStorage: tipsStorage, tutorialSettings: tutorialSettings, statistics: statistics)
         
-        XCTAssertFalse(feature.shouldShow(currentDate: installDate))
+        let variantManager = MockVariantManager(isSupportedReturns: false, currentVariant: nil)
+        XCTAssertFalse(feature.shouldShow(currentDate: installDate, variantManager: variantManager))
+    }
+    
+    func testWhenOnInstallDayAndDay0CTAEnabledThenShouldShow() {
+        let installDate = Date()
+        
+        statistics.installDate = installDate
+        tipsStorage.isEnabled = false
+        tutorialSettings.hasSeenOnboarding = true
+        
+        let feature = HomeRowCTA(storage: storage, tipsStorage: tipsStorage, tutorialSettings: tutorialSettings, statistics: statistics)
+        
+        let variantManager = MockVariantManager(isSupportedReturns: true, currentVariant: nil)
+        XCTAssert(feature.shouldShow(currentDate: installDate, variantManager: variantManager))
     }
     
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1151465514636396
Tech Design URL:
CC:

**Description**:
Show existing CTA on first open.

**Steps to test this PR**:
Control group: 
- CTA shown on the next day.
- Tips shown without any change.

Experiment:
- CTA shown after onboarding.
- HomeScreen tips delayed till CTA is dismissed.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
