### PR TITLE
Add configuration refresh info to the debug menu

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82023CEA1F800AA24EA /* DateExtension.swift */; };
 		1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */; };
 		22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */; };
+		4B0295192537BC6700E00CEF /* ConfigurationDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */; };
 		4B60AC97252EC07B00E8D219 /* fullscreenvideo.js in Resources */ = {isa = PBXBuildFile; fileRef = 4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */; };
 		4B60ACA1252EC0B100E8D219 /* FullScreenVideoUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */; };
 		83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */; };
@@ -691,6 +692,7 @@
 		1CB7B82023CEA1F800AA24EA /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeepLinksTests.swift; sourceTree = "<group>"; };
+		4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationDebugViewController.swift; sourceTree = "<group>"; };
 		4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = fullscreenvideo.js; sourceTree = "<group>"; };
 		4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenVideoUserScript.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
@@ -1806,6 +1808,7 @@
 			children = (
 				858566E7252E4F56007501B8 /* Debug.storyboard */,
 				858566FA252E55D6007501B8 /* ImageCacheDebugViewController.swift */,
+				4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */,
 			);
 			name = Debug;
 			sourceTree = "<group>";
@@ -3781,6 +3784,7 @@
 				9872D205247DCAC100CEF398 /* TabPreviewsSource.swift in Sources */,
 				F130D73A1E5776C500C45811 /* OmniBarDelegate.swift in Sources */,
 				85DFEDEF24C7EA3B00973FE7 /* SmallOmniBarState.swift in Sources */,
+				4B0295192537BC6700E00CEF /* ConfigurationDebugViewController.swift in Sources */,
 				984D035C24AE15CD0066CFB8 /* TabSwitcherSettings.swift in Sources */,
 				98B31292218CCB8C00E54DE1 /* AppDependencyProvider.swift in Sources */,
 				02C57C4B2514FEFB009E5129 /* DoNotSellSettingsViewController.swift in Sources */,

--- a/DuckDuckGo/ConfigurationDebugViewController.swift
+++ b/DuckDuckGo/ConfigurationDebugViewController.swift
@@ -26,13 +26,15 @@ class ConfigurationDebugViewController: UITableViewController {
 
     private let titles = [
         Sections.refreshInformation: "Background Refresh Info",
-        Sections.queuedTasks: "Queued Tasks (Earliest Execution Date)"
+        Sections.queuedTasks: "Queued Tasks (Earliest Execution Date)",
+        Sections.etags: "ETags"
     ]
 
     enum Sections: Int, CaseIterable {
 
         case refreshInformation
         case queuedTasks
+        case etags
 
     }
 
@@ -40,6 +42,17 @@ class ConfigurationDebugViewController: UITableViewController {
 
         case lastRefreshDate
         case resetLastRefreshDate
+
+    }
+
+    enum ETagRows: String, CaseIterable {
+
+        case httpsBloomFilterSpec
+        case httpsBloomFilter
+        case httpsExcludedDomains
+        case surrogates
+        case trackerDataSet
+        case temporaryUnprotectedSites
 
     }
 
@@ -95,7 +108,21 @@ class ConfigurationDebugViewController: UITableViewController {
             }
 
         case .queuedTasks:
-            cell.textLabel?.text = dateFormatter.string(from: queuedTasks[indexPath.row].earliestBeginDate!)
+            if queuedTasks.isEmpty {
+                cell.textLabel?.text = "None"
+            } else {
+                cell.textLabel?.text = dateFormatter.string(from: queuedTasks[indexPath.row].earliestBeginDate!)
+            }
+
+        case .etags:
+            let row = ETagRows.allCases[indexPath.row]
+            cell.textLabel?.text = row.rawValue
+
+            if let etag = etag(for: row) {
+                cell.detailTextLabel?.text = etag
+            } else {
+                cell.detailTextLabel?.text = "None"
+            }
 
         default: break
         }
@@ -106,7 +133,8 @@ class ConfigurationDebugViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Sections(rawValue: section) {
         case .refreshInformation: return RefreshInformationRows.allCases.count
-        case .queuedTasks: return queuedTasks.count
+        case .queuedTasks: return queuedTasks.isEmpty ? 1 : queuedTasks.count
+        case .etags: return ETagRows.allCases.count
         default: return 0
         }
     }
@@ -122,6 +150,14 @@ class ConfigurationDebugViewController: UITableViewController {
             }
         default: break
         }
