### PR TITLE
prevent GPC from disabling URL schemes

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1022,6 +1022,7 @@ extension TabViewController: WKNavigationDelegate {
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 
         if navigationAction.isTargetingMainFrame(),
+           !(navigationAction.request.url?.isCustomURLScheme() ?? false),
            navigationAction.navigationType != .backForward,
            let request = requestForDoNotSell(basedOn: navigationAction.request) {
             decisionHandler(.cancel)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408
Tech Design URL:
CC:

**Description**:

When GPC is enabled it would disable URL schemes inadvertently.

**Steps to test this PR**:
1. Enable GPC
1. Click on a link with a custom URL scheme (can try https://falkirkrpg.org.uk/noxwal/simple-zoom.html for now, I'll add something to the privacy test pages)
1. Should be prompted to open the corresponding app


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

