### PR TITLE
Avoid throwing exceptions when `fetch` is called with no arguments

### DIFF
--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -217,6 +217,10 @@
         originalFetch = window.fetch;
       }
       window.fetch = function() {
+        if (arguments.length == 0) {
+          return originalFetch.apply(window, arguments);
+        }
+
         if (typeof arguments[0] === 'string') {
           sendMessage(arguments[0], 'fetch');
         } else if (arguments[0].url) {

--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -217,7 +217,7 @@
         originalFetch = window.fetch;
       }
       window.fetch = function() {
-        if (arguments.length == 0) {
+        if (arguments.length === 0) {
           return originalFetch.apply(window, arguments);
         }
 


### PR DESCRIPTION
**Description**:

There was [a report on the DuckDuckGo subreddit](https://www.reddit.com/r/duckduckgo/comments/irl916/as_of_yesterday_i_can_no_longer_access_rotten/) recently about Rotten Tomatoes no longer working in the iOS app. Specifically, it has started redirecting the app to the Unsupported Browser page, with a hint in the URL that the JS `fetch` function is not available.

Rotten Tomatoes' approach to feature detection is to call `fetch()` with no arguments and check for any thrown exceptions to tell whether it's usable. Normally this is fine because `fetch()` with no arguments returns a Promise, but the content blocker script in the DDG app overrides `fetch` and [accesses its first argument](https://github.com/duckduckgo/iOS/blob/develop/Core/contentblockerrules.js#L222) even when no arguments are provided, resulting in a `TypeError` and thus a false negative compatibility check.

The fix is to delegate to the original `fetch` in the case that there are no arguments, since I don't think we care about passing those calls along via `sendMessage` if they're only being used for compatibility purposes (I could be wrong there).

The `WKWebView` user scripts in the app are still a massive blind spot for me, so I could be way off base with this fix - this works for me locally, but let me know. 😄 

CC: @brindy @bwaresiak @SlayterDev 

**Steps to test this PR**:

1. Visit rottentomatoes.com in the app. It's better to run in the simulator in this case because you can use the Safari Technology Preview to point the web inspector to its `WKWebView` instances, which is handy as Rotten Tomatoes caches the compatibility check in local storage – the STP web inspector will let you delete that entry in local storage.
1. Check whether you are redirected to the Unsupported Browser page.

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 13

