### PR TITLE
[TabSwitcher] fixes cell layout issues w/rotation

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -90,6 +90,11 @@ class TabSwitcherViewController: UIViewController {
         super.viewDidDisappear(animated)
         delegate?.tabSwitcherDidDisappear(self)
     }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         


### PR DESCRIPTION
Task/Issue URL: #547 
CC: @bwaresiak 

**Description**:
Rotating the device while viewing the tab switcher does not update the tab cells as expected.

![00_before](https://user-images.githubusercontent.com/276137/70746375-b656e480-1cf3-11ea-9562-4ee35919f271.gif)

**Steps to test this PR**:
1. Rotating the device while viewing the tab switcher should update the layout of tabs correctly.

![01_after](https://user-images.githubusercontent.com/276137/70746389-bbb42f00-1cf3-11ea-95db-2e5a549a6221.gif)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
