### PR TITLE
support javascript opening and closing of windows

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -849,6 +849,27 @@ extension MainViewController: HomeControllerDelegate {
 
 extension MainViewController: TabDelegate {
 
+    func tab(_ tab: TabViewController,
+             didRequestNewWebViewWithConfiguration configuration: WKWebViewConfiguration,
+             for navigationAction: WKNavigationAction) -> WKWebView? {
+
+        showBars()
+
+        let newTab = tabManager.addURLRequest(navigationAction.request, withConfiguration: configuration)
+        newTab.openedByPage = true
+        newTabAnimation {
+            self.omniBar.resignFirstResponder()
+            self.addToView(tab: newTab)
+            self.refreshOmniBar()
+        }
+
+        return newTab.webView
+    }
+
+    func tabDidRequestClose(_ tab: TabViewController) {
+        closeTab(tab.tabModel)
+    }
+
     func tabLoadingStateDidChange(tab: TabViewController) {
         findInPageView.done()
         
@@ -868,13 +889,14 @@ extension MainViewController: TabDelegate {
         animateBackgroundTab()
     }
 
-    func tab(_ tab: TabViewController, didRequestNewTabForUrl url: URL, animated: Bool) {
+    func tab(_ tab: TabViewController, didRequestNewTabForUrl url: URL, openedByPage: Bool) {
         _ = findInPageView.resignFirstResponder()
 
-        if animated {
+        if openedByPage {
             showBars()
             newTabAnimation {
                 self.loadUrlInNewTab(url)
+                self.tabManager.current?.openedByPage = true
             }
             tabSwitcherButton.incrementAnimated()
         } else {

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -24,7 +24,13 @@ protocol TabDelegate: class {
 
     func tabDidRequestNewTab(_ tab: TabViewController)
 
-    func tab(_ tab: TabViewController, didRequestNewTabForUrl url: URL, animated: Bool)
+    func tab(_ tab: TabViewController,
+             didRequestNewWebViewWithConfiguration configuration: WKWebViewConfiguration,
+             for navigationAction: WKNavigationAction) -> WKWebView?
+
+    func tabDidRequestClose(_ tab: TabViewController)
+
+    func tab(_ tab: TabViewController, didRequestNewTabForUrl url: URL, openedByPage: Bool)
 
     func tab(_ tab: TabViewController, didRequestNewBackgroundTabForUrl url: URL)
     

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -103,7 +103,8 @@ class TabManager {
         }
 
         let tab = Tab(link: request.url == nil ? nil : Link(title: nil, url: request.url!))
-        model.add(tab: tab)
+        model.insert(tab: tab, at: model.currentIndex + 1)
+        model.select(tabAt: model.currentIndex + 1)
 
         let controller = TabViewController.loadFromStoryboard(model: tab)
         controller.attachWebView(configuration: configCopy, andLoadRequest: request, consumeCookies: !model.hasActiveTabs)

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -47,7 +47,9 @@ class TabManager {
     private func buildController(forTab tab: Tab, url: URL?) -> TabViewController {
         let configuration =  WKWebViewConfiguration.persistent()
         let controller = TabViewController.loadFromStoryboard(model: tab)
-        controller.attachWebView(configuration: configuration, andLoadUrl: url, consumeCookies: model.isEmpty)
+        controller.attachWebView(configuration: configuration,
+                                 andLoadRequest: url == nil ? nil : URLRequest(url: url!),
+                                 consumeCookies: model.isEmpty)
         controller.delegate = delegate
         controller.loadViewIfNeeded()
         return controller
@@ -92,6 +94,26 @@ class TabManager {
 
         save()
         return current!
+    }
+
+    func addURLRequest(_ request: URLRequest,
+                       withConfiguration configuration: WKWebViewConfiguration) -> TabViewController {
+
+        guard let configCopy = configuration.copy() as? WKWebViewConfiguration else {
+            fatalError("Failed to copy configuration")
+        }
+
+        let tab = Tab(link: request.url == nil ? nil : Link(title: nil, url: request.url!))
+        model.add(tab: tab)
+
+        let controller = TabViewController.loadFromStoryboard(model: tab)
+        controller.attachWebView(configuration: configCopy, andLoadRequest: request, consumeCookies: model.isEmpty)
+        controller.delegate = delegate
+        controller.loadViewIfNeeded()
+        tabControllerCache.append(controller)
+
+        save()
+        return controller
     }
 
     func add(url: URL?, inBackground: Bool = false) -> TabViewController {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -960,7 +960,6 @@ extension TabViewController: WKNavigationDelegate {
         
         if isNewTargetBlankRequest(navigationAction: navigationAction) {
             delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: true)
-            print("***", #function)
             completion(.cancel)
             return
         }
@@ -1028,7 +1027,6 @@ extension TabViewController: WKUIDelegate {
                         createWebViewWith configuration: WKWebViewConfiguration,
                         for navigationAction: WKNavigationAction,
                         windowFeatures: WKWindowFeatures) -> WKWebView? {
-        print("***", #function)
         return delegate?.tab(self, didRequestNewWebViewWithConfiguration: configuration, for: navigationAction)
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -47,7 +47,9 @@ class TabViewController: UIViewController {
     var longPressGestureRecognizer: UILongPressGestureRecognizer?
     
     private let instrumentation = TabInstrumentation()
-   
+
+    var openedByPage = false
+    
     weak var delegate: TabDelegate?
     weak var chromeDelegate: BrowserChromeDelegate?
     var findInPage: FindInPage?
@@ -183,7 +185,7 @@ class TabViewController: UIViewController {
         shouldReloadOnError = true
     }
     
-    func attachWebView(configuration: WKWebViewConfiguration, andLoadUrl url: URL?, consumeCookies: Bool) {
+    func attachWebView(configuration: WKWebViewConfiguration, andLoadRequest request: URLRequest?, consumeCookies: Bool) {
         instrumentation.willPrepareWebView()
         webView = WKWebView(frame: view.bounds, configuration: configuration)
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -202,24 +204,31 @@ class TabViewController: UIViewController {
         webView.navigationDelegate = self
         webView.uiDelegate = self
         webViewContainer.addSubview(webView)
-        let controller = webView.configuration.userContentController
-        controller.add(self, name: MessageHandlerNames.trackerDetected)
-        controller.add(self, name: MessageHandlerNames.possibleLogin)
-        controller.add(self, name: MessageHandlerNames.signpost)
-        controller.add(self, name: MessageHandlerNames.log)
-        controller.add(self, name: MessageHandlerNames.findInPageHandler)
+
+        removeMessageHandlers() // incoming config might be a copy of an existing confg with handlers
+        addMessageHandlers()
+
         reloadScripts()
         updateUserAgent()
         
         instrumentation.didPrepareWebView()
 
         if consumeCookies {
-            consumeCookiesThenLoadUrl(url)
-        } else if let url = url {
-            load(url: url)
+            consumeCookiesThenLoadRequest(request)
+        } else if let request = request {
+            load(urlRequest: request)
         }
     }
-    
+
+    private func addMessageHandlers() {
+        let controller = webView.configuration.userContentController
+        controller.add(self, name: MessageHandlerNames.trackerDetected)
+        controller.add(self, name: MessageHandlerNames.possibleLogin)
+        controller.add(self, name: MessageHandlerNames.signpost)
+        controller.add(self, name: MessageHandlerNames.log)
+        controller.add(self, name: MessageHandlerNames.findInPageHandler)
+    }
+
     private func addObservers() {
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.hasOnlySecureContent), options: .new, context: nil)
@@ -236,16 +245,16 @@ class TabViewController: UIViewController {
         longPressGestureRecognizer = gestrueRecognizer
     }
     
-    private func consumeCookiesThenLoadUrl(_ url: URL?) {
+    private func consumeCookiesThenLoadRequest(_ request: URLRequest?) {
         webView.configuration.websiteDataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { _ in
             WebCacheManager.shared.consumeCookies { [weak self] in
                 guard let strongSelf = self else { return }
                 
-                if let url = url {
-                    strongSelf.load(url: url)
+                if let request = request {
+                    strongSelf.load(urlRequest: request)
                 }
                 
-                if url != nil {
+                if request != nil {
                     strongSelf.delegate?.tabLoadingStateDidChange(tab: strongSelf)
                     strongSelf.onWebpageDidStartLoading(httpsForced: false)
                 }
@@ -567,7 +576,10 @@ class TabViewController: UIViewController {
         tearDownExecuted = true
         removeObservers()
         webView.removeFromSuperview()
+        removeMessageHandlers()
+    }
 
+    private func removeMessageHandlers() {
         let controller = webView.configuration.userContentController
         controller.removeScriptMessageHandler(forName: MessageHandlerNames.trackerDetected)
         controller.removeScriptMessageHandler(forName: MessageHandlerNames.possibleLogin)
@@ -947,7 +959,8 @@ extension TabViewController: WKNavigationDelegate {
         }
         
         if isNewTargetBlankRequest(navigationAction: navigationAction) {
-            delegate?.tab(self, didRequestNewTabForUrl: url, animated: true)
+            delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: true)
+            print("***", #function)
             completion(.cancel)
             return
         }
@@ -1010,18 +1023,26 @@ extension TabViewController: PrivacyProtectionDelegate {
 }
 
 extension TabViewController: WKUIDelegate {
+
     public func webView(_ webView: WKWebView,
                         createWebViewWith configuration: WKWebViewConfiguration,
                         for navigationAction: WKNavigationAction,
                         windowFeatures: WKWindowFeatures) -> WKWebView? {
-        webView.load(navigationAction.request)
-        return nil
+        print("***", #function)
+        return delegate?.tab(self, didRequestNewWebViewWithConfiguration: configuration, for: navigationAction)
     }
-    
+
+    func webViewDidClose(_ webView: WKWebView) {
+        if openedByPage {
+            delegate?.tabDidRequestClose(self)
+        }
+    }
+
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         Pixel.fire(pixel: .webKitDidTerminate)
         delegate?.tabContentProcessDidTerminate(tab: self)
     }
+
 }
 
 extension TabViewController: UIPopoverPresentationControllerDelegate {

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -76,7 +76,7 @@ extension TabViewController {
     
     private func onNewTabAction(url: URL) {
         Pixel.fire(pixel: .longPressMenuNewTabItem)
-        delegate?.tab(self, didRequestNewTabForUrl: url, animated: false)
+        delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false)
     }
     
     private func onBackgroundTabAction(url: URL) {
@@ -152,7 +152,7 @@ extension TabViewController {
         let tabController = TabViewController.loadFromStoryboard(model: tab)
         tabController.decorate(with: ThemeManager.shared.currentTheme)
         let configuration = WKWebViewConfiguration.nonPersistent()
-        tabController.attachWebView(configuration: configuration, andLoadUrl: url, consumeCookies: false)
+        tabController.attachWebView(configuration: configuration, andLoadRequest: URLRequest(url: url), consumeCookies: false)
         tabController.loadViewIfNeeded()
         return tabController
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1150230163112681
Tech Design URL:
CC:

**Description**:

Allows JS to open and close new windows.  

**Steps to test this PR**:

1. Make a donation to ProtonMail.  Note they are blocking us from using PayPal so hack the user agent to be Safari when you test - see attached patch.

1.  Sign in to ProtonMail.  Click upgrade, choose an annual fee, select PayPal.  Login to PayPal but don't complete the transaction.  Close the tab.  The ProtonMail tab detects the tab has closed.

1. Visit https://falkirkrpg.org.uk/noxwall/openlater.html - wait 10+ seconds.  No new tab should appear.  Click the button a new tab should appear.  Click the close button and the tab should close.

1. Open a new tab and go directly to https://falkirkrpg.org.uk/noxwall/close.html - the close button should appear to do nothing.

1. Open a new tab and go to https://falkirkrpg.org.uk/noxwall/open.html - click the open button, a new tab should appear.  Clicking the close button should close the tab.

1. Open a new tab and go to https://falkirkrpg.org.uk/noxwall/open.html - click the link, a new tab should appear.  Clicking the close button should close the tab.

Exploratory testing as usual.


[safari-useragent.diff.txt](https://github.com/duckduckgo/iOS/files/4192895/safari-useragent.diff.txt)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
