### PR TITLE
Fix fullscreen video

### DIFF
--- a/Core/FullScreenVideoUserScript.swift
+++ b/Core/FullScreenVideoUserScript.swift
@@ -1,0 +1,32 @@
+//
+//  FullScreenVideoUserScript.swift
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+
+public class FullScreenVideoUserScript: NSObject, UserScript {
+    public var source: String {
+        return loadJS("fullscreenvideo")
+    }
+
+    public var injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    public var forMainFrameOnly: Bool = false
+    public var messageNames: [String] = []
+
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
+}

--- a/Core/fullscreenvideo.js
+++ b/Core/fullscreenvideo.js
@@ -1,0 +1,20 @@
+//
+//  fullscreenvideo.js
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+

--- a/Core/fullscreenvideo.js
+++ b/Core/fullscreenvideo.js
@@ -25,7 +25,7 @@
     let canEnterFullscreen = HTMLVideoElement.prototype.webkitEnterFullscreen !== undefined;
     let browserHasExistingFullScreenSupport = document.fullscreenEnabled || document.webkitFullscreenEnabled;
 
-    // YouTube Mobile won't exit fullscreen correctly if this patch is active. Reference: https://github.com/brave/brave-ios/pull/2002
+    // YouTube Mobile won't exit fullscreen correctly if requestFullscreen is overridden. Reference: https://github.com/brave/brave-ios/pull/2002
     let isMobile = /mobile/i.test(navigator.userAgent);
 
     if (!browserHasExistingFullScreenSupport && canEnterFullscreen && !isMobile) {

--- a/Core/fullscreenvideo.js
+++ b/Core/fullscreenvideo.js
@@ -25,7 +25,10 @@
     let canEnterFullscreen = HTMLVideoElement.prototype.webkitEnterFullscreen !== undefined;
     let browserHasExistingFullScreenSupport = document.fullscreenEnabled || document.webkitFullscreenEnabled;
 
-    if (!browserHasExistingFullScreenSupport && canEnterFullscreen) {
+    // YouTube Mobile won't exit fullscreen correctly if this patch is active. Reference: https://github.com/brave/brave-ios/pull/2002
+    let isMobile = /mobile/i.test(navigator.userAgent);
+
+    if (!browserHasExistingFullScreenSupport && canEnterFullscreen && !isMobile) {
         Object.defineProperty(document, "fullscreenEnabled", {
             get: function() {
                 return true;

--- a/Core/fullscreenvideo.js
+++ b/Core/fullscreenvideo.js
@@ -30,9 +30,7 @@
 
     if (!browserHasExistingFullScreenSupport && canEnterFullscreen && !isMobile) {
         Object.defineProperty(document, "fullscreenEnabled", {
-            get: function() {
-                return true;
-            }
+            value: true
         });
 
         HTMLElement.prototype.requestFullscreen = function() {

--- a/Core/fullscreenvideo.js
+++ b/Core/fullscreenvideo.js
@@ -17,4 +17,30 @@
 //  limitations under the License.
 //
 
+// WKWebView doesn't define the fullscreenEnabled property, although it does support webkitEnterFullscreen.
+// The workaround is to override fullscreenEnabled (if it isn't already defined), and add a custom implementation of the requestFullscreen function.
+// The implementation calls through to webkitEnterFullscreen, which is defined on HTMLVideoElement.
 
+(function() {
+    let canEnterFullscreen = HTMLVideoElement.prototype.webkitEnterFullscreen !== undefined;
+    let browserHasExistingFullScreenSupport = document.fullscreenEnabled || document.webkitFullscreenEnabled;
+
+    if (!browserHasExistingFullScreenSupport && canEnterFullscreen) {
+        Object.defineProperty(document, "fullscreenEnabled", {
+            get: function() {
+                return true;
+            }
+        });
+
+        HTMLElement.prototype.requestFullscreen = function() {
+            let video = this.querySelector("video");
+
+            if (video) {
+                video.webkitEnterFullscreen();
+                return true;
+            }
+
+            return false;
+        };
+    }
+})();

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82023CEA1F800AA24EA /* DateExtension.swift */; };
 		1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */; };
 		22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */; };
+		4B60AC97252EC07B00E8D219 /* fullscreenvideo.js in Resources */ = {isa = PBXBuildFile; fileRef = 4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */; };
+		4B60ACA1252EC0B100E8D219 /* FullScreenVideoUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */; };
 		83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */; };
 		83004E862193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */; };
 		83004E882193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E872193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift */; };
@@ -685,6 +687,8 @@
 		1CB7B82023CEA1F800AA24EA /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeepLinksTests.swift; sourceTree = "<group>"; };
