### PR TITLE
hide app contents when locked

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -167,6 +167,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else if AppDeepLinks.isBookmarks(url: url) {
             mainViewController?.onBookmarksPressed()
         } else if AppDeepLinks.isFire(url: url) {
+            if !privacyStore.authenticationEnabled {
+                removeOverlay()
+            }
             mainViewController?.onQuickFirePressed()
         }
         return true

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -117,11 +117,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         if !privacyStore.authenticationEnabled {
-            showKeyboard()
+            showKeyboardOnLaunch()
         }
     }
 
-    private func showKeyboard() {
+    private func showKeyboardOnLaunch() {
         guard KeyboardSettings().onAppLaunch && showKeyboardIfSettingOn else { return }
         self.mainViewController?.enterSearch()
         showKeyboardIfSettingOn = false
@@ -221,7 +221,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         controller.beginAuthentication { [weak self] in
             self?.removeOverlay()
-            self?.showKeyboard()
+            self?.showKeyboardOnLaunch()
         }
     }
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -102,6 +102,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
         
+        if privacyStore.authenticationEnabled {
+            beginAuthentication()
+        } else {
+            removeOverlay()
+        }
+
         StatisticsLoader.shared.load {
             StatisticsLoader.shared.refreshAppRetentionAtb()
             Pixel.fire(pixel: .appLaunch)
@@ -130,18 +136,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        if privacyStore.authenticationEnabled {
-            beginAuthentication()
-        } else {
-            removeOverlay()
-        }
-        
         autoClear?.applicationWillMoveToForeground()
         showKeyboardIfSettingOn = true
     }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         displayOverlay()
+    }
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
         autoClear?.applicationDidEnterBackground()
     }
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -116,10 +116,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             onApplicationLaunch(application)
         }
         
-        if KeyboardSettings().onAppLaunch && showKeyboardIfSettingOn {
-            self.mainViewController?.enterSearch()
-            showKeyboardIfSettingOn = false
+        if !privacyStore.authenticationEnabled {
+            showKeyboard()
         }
+    }
+
+    private func showKeyboard() {
+        guard KeyboardSettings().onAppLaunch && showKeyboardIfSettingOn else { return }
+        self.mainViewController?.enterSearch()
+        showKeyboardIfSettingOn = false
     }
     
     func applicationWillResignActive(_ application: UIApplication) {
@@ -139,7 +144,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        displayOverlay()
         autoClear?.applicationDidEnterBackground()
     }
 
@@ -183,14 +187,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         application.setMinimumBackgroundFetchInterval(60 * 60 * 24)
     }
     
-    private func displayOverlay() {
-        if privacyStore.authenticationEnabled {
-            displayAuthenticationWindow()
-        } else {
-            displayBlankSnapshotWindow()
-        }
-    }
-
     private func displayAuthenticationWindow() {
         guard overlayWindow == nil, let frame = window?.frame else { return }
         overlayWindow = UIWindow(frame: frame)
@@ -225,6 +221,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         controller.beginAuthentication { [weak self] in
             self?.removeOverlay()
+            self?.showKeyboard()
         }
     }
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -102,12 +102,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
         
-        if privacyStore.authenticationEnabled {
-            beginAuthentication()
-        } else {
-            removeOverlay()
-        }
-
         StatisticsLoader.shared.load {
             StatisticsLoader.shared.refreshAppRetentionAtb()
             Pixel.fire(pixel: .appLaunch)
@@ -136,15 +130,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
+        if privacyStore.authenticationEnabled {
+            beginAuthentication()
+        } else {
+            removeOverlay()
+        }
+        
         autoClear?.applicationWillMoveToForeground()
         showKeyboardIfSettingOn = true
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-        displayOverlay()
-    }
-    
     func applicationDidEnterBackground(_ application: UIApplication) {
+        displayOverlay()
         autoClear?.applicationDidEnterBackground()
     }
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1082,6 +1082,10 @@ extension MainViewController: AutoClearWorker {
             self.forgetTabs()
             completion()
             Instruments.shared.endTimedEvent(for: spid)
+
+            if KeyboardSettings().onNewTab {
+                self.enterSearch()
+            }
         }
         let window = UIApplication.shared.keyWindow
         window?.showBottomToast(UserText.actionForgetAllDone, duration: 1)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1169498296439393
Tech Design URL:
CC:

**Description**:

Hides the app contents when app switching and consistently hides the contents with the same view (blank snapshot)

Fixes #611 

**Steps to test this PR**:

***App Lock: off, Auto-Clear: off***

1. Switch apps - no content hidden
1. Background the app, then bring to foreground, no content hidden, no authentication
1. Kill the app then launch the app, no content hidden, no authentication

***App Lock: on, Auto-Clear: off***

1. Switch apps - content hidden by blank snapshot screen
1. Background the app, then bring to foreground, no content hidden, user is required to authenticate 
1. Kill the app then launch the app, no content hidden, user is required to authenticate 

***App Lock: off, Auto-Clear: on***

1. Switch apps - content hidden by blank snapshot screen
1. Background the app, then bring to foreground, no content hidden, no authentication required
1. Kill the app then launch the app, no content hidden but any open tabs have gone,  no authentication required

***App Lock: on, Auto-Clear: on***

1. Switch apps - content hidden by blank snapshot screen
1. Background the app, then bring to foreground, no content hidden, user is required to authenticate 
1. Kill the app then launch the app, no content hidden but any open tabs have gone, user is required to authenticate 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
