### PR TITLE
Removes a comment referring to a now removed dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,3 @@
-# We are using a more recent commit for exception handling. Upgrade
-# to next release after 3.1.4, when available
-
 github "duckduckgo/Kingfisher" ~> 5.14.1
 
 github "duckduckgo/Device.swift" ~> 1.1.2


### PR DESCRIPTION
The dependency referenced, SwiftyJSON, was removed in https://github.com/duckduckgo/iOS/pull/271

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

**Description**:
Removes an outdated comment in the Cartfile which could be confusing.