### PR TITLE
disable login detection

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -123,6 +123,7 @@ public enum PixelName: String {
     case browsingMenuWhitelistAdd = "mb_wla"
     case browsingMenuWhitelistRemove = "mb_wlr"
     case browsingMenuReportBrokenSite = "mb_rb"
+    case browsingMenuFireproof = "mb_f"
     
     case tabBarBackPressed = "mt_bk"
     case tabBarForwardPressed = "mt_fw"

--- a/Core/PreserveLogins.swift
+++ b/Core/PreserveLogins.swift
@@ -31,45 +31,58 @@ public class PreserveLogins {
 
     }
     
-    struct Constants {
-        static let detectedDomainsKey = "com.duckduckgo.ios.PreserveLogins.userDecision.detectedDomains"
-        static let allowedDomainsKey = "com.duckduckgo.ios.PreserveLogins.userDecision.allowedDomains"
-        static let userDecisionKey = "com.duckduckgo.ios.PreserveLogins.userDecision"
-        static let userPromptedKey = "com.duckduckgo.ios.PreserveLogins.userPrompted"
+    struct Keys {
+        static let detectedDomains = "com.duckduckgo.ios.PreserveLogins.userDecision.detectedDomains"
+        static let allowedDomains = "com.duckduckgo.ios.PreserveLogins.userDecision.allowedDomains2"
+        static let userDecision = "com.duckduckgo.ios.PreserveLogins.userDecision"
+        static let userPrompted = "com.duckduckgo.ios.PreserveLogins.userPrompted"
+        
+        static let legacyAllowedDomains = "com.duckduckgo.ios.PreserveLogins.userDecision.allowedDomains"
     }
     
     public static let shared = PreserveLogins()
     
     private(set) public var allowedDomains: [String] {
         get {
-            return userDefaults.array(forKey: Constants.allowedDomainsKey) as? [String] ?? []
+            return userDefaults.array(forKey: Keys.allowedDomains) as? [String] ?? []
         }
         
         set {
             let domains = [String](Set<String>(newValue))
-            userDefaults.set(domains, forKey: Constants.allowedDomainsKey)
+            userDefaults.set(domains, forKey: Keys.allowedDomains)
         }
     }
 
-    private(set) public var detectedDomains: [String] {
+    private(set) public var legacyAllowedDomains: [String] {
         get {
-            return userDefaults.array(forKey: Constants.detectedDomainsKey) as? [String] ?? []
+            return userDefaults.array(forKey: Keys.legacyAllowedDomains) as? [String] ?? []
         }
         
         set {
             let domains = [String](Set<String>(newValue))
-            userDefaults.set(domains, forKey: Constants.detectedDomainsKey)
+            userDefaults.set(domains, forKey: Keys.legacyAllowedDomains)
+        }
+    }
+    
+    private(set) public var detectedDomains: [String] {
+        get {
+            return userDefaults.array(forKey: Keys.detectedDomains) as? [String] ?? []
+        }
+        
+        set {
+            let domains = [String](Set<String>(newValue))
+            userDefaults.set(domains, forKey: Keys.detectedDomains)
         }
     }
 
     public var userDecision: UserDecision {
         get {
-            let decision = userDefaults.object(forKey: Constants.userDecisionKey) as? Int ?? UserDecision.default.rawValue
+            let decision = userDefaults.object(forKey: Keys.userDecision) as? Int ?? UserDecision.default.rawValue
             return UserDecision(rawValue: decision) ?? UserDecision.default
         }
         
         set {
-            userDefaults.set(newValue.rawValue, forKey: Constants.userDecisionKey)
+            userDefaults.set(newValue.rawValue, forKey: Keys.userDecision)
             if newValue == .preserveLogins {
                 allowedDomains += detectedDomains
                 detectedDomains = []
@@ -113,6 +126,10 @@ public class PreserveLogins {
     
     public func clearDetected() {
         detectedDomains = []
+    }
+    
+    public func clearLegacyAllowedDomains() {
+        legacyAllowedDomains = []
     }
 
 }

--- a/Core/PreserveLogins.swift
+++ b/Core/PreserveLogins.swift
@@ -99,12 +99,12 @@ public class PreserveLogins {
         self.userDefaults = userDefaults
     }
     
-    public func add(domain: String) {
-        if userDecision == .preserveLogins {
-            allowedDomains += [domain]
-        } else {
-            detectedDomains += [domain]
-        }
+    public func addToAllowed(domain: String) {
+        allowedDomains += [domain]
+    }
+
+    public func addToDetected(domain: String) {
+        detectedDomains += [domain]
     }
 
     public func isAllowed(cookieDomain: String) -> Bool {

--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -124,7 +124,6 @@ private struct Loader {
         loadMainFrameOnlyScripts()
 
         loadMessagingScripts()
-        loadLoginScript()
         
         if injectContentBlockingScripts {
             loadContentBlockingScripts()

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -79,9 +79,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             autoClear = AutoClear(worker: main)
             autoClear?.applicationDidLaunch()
         }
-
+        
+        clearLegacyAllowedDomainCookies()
+    
         appIsLaunching = true
         return true
+    }
+    
+    private func clearLegacyAllowedDomainCookies() {
+        let domains = PreserveLogins.shared.legacyAllowedDomains
+        guard !domains.isEmpty else { return }
+        WebCacheManager.shared.removeCookies(forDomains: domains, completion: {
+            os_log("Removed cookies for %d legacy allowed domains", domains.count)
+            PreserveLogins.shared.clearLegacyAllowedDomains()
+        })
     }
 
     private func migrateHomePageSettings(homePageSettings: HomePageSettings = DefaultHomePageSettings()) {

--- a/DuckDuckGo/Base.lproj/Settings.storyboard
+++ b/DuckDuckGo/Base.lproj/Settings.storyboard
@@ -230,8 +230,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Saved Website Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UNq-DI-x5m">
-                                                    <rect key="frame" x="20" y="14" width="143.66666666666666" height="16"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Fireproof Websites" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UNq-DI-x5m">
+                                                    <rect key="frame" x="20" y="14" width="134.66666666666666" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -1336,7 +1336,7 @@ upgraded by Privacy Protection.</string>
             </objects>
             <point key="canvasLocation" x="4942" y="930"/>
         </scene>
-        <!--Saved Website Data-->
+        <!--Fireproof Websites-->
         <scene sceneID="Kfp-VW-T6P">
             <objects>
                 <tableViewController id="Jzw-Jd-J97" customClass="PreserveLoginsSettingsViewController" customModule="DuckDuckGo" customModuleProvider="target" sceneMemberID="viewController">
@@ -1447,7 +1447,7 @@ upgraded by Privacy Protection.</string>
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.666667938232422"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sign Out of All Websites" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UZx-52-aer">
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Remove All Fireproof Websites" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UZx-52-aer">
                                             <rect key="frame" x="20" y="0.0" width="374" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
@@ -1465,7 +1465,7 @@ upgraded by Privacy Protection.</string>
                             <outlet property="delegate" destination="Jzw-Jd-J97" id="7MY-Jt-0Of"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Saved Website Data" id="xUX-nF-HOl">
+                    <navigationItem key="navigationItem" title="Fireproof Websites" id="xUX-nF-HOl">
                         <rightBarButtonItems>
                             <barButtonItem style="done" systemItem="done" id="6j1-I1-H7J">
                                 <connections>

--- a/DuckDuckGo/Base.lproj/Settings.storyboard
+++ b/DuckDuckGo/Base.lproj/Settings.storyboard
@@ -39,14 +39,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Theme" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="f1O-6u-LFY">
-                                                    <rect key="frame" x="19.999999999999996" y="14" width="49.666666666666664" height="16"/>
+                                                    <rect key="frame" x="20" y="13.000000000000002" width="49" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Default" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Gbx-kl-uOO">
-                                                    <rect key="frame" x="324.66666666666669" y="14" width="50.333333333333336" height="16"/>
+                                                    <rect key="frame" x="324" y="13.000000000000002" width="51" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -109,14 +109,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="New Tab" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jy0-Hs-WSz">
-                                                    <rect key="frame" x="19.999999999999996" y="14" width="62.666666666666664" height="16"/>
+                                                    <rect key="frame" x="20.000000000000004" y="13.000000000000002" width="62.333333333333336" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Default" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="O9k-vm-boT">
-                                                    <rect key="frame" x="324.66666666666669" y="14" width="50.333333333333336" height="16"/>
+                                                    <rect key="frame" x="324" y="13.000000000000002" width="51" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -231,14 +231,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Keep Me Signed In" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UNq-DI-x5m">
-                                                    <rect key="frame" x="20" y="14" width="134.33333333333334" height="16"/>
+                                                    <rect key="frame" x="20" y="13.000000000000002" width="136.66666666666666" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="On/Off" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QAv-VN-hEJ">
-                                                    <rect key="frame" x="327.66666666666669" y="14" width="47.333333333333336" height="16"/>
+                                                    <rect key="frame" x="327" y="13.000000000000002" width="48" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -259,14 +259,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Automatically Clear Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FgW-X9-qoE">
-                                                    <rect key="frame" x="20" y="14" width="177" height="16"/>
+                                                    <rect key="frame" x="20" y="13.000000000000002" width="176.66666666666666" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="On/Off" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ccm-w6-p6U">
-                                                    <rect key="frame" x="327.66666666666669" y="14" width="47.333333333333336" height="16"/>
+                                                    <rect key="frame" x="327" y="13.000000000000002" width="48" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -488,14 +488,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2ky-s9-1aZ">
-                                                    <rect key="frame" x="15" y="8" width="54" height="16"/>
+                                                    <rect key="frame" x="14.999999999999996" y="6" width="52.666666666666664" height="18.666666666666668"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="10.0.1 (Build 10005)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d5n-vG-8kF">
-                                                    <rect key="frame" x="15.000000000000007" y="24" width="98.666666666666671" height="12"/>
+                                                    <rect key="frame" x="15" y="24.666666666666668" width="107" height="14"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="12"/>
                                                     <color key="textColor" red="0.74509803919999995" green="0.76078431369999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DuckDuckGo/Base.lproj/Settings.storyboard
+++ b/DuckDuckGo/Base.lproj/Settings.storyboard
@@ -39,14 +39,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Theme" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="f1O-6u-LFY">
-                                                    <rect key="frame" x="20" y="13.000000000000002" width="49" height="18.666666666666668"/>
+                                                    <rect key="frame" x="19.999999999999996" y="14" width="49.666666666666664" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Default" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Gbx-kl-uOO">
-                                                    <rect key="frame" x="324" y="13.000000000000002" width="51" height="18.666666666666668"/>
+                                                    <rect key="frame" x="324.66666666666669" y="14" width="50.333333333333336" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -109,14 +109,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="New Tab" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jy0-Hs-WSz">
-                                                    <rect key="frame" x="20.000000000000004" y="13.000000000000002" width="62.333333333333336" height="18.666666666666668"/>
+                                                    <rect key="frame" x="19.999999999999996" y="14" width="62.666666666666664" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Default" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="O9k-vm-boT">
-                                                    <rect key="frame" x="324" y="13.000000000000002" width="51" height="18.666666666666668"/>
+                                                    <rect key="frame" x="324.66666666666669" y="14" width="50.333333333333336" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -230,15 +230,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Keep Me Signed In" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UNq-DI-x5m">
-                                                    <rect key="frame" x="20" y="13.000000000000002" width="136.66666666666666" height="18.666666666666668"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Saved Website Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UNq-DI-x5m">
+                                                    <rect key="frame" x="20" y="14" width="143.66666666666666" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="On/Off" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QAv-VN-hEJ">
-                                                    <rect key="frame" x="327" y="13.000000000000002" width="48" height="18.666666666666668"/>
+                                                    <rect key="frame" x="327.66666666666669" y="14" width="47.333333333333336" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -259,14 +259,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Automatically Clear Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FgW-X9-qoE">
-                                                    <rect key="frame" x="20" y="13.000000000000002" width="176.66666666666666" height="18.666666666666668"/>
+                                                    <rect key="frame" x="20" y="14" width="177" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="On/Off" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ccm-w6-p6U">
-                                                    <rect key="frame" x="327" y="13.000000000000002" width="48" height="18.666666666666668"/>
+                                                    <rect key="frame" x="327.66666666666669" y="14" width="47.333333333333336" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -488,14 +488,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2ky-s9-1aZ">
-                                                    <rect key="frame" x="14.999999999999996" y="6" width="52.666666666666664" height="18.666666666666668"/>
+                                                    <rect key="frame" x="15" y="8" width="54" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="10.0.1 (Build 10005)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d5n-vG-8kF">
-                                                    <rect key="frame" x="15" y="24.666666666666668" width="107" height="14"/>
+                                                    <rect key="frame" x="15.000000000000007" y="24" width="98.666666666666671" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="12"/>
                                                     <color key="textColor" red="0.74509803919999995" green="0.76078431369999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1336,7 +1336,7 @@ upgraded by Privacy Protection.</string>
             </objects>
             <point key="canvasLocation" x="4942" y="930"/>
         </scene>
-        <!--Keep Me Signed In-->
+        <!--Saved Website Data-->
         <scene sceneID="Kfp-VW-T6P">
             <objects>
                 <tableViewController id="Jzw-Jd-J97" customClass="PreserveLoginsSettingsViewController" customModule="DuckDuckGo" customModuleProvider="target" sceneMemberID="viewController">
@@ -1465,7 +1465,7 @@ upgraded by Privacy Protection.</string>
                             <outlet property="delegate" destination="Jzw-Jd-J97" id="7MY-Jt-0Of"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Keep Me Signed In" id="xUX-nF-HOl">
+                    <navigationItem key="navigationItem" title="Saved Website Data" id="xUX-nF-HOl">
                         <rightBarButtonItems>
                             <barButtonItem style="done" systemItem="done" id="6j1-I1-H7J">
                                 <connections>

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1056,12 +1056,6 @@ extension MainViewController: AutoClearWorker {
     func forgetData() {
         findInPageView?.done()
         
-        if PreserveLogins.shared.userDecision != .preserveLogins {
-            PreserveLogins.shared.clearAll()
-        } else {
-            PreserveLogins.shared.clearDetected()
-        }
-        
         ServerTrustCache.shared.clear()
         KingfisherManager.shared.cache.clearDiskCache()
 

--- a/DuckDuckGo/PreserveLoginsAlert.swift
+++ b/DuckDuckGo/PreserveLoginsAlert.swift
@@ -22,6 +22,17 @@ import Core
 
 class PreserveLoginsAlert {
     
+    static func showConfirmFireproofWebsite(usingController controller: UIViewController, completion: @escaping() -> Void) {
+        let prompt = UIAlertController(title: nil,
+                                       message: UserText.preserverLoginsFireproofWebsiteMessage,
+                                       preferredStyle: isPad ? .alert : .actionSheet)
+        prompt.addAction(title: UserText.preserveLoginsMenuTitle, style: .default) {
+            completion()
+        }
+        prompt.addAction(title: UserText.actionCancel, style: .cancel)
+        controller.present(prompt, animated: true)
+    }
+    
     static func showInitialPromptIfNeeded(usingController controller: UIViewController, completion: @escaping () -> Void) {
         guard #available(iOS 13, *) else {
             completion()

--- a/DuckDuckGo/PreserveLoginsAlert.swift
+++ b/DuckDuckGo/PreserveLoginsAlert.swift
@@ -22,12 +22,12 @@ import Core
 
 class PreserveLoginsAlert {
     
-    static func showConfirmFireproofWebsite(usingController controller: UIViewController, completion: @escaping() -> Void) {
+    static func showConfirmFireproofWebsite(usingController controller: UIViewController, onConfirmHandler: @escaping() -> Void) {
         let prompt = UIAlertController(title: nil,
                                        message: UserText.preserverLoginsFireproofWebsiteMessage,
                                        preferredStyle: isPad ? .alert : .actionSheet)
         prompt.addAction(title: UserText.preserveLoginsMenuTitle, style: .default) {
-            completion()
+            onConfirmHandler()
         }
         prompt.addAction(title: UserText.actionCancel, style: .cancel)
         controller.present(prompt, animated: true)

--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -117,7 +117,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return UserText.preserveLoginsDomainListHeaderTitle
+        return section == Sections.domainList ? UserText.preserveLoginsDomainListHeaderTitle : nil
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {

--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -28,11 +28,8 @@ protocol PreserveLoginsSettingsDelegate: NSObjectProtocol {
 
 class PreserveLoginsSettingsViewController: UITableViewController {
     
-    struct Sections {
-        
-        static let domainList = 0
-        static let removeAll = 1
-        
+    enum Section: Int {
+        case domainList
     }
     
     @IBOutlet var doneButton: UIBarButtonItem!
@@ -90,19 +87,16 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch section {
-        case Sections.domainList: return max(1, model.count)
-        default: return 1
-        }
+        return Section(rawValue: section) == Section.domainList ? max(1, model.count) : 1
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         let theme = ThemeManager.shared.currentTheme
         let cell: UITableViewCell
-        switch indexPath.section {
+        switch Section(rawValue: indexPath.section) {
 
-        case Sections.domainList:
+        case .some(Section.domainList):
             if model.isEmpty {
                 cell = createNoDomainCell(forTableView: tableView, withTheme: theme)
             } else {
@@ -117,15 +111,15 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return section == Sections.domainList ? UserText.preserveLoginsDomainListHeaderTitle : nil
+        return Section(rawValue: section) == Section.domainList ? UserText.preserveLoginsDomainListHeaderTitle : nil
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return indexPath.section == Sections.domainList && !model.isEmpty
+        return indexPath.isInSection(section: Section.domainList) && !model.isEmpty
     }
 
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        guard !model.isEmpty, indexPath.section == Sections.domainList else { return .none }
+        guard !model.isEmpty, indexPath.isInSection(section: .domainList) else { return .none }
         return .delete
     }
 
@@ -257,4 +251,12 @@ class PreserveLoginDomainCell: UITableViewCell {
     @IBOutlet weak var faviconImage: UIImageView!
     @IBOutlet weak var label: UILabel!
 
+}
+
+fileprivate extension IndexPath {
+    
+    func isInSection(section: PreserveLoginsSettingsViewController.Section) -> Bool {
+        return self.section == section.rawValue
+    }
+    
 }

--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -28,6 +28,13 @@ protocol PreserveLoginsSettingsDelegate: NSObjectProtocol {
 
 class PreserveLoginsSettingsViewController: UITableViewController {
     
+    struct Sections {
+        
+        static let domainList = 0
+        static let removeAll = 1
+        
+    }
+    
     @IBOutlet var doneButton: UIBarButtonItem!
     @IBOutlet var editButton: UIBarButtonItem!
 
@@ -79,7 +86,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        var sections = 1 // the switch
+        var sections = 0 // the switch - disabled for now
         sections += PreserveLogins.shared.userDecision == .preserveLogins ? 1 : 0 // the domains
         sections += tableView.isEditing ? 1 : 0 // the clear all button
         return sections
@@ -87,7 +94,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case 1: return model.isEmpty ? 1 : model.count
+        case Sections.domainList: return max(1, model.count)
         default: return 1
         }
     }
@@ -98,10 +105,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
         let cell: UITableViewCell
         switch indexPath.section {
 
-        case 0:
-            cell = createSwitchCell(forTableView: tableView, withTheme: theme)
-
-        case 1:
+        case Sections.domainList:
             if model.isEmpty {
                 cell = createNoDomainCell(forTableView: tableView, withTheme: theme)
             } else {
@@ -116,19 +120,15 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return section == 1 ? UserText.preserveLoginsDomainListHeaderTitle : nil
-    }
-    
-    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return section == 0 ? UserText.preserveLoginsSwitchFooter : nil
+        return UserText.preserveLoginsDomainListHeaderTitle
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return indexPath.section == 1 && !model.isEmpty
+        return indexPath.section == Sections.domainList && !model.isEmpty
     }
 
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-        guard !model.isEmpty, indexPath.section == 1 else { return .none }
+        guard !model.isEmpty, indexPath.section == Sections.domainList else { return .none }
         return .delete
     }
 
@@ -149,11 +149,11 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
-        return indexPath.section == 1 && !model.isEmpty
+        return indexPath.section == 0 && !model.isEmpty
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if indexPath.section == 2 {
+        if indexPath.section == 1 {
             Pixel.fire(pixel: .preserveLoginsSettingsClearAll)
             clearAll()
             tableView.deselectRow(at: indexPath, animated: true)

--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -86,10 +86,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        var sections = 0 // the switch - disabled for now
-        sections += PreserveLogins.shared.userDecision == .preserveLogins ? 1 : 0 // the domains
-        sections += tableView.isEditing ? 1 : 0 // the clear all button
-        return sections
+        return tableView.isEditing ? 2 : 1
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -185,7 +185,7 @@ class SettingsViewController: UITableViewController {
     
     private func configureRememberLogins() {
         if #available(iOS 13, *) {
-            rememberLoginsAccessoryText.text = ""
+            rememberLoginsAccessoryText.text = PreserveLogins.shared.allowedDomains.isEmpty ? "" : "\(PreserveLogins.shared.allowedDomains.count)"
         } else {
             rememberLoginsCell.isHidden = true
         }        

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -184,24 +184,11 @@ class SettingsViewController: UITableViewController {
     }
     
     private func configureRememberLogins() {
-        
         if #available(iOS 13, *) {
-            rememberLoginsCell.isHidden = false
-            
-            switch PreserveLogins.shared.userDecision {
-                
-            case .preserveLogins:
-                rememberLoginsAccessoryText.text = UserText.preserveLoginsAccessoryOn
-                
-            case .forgetAll, .unknown:
-                rememberLoginsAccessoryText.text = UserText.preserveLoginsAccessoryOff
-                
-            }
-            
+            rememberLoginsAccessoryText.text = ""
         } else {
             rememberLoginsCell.isHidden = true
-        }
-        
+        }        
     }
 
     private func configureVersionText() {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -318,6 +318,7 @@ class TabViewController: UIViewController {
     func fireproofWebsite(domain: String) {
         
         PreserveLoginsAlert.showConfirmFireproofWebsite(usingController: self) {
+            Pixel.fire(pixel: .browsingMenuFireproof)
             PreserveLogins.shared.addToAllowed(domain: domain)
             self.view.showBottomToast(UserText.preserveLoginsToast.format(arguments: domain))
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -315,6 +315,15 @@ class TabViewController: UIViewController {
         updateSiteRating()
     }
     
+    func fireproofWebsite(domain: String) {
+        
+        PreserveLoginsAlert.showConfirmFireproofWebsite(usingController: self) {
+            PreserveLogins.shared.addToAllowed(domain: domain)
+            self.view.showBottomToast(UserText.preserveLoginsToast.format(arguments: domain))
+        }
+        
+    }
+    
     private func checkForReloadOnError() {
         guard shouldReloadOnError else { return }
         shouldReloadOnError = false

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -919,17 +919,8 @@ extension TabViewController: WKNavigationDelegate {
                 }
                 
                 self?.findInPage?.done()
-                            
-                self?.loginDetection = nil
-                LoginDetection.webView(withURL: webView.url,
-                                       andCookies: webView.configuration.websiteDataStore,
-                                       allowedAction: navigationAction) { loginDetection in
-                    self?.loginDetection = loginDetection
-                    decisionHandler(decision)
-                }
-            } else {
-                decisionHandler(decision)
             }
+            decisionHandler(decision)
         }
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -661,7 +661,11 @@ extension TabViewController: WKScriptMessageHandler {
             view.showBottomToast("Login detected for \(domain) via \(source)")
         }
         
-        PreserveLogins.shared.add(domain: domain)
+        if PreserveLogins.shared.userDecision == .preserveLogins {
+            PreserveLogins.shared.addToAllowed(domain: domain)
+        } else {
+            PreserveLogins.shared.addToDetected(domain: domain)
+        }
     }
     
     private func handleFindInPage(message: WKScriptMessage) {

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -73,11 +73,11 @@ extension TabViewController {
     }
     
     private func buildKeepSignInAction(forLink link: Link) -> UIAlertAction? {
+        guard #available(iOS 13, *) else { return nil }
         guard let domain = link.url.host, !appUrls.isDuckDuckGo(url: link.url) else { return nil }
         guard !PreserveLogins.shared.isAllowed(cookieDomain: domain) else { return nil }
         return UIAlertAction(title: UserText.preserveLoginsMenuTitle, style: .default) { [weak self] _ in
-            PreserveLogins.shared.addToAllowed(domain: domain)
-            self?.view.showBottomToast(UserText.preserveLoginsToast.format(arguments: domain))
+            self?.fireproofWebsite(domain: domain)
         }
     }
     

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -73,10 +73,10 @@ extension TabViewController {
     }
     
     private func buildKeepSignInAction(forLink link: Link) -> UIAlertAction? {
-        guard let domain = link.url.host else { return nil }
+        guard let domain = link.url.host, !appUrls.isDuckDuckGo(url: link.url) else { return nil }
         guard !PreserveLogins.shared.isAllowed(cookieDomain: domain) else { return nil }
         return UIAlertAction(title: UserText.preserveLoginsMenuTitle, style: .default) { [weak self] _ in
-            PreserveLogins.shared.add(domain: domain)
+            PreserveLogins.shared.addToAllowed(domain: domain)
             self?.view.showBottomToast(UserText.preserveLoginsToast.format(arguments: domain))
         }
     }

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -43,6 +43,10 @@ extension TabViewController {
                 alert.addAction(action)
             }
 
+            if let action = buildKeepSignInAction(forLink: link) {
+                alert.addAction(action)
+            }
+
             alert.addAction(title: UserText.actionShare) { [weak self] in
                 guard let self = self else { return }
                 self.onShareAction(forLink: link, printFormatter: self.webView.viewPrintFormatter())
@@ -66,6 +70,15 @@ extension TabViewController {
         }
         alert.addAction(title: UserText.actionCancel, style: .cancel)
         return alert
+    }
+    
+    private func buildKeepSignInAction(forLink link: Link) -> UIAlertAction? {
+        guard let domain = link.url.host else { return nil }
+        guard !PreserveLogins.shared.isAllowed(cookieDomain: domain) else { return nil }
+        return UIAlertAction(title: UserText.preserveLoginsMenuTitle, style: .default) { [weak self] _ in
+            PreserveLogins.shared.add(domain: domain)
+            self?.view.showBottomToast(UserText.preserveLoginsToast.format(arguments: domain))
+        }
     }
     
     private func onNewTabAction() {

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -252,7 +252,9 @@ public struct UserText {
     public static let preserveLoginsDomainListHeaderTitle = NSLocalizedString("preserveLogins.domain.list.title", comment: "Preserve logins domain list title")
     public static let preserveLoginsSwitchFooter = NSLocalizedString("preserveLogins.switch.footer", comment: "Preserve logins switch footer")
     public static let preserveLoginsSignOut = NSLocalizedString("preserveLogins.sign.out", comment: "Preserve logins clear all prompt")
-
+    public static let preserveLoginsMenuTitle = NSLocalizedString("preserveLogins.menu.title", comment: "Preserve logins menu title")
+    public static let preserveLoginsToast = NSLocalizedString("preserveLogins.toast", comment: "Preserve toast message")
+    
     public static let homeTabSearchOnly = NSLocalizedString("homeTab.searchOnly", comment: "Home tab search only")
     public static let homeTabSearchAndFavorites = NSLocalizedString("homeTab.searchAndFavorites", comment: "Home tab search and favorites")
     public static let homeTabTitle = NSLocalizedString("homeTab.title", comment: "Home tab title")

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -254,6 +254,7 @@ public struct UserText {
     public static let preserveLoginsSignOut = NSLocalizedString("preserveLogins.sign.out", comment: "Preserve logins clear all prompt")
     public static let preserveLoginsMenuTitle = NSLocalizedString("preserveLogins.menu.title", comment: "Preserve logins menu title")
     public static let preserveLoginsToast = NSLocalizedString("preserveLogins.toast", comment: "Preserve toast message")
+    public static let preserverLoginsFireproofWebsiteMessage = NSLocalizedString("preserveLogins.fireproof.message", comment: "Fireproof website message")
     
     public static let homeTabSearchOnly = NSLocalizedString("homeTab.searchOnly", comment: "Home tab search only")
     public static let homeTabSearchAndFavorites = NSLocalizedString("homeTab.searchAndFavorites", comment: "Home tab search and favorites")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -297,10 +297,10 @@
 "preserveLogins.accessory.on" = "On";
 "preserveLogins.accessory.off" = "Off";
 "preserveLogins.switch.footer" = "Allows you to stay signed in to websites when you clear your data";
-"preserveLogins.domain.list.title" = "Signed In Websites";
-"preserveLogins.sign.out" = "Sign Out";
-"preserveLogins.menu.title" = "Keep Me Signed In";
-"preserveLogins.toast" = "Sign in saved for '%@'.  Remove in settings.";
+"preserveLogins.domain.list.title" = "Websites";
+"preserveLogins.sign.out" = "Remove Data";
+"preserveLogins.menu.title" = "Keep Website Data";
+"preserveLogins.toast" = "Website data for '%@' will be saved.  Remove in settings.";
 
 "homeTab.searchOnly" = "Search in a new tab";
 "homeTab.searchAndFavorites" = "Search and favorites in a new tab";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -299,8 +299,8 @@
 "preserveLogins.switch.footer" = "Allows you to stay signed in to websites when you clear your data";
 "preserveLogins.domain.list.title" = "Signed In Websites";
 "preserveLogins.sign.out" = "Sign Out";
-"preserveLogins.menu.title" = "Stay Signed In";
-"preserveLogins.toast" = "Keeping sign in for '%@'.  Remove in settings.";
+"preserveLogins.menu.title" = "Keep Me Signed In";
+"preserveLogins.toast" = "Sign in saved for '%@'.  Remove in settings.";
 
 "homeTab.searchOnly" = "Search in a new tab";
 "homeTab.searchAndFavorites" = "Search and favorites in a new tab";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -299,6 +299,8 @@
 "preserveLogins.switch.footer" = "Allows you to stay signed in to websites when you clear your data";
 "preserveLogins.domain.list.title" = "Signed In Websites";
 "preserveLogins.sign.out" = "Sign Out";
+"preserveLogins.menu.title" = "Stay Signed In";
+"preserveLogins.toast" = "Keeping sign in for '%@'.  Remove in settings.";
 
 "homeTab.searchOnly" = "Search in a new tab";
 "homeTab.searchAndFavorites" = "Search and favorites in a new tab";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -298,9 +298,10 @@
 "preserveLogins.accessory.off" = "Off";
 "preserveLogins.switch.footer" = "Allows you to stay signed in to websites when you clear your data";
 "preserveLogins.domain.list.title" = "Websites";
-"preserveLogins.sign.out" = "Remove Data";
-"preserveLogins.menu.title" = "Keep Website Data";
-"preserveLogins.toast" = "Website data for '%@' will be saved.  Remove in settings.";
+"preserveLogins.sign.out" = "Remove All";
+"preserveLogins.menu.title" = "Fireproof Website";
+"preserveLogins.toast" = "'%@' is now fireproof!  Remove in settings.";
+"preserveLogins.fireproof.message" = "Website data will be saved when using the fire button or auto clear.";
 
 "homeTab.searchOnly" = "Search in a new tab";
 "homeTab.searchAndFavorites" = "Search and favorites in a new tab";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -300,8 +300,8 @@
 "preserveLogins.domain.list.title" = "Websites";
 "preserveLogins.sign.out" = "Remove All";
 "preserveLogins.menu.title" = "Fireproof Website";
-"preserveLogins.toast" = "'%@' is now fireproof!  Remove in settings.";
-"preserveLogins.fireproof.message" = "Website data will be saved when using the fire button or auto clear.";
+"preserveLogins.toast" = "'%@' is now fireproof!  Visit Settings to remove.";
+"preserveLogins.fireproof.message" = "Website data will be saved when using the Fire Button or Auto Clear.";
 
 "homeTab.searchOnly" = "Search in a new tab";
 "homeTab.searchAndFavorites" = "Search and favorites in a new tab";

--- a/DuckDuckGoTests/PreserveLoginsTests.swift
+++ b/DuckDuckGoTests/PreserveLoginsTests.swift
@@ -32,7 +32,7 @@ class PreserveLoginsTests: XCTestCase {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "www.boardgamegeek.com")
+        logins.addToAllowed(domain: "www.boardgamegeek.com")
         XCTAssertTrue(logins.isAllowed(cookieDomain: ".boardgamegeek.com"))
 
     }
@@ -41,7 +41,7 @@ class PreserveLoginsTests: XCTestCase {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "boardgamegeek.com")
+        logins.addToAllowed(domain: "boardgamegeek.com")
         XCTAssertTrue(logins.isAllowed(cookieDomain: ".boardgamegeek.com"))
 
     }
@@ -50,7 +50,7 @@ class PreserveLoginsTests: XCTestCase {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "boardgamegeek.com")
+        logins.addToAllowed(domain: "boardgamegeek.com")
         XCTAssertTrue(logins.isAllowed(cookieDomain: "boardgamegeek.com"))
 
     }
@@ -59,7 +59,7 @@ class PreserveLoginsTests: XCTestCase {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         XCTAssertEqual(["www.example.com"], logins.allowedDomains)
         XCTAssertTrue(logins.detectedDomains.isEmpty)
         
@@ -71,7 +71,7 @@ class PreserveLoginsTests: XCTestCase {
     func testWhenUserEnablesPreserveLoginsThenDetectedDomainsAreMovedToAllowedDomains() {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
-        logins.add(domain: "www.example.com")
+        logins.addToDetected(domain: "www.example.com")
         XCTAssertEqual(["www.example.com"], logins.detectedDomains)
         XCTAssertTrue(logins.allowedDomains.isEmpty)
 
@@ -85,13 +85,13 @@ class PreserveLoginsTests: XCTestCase {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         logins.clearAll()
         XCTAssertTrue(logins.detectedDomains.isEmpty)
         XCTAssertTrue(logins.allowedDomains.isEmpty)
         
         logins.userDecision = .forgetAll
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         logins.clearAll()
         XCTAssertTrue(logins.detectedDomains.isEmpty)
         XCTAssertTrue(logins.allowedDomains.isEmpty)
@@ -101,28 +101,28 @@ class PreserveLoginsTests: XCTestCase {
     func testWhenClearDetectedIsCalledThenDetectedDomainsAreCleared() {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
-        logins.add(domain: "www.example.com")
+        logins.addToDetected(domain: "www.example.com")
         logins.clearDetected()
         XCTAssertTrue(logins.allowedDomains.isEmpty)
         XCTAssertTrue(logins.detectedDomains.isEmpty)
 
     }
 
-    func testWhenDuplicateDomainWhenPreserveLoginsIsSelectedAddedThenUniqueDomainsPersistedToAllowedDomains() {
+    func testWhenDuplicateDomainAddedToAllowedThenNotAddedAgain() {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "www.example.com")
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         XCTAssertEqual(["www.example.com"], logins.allowedDomains)
 
     }
 
-    func testWhenDuplicateDomainWhenPreserveLoginsIsNotSelectedAddedThenUniqueDomainsPersistedToDetectedDomains() {
+    func testWhenDuplicateDomainAddedToDetectedThenNotAddedAgain() {
 
         let logins = PreserveLogins(userDefaults: userDefaults)
-        logins.add(domain: "www.example.com")
-        logins.add(domain: "www.example.com")
+        logins.addToDetected(domain: "www.example.com")
+        logins.addToDetected(domain: "www.example.com")
         XCTAssertEqual(["www.example.com"], logins.detectedDomains)
 
     }
@@ -131,19 +131,19 @@ class PreserveLoginsTests: XCTestCase {
         
         let logins = PreserveLogins(userDefaults: userDefaults)
         
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         logins.userDecision = .preserveLogins
         XCTAssertFalse(logins.allowedDomains.isEmpty)
         
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         logins.userDecision = .forgetAll
         XCTAssertTrue(logins.allowedDomains.isEmpty)
 
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         logins.userDecision = .preserveLogins
         XCTAssertFalse(logins.allowedDomains.isEmpty)
 
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         logins.userDecision = .unknown
         XCTAssertTrue(logins.allowedDomains.isEmpty)
 
@@ -165,20 +165,20 @@ class PreserveLoginsTests: XCTestCase {
         
     }
 
-    func testWhenDomainAddedWhenNotPreservingLoginsThenItIsPersistedToDetectedDomains() {
+    func testWhenDomainAddedToDetectedThenPersisted() {
         
         let logins = PreserveLogins(userDefaults: userDefaults)
-        logins.add(domain: "www.example.com")
+        logins.addToDetected(domain: "www.example.com")
         XCTAssertEqual(["www.example.com"], logins.detectedDomains)
         XCTAssertEqual(["www.example.com"], PreserveLogins(userDefaults: userDefaults).detectedDomains)
     
     }
 
-    func testWhenDomainAddedWhenPreservingLoginsThenItIsPersistedToAllowedDomains() {
+    func testWhenDomainAddedToAllowedThenPersisted() {
         
         let logins = PreserveLogins(userDefaults: userDefaults)
         logins.userDecision = .preserveLogins
-        logins.add(domain: "www.example.com")
+        logins.addToAllowed(domain: "www.example.com")
         XCTAssertEqual(["www.example.com"], logins.allowedDomains)
         XCTAssertEqual(["www.example.com"], PreserveLogins(userDefaults: userDefaults).allowedDomains)
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1164681539353125
Tech Design URL:
CC:

**Description**:

Emergency fix to lock down login detection.  Existing code is still mostly in place, just disabled for now.  Will tidy up/remove/fix as part of follow up project.

**Steps to test this PR**:

1. Migrate from previous version - ensure that previously detected domains and cookies are removed (won't affect other sites that are logged in but not detected)
1. Fireproof a website using the menu item - should stay logged in after using the fire button / auto-clear
1. Ensure settings still allows remove / remove all of domains

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
