### PR TITLE
Fix retain cycle in EasyTipView

### DIFF
--- a/DuckDuckGo/EasyTipViewExtension.swift
+++ b/DuckDuckGo/EasyTipViewExtension.swift
@@ -61,6 +61,7 @@ extension EasyTipView {
             self.dismiss()
             completion()
             NotificationCenter.default.removeObserver(token!)
+            token = nil // break reference cycle
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/iOS/issues/621
CC: @bwaresiak 

**Description**:

This clears the observer token at the end of the one-shot block. Against all
reason, the token appears to be holding a strong reference back to the block
which creates a memory leak.

**Steps to test this PR**:

1. Perform a clean install of the app
1. Navigate through three URLs and click away the three tip views
1. Start the memory-graph debugger
1. With the fix applied no instances of `TouchView` should occur

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
