### PR TITLE
Update iPad tabs to re-render when setting the app theme

### DIFF
--- a/DuckDuckGo/TabsBarCell.swift
+++ b/DuckDuckGo/TabsBarCell.swift
@@ -140,8 +140,12 @@ extension TabsBarCell: UIPointerInteractionDelegate {
 // Based on https://stackoverflow.com/a/53847223/73479
 class FadeOutLabel: UILabel {
     
-    var primaryColor: UIColor = .black
-        
+    var primaryColor: UIColor = .black {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
     override func drawText(in rect: CGRect) {
         let gradientColors = [primaryColor.cgColor, UIColor.clear.cgColor]
         if let gradientColor = drawGradientColor(in: rect, colors: gradientColors) {


### PR DESCRIPTION
**Description**:

When using the latest App Store release of the app on iPad, I noticed that browser tab labels were either extremely faint or entirely invisible after manually changing the theme in the settings menu. When using the system level theme via the `Auto` option, the tabs are displayed correctly when the iOS theme changes. The bug goes away the next time a tab is selected, as the label is re-rendered.

The root issue appears to be that `FadeOutLabel`'s implementation of`drawText` is not called when the theme is changed, unless it is changed at the system level.

The fix is to call `setNeedsDisplay` when changing `FadeOutLabel`'s primary color, so that `drawText` is called the next time the labels appear on screen.

CC: @brindy @bwaresiak

---

**Screenshots**:

Here's what it looks like with the bug in effect:

![dark-to-light](https://user-images.githubusercontent.com/183774/92315572-4fbdd900-ef9c-11ea-9991-8ce61f0c6bc9.jpeg)

![light-to-dark](https://user-images.githubusercontent.com/183774/92315573-53516000-ef9c-11ea-9256-7e5cfcfcedf7.jpeg)

---

**Steps to test this PR**:

1. Pick one of the light or dark themes (not `Auto`, as using the system level theme does not trigger this bug)
1. Open a new tab and confirm that tabs are rendered correctly
1. Change the theme to either light or dark
1. Close settings and confirm that tabs are rendered correctly

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

