### PR TITLE
handle first party correctly when a surrogate is available

### DIFF
--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -504,11 +504,10 @@ _utf8_encode : function (string) {
 
         var blocked = false;
         if (unprotectedDomain) {
-            blocked = false;
             result.reason = "unprotectedDomain";
-        } else if (result.action === 'block') {
-            blocked = true;
-        } else if (result.matchedRule && result.matchedRule.surrogate) {
+        } else if (result.action !== 'ignore') {
+            // other actions are "block" or "redirect" - anything that is not ignored should be blocked. Surrogates are handled below since
+            //  we can't do a redirect.
             blocked = true;
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1188029537284169
Tech Design URL:
CC:

**Description**:

When a surrogate was available for a first party tracker it would get blocked anyway.

**Steps to test this PR**:
1. Visit YouTube.com
1. Check the privacy dashboard - should be no trackers blocked
1. Browse other sites and ensure blocking continues to work as expected



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

