### PR TITLE
serp experiment excluding ipad

### DIFF
--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -42,12 +42,12 @@ public struct Variant {
     
     public static let defaultVariants: [Variant] = [
         // SERP testing
-        Variant(name: "sc", weight: doNotAllocate, features: []),
+        Variant(name: "sc", weight: 1, features: []),
         Variant(name: "sd", weight: doNotAllocate, features: []),
-        Variant(name: "se", weight: doNotAllocate, features: []),
+        Variant(name: "se", weight: 1, features: []),
         
-        Variant(name: "me", weight: 1, features: []),
-        Variant(name: "mf", weight: 1, features: [.tabSwitcherListLayout])
+        Variant(name: "me", weight: doNotAllocate, features: []),
+        Variant(name: "mf", weight: doNotAllocate, features: [.tabSwitcherListLayout])
     ]
     
     public let name: String

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -73,9 +73,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AtbAndVariantCleanup.cleanup()
         DefaultVariantManager().assignVariantIfNeeded { _ in
             // MARK: perform first time launch logic here
-            
             DaxDialogs().primeForUse()
-            return .includeInCohort
+            
+            // current SERP experiment does not include tablet
+            return isPad ? .excludeFromCohort : .includeInCohort
         }
 
         if let main = mainViewController {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1188203430400379/1188203771656673
Tech Design URL:
CC:

**Description**:

Allocates SERP experiment variants.  Puts previous experiment on hold (it has got enough samples).

**Steps to test this PR**:
1. Migrate app - no new variant allocated
1. Clean install app on iPad - no variant allocate
1. Clean install app on iPhone - allocated to `sc` or `se` variant

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

