### PR TITLE
remove delay when opening the tab switcher

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -764,13 +764,23 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func preparePreview(completion: @escaping (UIImage?) -> Void) {
-        DispatchQueue.main.async { [weak self] in
-            guard let webView = self?.webView else { completion(nil); return }
-            UIGraphicsBeginImageContextWithOptions(webView.bounds.size, false, UIScreen.main.scale)
-            webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: true)
-            let image = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            completion(image)
+        if #available(iOS 11.0, *) {
+            let config = WKSnapshotConfiguration()
+            config.rect = webView.bounds
+            let snapshotWidth = Float(webView.bounds.width / 2)
+            config.snapshotWidth = NSNumber(value: snapshotWidth)
+            webView.takeSnapshot(with: config) { image, _ in
+                completion(image)
+            }
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                guard let webView = self?.webView else { completion(nil); return }
+                UIGraphicsBeginImageContextWithOptions(webView.bounds.size, false, UIScreen.main.scale)
+                webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: true)
+                let image = UIGraphicsGetImageFromCurrentImageContext()
+                UIGraphicsEndImageContext()
+                completion(image)
+            }
         }
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -764,23 +764,13 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func preparePreview(completion: @escaping (UIImage?) -> Void) {
-        if #available(iOS 11.0, *) {
-            let config = WKSnapshotConfiguration()
-            config.rect = webView.bounds
-            let snapshotWidth = Float(webView.bounds.width / 2)
-            config.snapshotWidth = NSNumber(value: snapshotWidth)
-            webView.takeSnapshot(with: config) { image, _ in
-                completion(image)
-            }
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                guard let webView = self?.webView else { completion(nil); return }
-                UIGraphicsBeginImageContextWithOptions(webView.bounds.size, false, UIScreen.main.scale)
-                webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: true)
-                let image = UIGraphicsGetImageFromCurrentImageContext()
-                UIGraphicsEndImageContext()
-                completion(image)
-            }
+        DispatchQueue.main.async { [weak self] in
+            guard let webView = self?.webView else { completion(nil); return }
+            UIGraphicsBeginImageContextWithOptions(webView.bounds.size, false, UIScreen.main.scale)
+            webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: true)
+            let image = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            completion(image)
         }
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -764,11 +764,17 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     func preparePreview(completion: @escaping (UIImage?) -> Void) {
-        if #available(iOS 11.0, *) {
+        if #available(iOS 13.0, *) {
             let config = WKSnapshotConfiguration()
             config.rect = webView.bounds
             let snapshotWidth = Float(webView.bounds.width / 2)
             config.snapshotWidth = NSNumber(value: snapshotWidth)
+            
+             // takeSnapshot will block if the web view is in the connecting phase of a load which may be prominent on slow connections
+            if webView.isLoading {
+                config.afterScreenUpdates = false
+            }
+            
             webView.takeSnapshot(with: config) { image, _ in
                 completion(image)
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1183972715133805
Tech Design URL:
CC:

**Description**:

Just use graphics context for screenshots when opening tabs.

**Steps to test this PR**:

1. Open the tab switcher while webkit is connecting before the page starts loading - it should react near instantly.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 10
* [x] iOS 11
* [x] iOS 12
* [x] iOS 13

**Theme Testing**:

* [x] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

