### PR TITLE
Show tips when onboarding is finished

### DIFF
--- a/DuckDuckGo/BrowsingTips.swift
+++ b/DuckDuckGo/BrowsingTips.swift
@@ -58,21 +58,20 @@ class BrowsingTips {
         guard !appUrls.isDuckDuckGo(url: url) else { return }
         guard let tip = Tips(rawValue: storage.nextBrowsingTip) else { return }
         
+        let completion: (Bool) -> Void = { shown in
+            guard shown else { return }
+            self.storage.nextBrowsingTip = tip.rawValue + 1
+        }
+        
         switch tip {
             
         case .privacyGrade:
-            delegate?.showPrivacyGradeTip(didShow: didShow)
+            delegate?.showPrivacyGradeTip(didShow: completion)
             
         case .fireButton:
-            delegate?.showFireButtonTip(didShow: didShow)
+            delegate?.showFireButtonTip(didShow: completion)
             
         }
         
     }
- 
-    private func didShow(_ shown: Bool) {
-        guard shown else { return }
-        storage.nextBrowsingTip += 1
-    }
-    
 }

--- a/DuckDuckGo/EasyTipViewExtension.swift
+++ b/DuckDuckGo/EasyTipViewExtension.swift
@@ -50,7 +50,7 @@ extension EasyTipView {
         EasyTipView.globalPreferences = preferences
     }
     
-    func handleGlobalTouch() {
+    func handleGlobalTouch(completion: @escaping () -> Void) {
         
         let view = TouchView()
         UIApplication.shared.keyWindow?.addSubview(view)
@@ -59,6 +59,7 @@ extension EasyTipView {
         token = NotificationCenter.default.addObserver(forName: TouchView.touchNotification, object: nil, queue: nil) { _ in
             view.removeFromSuperview()
             self.dismiss()
+            completion()
             NotificationCenter.default.removeObserver(token!)
         }
     }

--- a/DuckDuckGo/HomeRowCTA.swift
+++ b/DuckDuckGo/HomeRowCTA.swift
@@ -51,7 +51,7 @@ class HomeRowCTA {
             return true
         }
         
-        if tipsStorage.isEnabled && tipsStorage.nextHomeScreenTip < HomeScreenTips.Tips.allCases.count {
+        if tipsStorage.isEnabled && tipsStorage.nextHomeScreenTip < HomeScreenTips.Tip.allCases.count {
             return false
         }
         

--- a/DuckDuckGo/HomeScreenTips.swift
+++ b/DuckDuckGo/HomeScreenTips.swift
@@ -30,7 +30,7 @@ protocol HomeScreenTipsDelegate: NSObjectProtocol {
 
 class HomeScreenTips {
     
-    enum Tips: Int, CaseIterable {
+    enum Tip: Int, CaseIterable {
         case privateSearch
         case showCustomize
     }
@@ -56,22 +56,21 @@ class HomeScreenTips {
         guard storage.isEnabled else { return }
         guard tutorialSettings.hasSeenOnboarding else { return }
         if variantManager.isSupported(feature: .firstOpenCTA), !UserDefaultsHomeRowCTAStorage().dismissed { return }
-        guard let tip = Tips(rawValue: storage.nextHomeScreenTip) else { return }
+        guard let tip = Tip(rawValue: storage.nextHomeScreenTip) else { return }
+        
+        let completion: (Bool) -> Void = { shown in
+            guard shown else { return }
+            self.storage.nextHomeScreenTip = tip.rawValue + 1
+        }
         
         switch tip {
             
         case .privateSearch:
-            delegate?.showPrivateSearchTip(didShow: didShow)
+            delegate?.showPrivateSearchTip(didShow: completion)
             
         case .showCustomize:
-            delegate?.showCustomizeTip(didShow: didShow)
+            delegate?.showCustomizeTip(didShow: completion)
         }
         
     }
-    
-    private func didShow(_ shown: Bool) {
-        guard shown else { return }
-        storage.nextHomeScreenTip += 1
-    }
-    
 }

--- a/DuckDuckGo/HomeViewController+HomeScreenDelegate.swift
+++ b/DuckDuckGo/HomeViewController+HomeScreenDelegate.swift
@@ -52,9 +52,11 @@ extension HomeViewController: HomeScreenTipsDelegate {
                                   icon: icon,
                                   preferences: preferences)
             tip.show(animated: true, forView: view, withinSuperview: superView)
-            didShow(true)
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                tip.handleGlobalTouch()
+                tip.handleGlobalTouch {
+                    didShow(true)
+                }
             }
         }
         
@@ -92,9 +94,11 @@ extension HomeViewController: HomeScreenTipsDelegate {
                                   preferences: preferences)
 
             tip.show(animated: true, forView: settings, withinSuperview: superView)
-            didShow(true)
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                tip.handleGlobalTouch()
+                tip.handleGlobalTouch {
+                    didShow(true)
+                }
             }
         }
 

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -137,6 +137,8 @@ class HomeViewController: UIViewController {
     }
 
     func resetHomeRowCTAAnimations(variantManager: VariantManager = DefaultVariantManager()) {
+        installHomeScreenTips()
+        
         if variantManager.isSupported(feature: .firstOpenCTA) {
             if HomeRowCTA().shouldShow() {
                 showHomeRowCTA()

--- a/DuckDuckGo/TabViewController+BrowsingTipsDelegate.swift
+++ b/DuckDuckGo/TabViewController+BrowsingTipsDelegate.swift
@@ -44,9 +44,11 @@ extension TabViewController: BrowsingTipsDelegate {
                                   preferences: preferences)
 
             tip.show(animated: true, forView: grade, withinSuperview: superView)
-            didShow(true)
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                tip.handleGlobalTouch()
+                tip.handleGlobalTouch {
+                    didShow(true)
+                }
             }
         }
 
@@ -74,9 +76,11 @@ extension TabViewController: BrowsingTipsDelegate {
                                   icon: icon,
                                   preferences: preferences)
             tip.show(forItem: button, withinSuperView: superView)            
-            didShow(true)
+
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                tip.handleGlobalTouch()
+                tip.handleGlobalTouch {
+                    didShow(true)
+                }
             }
         }
     }

