### PR TITLE
prompt existing users to preserve logins

### DIFF
--- a/Core/PreserveLogins.swift
+++ b/Core/PreserveLogins.swift
@@ -78,16 +78,6 @@ public class PreserveLogins {
         }
     }
     
-    public var prompted: Bool {
-        get {
-            return userDefaults.bool(forKey: Constants.userPromptedKey)
-        }
-        
-        set {
-            userDefaults.set(newValue, forKey: Constants.userPromptedKey)
-        }
-    }
-
     private var userDefaults: UserDefaults
 
     init(userDefaults: UserDefaults = UserDefaults.standard) {
@@ -140,8 +130,7 @@ extension PreserveLogins {
         }
 
         return [
-            "pls": value,
-            "plu": PreserveLogins.shared.prompted ? "n" : "e"
+            "pls": value
         ]
     }
 

--- a/Core/PreserveLogins.swift
+++ b/Core/PreserveLogins.swift
@@ -22,8 +22,10 @@ import Foundation
 public class PreserveLogins {
     
     public enum UserDecision: Int {
+
+        static let `default` = UserDecision.unknown
         
-        case forgetAll = 0 // this is the default so that existing users have same behaviour
+        case forgetAll = 0
         case preserveLogins
         case unknown
 
@@ -62,8 +64,8 @@ public class PreserveLogins {
 
     public var userDecision: UserDecision {
         get {
-            let decision = userDefaults.object(forKey: Constants.userDecisionKey) as? Int ?? UserDecision.unknown.rawValue
-            return UserDecision(rawValue: decision)!
+            let decision = userDefaults.object(forKey: Constants.userDecisionKey) as? Int ?? UserDecision.default.rawValue
+            return UserDecision(rawValue: decision) ?? UserDecision.default
         }
         
         set {

--- a/Core/PreserveLogins.swift
+++ b/Core/PreserveLogins.swift
@@ -62,7 +62,8 @@ public class PreserveLogins {
 
     public var userDecision: UserDecision {
         get {
-            return UserDecision(rawValue: userDefaults.integer(forKey: Constants.userDecisionKey))!
+            let decision = userDefaults.object(forKey: Constants.userDecisionKey) as? Int ?? UserDecision.unknown.rawValue
+            return UserDecision(rawValue: decision)!
         }
         
         set {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -67,12 +67,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AtbAndVariantCleanup.cleanup()
         DefaultVariantManager().assignVariantIfNeeded { _ in
             // MARK: perform first time launch logic here
-            
-            // Force the prompt for new users only, and only if they are on iOS 13 or better
-            if #available(iOS 13, *) {
-                PreserveLogins.shared.userDecision = .unknown
-                PreserveLogins.shared.prompted = true
-            }
         }
 
         if let main = mainViewController {

--- a/DuckDuckGo/TabsModel.swift
+++ b/DuckDuckGo/TabsModel.swift
@@ -40,7 +40,7 @@ public class TabsModel: NSObject, NSCoding {
     }
 
     public convenience required init?(coder decoder: NSCoder) {
-        guard let tabs = decoder.decodeObject(forKey: NSCodingKeys.tabs) as? [Tab] else { return nil }
+        guard let tabs = decoder.decodeObject(forKey: NSCodingKeys.tabs) as? [Tab], !tabs.isEmpty else { return nil }
 
         // we migrated from an optional int to an actual int
         var currentIndex = 0

--- a/DuckDuckGoTests/PreserveLoginsTests.swift
+++ b/DuckDuckGoTests/PreserveLoginsTests.swift
@@ -149,15 +149,6 @@ class PreserveLoginsTests: XCTestCase {
 
     }
 
-    func testWhenPromptedIsChangedThenPersisted() {
-        
-        let logins = PreserveLogins(userDefaults: userDefaults)
-        logins.prompted = true
-        XCTAssertTrue(logins.prompted)
-        XCTAssertTrue(PreserveLogins(userDefaults: userDefaults).prompted)
-        
-    }
-
     func testWhenUserDecisionIsChangedThenItIsPersisted() {
         
         let logins = PreserveLogins(userDefaults: userDefaults)
@@ -167,19 +158,10 @@ class PreserveLoginsTests: XCTestCase {
         
     }
 
-    /// Existing users get the same behaviour as always
-    func testWhenNewThenDefaultPromptedIsFalse() {
+    func testWhenNewThenDefaultIsUnkonwn() {
         
         let logins = PreserveLogins(userDefaults: userDefaults)
-        XCTAssertFalse(logins.prompted)
-        
-    }
-
-    /// Existing users get the same behaviour as always
-    func testWhenNewThenDefaultUserDecisionIsForgetAll() {
-        
-        let logins = PreserveLogins(userDefaults: userDefaults)
-        XCTAssertEqual(logins.userDecision, .forgetAll)
+        XCTAssertEqual(logins.userDecision, .unknown)
         
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1162014199122092
Tech Design URL:
CC:

**Description**:

Prompt existing users when login detected and fire button is used.

**Steps to test this PR**:

1. Checkout and launch a version of the app before 7.38.0 and browse the web
1. Checkout and launch this branch
1. Login in to a site, e.g. reddit.com 
1. Clear all
1. Ensure keep logins prompt is shown
1. Choose "yes"
1. Check the settings are updated
1. Clear all
1. Navigate to site and ensure still logged in
1. Log out
1. Log in again
1. Clear all
1. No prompt displayed
1. Navigate to site and ensure still logged in
1. Change setting to disable keep logins
1. Fire button
1. Navigate to site, should not be logged in

Using a fresh install, make sure it still works for new users too

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