+		4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = fullscreenvideo.js; sourceTree = "<group>"; };
+		4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenVideoUserScript.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
 		83004E832193E14C00DA013C /* UIAlertControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtension.swift; path = ../Core/UIAlertControllerExtension.swift; sourceTree = "<group>"; };
@@ -1817,6 +1821,7 @@
 			children = (
 				85F2FFFC2215C020006BB258 /* findinpage.js */,
 				02C57C5E251533CE009E5129 /* donotsell.js */,
+				4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */,
 			);
 			name = "ios-js-support";
 			sourceTree = "<group>";
@@ -2485,6 +2490,7 @@
 				85BDC3182436161C0053DB07 /* LoginFormDetectionUserScript.swift */,
 				836A941C247F23C600BF8EF5 /* UserAgentManager.swift */,
 				02C57C5425153330009E5129 /* DoNotSellUserScript.swift */,
+				4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */,
 			);
 			name = Web;
 			sourceTree = "<group>";
@@ -3463,6 +3469,7 @@
 				02C57C5F251533CE009E5129 /* donotsell.js in Resources */,
 				850559C923C61B5D0055C0D5 /* login-form-detection.js in Resources */,
 				856D57C5206568BE000170B5 /* tlds.json in Resources */,
+				4B60AC97252EC07B00E8D219 /* fullscreenvideo.js in Resources */,
 				85047B8A1F69692C002A95D8 /* contentblocker.js in Resources */,
 				83D306A41F6D500B00ED7CE2 /* tosdr.json in Resources */,
 				0254AC2424EDACDE004855DF /* contentblockerrules.js in Resources */,
@@ -3982,6 +3989,7 @@
 				830381C01F850AAF00863075 /* WKWebViewConfigurationExtension.swift in Sources */,
 				85B718F51FD071E50031A14F /* HTTPSUpgrade.xcdatamodeld in Sources */,
 				85CA53AA24BB376800A6288C /* NotFoundCachingDownloader.swift in Sources */,
+				4B60ACA1252EC0B100E8D219 /* FullScreenVideoUserScript.swift in Sources */,
 				F1A886781F29394E0096251E /* WebCacheManager.swift in Sources */,
 				8331AEDE20AA37560024962B /* APIHeaders.swift in Sources */,
 				9896632422C56716007BE4FE /* EtagStorage.swift in Sources */,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -161,6 +161,7 @@ class TabViewController: UIViewController {
     private var doNotSellScript = DoNotSellUserScript()
     private var documentScript = DocumentUserScript()
     private var findInPageScript = FindInPageUserScript()
+    private var fullScreenVideoScript = FullScreenVideoUserScript()
     private var debugScript = DebugUserScript()
     
     private var generalScripts: [UserScript] = []
@@ -214,7 +215,8 @@ class TabViewController: UIViewController {
             navigatorPatchScript,
             contentBlockerScript,
             contentBlockerRulesScript,
-            faviconScript
+            faviconScript,
+            fullScreenVideoScript
         ]
         
         ddgScripts = [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1183304843940541
Fixes: #675 
CC: @SlayterDev 

**Description**:

This PR fixes a gap in WKWebView's JS APIs, where the fullscreen APIs exist and function correctly, but [`fullscreenEnabled`](https://developer.mozilla.org/en-US/docs/Web/API/Document/fullscreenEnabled) is undefined. That property is checked by YouTube and others to determine whether fullscreen is possible.

There is a new script which checks whether `fullscreenEnabled` is defined and overrides it if it isn't. In case this gets fixed one day, the builtin implementation is checked for and used if it's found instead. An implementation of `requestFullscreen` was required to get this to work, which just calls through to `webkitEnterFullscreen` on the HTML element requesting it.

@SlayterDev I'd love to get your eyes on this to verify that the JS makes sense. 🙂

**Steps to test this PR**:
1. Open a video on YouTube.com on an iPad
1. Test that the video is able to go fullscreen

_**Note:** I tested this on iPhone and iPad with all supported iOS versions but found that iPhones running iOS 11 and 12 will exit fullscreen immediately after entering it, even on `develop`. It only happens on mobile, iPhones on 11 and 12 will work correctly if desktop mode is requested. I'd love for someone else to double check that and confirm this PR hasn't caused a regression._

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14