### PR TITLE
Fix address bar text sometimes not being selected properly

### DIFF
--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -389,6 +389,11 @@ extension OmniBar: UITextFieldDelegate {
         DispatchQueue.main.async {
             self.omniDelegate?.onTextFieldDidBeginEditing(self)
             self.refreshState(self.state.onEditingStartedState)
+        }
+
+        // Allow the cursor to move to the end before selecting all the text
+        // to avoid text not being selected properly
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             self.textField.selectAll(nil)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/iOS/issues/741
Tech Design URL:
CC:

**Description**:

- Fix address bar text not being selected properly occasionally due to cursor appearing at end of address string after or while select is occurring


**Steps to test this PR**:
1. Enter URL on address bar (a long URL failed more frequently)
2. Tap address
3. Deselect address by tapping Cancel
4. Repeat multiple times with same address and different addresses

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone 11 Pro

**OS Testing**:

* [x] iOS 14

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

