### PR TITLE
make nav controller unowned so that it doesn't retain

### DIFF
--- a/DuckDuckGo/PrivacyProtectionOverviewController.swift
+++ b/DuckDuckGo/PrivacyProtectionOverviewController.swift
@@ -178,14 +178,14 @@ class ProtectionUpgradedView: UIView {
 
 private class InteractivePopRecognizer: NSObject, UIGestureRecognizerDelegate {
     
-    unowned var navigationController: UINavigationController
+    weak var navigationController: UINavigationController?
     
     init(controller: UINavigationController) {
         self.navigationController = controller
     }
     
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return navigationController.viewControllers.count > 1
+        return navigationController?.viewControllers.count ?? 0 > 1
     }
     
     // This is necessary because without it, subviews of your top controller can

--- a/DuckDuckGo/PrivacyProtectionOverviewController.swift
+++ b/DuckDuckGo/PrivacyProtectionOverviewController.swift
@@ -178,7 +178,7 @@ class ProtectionUpgradedView: UIView {
 
 private class InteractivePopRecognizer: NSObject, UIGestureRecognizerDelegate {
     
-    var navigationController: UINavigationController
+    unowned var navigationController: UINavigationController
     
     init(controller: UINavigationController) {
         self.navigationController = controller


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1170462535379951
Tech Design URL:
CC:

**Description**:

Remove a retain cycle, fixing #617 

**Steps to test this PR**:

1. Launch the dashboard, on both iPhone and iPad.  
1. Profile in instruments - the Privacy Dashboard hierarchy should not be retained

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
