### PR TITLE
Add SwiftUI previews for widgets

### DIFF
--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:DuckDuckGo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "84E341A51E2F7EFB00BDBA6F"
-               BuildableName = "UnitTests.xctest"
-               BlueprintName = "UnitTests"
-               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "84E341A51E2F7EFB00BDBA6F"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Widgets/WidgetViews.swift
+++ b/Widgets/WidgetViews.swift
@@ -238,3 +238,43 @@ extension Image {
     }
 
 }
+
+struct WidgetViews_Previews: PreviewProvider {
+    static let mockFavorites: [Favorite] = {
+        let duckDuckGoFavorite = Favorite(url: URL(string: "https://duckduckgo.com/")!, domain: "duckduckgo.com", favicon: nil)
+
+        let favorites = "abcdefghijk".map {
+            Favorite(url: URL(string: "https://\($0).com/")!, domain: "\($0).com", favicon: nil)
+        }
+
+        return [duckDuckGoFavorite] + favorites
+    }()
+
+    static let entry = FavoritesEntry(date: Date(), favorites: mockFavorites, isPreview: false)
+
+    static var previews: some View {
+        SearchWidgetView(entry: entry)
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environment(\.colorScheme, .light)
+
+        SearchWidgetView(entry: entry)
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environment(\.colorScheme, .dark)
+
+        FavoritesWidgetView(entry: entry)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.colorScheme, .light)
+
+        FavoritesWidgetView(entry: entry)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.colorScheme, .dark)
+
+        FavoritesWidgetView(entry: entry)
+            .previewContext(WidgetPreviewContext(family: .systemLarge))
+            .environment(\.colorScheme, .light)
+
+        FavoritesWidgetView(entry: entry)
+            .previewContext(WidgetPreviewContext(family: .systemLarge))
+            .environment(\.colorScheme, .dark)
+    }
+}

--- a/Widgets/WidgetViews.swift
+++ b/Widgets/WidgetViews.swift
@@ -97,7 +97,7 @@ struct LargeSearchFieldView: View {
 
                 }.padding(EdgeInsets(top: 0, leading: 27, bottom: 0, trailing: 27))
 
-            }
+            }.unredacted()
         }
     }
 

--- a/Widgets/WidgetViews.swift
+++ b/Widgets/WidgetViews.swift
@@ -240,6 +240,7 @@ extension Image {
 }
 
 struct WidgetViews_Previews: PreviewProvider {
+
     static let mockFavorites: [Favorite] = {
         let duckDuckGoFavorite = Favorite(url: URL(string: "https://duckduckgo.com/")!, domain: "duckduckgo.com", favicon: nil)
 

--- a/Widgets/WidgetViews.swift
+++ b/Widgets/WidgetViews.swift
@@ -252,6 +252,7 @@ struct WidgetViews_Previews: PreviewProvider {
     }()
 
     static let entry = FavoritesEntry(date: Date(), favorites: mockFavorites, isPreview: false)
+    static let previewEntry = FavoritesEntry(date: Date(), favorites: mockFavorites, isPreview: true)
 
     static var previews: some View {
         SearchWidgetView(entry: entry)
@@ -262,17 +263,37 @@ struct WidgetViews_Previews: PreviewProvider {
             .previewContext(WidgetPreviewContext(family: .systemSmall))
             .environment(\.colorScheme, .dark)
 
+        // Medium size:
+
+        FavoritesWidgetView(entry: previewEntry)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.colorScheme, .light)
+
         FavoritesWidgetView(entry: entry)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
             .environment(\.colorScheme, .light)
+
+        FavoritesWidgetView(entry: previewEntry)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.colorScheme, .dark)
 
         FavoritesWidgetView(entry: entry)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
             .environment(\.colorScheme, .dark)
 
+        // Large size:
+
+        FavoritesWidgetView(entry: previewEntry)
+            .previewContext(WidgetPreviewContext(family: .systemLarge))
+            .environment(\.colorScheme, .light)
+
         FavoritesWidgetView(entry: entry)
             .previewContext(WidgetPreviewContext(family: .systemLarge))
             .environment(\.colorScheme, .light)
+
+        FavoritesWidgetView(entry: previewEntry)
+            .previewContext(WidgetPreviewContext(family: .systemLarge))
+            .environment(\.colorScheme, .dark)
 
         FavoritesWidgetView(entry: entry)
             .previewContext(WidgetPreviewContext(family: .systemLarge))


### PR DESCRIPTION
CC: @brindy 

**Description**:

This PR adds previews of the widgets added in the iOS 14 update. Each widget has been added with both dark and light mode variants, and the widgets are populated with mock data to show that the randomized favourite color is working correctly. Here's a peek at a few of the widgets:

<img width="309" alt="widgets" src="https://user-images.githubusercontent.com/183774/93290896-9a0e3980-f796-11ea-8cb6-ccc79d68b47c.png">

There is a minor scheme change in this PR which was needed for SwiftUI previews to work. Before this change, the unit test target was being built when the main `DuckDuckGo` scheme builds, which caused compile errors when previews were displayed.

The solution to the compile error issue is to move the unit test config into its own scheme and wire it up to the `DuckDuckGo` scheme so that Command+U works as it always has. I also unchecked the `Show` option in the new `UnitTest` scheme so that it doesn't clutter up the scheme dropdown, since it can just be run from the main app scheme like always – from a dev work perspective, nothing should have changed.

Here's a before and after of the build log to prove that test targets are no longer being built during normal builds:

**Before:**

<img width="1441" alt="build-process-before" src="https://user-images.githubusercontent.com/183774/93290524-c7a6b300-f795-11ea-8b56-5f110b96e008.png">

**After:**

<img width="1441" alt="build-process-after" src="https://user-images.githubusercontent.com/183774/93290540-ce352a80-f795-11ea-9c84-2886c0f52819.png">

**Steps to test this PR**:

1. Open this branch in Xcode 12
1. Go to the `WidgetViews.swift` file and open the Canvas pane to verify that SwiftUI previews are displayed

**OS Testing**:

* [x] iOS 14

**Theme Testing**:

* [x] Light theme
* [x] Dark theme
