### PR TITLE
allow back button to close new tabs

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -941,10 +941,12 @@ extension MainViewController: TabDelegate {
             newTabAnimation {
                 self.loadUrlInNewTab(url)
                 self.tabManager.current?.openedByPage = true
+                self.tabManager.current?.openingTab = tab
             }
             tabSwitcherButton.incrementAnimated()
         } else {
             loadUrlInNewTab(url)
+            self.tabManager.current?.openingTab = tab
         }
 
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -57,6 +57,11 @@ class TabViewController: UIViewController {
 
     var openedByPage = false
     var daxDialogsDisabled = false
+    weak var openingTab: TabViewController? {
+        didSet {
+            delegate?.tabLoadingStateDidChange(tab: self)
+        }
+    }
     
     weak var delegate: TabDelegate?
     weak var chromeDelegate: BrowserChromeDelegate?
@@ -111,7 +116,7 @@ class TabViewController: UIViewController {
     public var canGoBack: Bool {
         let webViewCanGoBack = webView.canGoBack
         let navigatedToError = webView.url != nil && isError
-        return webViewCanGoBack || navigatedToError
+        return webViewCanGoBack || navigatedToError || openingTab != nil
     }
     
     public var canGoForward: Bool {
@@ -432,8 +437,10 @@ class TabViewController: UIViewController {
             url = webView.url
             onWebpageDidStartLoading(httpsForced: false)
             onWebpageDidFinishLoading()
-        } else {
+        } else if webView.canGoBack {
             webView.goBack()
+        } else if openingTab != nil {
+            delegate?.tabDidRequestClose(self)
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/715106103902962/1165288656835289
Tech Design URL:
CC:

**Description**:

Allows back button to open new tabs opened as follows:

* Open in new tab context menu option (on a link on the page)
* Opened by the page

**Steps to test this PR**:
1. Go to duckduckgo.com and change the settings to open links in a new window
1. Perform a search
1. Click on a link - should open a new tab
1. Click back - new tab should close
--
1. Click on another link
1. Use the tab switcher to close the opening tab
1. Go back to opened page, but button should not close page
--
1. Go to https://news.ycombinator.com
1. Open a link using the open in new tab menu option
1. Perform above tests
--
1. Open a new link using open in background menu option
1. Use tab switcher to go to new tab
1. Should not be able to close tab using back button


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 10
* [x] iOS 11
* [x] iOS 12
* [x] iOS 13

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

