### PR TITLE
Pixels for app icon settings screen

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -73,6 +73,15 @@ public enum PixelName: String {
     case settingsThemeChangedLight = "ms_tl"
     case settingsThemeChangedDark = "ms_td"
 
+    case settingsAppIconShown = "ms_ais"
+    case settingsAppIconChangedPrefix = "ms_aic_"
+    case settingsAppIconChangedRed = "ms_aic_red"
+    case settingsAppIconChangedYellow = "ms_aic_yellow"
+    case settingsAppIconChangedGreen = "ms_aic_green"
+    case settingsAppIconChangedBlue = "ms_aic_blue"
+    case settingsAppIconChangedPurple = "ms_aic_purple"
+    case settingsAppIconChangedBlack = "ms_aic_black"
+
     case settingsHomePageShown = "ms_hp"
     case settingsHomePageSimple = "ms_hp_s"
     case settingsHomePageCenterSearch = "ms_hp_c"

--- a/DuckDuckGo/AppIconSettingsViewController.swift
+++ b/DuckDuckGo/AppIconSettingsViewController.swift
@@ -39,12 +39,25 @@ class AppIconSettingsViewController: UICollectionViewController {
 
     private func changeAppIcon(_ appIcon: AppIcon) {
         AppIconManager.shared.changeAppIcon(appIcon) { error in
-            if error != nil {
+            guard error == nil else {
                 DispatchQueue.main.async {
                     self.initSelection()
                 }
+                return
             }
+
+            self.firePixel(with: appIcon)
         }
+    }
+
+    private func firePixel(with appIcon: AppIcon) {
+        let pixelNameString = PixelName.settingsAppIconChangedPrefix.rawValue + appIcon.rawValue
+
+        guard let pixel = PixelName(rawValue: pixelNameString) else {
+            fatalError("Could not match AppIcon with Pixel")
+        }
+
+        Pixel.fire(pixel: pixel)
     }
 
     // MARK: UICollectionViewDataSource

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -91,6 +91,11 @@ class SettingsViewController: UITableViewController {
             Pixel.fire(pixel: .settingsThemeShown)
             return
         }
+
+        if segue.destination is AppIconSettingsViewController {
+            Pixel.fire(pixel: .settingsAppIconShown)
+            return
+        }
         
         if let controller = segue.destination as? HomePageSettingsViewController {
             Pixel.fire(pixel: .settingsHomePageShown)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1142021229838617/1157874377105498/f

**Description**: 
New pixels are fired when:
- app icon settings screen is shown
- app icon is selected

**Steps to test this PR**:
Select icons and monitor statistics:
 red icon = "ms_aic_red"
 yellow icon = "ms_aic_yellow"
 green icon = "ms_aic_green"
 blue icon = "ms_aic_blue"
 purple icon = "ms_aic_purple"
 black icon = "ms_aic_black"

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
