### PR TITLE
Make alternate app icon buttons accessible

### DIFF
--- a/DuckDuckGo/AppIcon.swift
+++ b/DuckDuckGo/AppIcon.swift
@@ -27,6 +27,11 @@ enum AppIcon: String, CaseIterable {
     case purple
     case black
 
+    /// Returns a user facing string representation of the app icon.
+    var name: String {
+        rawValue
+    }
+
     static var defaultAppIcon: AppIcon {
         return .red
     }

--- a/DuckDuckGo/AppIconSettingsCell.swift
+++ b/DuckDuckGo/AppIconSettingsCell.swift
@@ -23,7 +23,19 @@ class AppIconSettingsCell: UICollectionViewCell {
 
     static let reuseIdentifier = "AppIconSettingsCell"
 
+    var appIcon: AppIcon! {
+        didSet {
+            imageView.image = appIcon.mediumImage
+            accessibilityLabel = appIcon.name
+        }
+    }
     @IBOutlet weak var imageView: UIImageView!
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        isAccessibilityElement = true
+        accessibilityTraits.insert(.button)
+    }
 
     override var isSelected: Bool {
         didSet {

--- a/DuckDuckGo/AppIconSettingsViewController.swift
+++ b/DuckDuckGo/AppIconSettingsViewController.swift
@@ -69,7 +69,7 @@ class AppIconDataSource: NSObject, UICollectionViewDataSource {
         cell.decorate(with: ThemeManager.shared.currentTheme)
 
         let appIcon = appIcons[indexPath.row]
-        cell.imageView.image = appIcon.mediumImage
+        cell.appIcon = appIcon
 
         return cell
     }


### PR DESCRIPTION
References #676

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

<img width="989" alt="Screenshot 2020-07-18 at 13 34 33" src="https://user-images.githubusercontent.com/4190298/87876847-01984a80-c9db-11ea-9ea8-c5deaf4074cd.png">
<img width="989" alt="Screenshot 2020-07-18 at 13 34 40" src="https://user-images.githubusercontent.com/4190298/87876849-052bd180-c9db-11ea-9f7b-6795596471a5.png">

**Description**:
Whereas previously the alternate app icon screen's buttons weren't accessible, this makes sure the buttons are seen as accessibility elements, adds the expected traits, and adds an accessibility label.

**Steps to test this PR**:
1. In VoiceOver, go to Settings > App Icon
1. Verify that the buttons are now accessible, show correct traits (button, button + selected if selected)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 10
* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 13