### PR TITLE
Hide back buttons

### DIFF
--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -408,7 +408,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="240"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
-                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KSV-Ab-2VI">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KSV-Ab-2VI">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -706,7 +706,7 @@
                                                 <constraint firstAttribute="height" constant="75" id="xN7-nQ-eyz"/>
                                             </constraints>
                                         </view>
-                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ict-Tf-vBn">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ict-Tf-vBn">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -1005,7 +1005,7 @@
                                                 <constraint firstItem="hx0-Fc-Kk1" firstAttribute="centerX" secondItem="qwM-eP-cbc" secondAttribute="centerX" id="yyL-fN-okf"/>
                                             </constraints>
                                         </view>
-                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m0O-GE-gIK">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m0O-GE-gIK">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -1222,7 +1222,7 @@
                                                 <constraint firstItem="JrS-AS-COd" firstAttribute="centerY" secondItem="V7a-BI-Cm8" secondAttribute="centerY" id="szE-gj-hqc"/>
                                             </constraints>
                                         </view>
-                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zqk-Al-R2h">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zqk-Al-R2h">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -1463,7 +1463,7 @@
                                                         <segue destination="8eA-o1-lUc" kind="embed" id="lZI-wu-ujD"/>
                                                     </connections>
                                                 </containerView>
-                                                <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0FD-as-X0W">
+                                                <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0FD-as-X0W">
                                                     <rect key="frame" x="20" y="90.666666666666671" width="30" height="22"/>
                                                     <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                                     <constraints>

--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -408,7 +408,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="240"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KSV-Ab-2VI">
+                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KSV-Ab-2VI">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -705,7 +705,7 @@
                                                 <constraint firstAttribute="height" constant="75" id="xN7-nQ-eyz"/>
                                             </constraints>
                                         </view>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ict-Tf-vBn">
+                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ict-Tf-vBn">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -1003,7 +1003,7 @@
                                                 <constraint firstItem="hx0-Fc-Kk1" firstAttribute="centerX" secondItem="qwM-eP-cbc" secondAttribute="centerX" id="yyL-fN-okf"/>
                                             </constraints>
                                         </view>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m0O-GE-gIK">
+                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m0O-GE-gIK">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -1219,7 +1219,7 @@
                                                 <constraint firstItem="JrS-AS-COd" firstAttribute="centerY" secondItem="V7a-BI-Cm8" secondAttribute="centerY" id="szE-gj-hqc"/>
                                             </constraints>
                                         </view>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zqk-Al-R2h">
+                                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zqk-Al-R2h">
                                             <rect key="frame" x="20" y="20" width="30" height="22"/>
                                             <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                             <constraints>
@@ -1459,7 +1459,7 @@
                                                         <segue destination="8eA-o1-lUc" kind="embed" id="lZI-wu-ujD"/>
                                                     </connections>
                                                 </containerView>
-                                                <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0FD-as-X0W">
+                                                <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0FD-as-X0W">
                                                     <rect key="frame" x="20" y="90.666666666666671" width="30" height="22"/>
                                                     <accessibility key="accessibilityConfiguration" identifier="backButton"/>
                                                     <constraints>

--- a/DuckDuckGo/PrivacyProtection.storyboard
+++ b/DuckDuckGo/PrivacyProtection.storyboard
@@ -624,6 +624,7 @@
                         <viewLayoutGuide key="safeArea" id="WMb-j1-aK5"/>
                     </view>
                     <connections>
+                        <outlet property="backButton" destination="KSV-Ab-2VI" id="Svj-nh-i0A"/>
                         <outlet property="domainLabel" destination="F5w-e3-JfY" id="Kex-XA-LPL"/>
                         <outlet property="encryptedLabel" destination="dZC-7f-pp3" id="EUt-Lm-BrG"/>
                         <outlet property="iconImage" destination="8ma-gb-nuk" id="cFw-wO-y2m"/>
@@ -906,6 +907,7 @@
                         <viewLayoutGuide key="safeArea" id="s83-RN-jpp"/>
                     </view>
                     <connections>
