### PR TITLE
Prevent deadlocks when sending stats after background refreshes

### DIFF
--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -68,7 +68,7 @@ class AppConfigurationFetch {
         guard shouldRefresh else {
             // Statistics are not sent after a successful background refresh in order to reduce the time spent in the background, so they are checked
             // here in case a background refresh has happened recently.
-            type(of: self).fetchQueue.async {
+            Self.fetchQueue.async {
                 self.sendStatistics {
                     completion?(false)
                 }

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -68,8 +68,10 @@ class AppConfigurationFetch {
         guard shouldRefresh else {
             // Statistics are not sent after a successful background refresh in order to reduce the time spent in the background, so they are checked
             // here in case a background refresh has happened recently.
-            sendStatistics {
-                completion?(false)
+            type(of: self).fetchQueue.async {
+                self.sendStatistics {
+                    completion?(false)
+                }
             }
 
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1198172269427377/f
CC: @brindy 

**Description**:

The background refresh changes added a check for any changes to the stats, triggered every time the app becomes active. The usecase there is that background tasks will increment stat counters after completion but not actually send them in order to save background execution time. Because of this, the app needs to check in order for those stats to be reported.

However, I missed that the network request to do so will always come back on the main thread. This change triggered a deadlock where the semaphore was waiting on the main thread for a signal that was supposed to arrive... also on the main thread. 🤦

The fix is to send stats from the fetch queue, allowing it to complete on the main thread successfully.

Offending commit: https://github.com/duckduckgo/iOS/pull/726/commits/490a34778fc1b7185ddea9071cf2e92d5ca1ad96

**Steps to test this PR**:

This PR can be tested by having a background refresh task run, and then by launching the app. When the app launches it will check for any changes in stats and send them if needed.

However an easy way to test this in development is to comment out the guard statement at the top of `sendStatistics` and just launch the app, which will trigger the stats API call every time the app becomes active. You can do that and comment out the new change to reproduce the deadlock every time.

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 14

