### PR TITLE
fix broken atb integration tests on Xcode 11.4

### DIFF
--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -254,7 +254,11 @@ class AtbIntegrationTests: XCTestCase {
     private func clearTabsAndData() {
         app.toolbars["Toolbar"].buttons["Fire"].tap()
         app.sheets.scrollViews.otherElements.buttons["Close Tabs and Clear Data"].tap()
-        app.staticTexts["Cancel"].tap()
+        
+        let cancel = app.staticTexts["Cancel"]
+        if cancel.exists {
+            cancel.tap()
+        }
     }
 
 }

--- a/AtbIntegrationTests/AtbIntegrationTests.swift
+++ b/AtbIntegrationTests/AtbIntegrationTests.swift
@@ -240,25 +240,21 @@ class AtbIntegrationTests: XCTestCase {
     }
     
     private func skipOnboarding() {
-        waitForButtonThenTap("Continue")
-        waitForButtonThenTap("Start Browsing")
+        tapButtonIfExists("Continue")
+        tapButtonIfExists("Start Browsing")
     }
     
-    private func waitForButtonThenTap(_ named: String) {
+    private func tapButtonIfExists(_ named: String) {
         let button = app.buttons[named]
-//        guard button.waitForExistence(timeout: Constants.defaultTimeout) else {
-//            // fatalError("Could not find button named \(named)")
-//            return
-//        }
         if button.exists {
             button.tap()
         }
     }
     
     private func clearTabsAndData() {
-        app.toolbars["Toolbar"]/*@START_MENU_TOKEN@*/.buttons["Fire"]/*[[".buttons[\"Erase Tabs and Data\"]",".buttons[\"Fire\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.toolbars["Toolbar"].buttons["Fire"].tap()
         app.sheets.scrollViews.otherElements.buttons["Close Tabs and Clear Data"].tap()
-        app/*@START_MENU_TOKEN@*/.staticTexts["Cancel"]/*[[".buttons[\"Cancel\"].staticTexts[\"Cancel\"]",".staticTexts[\"Cancel\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.staticTexts["Cancel"].tap()
     }
 
 }

--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -35,12 +35,6 @@ public class StatisticsLoader {
         self.appUrls = AppUrls(statisticsStore: statisticsStore)
     }
     
-    public func clear() {
-        statisticsStore.atb = nil
-        statisticsStore.appRetentionAtb = nil
-        statisticsStore.searchRetentionAtb = nil
-    }
-    
     public func load(completion: @escaping Completion = {}) {
         if statisticsStore.hasInstallStatistics {
             completion()

--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -35,6 +35,12 @@ public class StatisticsLoader {
         self.appUrls = AppUrls(statisticsStore: statisticsStore)
     }
     
+    public func clear() {
+        statisticsStore.atb = nil
+        statisticsStore.appRetentionAtb = nil
+        statisticsStore.searchRetentionAtb = nil
+    }
+    
     public func load(completion: @escaping Completion = {}) {
         if statisticsStore.hasInstallStatistics {
             completion()

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -43,11 +43,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-                
-        if runningAtbTests() {
-            closeAllTabsAndResetStatisticsData()
-        }
-        
         testing = ProcessInfo().arguments.contains("testing")
         if testing {
             Database.shared.loadStore { _ in }
@@ -88,13 +83,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
         appIsLaunching = true
         return true
-    }
-
-    private func closeAllTabsAndResetStatisticsData() {
-        if mainViewController?.tabManager != nil {
-            mainViewController?.forgetTabs()
-        }
-        StatisticsLoader.shared.clear()
     }
 
     private func runningAtbTests() -> Bool {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -85,10 +85,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    private func runningAtbTests() -> Bool {
-        return ProcessInfo.processInfo.environment.contains(where: { $0.key == "atb-testing" })
-    }
-
     private func clearLegacyAllowedDomainCookies() {
         let domains = PreserveLogins.shared.legacyAllowedDomains
         guard !domains.isEmpty else { return }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -43,6 +43,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: lifecycle
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+                
+        if ProcessInfo.processInfo.environment.contains(where: { $0.key == "atb-testing" }) {
+            if mainViewController?.tabManager != nil {
+                mainViewController?.forgetTabs()
+            }
+            StatisticsLoader.shared.clear()
+        }
         
         testing = ProcessInfo().arguments.contains("testing")
         if testing {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -44,11 +44,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
                 
-        if ProcessInfo.processInfo.environment.contains(where: { $0.key == "atb-testing" }) {
-            if mainViewController?.tabManager != nil {
-                mainViewController?.forgetTabs()
-            }
-            StatisticsLoader.shared.clear()
+        if runningAtbTests() {
+            closeAllTabsAndResetStatisticsData()
         }
         
         testing = ProcessInfo().arguments.contains("testing")
@@ -92,7 +89,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         appIsLaunching = true
         return true
     }
-    
+
+    private func closeAllTabsAndResetStatisticsData() {
+        if mainViewController?.tabManager != nil {
+            mainViewController?.forgetTabs()
+        }
+        StatisticsLoader.shared.clear()
+    }
+
+    private func runningAtbTests() -> Bool {
+        return ProcessInfo.processInfo.environment.contains(where: { $0.key == "atb-testing" })
+    }
+
     private func clearLegacyAllowedDomainCookies() {
         let domains = PreserveLogins.shared.legacyAllowedDomains
         guard !domains.isEmpty else { return }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1174879355199843
Tech Design URL:
CC:

**Description**:

Clear the ATB when launching from atb-tests

**Steps to test this PR**:
1. Using latest Xcode run the ATB integration tests
1. Launch the app and browse regularly to make sure there's no regressions

<!--
Do not delete these, they are reminders to test against different device configurations.  

Before submitting a PR, please ensure you have tested a reasonable combination of the following.  Using a simulator where a physical device is unavailable is acceptable.
-->

**Orientation Testing**:

* [x] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE
* [x] iPhone 8
* [x] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 10
* [ ] iOS 11
* [x] iOS 12
* [x] iOS 13

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

