### PR TITLE
Do not reload items if we are already processing updates

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -257,10 +257,10 @@ extension TabSwitcherViewController: TabViewCellDelegate {
                 currentSelection = tabsModel.currentIndex
                 collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
             }, completion: { _ in
+                self.isProcessingUpdates = false
                 guard let current = self.currentSelection else { return }
                 self.refreshTitle()
                 self.collectionView.reloadItems(at: [IndexPath(row: current, section: 0)])
-                self.isProcessingUpdates = false
             })
         }
     }

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -54,6 +54,8 @@ class TabSwitcherViewController: UIViewController {
     override var canBecomeFirstResponder: Bool { return true }
     
     var currentSelection: Int?
+    
+    private var isProcessingUpdates = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -250,6 +252,7 @@ extension TabSwitcherViewController: TabViewCellDelegate {
             collectionView.reloadData()
         } else {
             collectionView.performBatchUpdates({
+                isProcessingUpdates = true
                 delegate.tabSwitcher(self, didRemoveTab: tab)
                 currentSelection = tabsModel.currentIndex
                 collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
@@ -257,6 +260,7 @@ extension TabSwitcherViewController: TabViewCellDelegate {
                 guard let current = self.currentSelection else { return }
                 self.refreshTitle()
                 self.collectionView.reloadItems(at: [IndexPath(row: current, section: 0)])
+                self.isProcessingUpdates = false
             })
         }
     }
@@ -364,6 +368,9 @@ extension TabSwitcherViewController: UICollectionViewDelegateFlowLayout {
 extension TabSwitcherViewController: TabObserver {
     
     func didChange(tab: Tab) {
+        //Reloading when updates are processed will result in a crash
+        guard !isProcessingUpdates else { return }
+        
         if let index = tabsModel.indexOf(tab: tab) {
             collectionView.reloadItems(at: [IndexPath(row: index, section: 0)])
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1182410196365593
Tech Design URL:
CC:

**Description**:
Fixes a crash that happens when item is reloaded while other item is being removed from the collection view.

**Steps to test this PR**:
1.  Restart the app.
2. Open tab switcher.
3. Try to delete first cell when there is more than one present.

General smoke tests on Tab Switcher screen.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 10
* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 13

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

