### PR TITLE
remove excessive loading of url requests

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1004,7 +1004,6 @@ extension TabViewController: WKNavigationDelegate {
             if let headers = request.allHTTPHeaderFields,
                headers.firstIndex(where: { $0.key == Constants.secGPCHeader }) == nil {
                 request.addValue("1", forHTTPHeaderField: Constants.secGPCHeader)
-                load(urlRequest: request)
                 return request
             }
         } else {
@@ -1012,7 +1011,6 @@ extension TabViewController: WKNavigationDelegate {
             if let headers = request.allHTTPHeaderFields,
                let _ = headers.firstIndex(where: { $0.key == Constants.secGPCHeader }) {
                 request.setValue(nil, forHTTPHeaderField: Constants.secGPCHeader)
-                load(urlRequest: request)
                 return request
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL :https://app.asana.com/0/392891325557410/1198194737172882
Tech Design URL:
CC:

**Description**:

Fix a bug where the tab history would get messaged up when GPC was enabled.

**Steps to test this PR**:
1. Visit https://news.ycombinator.com/
1. Scroll down the page and navigate to a site
1. Go back - button should be disabled and location on page should not have change
1. Check that GPC header is still being sent


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

