### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,4 @@ fastlane/test_output
 # DuckDuckGo
 
 Configuration/ExternalDeveloper.xcconfig
-fonts/licensed/*
+fonts/licensed/*.otf

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ fastlane/test_output
 # DuckDuckGo
 
 Configuration/ExternalDeveloper.xcconfig
+fonts/licensed/*


### PR DESCRIPTION
Updates .gitignore to exclude font files to ensure they don't get checked in. Let me know if I'm missing something! Seems like the easiest way to ensure they don't accidentally end up in the repo.
