### PR TITLE
remove query string from broken site url

### DIFF
--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -53,8 +53,8 @@ public struct BrokenSiteInfo {
     }
     
     func send(with category: String) {
-           
-        let parameters = [Keys.url: url?.absoluteString ?? "",
+        
+        let parameters = [Keys.url: normalize(url),
                           Keys.category: category,
                           Keys.upgradedHttps: httpsUpgrade ? "true" : "false",
                           Keys.siteType: isDesktop ? "desktop" : "mobile",
@@ -68,4 +68,16 @@ public struct BrokenSiteInfo {
         
         Pixel.fire(pixel: .brokenSiteReport, withAdditionalParameters: parameters)
     }
+    
+    private func normalize(_ url: URL?) -> String {
+        guard let url = url else { return "" }
+        
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        components?.queryItems = []
+        components?.path = ""
+        
+        guard let nomalizedUrl = try? components?.asURL() else { return "" }
+        return nomalizedUrl.absoluteString
+    }
+    
 }

--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -76,7 +76,7 @@ public struct BrokenSiteInfo {
         components?.queryItems = []
         components?.path = ""
         
-        guard let nomalizedUrl = try? components?.asURL() else { return "" }
+        guard let nomalizedUrl = components?.url else { return "" }
         return nomalizedUrl.absoluteString
     }
     

--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -74,7 +74,6 @@ public struct BrokenSiteInfo {
         
         var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         components?.queryItems = []
-        components?.path = ""
         
         guard let nomalizedUrl = components?.url else { return "" }
         return nomalizedUrl.absoluteString


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1170386777246545
Tech Design URL:
CC:

**Description**:

Removes the query string from the url set when reporting broken sites.

**Steps to test this PR**:
1.  Report a broken site - (using Charles or a breakpoint) ensure the query string of the site you're reporting is not included 
1.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
