### PR TITLE
Remove manual encoding, as query paramters are already encoded

### DIFF
--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -47,16 +47,6 @@ extension URL {
         components.host = components.host?.dropPrefix(prefix: "mobile.")
         return (try? components.asURL()) ?? self
     }
-    
-    public func toEncodedString() -> String? {
-        // Based on https://tools.ietf.org/html/rfc3986#page-13
-        var characterSet = NSCharacterSet.alphanumerics
-        characterSet.insert(".")
-        characterSet.insert("-")
-        characterSet.insert("~")
-        characterSet.insert("_")
-        return absoluteString.addingPercentEncoding(withAllowedCharacters: characterSet)
-    }
 
     public func getParam(name: String) -> String? {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }

--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -54,7 +54,7 @@ public struct BrokenSiteInfo {
     
     func send(with category: String) {
            
-        let parameters = [Keys.url: url?.toEncodedString() ?? "",
+        let parameters = [Keys.url: url?.absoluteString ?? "",
                           Keys.category: category,
                           Keys.upgradedHttps: httpsUpgrade ? "true" : "false",
                           Keys.siteType: isDesktop ? "desktop" : "mobile",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1154001374942564
Tech Design URL:
CC:

**Description**:
Fix double-encoding by removing manual encoding of site URL.

**Steps to test this PR**:
1. Report broken site URL.
2. Query parameters should be encoded as needed.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
