### PR TITLE
[TabSwitcher] adds a tap handler that dismisses

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -57,9 +57,16 @@ class TabSwitcherViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        // `backgroundView` can be tapped in lieu of tapping the 'done()' button
+        collectionView.backgroundView = UIView(frame: collectionView.frame)
+        collectionView.backgroundView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(gesture:))))
         collectionView.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(gesture:))))
-        
+
         collectionView.reloadData()
+    }
+    
+    @objc func handleTap(gesture: UITapGestureRecognizer) {
+        dismiss()
     }
 
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {


### PR DESCRIPTION
Task/Issue URL: #545 
CC: @bwaresiak 

**Description**:
Tap the background view in lieu of pressing the _Done_ tab-bar button.

**How it works:**
This adds a background view to the tab switcher's collection view
which includes a tap handler that can dismiss the tab switcher in
lieu of pressing the 'Done' tab-bar button.


**Steps to test this PR**:
1. Open the tab switcher, and tap the background to dismiss it

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
