### PR TITLE
Reload protection grade cell when updaing UI

### DIFF
--- a/DuckDuckGo/PrivacyProtectionOverviewController.swift
+++ b/DuckDuckGo/PrivacyProtectionOverviewController.swift
@@ -108,6 +108,7 @@ class PrivacyProtectionOverviewController: UITableViewController {
         // not keen on this, but there seems to be a race condition when the site rating is updated and the controller hasn't be loaded yet
         guard isViewLoaded else { return }
         
+        tableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .none)
         updateEncryption()
         updateTrackers()
         updatePrivacyPractices()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1198191970712393
CC:

**Description**:
Grade section on Privacy Protection screen is not reloaded properly.

Steps to reproduce: Open privacy Practices screen, toggle protection.

**Steps to test this PR**:
1. Open privacy Practices screen
2. Toggle protection.

Protection grade and description should be updated.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [x] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

