### PR TITLE
if snapshot fails during onboarding just delegate to the actual icons

### DIFF
--- a/DuckDuckGo/DaxOnboardingViewController.swift
+++ b/DuckDuckGo/DaxOnboardingViewController.swift
@@ -89,12 +89,12 @@ class DaxOnboardingViewController: UIViewController, Onboarding {
     func transitionFromOnboarding() {
 
         // using snapshots means the original views don't get messed up by their constraints when subsequent animations kick off
-        let transitionIconSS: UIView = self.transitionalIcon.snapshotView(afterScreenUpdates: false) ?? self.transitionalIcon
+        let transitionIconSS: UIView = self.transitionalIcon.snapshotView(afterScreenUpdates: true) ?? self.transitionalIcon
         transitionIconSS.frame = self.transitionalIcon.frame
         view.addSubview(transitionIconSS)
         self.transitionalIcon.isHidden = true
         
-        let onboardingIconSS: UIView = self.onboardingIcon.snapshotView(afterScreenUpdates: false) ?? self.onboardingIcon
+        let onboardingIconSS: UIView = self.onboardingIcon.snapshotView(afterScreenUpdates: true) ?? self.onboardingIcon
         onboardingIconSS.frame = self.onboardingIcon.frame
         view.addSubview(onboardingIconSS)
         self.onboardingIcon.isHidden = true
@@ -127,7 +127,7 @@ class DaxOnboardingViewController: UIViewController, Onboarding {
 
     func transitionToDaxDialog() {
 
-        let snapshot: UIView = self.daxIcon.snapshotView(afterScreenUpdates: false) ?? self.daxIcon
+        let snapshot: UIView = self.daxIcon.snapshotView(afterScreenUpdates: true) ?? self.daxIcon
         snapshot.frame = self.daxIcon.frame
         view.addSubview(snapshot)
         self.daxIcon.isHidden = true

--- a/DuckDuckGo/DaxOnboardingViewController.swift
+++ b/DuckDuckGo/DaxOnboardingViewController.swift
@@ -89,12 +89,12 @@ class DaxOnboardingViewController: UIViewController, Onboarding {
     func transitionFromOnboarding() {
 
         // using snapshots means the original views don't get messed up by their constraints when subsequent animations kick off
-        let transitionIconSS = self.transitionalIcon.snapshotView(afterScreenUpdates: false)!
+        let transitionIconSS: UIView = self.transitionalIcon.snapshotView(afterScreenUpdates: false) ?? self.transitionalIcon
         transitionIconSS.frame = self.transitionalIcon.frame
         view.addSubview(transitionIconSS)
         self.transitionalIcon.isHidden = true
         
-        let onboardingIconSS = self.onboardingIcon.snapshotView(afterScreenUpdates: false)!
+        let onboardingIconSS: UIView = self.onboardingIcon.snapshotView(afterScreenUpdates: false) ?? self.onboardingIcon
         onboardingIconSS.frame = self.onboardingIcon.frame
         view.addSubview(onboardingIconSS)
         self.onboardingIcon.isHidden = true
@@ -127,7 +127,7 @@ class DaxOnboardingViewController: UIViewController, Onboarding {
 
     func transitionToDaxDialog() {
 
-        let snapshot = self.daxIcon.snapshotView(afterScreenUpdates: false)!
+        let snapshot: UIView = self.daxIcon.snapshotView(afterScreenUpdates: false) ?? self.daxIcon
         snapshot.frame = self.daxIcon.frame
         view.addSubview(snapshot)
         self.daxIcon.isHidden = true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: n/a
Tech Design URL: n/a
CC:

**Description**:

If snapshot fails during onboarding it can crash, rather just delegate to the actual icons.  Animations won't work as expected, but it looks ok and won't crash.

**Steps to test this PR**:
1.  Test onboarding with thermal state set to critical - still may not cause snapshots to update
1. Hack code to remove snapshot function to see effect without snapshots


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

