### PR TITLE
dismiss keyboard when scrolling home screen

### DIFF
--- a/DuckDuckGo/Home.storyboard
+++ b/DuckDuckGo/Home.storyboard
@@ -25,7 +25,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="H74-G9-0WZ" customClass="HomeCollectionView" customModule="DuckDuckGo" customModuleProvider="target">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" keyboardDismissMode="onDrag" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="H74-G9-0WZ" customClass="HomeCollectionView" customModule="DuckDuckGo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="5" width="414" height="896"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>

--- a/DuckDuckGo/PaddingHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/PaddingHomeViewSectionRenderer.swift
@@ -65,7 +65,7 @@ class PaddingHomeViewSectionRenderer: HomeViewSectionRenderer {
 
         let maxFavoritesPerRow = isPad ? 5 : 4
         let itemsPerRow = collectionView.frame.width > 320 ? maxFavoritesPerRow : 3
-        let rows = CGFloat((bookmarksManager.favoritesCount / itemsPerRow) + 1)
+        let rows = ceil(CGFloat(bookmarksManager.favoritesCount) / CGFloat(itemsPerRow))
         let spaceUsedByCells = (rows * cellHeight)
         let spaceUsedByLineSpacing = (rows - 2) * 10
         let spaceUsedByFavorites = spaceUsedByCells + spaceUsedByLineSpacing


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1165288656835281
Tech Design URL:
CC:

**Description**:

Dismiss keyboard when scrolling home screen and fix a bug with padding calculation.

**Steps to test this PR**:

1. Add a bunch of favorites.  Check home screen in different modes dismisses the keyboard when scrolling.

1. Make sure the last row of the favorites is full - ensure centre layout scrolls to the top correctly.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