+                        <outlet property="backButton" destination="Ict-Tf-vBn" id="1oK-Rb-SXK"/>
                         <outlet property="heroIconImage" destination="HGe-jW-qhx" id="fHi-CA-OCI"/>
                         <outlet property="hoveringResetContainer" destination="nFB-0r-HZW" id="hZ6-ca-wPv"/>
                         <outlet property="hoveringView" destination="zKA-e0-nkA" id="GE0-aa-qKX"/>
@@ -1128,6 +1130,7 @@
                         <viewLayoutGuide key="safeArea" id="Nn0-tl-oIk"/>
                     </view>
                     <connections>
+                        <outlet property="backButton" destination="m0O-GE-gIK" id="QkH-d9-oc2"/>
                         <outlet property="domainLabel" destination="7nh-8f-M2e" id="SKd-Ck-a0Y"/>
                         <outlet property="iconImage" destination="q0F-D6-aaO" id="DKn-oW-8NY"/>
                         <outlet property="messageLabel" destination="VYv-1m-cZo" id="DTq-1R-9To"/>
@@ -1402,6 +1405,7 @@
                         <viewLayoutGuide key="safeArea" id="RU8-yV-5bJ"/>
                     </view>
                     <connections>
+                        <outlet property="backButton" destination="zqk-Al-R2h" id="5bX-Cg-6VV"/>
                         <outlet property="domainLabel" destination="0SO-8y-5QH" id="kup-a3-DH3"/>
                         <outlet property="iconImage" destination="9WR-Wf-9ad" id="nLQ-bJ-bkT"/>
                         <outlet property="messageLabel" destination="JrS-AS-COd" id="Qfr-uW-sls"/>
@@ -1773,6 +1777,7 @@
                         </connections>
                     </tableView>
                     <connections>
+                        <outlet property="backButton" destination="0FD-as-X0W" id="BuL-4s-Awz"/>
                         <outlet property="connectionCell" destination="Bfa-LO-5TA" id="oph-LH-7xv"/>
                         <outlet property="enhancedGradeCell" destination="8L0-Nl-oii" id="GN3-LR-nQl"/>
                         <outlet property="isMajorNetworkCell" destination="YWf-b0-9Jx" id="sHo-Ui-l1Y"/>

