### PR TITLE
url spoof fix

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -332,7 +332,7 @@ class TabViewController: UIViewController {
             hasOnlySecureContentChanged(hasOnlySecureContent: webView.hasOnlySecureContent)
             
         case #keyPath(WKWebView.url):
-            self.url = self.webView.url
+            webViewUrlHasChanged()
             
         case #keyPath(WKWebView.canGoBack):
             delegate?.tabLoadingStateDidChange(tab: self)
@@ -346,6 +346,11 @@ class TabViewController: UIViewController {
         default:
             os_log("Unhandled keyPath %s", log: generalLog, type: .debug, keyPath)
         }
+    }
+    
+    func webViewUrlHasChanged() {
+        guard let currentHost = url?.host, let newHost = webView.url?.host, currentHost == newHost else { return }
+        url = webView.url
     }
     
     func hasOnlySecureContentChanged(hasOnlySecureContent: Bool) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -349,8 +349,11 @@ class TabViewController: UIViewController {
     }
     
     func webViewUrlHasChanged() {
-        guard let currentHost = url?.host, let newHost = webView.url?.host, currentHost == newHost else { return }
-        url = webView.url
+        if url == nil {
+            url = webView.url
+        } else if let currentHost = url?.host, let newHost = webView.url?.host, currentHost == newHost {
+            url = webView.url
+        }
     }
     
     func hasOnlySecureContentChanged(hasOnlySecureContent: Bool) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1173867845774569
Tech Design URL:
CC:

**Description**:

Prevents the URL from being updated when JS redirects to a different page then enters a loop.

**Steps to test this PR**:
1.  Visit https://ios.browsr-tests.com/alt/native.abs.php and run the last test - the URL should not change
1. Kill the app while still loading the previous URL and launch again - the test page should load
1. Browse the web,  especially sites which use JS pushState to update the URL (e.g. twitter.com)

**Device Testing**:

* [x] iPhone SE
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 10
* [x] iOS 11
* [x] iOS 12
* [x] iOS 13


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
