### PR TITLE
crash fix: only update cell with tab if the tab is still available

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -250,14 +250,18 @@ extension TabSwitcherViewController: UICollectionViewDataSource {
     }
 
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let tab = tabsModel.get(tabAt: indexPath.row)
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TabViewCell.reuseIdentifier, for: indexPath) as? TabViewCell else {
             fatalError("Failed to dequeue cell \(TabViewCell.reuseIdentifier) as TablViewCell")
         }
         cell.delegate = self
 
         cell.isDeleting = false
-        cell.update(withTab: tab)
+        
+        if indexPath.row < tabsModel.count {
+            let tab = tabsModel.get(tabAt: indexPath.row)
+            cell.update(withTab: tab)
+        }
+        
         return cell
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1157404271742426
Tech Design URL:
CC:

**Description**:

When swiping tabs closed quickly it's easy to crash the app.  This fixes that by only updating the cell with the tab if the tab is still available.

**Steps to test this PR**:
1. Open a few tabs
1. Start swiping them closed from the bottom

<!--
Do not delete these, they are reminders to test against different device configurations.  

Before submitting a PR, please ensure you have tested a reasonable combination of the following.  Using a simulator where a physical device is unavailable is acceptable.
-->

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE
* [ ] iPhone 8
* [x] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 10
* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 13

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