+    }
+
+    // MARK: - ETag User Defaults Wrapper
+
+    lazy var defaults = UserDefaults(suiteName: "com.duckduckgo.blocker-list.etags")
+
+    private func etag(for config: ETagRows) -> String? {
+        return defaults?.string(forKey: config.rawValue)
     }
 
 }

--- a/DuckDuckGo/ConfigurationDebugViewController.swift
+++ b/DuckDuckGo/ConfigurationDebugViewController.swift
@@ -49,7 +49,7 @@ class ConfigurationDebugViewController: UITableViewController {
 
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateStyle = .medium
+        formatter.dateStyle = .short
         formatter.timeStyle = .long
         return formatter
     }()
@@ -82,10 +82,12 @@ class ConfigurationDebugViewController: UITableViewController {
         case .refreshInformation:
             switch RefreshInformationRows(rawValue: indexPath.row) {
             case .lastRefreshDate:
+                cell.textLabel?.text = "Last Refresh"
+
                 if lastConfigurationRefreshDate == Date.distantPast {
-                    cell.textLabel?.text = "Last Refresh Date: Never"
+                    cell.detailTextLabel?.text = "Never"
                 } else {
-                    cell.textLabel?.text = "Last Refresh Date: \(dateFormatter.string(from: lastConfigurationRefreshDate))"
+                    cell.detailTextLabel?.text = dateFormatter.string(from: lastConfigurationRefreshDate)
                 }
             case .resetLastRefreshDate:
                 cell.textLabel?.text = "Reset Last Refresh Date"

--- a/DuckDuckGo/ConfigurationDebugViewController.swift
+++ b/DuckDuckGo/ConfigurationDebugViewController.swift
@@ -62,7 +62,7 @@ class ConfigurationDebugViewController: UITableViewController {
 
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateStyle = .short
+        formatter.dateStyle = .medium
         formatter.timeStyle = .long
         return formatter
     }()

--- a/DuckDuckGo/ConfigurationDebugViewController.swift
+++ b/DuckDuckGo/ConfigurationDebugViewController.swift
@@ -1,0 +1,125 @@
+//
+//  ConfigurationDebugViewController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import BackgroundTasks
+import Core
+
+@available(iOS 13.0, *)
+class ConfigurationDebugViewController: UITableViewController {
+
+    private let titles = [
+        Sections.refreshInformation: "Background Refresh Info",
+        Sections.queuedTasks: "Queued Tasks (Earliest Execution Date)"
+    ]
+
+    enum Sections: Int, CaseIterable {
+
+        case refreshInformation
+        case queuedTasks
+
+    }
+
+    enum RefreshInformationRows: Int, CaseIterable {
+
+        case lastRefreshDate
+        case resetLastRefreshDate
+
+    }
+
+    @UserDefaultsWrapper(key: .lastConfigurationRefreshDate, defaultValue: .distantPast)
+    private var lastConfigurationRefreshDate: Date
+    private var queuedTasks: [BGTaskRequest] = []
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .long
+        return formatter
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        BGTaskScheduler.shared.getPendingTaskRequests { tasks in
+            self.queuedTasks = tasks
+
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        }
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return Sections.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard let section = Sections(rawValue: section) else { return nil }
+        return titles[section]
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        switch Sections(rawValue: indexPath.section) {
+
+        case .refreshInformation:
+            switch RefreshInformationRows(rawValue: indexPath.row) {
+            case .lastRefreshDate:
+                if lastConfigurationRefreshDate == Date.distantPast {
+                    cell.textLabel?.text = "Last Refresh Date: Never"
+                } else {
+                    cell.textLabel?.text = "Last Refresh Date: \(dateFormatter.string(from: lastConfigurationRefreshDate))"
+                }
+            case .resetLastRefreshDate:
+                cell.textLabel?.text = "Reset Last Refresh Date"
+            default: break
+            }
+
+        case .queuedTasks:
+            cell.textLabel?.text = dateFormatter.string(from: queuedTasks[indexPath.row].earliestBeginDate!)
+
+        default: break
+        }
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch Sections(rawValue: section) {
+        case .refreshInformation: return RefreshInformationRows.allCases.count
+        case .queuedTasks: return queuedTasks.count
+        default: return 0
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch Sections(rawValue: indexPath.section) {
+        case .refreshInformation:
+            switch RefreshInformationRows(rawValue: indexPath.row) {
+            case .resetLastRefreshDate:
+                lastConfigurationRefreshDate = Date.distantPast
+                tableView.reloadData()
+            default: break
+            }
+        default: break
+        }
+    }
+
+}

--- a/DuckDuckGo/Debug.storyboard
+++ b/DuckDuckGo/Debug.storyboard
@@ -39,6 +39,26 @@
                                             <segue destination="Hg0-3R-I9z" kind="show" id="14W-OX-fVR"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="ugj-c7-9Rr" style="IBUITableViewCellStyleDefault" id="HWQ-dk-Dth">
+                                        <rect key="frame" x="0.0" y="71.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HWQ-dk-Dth" id="GuE-vY-UYO">
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Configuration Refresh Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ugj-c7-9Rr">
+                                                    <rect key="frame" x="20" y="0.0" width="355" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="sSL-cj-dyo" kind="show" id="ioK-wz-zwJ"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -117,6 +137,44 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OjJ-fr-oiF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1154" y="213"/>
+        </scene>
+        <!--Configuration Refresh Info-->
+        <scene sceneID="Aol-tl-zZp">
+            <objects>
+                <tableViewController id="sSL-cj-dyo" userLabel="Configuration Refresh Info" customClass="ConfigurationDebugViewController" customModule="DuckDuckGo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="802-ar-D9S">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="TcD-oV-gfN" style="IBUITableViewCellStyleDefault" id="wcr-2q-4Tq">
+                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wcr-2q-4Tq" id="xRl-7k-yt9">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TcD-oV-gfN">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="sSL-cj-dyo" id="pJf-EY-nyx"/>
+                            <outlet property="delegate" destination="sSL-cj-dyo" id="bt0-bZ-yHh"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Image Cache" id="42K-hM-uzg"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="rC6-OZ-nkP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="638" y="942"/>
         </scene>
     </scenes>
     <resources>

--- a/DuckDuckGo/Debug.storyboard
+++ b/DuckDuckGo/Debug.storyboard
@@ -177,7 +177,7 @@
                             <outlet property="delegate" destination="sSL-cj-dyo" id="bt0-bZ-yHh"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Image Cache" id="42K-hM-uzg"/>
+                    <navigationItem key="navigationItem" title="Configuration Refresh Info" id="42K-hM-uzg"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rC6-OZ-nkP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/DuckDuckGo/Debug.storyboard
+++ b/DuckDuckGo/Debug.storyboard
@@ -147,15 +147,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="TcD-oV-gfN" style="IBUITableViewCellStyleDefault" id="wcr-2q-4Tq">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="TcD-oV-gfN" detailTextLabel="MYU-Tt-aou" style="IBUITableViewCellStyleValue1" id="wcr-2q-4Tq">
                                 <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wcr-2q-4Tq" id="xRl-7k-yt9">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TcD-oV-gfN">
-                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TcD-oV-gfN">
+                                            <rect key="frame" x="20" y="12" width="33" height="20.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MYU-Tt-aou">
+                                            <rect key="frame" x="350" y="12" width="44" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>

--- a/DuckDuckGo/Debug.storyboard
+++ b/DuckDuckGo/Debug.storyboard
@@ -147,24 +147,24 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="TcD-oV-gfN" detailTextLabel="MYU-Tt-aou" style="IBUITableViewCellStyleValue1" id="wcr-2q-4Tq">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="TcD-oV-gfN" detailTextLabel="MYU-Tt-aou" style="IBUITableViewCellStyleSubtitle" id="wcr-2q-4Tq">
+                                <rect key="frame" x="0.0" y="55.5" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wcr-2q-4Tq" id="xRl-7k-yt9">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TcD-oV-gfN">
-                                            <rect key="frame" x="20" y="12" width="33" height="20.5"/>
+                                            <rect key="frame" x="20" y="10" width="33" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MYU-Tt-aou">
-                                            <rect key="frame" x="350" y="12" width="44" height="20.5"/>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MYU-Tt-aou">
+                                            <rect key="frame" x="20" y="31.5" width="44" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>


### PR DESCRIPTION
CC: @brindy 

**Description**:

This PR adds info around the config refresh process to the debug menu. Specifically, it adds:

1. The last refresh date
2. A way to reset the last refresh date
3. A list of pending `BGTaskRequest` objects
4. A list of cached config files with their ETags

**Steps to test this PR**:
1. Run the app in a debug configuration
1. Go into settings and tap the Version row at the bottom
1. Tap the `Configuration Refresh Info` row



