### PR TITLE
Pixel for accessing Settings from Tabs screen

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -65,6 +65,7 @@ public enum PixelName: String {
     case overlayFavoriteLaunched = "m_ov_f"
     
     case settingsOpened = "ms"
+    case settingsOpenedFromTabsSwitcher = "ms_ot"
     case settingsHomeRowInstructionsRequested = "ms_hr"
     
     case settingsThemeShown = "ms_tp"

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -143,7 +143,7 @@ class TabSwitcherViewController: UIViewController {
     
     @IBAction func onSettingsPressed(_ sender: UIButton) {
         // Segue performed from storyboard
-        Pixel.fire(pixel: .settingsOpened)
+        Pixel.fire(pixel: .settingsOpenedFromTabsSwitcher)
     }
 
     @IBAction func onAddPressed(_ sender: UIBarButtonItem) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1152005695670389
Tech Design URL:
CC:

**Description**:
Pixel for accessing Settings from Tabs screen

**Steps to test this PR**:
1. Launch Tabs Switcher.
2. Open settings -> pixel `ms_ot` should be fired.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
