### PR TITLE
add a timed pixel to measure taken to clear data and number of tabs when using fire button

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -28,7 +28,8 @@ public enum PixelName: String {
     case forgetAllPressedBrowsing = "mf_bp"
     case forgetAllPressedTabSwitching = "mf_tp"
     case forgetAllExecuted = "mf"
-    
+    case forgetAllDataCleared = "mf_dc"
+
     case privacyDashboardOpened = "mp"
     case privacyDashboardScorecard = "mp_c"
     case privacyDashboardEncryption = "mp_e"
@@ -230,7 +231,8 @@ public struct PixelParameters {
     static let errorCount = "c"
     static let underlyingErrorCode = "ue"
     static let underlyingErrorDesc = "ud"
-    
+
+    public static let tabCount = "tc"
 }
 
 public struct PixelValues {
@@ -305,9 +307,11 @@ public class TimedPixel {
         self.date = date
     }
     
-    public func fire(_ fireDate: Date = Date()) {
+    public func fire(_ fireDate: Date = Date(), withAdditionalParmaeters params: [String: String?] = [:]) {
         let duration = String(fireDate.timeIntervalSince(date))
-        Pixel.fire(pixel: pixel, withAdditionalParameters: [PixelParameters.duration: duration])
+        var newParams = params
+        newParams[PixelParameters.duration] = duration
+        Pixel.fire(pixel: pixel, withAdditionalParameters: newParams)
     }
     
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1052,7 +1052,11 @@ extension MainViewController: AutoClearWorker {
         
         ServerTrustCache.shared.clear()
         KingfisherManager.shared.cache.clearDiskCache()
-        WebCacheManager.shared.clear { }
+
+        let pixel = TimedPixel(.forgetAllDataCleared)
+        WebCacheManager.shared.clear {
+            pixel.fire(withAdditionalParmaeters: [PixelParameters.tabCount: "\(self.tabManager.count)"])
+        }
     }
     
     fileprivate func forgetAllWithAnimation(completion: @escaping () -> Void) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1161522674005625
Tech Design URL:
CC:

**Description**:

Allow us to gather metrics on how long it takes to clear data and how many tabs users have when they use the fire button.

**Steps to test this PR**:
1. Open some tabs, browse and use the fire button
1. Use the fire button with no tabs
1. Check kibana for the pixels. e.g. `pixel:/mf.dc.*ios.*/ AND request:/.*test=1.*/`


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
