### PR TITLE
fix javascript error in favicon user script

### DIFF
--- a/Core/FaviconUserScript.swift
+++ b/Core/FaviconUserScript.swift
@@ -40,14 +40,15 @@ public class FaviconUserScript: NSObject, UserScript {
     function findFavicons() {
 
          var selectors = [
-            "link[rel='apple-touch-icon-precomposed']",
+            "link[rel~='icon']",
             "link[rel='apple-touch-icon']",
-            "link[rel~='icon']"
+            "link[rel='apple-touch-icon-precomposed']"
         ];
 
         var favicons = [];
-        for (var selector in selectors) {
-            var icons = document.head.querySelectorAll(selectors[selector]);
+        while (selectors.length > 0) {
+            var selector = selectors.pop()
+            var icons = document.head.querySelectorAll(selector);
             for (var i = 0; i < icons.length; i++) {
                 var href = icons[i].href;
                 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1198499791002680
Tech Design URL:
CC:

**Description**:

Fixes a JS bug which would cause no favicon to be loaded on some sites.

**Steps to test this PR**:
1.  Visit dndbeyond.com 
1.  Check the tab has an icon
1. Add as a favorite and make sure it has an icon
1. Check a few other sites still work as expected (Twitter, Tech Crunch, Hacker News, BBC), etc.

--
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

