### PR TITLE
fix home screen and privacy dashboard back button bugs

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1171,8 +1171,10 @@ extension MainViewController: BookmarksDelegate {
     }
     
     func bookmarksUpdated() {
-        removeHomeScreen()
-        attachHomeScreen()
+        if homeController != nil {
+            removeHomeScreen()
+            attachHomeScreen()
+        }
     }
 }
 

--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -61,7 +61,11 @@ class PrivacyProtectionScoreCardController: UITableViewController {
     }
 
     private func initBackButton() {
-        backButton.isHidden = !isPad
+        if DefaultVariantManager().isSupported(feature: .iPadImprovements) {
+            backButton.isHidden = !AppWidthObserver.shared.isLargeWidth
+        } else {
+            backButton.isHidden = UIDevice.current.userInterfaceIdiom != .pad
+        }
     }
 
     private func update() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1189129807740018
Tech Design URL:
CC:

**Description**:

Only reload home screen if home screen is showing and show back butto…n on privacy dashboard correctly

**Steps to test this PR**:
1. Navigate to a website, open and close bookmarks
1. On home screen open bookmarks, move a favorite to a bookmark, close bookmarks
1. In large mode open privacy dashboard and navigate, back button should appear
1. In phone/small mode open privacy dashboard and navigation bar should appear


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

