### PR TITLE
Added extension to check same day

### DIFF
--- a/Core/DateExtension.swift
+++ b/Core/DateExtension.swift
@@ -1,5 +1,5 @@
 //
-//  Debounce.swift
+//  DateExtension.swift
 //  DuckDuckGo
 //
 //  Copyright © 2020 DuckDuckGo. All rights reserved.

--- a/Core/DateExtension.swift
+++ b/Core/DateExtension.swift
@@ -1,0 +1,27 @@
+//
+//  Debounce.swift
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension Date {
+    public func isSameDay(_ otherDate: Date?) -> Bool {
+        guard let otherDate = otherDate else { return false }
+        return Calendar.current.isDate(self, inSameDayAs: otherDate)
+    }
+}

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0A6CC0EF23904D5400E4F627 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A6CC0EE23904D5400E4F627 /* Settings.bundle */; };
+		1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82023CEA1F800AA24EA /* DateExtension.swift */; };
+		1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */; };
 		22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */; };
 		83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */; };
 		83004E862193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */; };
@@ -572,6 +574,8 @@
 
 /* Begin PBXFileReference section */
 		0A6CC0EE23904D5400E4F627 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		1CB7B82023CEA1F800AA24EA /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
+		1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeepLinksTests.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
@@ -2160,6 +2164,7 @@
 				F143C3251E4A9A0E00CFDE3A /* URLExtension.swift */,
 				F1075C911E9EF827006BE8A8 /* UserDefaultsExtension.swift */,
 				98982B3322F8D8E400578AC9 /* Debounce.swift */,
+				1CB7B82023CEA1F800AA24EA /* DateExtension.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -2367,6 +2372,7 @@
 				F1DA2F7C1EBCF23700313F51 /* ExternalUrlSchemeTests.swift */,
 				83C05D04212C74600068712A /* BloomFilterWrapperTest.swift */,
 				8341D804212D5DFB000514C2 /* HashExtensionTest.swift */,
+				1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -3553,6 +3559,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8528AE84212FF9A100D0BD74 /* AppRatingPromptStorageTests.swift in Sources */,
+				1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */,
 				853A717820F645FB00FE60BC /* PixelTests.swift in Sources */,
 				85C9E5F821B4232A00460EBC /* HomePageConfigurationTests.swift in Sources */,
 				85200F9A1FBBC012001AF290 /* NetworkLeaderboardTests.swift in Sources */,
@@ -3742,6 +3749,7 @@
 				85F45B2A1F875DFF00DB1978 /* ContentBlockerRequest.swift in Sources */,
 				F1D477CB1F2149C40031ED49 /* Type.swift in Sources */,
 				F1134EC61F40E3B400B73467 /* AppVersion.swift in Sources */,
+				1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */,
 				988F3DCF237D5C0F00AEE34C /* ExternalSchemeHandler.swift in Sources */,
 				9875E00722316B8400B1373F /* Instruments.swift in Sources */,
 				85C271D81FD0311A007216B4 /* HTTPSUpgradeParser.swift in Sources */,

--- a/DuckDuckGo/AppRatingPrompt.swift
+++ b/DuckDuckGo/AppRatingPrompt.swift
@@ -40,24 +40,18 @@ class AppRatingPrompt {
     }
     
     func registerUsage(onDate date: Date = Date()) {
-        if !sameDay(date1: storage.lastAccess, date2: date) {
+        if !date.isSameDay(storage.lastAccess) {
             storage.uniqueAccessDays += 1
         }        
         storage.lastAccess = date
     }
     
     func shouldPrompt(onDate date: Date = Date()) -> Bool {
-        return [3, 7].contains(storage.uniqueAccessDays) && !sameDay(date1: date, date2: storage.lastShown)
+        return [3, 7].contains(storage.uniqueAccessDays) && !date.isSameDay(storage.lastShown)
     }
     
     func shown(onDate date: Date = Date()) {
         storage.lastShown = date
-    }
- 
-    private func sameDay(date1: Date?, date2: Date?) -> Bool {
-        guard let date1 = date1 else { return false }
-        guard let date2 = date2 else { return false }
-        return Calendar.current.isDate(date1, inSameDayAs: date2)
     }
     
 }

--- a/DuckDuckGoTests/DateExtensionTests.swift
+++ b/DuckDuckGoTests/DateExtensionTests.swift
@@ -1,0 +1,42 @@
+//
+//  DateExtensionTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+ class DateExtensionTests: XCTestCase {
+
+     func testWhenDatesAreSame() {
+        let today: Date = Date()
+        let secondDate: Date = Date()
+        XCTAssertTrue(today.isSameDay(secondDate))
+    }
+
+     func testWhenDatesAreNotSame() {
+        let today: Date = Date()
+        let secondDate: Date? = Calendar.current.date(byAdding: .day, value: -1, to: today)
+        XCTAssertFalse(today.isSameDay(secondDate))
+    }
+
+     func testWhenOtherDateIsNil() {
+        let today: Date = Date()
+        let secondDate: Date? = nil
+        XCTAssertFalse(today.isSameDay(secondDate))
+    }
+
+ }


### PR DESCRIPTION
**Description**:
I've refactored some parts that use verification of the same day. I've put into an extension to reuse code in the entire application with simple method calling, avoiding "copying and pasting" of the same day logic. Also, I've created some unit tests for this.

**Steps to test this PR**:
1 - Use the app in the parts refactored or use the Unit Tests