### PR TITLE
Fix bookmarklets not working with Open In External apps setting

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1078,7 +1078,7 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
 
-        if url.isBookmarklet() && allowPolicy == .allow {
+        if url.isBookmarklet() {
             completion(.cancel)
 
             if let js = url.toDecodedBookmarklet() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1198498661154765
Tech Design URL:
CC:

**Description**:
Fix bookmarklets not working with Open In External apps setting is set to false.

**Steps to test this PR**:
1.  Disable Open In External apps settings (set it to false).
2. Try to use bookmarklet.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