--- a/DuckDuckGoTests/HomeRowCTATests.swift
+++ b/DuckDuckGoTests/HomeRowCTATests.swift
@@ -32,7 +32,7 @@ class HomeRowCTATests: XCTestCase {
         statistics.installDate = Date.distantPast
         tutorialSettings.hasSeenOnboarding = false
         tipsStorage.isEnabled = true
-        tipsStorage.nextHomeScreenTip = HomeScreenTips.Tips.allCases.count
+        tipsStorage.nextHomeScreenTip = HomeScreenTips.Tip.allCases.count
 
         let feature = HomeRowCTA(storage: storage, tipsStorage: tipsStorage, tutorialSettings: tutorialSettings, statistics: statistics)
         
@@ -43,7 +43,7 @@ class HomeRowCTATests: XCTestCase {
         statistics.installDate = Date.distantPast
         tutorialSettings.hasSeenOnboarding = true
         tipsStorage.isEnabled = true
-        tipsStorage.nextHomeScreenTip = HomeScreenTips.Tips.allCases.count
+        tipsStorage.nextHomeScreenTip = HomeScreenTips.Tip.allCases.count
 
         let feature = HomeRowCTA(storage: storage, tipsStorage: tipsStorage, tutorialSettings: tutorialSettings, statistics: statistics)
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/856498667309057/1151590414948009/1151591896110085
Tech Design URL:
CC:

**Description**:
Show Home Screen tips when onboarding is finished.

**Steps to test this PR**:
Note: for HomeRow CTA variant tips are shown when CTA is dismissed.

Regular scenario:
1. Fresh install.
2. Finish onboarding.
3. Tips should show as expected.

API test:
1. Duplicate calls too `installHomeScreenTips()` in `HomeVIewConotroller:viewDidAppear(:)`
2. Run regular scenario.
3. Tips should work as expected.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
