### PR TITLE
Fix grade label on Privacy Protection screen

### DIFF
--- a/DuckDuckGo/PrivacyProtectionHeaderCell.swift
+++ b/DuckDuckGo/PrivacyProtectionHeaderCell.swift
@@ -68,7 +68,7 @@ class PrivacyProtectionHeaderConfigurator {
         } else if differentGrades(in: siteRating) {
             cell.gradeLabel.attributedText = makeEnhancedProtectionLabel(siteRating, fromText: cell.gradeLabel.attributedText!)
         } else {
-            cell.gradeLabel.setAttributedTextString(UserText.privacyProtectionProtectionDisabled)
+            cell.gradeLabel.setAttributedTextString(UserText.privacyProtectionPrivacyGrade)
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1195919669085065
Tech Design URL:
CC:

**Description**:
On Privacy Protection screen, in case grade is not enhanced label should say "Privacy Grade" instead of protection disabled.

**Steps to test this PR**:

1. Navigate to SERP or any other page where grade is not enhanced.
2. See if Privacy Protection screen behaves as expected.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

