### PR TITLE
Reveal bars when scrolling below bottom of the web page

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -289,11 +289,11 @@ fileprivate extension UIScrollView {
     
     /// Calculate Y-axis content offset corresponding to very bottom of the scroll area
     var contentOffsetYAtBottom: CGFloat {
-        let yOffset = contentSize.height - bounds.height - contentInset.top + contentInset.bottom
+        let yOffset = contentSize.height - bounds.height
         if #available(iOS 11.0, *) {
-            return yOffset - safeAreaInsets.top + safeAreaInsets.bottom
+            return yOffset - adjustedContentInset.top + adjustedContentInset.bottom
         } else {
-            return yOffset
+            return yOffset - contentInset.top + contentInset.bottom
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/iOS/issues/495
CC: @bwaresiak

**Description**:

Replicate Safari behavior - show the navigation bars when you reach the bottom of a web page and try to scroll down more.

**Technical notes**:

`contentOffsetYAtBottom` change:
This issue surfaced when I started testing bottom drag detection. UIScrollView safe area handling depends on `contentInsetAdjustmentBehavior`. To keep correct behaviour in all cases I propose changing `contentInset + safeAreaInsets` to `adjustedContentInset`.
This change contained in separate commit, feel free to cherry-pick it from PR or squash.

Bottom scroll handling:
Bars will appear only if scroll started from the very end of web page.

**Steps to test this PR**:

0. For every scenario - load webpage bigger than screen height.

##### Basic scenario
Steps:
1. Hide bars and scroll to the very bottom of the web page.
2. Scroll webpage down again (with rubber band effect).

Expectation: bars are revealed.

##### First scenario
(from https://github.com/duckduckgo/iOS/pull/505#pullrequestreview-307847045 comment)
In Safari, user is able to reach bottom of the web page and not reveal bars when actively scrolling (not decelerating).

Steps:
1. Hide bars and scroll just above bottom of the web page.
2. Start dragging the webpage towards the bottom without lifting the finger.

Expectation: bars are not revealed.

##### Second scenario
(from https://github.com/duckduckgo/iOS/pull/505#pullrequestreview-307847045 comment)
In Safari, bars will only appear when user scrolls downwards from the very bottom (end) of the webpage.

Steps:
1. Hide bars and scroll to the very end of the page in a way that bars remain hidden.
2. Start dragging the webpage a bit towards the top, then move back to the bottom.

Expectation: bars are not revealed.

##### Third scenario
In Safari, bars will not disappear when user scrolls downwards just above bottom of the web page (threshold estimated to 110, see `Constants.bottomThreshold`).

Steps:
1. Let bars appear at the bottom of webpage (*basic* scenario above)
2. Scroll up 2-3 lines
3. Start scrolling down.

Expectation: bars are revealed after 1st step and remain in place on steps 2 and 3. 

2. Scroll up >5 lines
3. Start scrolling down.

Expectation: bars are revealed after 1st step and hidden on step 3. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
