### PR TITLE
use external-content domain for favicons

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -28,6 +28,7 @@ public struct AppUrls {
         }
         
         static let base = ProcessInfo.processInfo.environment["BASE_URL", default: "https://duckduckgo.com"]
+        static let externalContentBase = "https://external-content.duckduckgo.com"
         static let staticBase = "https://staticcdn.duckduckgo.com"
         
         static let autocomplete = "\(base)/ac/"
@@ -39,7 +40,7 @@ public struct AppUrls {
         static let atb = "\(base)/atb.js\(devMode)"
         static let exti = "\(base)/exti/\(devMode)"
         static let feedback = "\(base)/feedback.js?type=app-feedback"
-        static let faviconService = "\(base)/ip3/%@.ico"
+        static let faviconService = "\(externalContentBase)/ip3/%@.ico"
  
         static let httpsBloomFilter = "\(staticBase)/https/https-mobile-bloom.bin?cache-version=1"
         static let httpsBloomFilterSpec = "\(staticBase)/https/https-mobile-bloom-spec.json?cache-version=1"

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -63,7 +63,7 @@ class AppUrlsTests: XCTestCase {
     func testWhenFaviconUrlForDomainRequestedThenCorrectDomainIsCreated() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let faviconURL = testee.faviconUrl(forDomain: "example.com")
-        XCTAssertEqual("https://duckduckgo.com/ip3/example.com.ico", faviconURL?.absoluteString)
+        XCTAssertEqual("https://external-content.duckduckgo.com/ip3/example.com.ico", faviconURL?.absoluteString)
     }
 
     func testBaseUrlDoesNotHaveSubDomain() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1160956277188287
Tech Design URL:
CC:

**Description**:

Update favicon URL to use external content domain

**Steps to test this PR**:
1. Open some tabs and check the tab switcher - icons should load
1. Save some bookmarks and check the bookmarks view - icons should load


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
