### PR TITLE
Patch navigator to not allow file sharing

### DIFF
--- a/Core/NavigatorSharePatchUserScript.swift
+++ b/Core/NavigatorSharePatchUserScript.swift
@@ -1,9 +1,20 @@
 //
 //  NavigatorSharePatchUserScript.swift
-//  Core
+//  DuckDuckGo
 //
-//  Created by Brad Slayter on 8/26/20.
 //  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import UIKit

--- a/Core/NavigatorSharePatchUserScript.swift
+++ b/Core/NavigatorSharePatchUserScript.swift
@@ -1,0 +1,28 @@
+//
+//  NavigatorSharePatchUserScript.swift
+//  Core
+//
+//  Created by Brad Slayter on 8/26/20.
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+
+import UIKit
+import WebKit
+
+public class NavigatorSharePatchUserScript: NSObject, UserScript {
+    public var source: String {
+        return loadJS("navigatorsharepatch")
+    }
+    
+    public var injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    
+    public var forMainFrameOnly: Bool = false
+    
+    public var messageNames: [String] = []
+    
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        
+    }
+    
+
+}

--- a/Core/navigatorsharepatch.js
+++ b/Core/navigatorsharepatch.js
@@ -18,7 +18,14 @@
  //
 
 function isSensitiveFile(filename) {
-    return /^file:\/\/\/(private|var|etc|usr)/i.test(filename);
+    let uriObj = null;
+    try {
+       uriObj = new URL(filename);
+    } catch (e) {
+       return true;
+    }
+    
+    return uriObj.protocol === 'file:';
 }
 
 (function() {

--- a/Core/navigatorsharepatch.js
+++ b/Core/navigatorsharepatch.js
@@ -17,11 +17,21 @@
  //  limitations under the License.
  //
 
+function isSensitiveFile(filename) {
+    return /^file:\/\/\/(private|var|etc|usr)/i.test(filename);
+}
+
 (function() {
      const oldShare = navigator.share;
      navigator.share = function(data) {
-         if (data.url && data.url.includes('file://')) {
-             return Promise.reject(new Error('File sharing is not supported in this browser'));
+         if (data.url && isSensitiveFile(data.url)) {
+             return Promise.reject(new Error('System file sharing is not supported in this browser'));
+         } else if (data.files) {
+             for (var i in data.files) {
+                 if (isSensitiveFile(data.files[i])) {
+                     return Promise.reject(new Error('System file sharing is not supported in this browser'));
+                 }
+             }
          }
          
          return oldShare(data);

--- a/Core/navigatorsharepatch.js
+++ b/Core/navigatorsharepatch.js
@@ -22,8 +22,8 @@ function isSensitiveFile(filename) {
 }
 
 (function() {
-     const oldShare = navigator.share;
-     navigator.share = function(data) {
+    const oldShare = Navigator.prototype.share;
+    Navigator.prototype.share = function(data) {
          if (data.url && isSensitiveFile(data.url)) {
              return Promise.reject(new Error('System file sharing is not supported in this browser'));
          } else if (data.files) {
@@ -34,6 +34,6 @@ function isSensitiveFile(filename) {
              }
          }
          
-         return oldShare(data);
+        return oldShare.call(this, data);
      }
  })();

--- a/Core/navigatorsharepatch.js
+++ b/Core/navigatorsharepatch.js
@@ -17,18 +17,18 @@
  //  limitations under the License.
  //
 
-function isSensitiveFile(filename) {
-    let uriObj = null;
-    try {
-       uriObj = new URL(filename);
-    } catch (e) {
-       return true;
+(function() {
+    function isSensitiveFile(filename) {
+        let uriObj = null;
+        try {
+           uriObj = new URL(filename);
+        } catch (e) {
+           return true;
+        }
+        
+        return uriObj.protocol === 'file:';
     }
     
-    return uriObj.protocol === 'file:';
-}
-
-(function() {
     const oldShare = Navigator.prototype.share;
     Navigator.prototype.share = function(data) {
          if (data.url && isSensitiveFile(data.url)) {

--- a/Core/navigatorsharepatch.js
+++ b/Core/navigatorsharepatch.js
@@ -1,0 +1,29 @@
+ //
+ //  navigatorsharepatch.js
+ //  DuckDuckGo
+ //
+ //  Copyright © 2020 DuckDuckGo. All rights reserved.
+ //
+ //  Licensed under the Apache License, Version 2.0 (the "License");
+ //  you may not use this file except in compliance with the License.
+ //  You may obtain a copy of the License at
+ //
+ //  http://www.apache.org/licenses/LICENSE-2.0
+ //
+ //  Unless required by applicable law or agreed to in writing, software
+ //  distributed under the License is distributed on an "AS IS" BASIS,
+ //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ //  See the License for the specific language governing permissions and
+ //  limitations under the License.
+ //
+
+(function() {
+     const oldShare = navigator.share;
+     navigator.share = function(data) {
+         if (data.url && data.url.includes('file://')) {
+             return Promise.reject(new Error('File sharing is not supported in this browser'));
+         }
+         
+         return oldShare(data);
+     }
+ })();

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02CA904924F6BFE700D41DDF /* navigatorsharepatch.js in Resources */ = {isa = PBXBuildFile; fileRef = 02CA904824F6BFE700D41DDF /* navigatorsharepatch.js */; };
+		02CA904B24F6C11A00D41DDF /* NavigatorSharePatchUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA904A24F6C11A00D41DDF /* NavigatorSharePatchUserScript.swift */; };
 		0A6CC0EF23904D5400E4F627 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A6CC0EE23904D5400E4F627 /* Settings.bundle */; };
 		1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82023CEA1F800AA24EA /* DateExtension.swift */; };
 		1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */; };
@@ -620,6 +622,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02CA904824F6BFE700D41DDF /* navigatorsharepatch.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = navigatorsharepatch.js; sourceTree = "<group>"; };
+		02CA904A24F6C11A00D41DDF /* NavigatorSharePatchUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorSharePatchUserScript.swift; sourceTree = "<group>"; };
 		0A6CC0EE23904D5400E4F627 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		1CB7B82023CEA1F800AA24EA /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
@@ -1325,6 +1329,7 @@
 				987AFB6B22AE83C2001B84CF /* debug-messaging-enabled.js */,
 				9833FD7122BCE44C00E95CD8 /* debug-messaging-disabled.js */,
 				850559C823C61B5D0055C0D5 /* login-form-detection.js */,
+				02CA904824F6BFE700D41DDF /* navigatorsharepatch.js */,
 			);
 			name = contentblocking;
 			sourceTree = "<group>";
@@ -1751,6 +1756,7 @@
 			isa = PBXGroup;
 			children = (
 				85BDC3162434E55D0053DB07 /* ContentBlockerUserScript.swift */,
+				02CA904A24F6C11A00D41DDF /* NavigatorSharePatchUserScript.swift */,
 			);
 			name = Web;
 			sourceTree = "<group>";
@@ -3290,6 +3296,7 @@
 				83D306A41F6D500B00ED7CE2 /* tosdr.json in Resources */,
 				9833FD7222BCE44C00E95CD8 /* debug-messaging-disabled.js in Resources */,
 				8521FDEA238DA9D800A44CC3 /* trackerData.json in Resources */,
+				02CA904924F6BFE700D41DDF /* navigatorsharepatch.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3828,6 +3835,7 @@
 				9876B75E2232B36900D81D9F /* TabInstrumentation.swift in Sources */,
 				85A53ECA200D1FA20010D13F /* FileStore.swift in Sources */,
 				F1134EB31F40AD2500B73467 /* Atb.swift in Sources */,
+				02CA904B24F6C11A00D41DDF /* NavigatorSharePatchUserScript.swift in Sources */,
 				85BDC3192436161C0053DB07 /* LoginFormDetectionUserScript.swift in Sources */,
 				8328AAB9212A3DF200293140 /* BloomFilterWrapper.mm in Sources */,
 				98982B3422F8D8E400578AC9 /* Debounce.swift in Sources */,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -154,6 +154,7 @@ class TabViewController: UIViewController {
     private var faviconScript = FaviconUserScript()
     private var loginFormDetectionScript = LoginFormDetectionUserScript()
     private var contentBlockerScript = ContentBlockerUserScript()
+    private var navigatorPatchScript = NavigatorSharePatchUserScript()
     private var documentScript = DocumentUserScript()
     private var findInPageScript = FindInPageUserScript()
     private var debugScript = DebugUserScript()
@@ -207,6 +208,7 @@ class TabViewController: UIViewController {
         generalScripts = [
             debugScript,
             findInPageScript,
+            navigatorPatchScript,
             contentBlockerScript,
             faviconScript
         ]


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/69071770703008/1190774066966114/f
Tech Design URL: N/A
CC: @brindy @bwaresiak @catehstn 

**Description**:
This patches the security vulnerability described here: https://blog.redteam.pl/2020/08/stealing-local-files-using-safari-web.html

In this PR we are disallowing the sharing of any files in the var, private, etc, and usr system directories. If we want we can narrow this down to system files or some other filter.

**Steps to test this PR**:
1. Navigate to https://overflow.pl/webshare/poc1.html
1. Pressing the button on the page should do nothing.
1. Navigate to https://jsfiddle.net/gnk4jxa3/
1. Pressing "Change color" should do nothing (tests sharing via the `files` array)
1. Navigate to https://jsfiddle.net/5a82ogh7/
1. Pressing "Change color" should open the share dialog

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

