### PR TITLE
Hide views in footer by default

### DIFF
--- a/DuckDuckGo/PrivacyProtectionFooter.storyboard
+++ b/DuckDuckGo/PrivacyProtectionFooter.storyboard
@@ -113,7 +113,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4jR-2G-yON" customClass="TrackerNetworkLeaderboardView" customModule="DuckDuckGo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="112" width="320" height="152"/>
                                 <subviews>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLL-zs-goU">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLL-zs-goU">
                                         <rect key="frame" x="0.0" y="32" width="320" height="88"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="rO0-0v-ngG">
@@ -254,7 +254,7 @@
                                         </constraints>
                                         <viewLayoutGuide key="safeArea" id="MFi-fD-lyi"/>
                                     </view>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="frY-3a-m4a">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="frY-3a-m4a">
                                         <rect key="frame" x="0.0" y="16" width="320" height="120"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Network Leaderboard No Stats" translatesAutoresizingMaskIntoConstraints="NO" id="gPE-Br-bJP">

--- a/DuckDuckGo/PrivacyProtectionFooter.storyboard
+++ b/DuckDuckGo/PrivacyProtectionFooter.storyboard
@@ -113,7 +113,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4jR-2G-yON" customClass="TrackerNetworkLeaderboardView" customModule="DuckDuckGo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="112" width="320" height="152"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLL-zs-goU">
+                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLL-zs-goU">
                                         <rect key="frame" x="0.0" y="32" width="320" height="88"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="rO0-0v-ngG">
@@ -254,7 +254,7 @@
                                         </constraints>
                                         <viewLayoutGuide key="safeArea" id="MFi-fD-lyi"/>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="frY-3a-m4a">
+                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="frY-3a-m4a">
                                         <rect key="frame" x="0.0" y="16" width="320" height="120"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PP Network Leaderboard No Stats" translatesAutoresizingMaskIntoConstraints="NO" id="gPE-Br-bJP">

--- a/DuckDuckGo/PrivacyProtectionFooterController.swift
+++ b/DuckDuckGo/PrivacyProtectionFooterController.swift
@@ -33,6 +33,7 @@ class PrivacyProtectionFooterController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         leaderboard.didLoad()
+        leaderboard.update()
     }
     
     @IBAction func toggleProtection() {
@@ -43,7 +44,6 @@ class PrivacyProtectionFooterController: UIViewController {
         } else {
             contentBlockerConfiguration.removeFromWhitelist(domain: domain)
         }
-        update()
         Pixel.fire(pixel: whitelisted ? .privacyDashboardWhitelistAdd : .privacyDashboardWhitelistRemove)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:https://github.com/duckduckgo/iOS/issues/640
Tech Design URL:
CC:

**Description**:
Both `gatheringView` and `scoresView` is visible in the dashboard when we are in error state.
In the patch, we fix it by setting them to hidden by default. Such that none of them will be visible in error state, and one and only one of them will be visible if the site is correctly loaded.

**Steps to test this PR**:
1. Visit a broken site, e.g. http://sdhlkjashdlk.com
1. Open privacy dashboard

Before the patch:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-05-18 at 17 57 57](https://user-images.githubusercontent.com/3814422/82202530-a099bb00-9934-11ea-894a-9f0d30eb76f1.png)

After the patch:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-05-18 at 17 57 12](https://user-images.githubusercontent.com/3814422/82202559-ab545000-9934-11ea-9724-80e74ac2cef2.png)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad
* [x] iPhone SE (2nd Gen) 

**OS Testing**:

* [x] iOS 10
* [x] iOS 11
* [x] iOS 12
* [x] iOS 13

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

