### PR TITLE
remove unnecessary call to reload of home view controller when traits change

### DIFF
--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -131,11 +131,6 @@ class HomeViewController: UIViewController {
         viewHasAppeared = true
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        collectionView.reloadData()
-    }
-
     func resetHomeRowCTAAnimations(variantManager: VariantManager = DefaultVariantManager()) {
         installHomeScreenTips()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1155768729570218
Tech Design URL:
CC:

**Description**:

Putting the app in the background can cause some favorites to use their favicon, even when it's too small.  This causes the icon of the favorite to change from a letter with coloured background to the small favicon.

This change stops the home view controller from reloading when going to the background.

**Steps to test this PR**:
1.  Add a few favourites, but in particular giphy.com 
1. Put the app to the background, the icon for giphy should remain a letter with background color
1. Change that configuring and interacting with the home view works properly (orientation changes, scrolling, etc)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
