### PR TITLE
FIX: centre search, show keyboard on new tab, fire button glitch

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1084,7 +1084,9 @@ extension MainViewController: AutoClearWorker {
             Instruments.shared.endTimedEvent(for: spid)
 
             if KeyboardSettings().onNewTab {
-                self.enterSearch()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.enterSearch()
+                }
             }
         }
         let window = UIApplication.shared.keyWindow


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1170620890646722
Tech Design URL:
CC:

**Description**:

Fixes a glitch after pressing fire button when centre search and keyboard on new tab selected.

**Steps to test this PR**:
1. Set center search
1. Set keyboard on new tab
1. Browse to a page
1. Hit the fire button
1. The keyboard should show and the omnibar should be correctly focussed


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
