### PR TITLE
Fix Tab Switcher crash

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -219,17 +219,21 @@ extension TabSwitcherViewController: TabViewCellDelegate {
 
     func deleteTab(tab: Tab) {
         guard let index = tabsModel.indexOf(tab: tab) else { return }
+        let isLastTab = tabsModel.count == 1
         delegate.tabSwitcher(self, didRemoveTab: tab)
         currentSelection = tabsModel.currentIndex
         refreshTitle()
         
-        collectionView.performBatchUpdates({
-            self.collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
-        }, completion: { _ in
-            guard let current = self.currentSelection else { return }
-            self.collectionView.reloadItems(at: [IndexPath(row: current, section: 0)])
-        })
-        
+        if isLastTab {
+            collectionView.reloadData()
+        } else {
+            collectionView.performBatchUpdates({
+                self.collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
+            }, completion: { _ in
+                guard let current = self.currentSelection else { return }
+                self.collectionView.reloadItems(at: [IndexPath(row: current, section: 0)])
+            })
+        }
     }
     
     func isCurrent(tab: Tab) -> Bool {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1163347937943937
Tech Design URL:
CC:

**Description**:
Fix animation to make sure we don't animate deletions if model does not change.

**Steps to test this PR**:

On iOS 12:
1. Enter tabs switcher.
2. Delete last tab.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
