### PR TITLE
Fix Latvian translation crash

### DIFF
--- a/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/DuckDuckGo/lv.lproj/Localizable.strings
@@ -689,7 +689,7 @@
 "privacy.protection.main.disabled" = "VIETAS AIZSARDZĪBA IR ATSPĒJOTA";
 
 /* $1 and $2 are grades - letters. Example: Enhanced from D to B */
-"privacy.protection.main.enhanced" = "UZLABOTS NO 1$ uz 2$";
+"privacy.protection.main.enhanced" = "UZLABOTS NO $1 uz $2";
 
 /* No comment provided by engineer. */
 "privacy.protection.main.grade" = "Privātuma līmenis";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1198500992341725
Tech Design URL:
CC:

**Description**:
Due to missing placeholders opening Privacy Protection screen results in a crash.

**Steps to test this PR**:
1. Select Latvian locale.
2. Open privacy protection screen to see grade enhanced label.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

