### PR TITLE
allow the about scheme to fix sites that depend on it

### DIFF
--- a/Core/ExternalSchemeHandler.swift
+++ b/Core/ExternalSchemeHandler.swift
@@ -47,7 +47,6 @@ public class ExternalSchemeHandler {
     }
     
     private enum BlacklistedScheme: String {
-        case about
         case appleDataDetectors = "x-apple-data-detectors"
     }
     

--- a/DuckDuckGoTests/ExternalUrlSchemeTests.swift
+++ b/DuckDuckGoTests/ExternalUrlSchemeTests.swift
@@ -58,9 +58,9 @@ class ExternalUrlSchemeTests: XCTestCase {
                        ExternalSchemeHandler.SchemeType.other)
     }
     
-    func testThatAboutSchemesAreProhibited() {
+    func testThatAboutSchemesAreAllowed() {
         let url = URL(string: "about:blank")!
-        XCTAssertEqual(ExternalSchemeHandler.schemeType(for: url),
+        XCTAssertNotEqual(ExternalSchemeHandler.schemeType(for: url),
                        ExternalSchemeHandler.SchemeType.external(.cancel))
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1153828299682785
Tech Design URL:
CC:

**Description**:

Re-allows the about scheme as some sites seem to break without it.

**Steps to test this PR**:
1. Visit ticketmaster.com
1. Click on profile icon
1. Select my account or login - the forms should appear as expected (the bug was that the screen would go blank)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