--- a/DuckDuckGo/PrivacyProtectionEncryptionDetailController.swift
+++ b/DuckDuckGo/PrivacyProtectionEncryptionDetailController.swift
@@ -37,6 +37,7 @@ class PrivacyProtectionEncryptionDetailController: UIViewController {
     @IBOutlet weak var domainLabel: UILabel!
     @IBOutlet weak var encryptedLabel: UILabel!
     @IBOutlet weak var messageLabel: UILabel!
+    @IBOutlet weak var backButton: UIButton!
 
     private weak var siteRating: SiteRating!
 
@@ -50,6 +51,7 @@ class PrivacyProtectionEncryptionDetailController: UIViewController {
         initTableView()
         initHttpsStatus()
         initDomain()
+        initBackButton()
         beginCertificateInfoExtraction()
 
     }
@@ -65,6 +67,10 @@ class PrivacyProtectionEncryptionDetailController: UIViewController {
 
     private func initDomain() {
         domainLabel.text = siteRating.domain
+    }
+
+    private func initBackButton() {
+        backButton.isHidden = !isPad
     }
 
     private func initHttpsStatus() {

--- a/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
+++ b/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
@@ -28,6 +28,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
     @IBOutlet weak var resetButton: UIButton!
     @IBOutlet weak var domainLabel: UILabel!
     @IBOutlet weak var messageLabel: UILabel!
+    @IBOutlet weak var backButton: UIButton!
 
     @IBOutlet weak var inlineResetContainer: UIView!
     @IBOutlet weak var hoveringResetContainer: UIView!
@@ -51,6 +52,7 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
         initHeroIcon()
         initResetButton()
         initDrama()
+        initBackButton()
         update()
 
     }
@@ -101,6 +103,10 @@ class PrivacyProtectionNetworkLeaderboardController: UIViewController {
             self?.drama = false
             self?.tableView.reloadData()
         }
+    }
+
+    private func initBackButton() {
+        backButton.isHidden = !isPad
     }
 
     private func initMessageLabel() {

--- a/DuckDuckGo/PrivacyProtectionPracticesController.swift
+++ b/DuckDuckGo/PrivacyProtectionPracticesController.swift
@@ -41,6 +41,7 @@ class PrivacyProtectionPracticesController: UIViewController {
     @IBOutlet weak var domainLabel: UILabel!
     @IBOutlet weak var subtitleLabel: UILabel!
     @IBOutlet weak var messageLabel: UILabel!
+    @IBOutlet weak var backButton: UIButton!
 
     private var siteRating: SiteRating!
     private var contentBlockerConfiguration = AppDependencyProvider.shared.storageCache.current.configuration
@@ -52,6 +53,7 @@ class PrivacyProtectionPracticesController: UIViewController {
         Pixel.fire(pixel: .privacyDashboardPrivacyPractices)
         
         initTable()
+        initBackButton()
         update()
     }
 
@@ -97,6 +99,9 @@ class PrivacyProtectionPracticesController: UIViewController {
         tableView.delegate = self
     }
 
+    private func initBackButton() {
+        backButton.isHidden = !isPad
+    }
 }
 
 extension PrivacyProtectionPracticesController: UITableViewDataSource {

--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -29,6 +29,7 @@ class PrivacyProtectionScoreCardController: UITableViewController {
     @IBOutlet weak var privacyGradeCell: PrivacyProtectionScoreCardCell!
     @IBOutlet weak var enhancedGradeCell: PrivacyProtectionScoreCardCell!
     @IBOutlet weak var isMajorNetworkCell: PrivacyProtectionScoreCardCell!
+    @IBOutlet weak var backButton: UIButton!
 
     private var siteRating: SiteRating!
     private var contentBlockerConfiguration = AppDependencyProvider.shared.storageCache.current.configuration
@@ -37,7 +38,7 @@ class PrivacyProtectionScoreCardController: UITableViewController {
     override func viewDidLoad() {
         
         Pixel.fire(pixel: .privacyDashboardScorecard)
-        
+        initBackButton()
         update()
     }
 
@@ -57,6 +58,10 @@ class PrivacyProtectionScoreCardController: UITableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let cell = super.tableView(tableView, cellForRowAt: indexPath)
         return cell.isHidden ? 0 : super.tableView(tableView, heightForRowAt: indexPath)
+    }
+
+    private func initBackButton() {
+        backButton.isHidden = !isPad
     }
 
     private func update() {

--- a/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
+++ b/DuckDuckGo/PrivacyProtectionTrackerNetworksController.swift
@@ -27,6 +27,7 @@ class PrivacyProtectionTrackerNetworksController: UIViewController {
     @IBOutlet weak var subtitleLabel: UILabel!
     @IBOutlet weak var messageLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var backButton: UIButton!
 
     private var siteRating: SiteRating!
     private var contentBlockerConfiguration = AppDependencyProvider.shared.storageCache.current.configuration
@@ -59,6 +60,7 @@ class PrivacyProtectionTrackerNetworksController: UIViewController {
         Pixel.fire(pixel: .privacyDashboardNetworks)
         
         initTableView()
+        initBackButton()
         update()
     }
 
@@ -102,6 +104,10 @@ class PrivacyProtectionTrackerNetworksController: UIViewController {
     private func initTableView() {
         tableView.delegate = self
         tableView.dataSource = self
+    }
+
+    private func initBackButton() {
+        backButton.isHidden = !isPad
     }
 
     private func protecting() -> Bool {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #628 
Tech Design URL:
CC:

**Description**:
In this PR, one of the back button on each sub page are hidden. These buttons are set to be hidden but not removed because they are being used in UI test. As a result, user can still click the left area to go back to the overview of the privacy protection from sub pages.

**Steps to test this PR**:
1. Open the privacy protection
1. Navigate to each of the sub page

Only one back button per page is visible.

**Device Testing**:
* [x] iPhone XR

**OS Testing**:

* [ ] iOS 10
* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 13


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
