### PR TITLE
show bars when using keyboard to focus address bar

### DIFF
--- a/DuckDuckGo/MainViewController+KeyCommands.swift
+++ b/DuckDuckGo/MainViewController+KeyCommands.swift
@@ -87,6 +87,7 @@ extension MainViewController {
         if let controller = homeController {
             controller.launchNewSearch()
         } else {
+            showBars()
             omniBar.becomeFirstResponder()
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1162796744284121
Tech Design URL:
CC:

**Description**:

Show bars when focusing address bar with physical keyboard

**Steps to test this PR**:

1. On iPad with physical keyboard (or iPad simulator with "send device shortcuts enabled), search for something
1. Scroll up to hide the bards
1. Press Cmd+L
1. Expected: Omnibar should receive focus and the bars should show


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
