### PR TITLE
Fix build for external developers

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -4767,7 +4767,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.mobile.ios.OpenAction;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).OpenAction";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -4791,7 +4791,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.duckduckgo.mobile.ios.OpenAction;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_ID).OpenAction";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
**Description:**

The PR #633 added the 'Open in DuckDuckGo' action.
However the PRODUCT_BUNDLE_IDENTIFIER for the `OpenAction` target is hardcoded to `com.duckduckgo.mobile.ios.OpenAction`. See https://github.com/duckduckgo/iOS/pull/633/commits/42804d85c37f8c14ed3203ea0c96f10e365f4013#diff-9e6bc0fba251950ba65ffa409e75b9b0R4792

This is causing a build error for developers that are not part of the DuckDuckGo team and using the `ExternalDeveloper.xcconfig` configuration.


**Steps to test this PR:**

Follow the steps to compile the project when you are not part of the DuckDuckGo team.

1. Run cp Configuration/DuckDuckGoDeveloper.xcconfig Configuration/ExternalDeveloper.xcconfig
2. Edit Configuration/ExternalDeveloper.xcconfig and change the values of all fields
3. Clean and rebuild the project
	
Result: You get a compilation error

```
error: Embedded binary's bundle identifier is not prefixed with the parent app's bundle identifier.

		Embedded Binary Bundle Identifier:	com.duckduckgo.mobile.ios.OpenAction
		Parent App Bundle Identifier:		com.example.duckduckgo

 (in target 'DuckDuckGo' from project 'DuckDuckGo')
```


Expected result: External developers should be able to build the project


**Proposed solution:**

In this PR, I propose to change the PRODUCT_BUNDLE_IDENTIFIER for the `OpenAction` target from the hardcoded `com.duckduckgo.mobile.ios.OpenAction` to `"$(APP_ID).OpenAction"`.

This fixes the build for external developers and should not break the build for the DuckDuckGo team. This is also consistent with the product identifier of the other targets in the project.


**Configuration Testing:**

- [x] ExternalDeveloper.xcconfig
- [ ] DuckDuckGoDeveloper.xcconfig


**Build Testing:**

- [x] Xcode 11.4.1
- [x] macOS Catalina 10.15.4
- [x] Compile for iPhone Xs device with iOS 13.4.1
  