### PR TITLE
Check if trackers are first party before reporting

### DIFF
--- a/Core/ContentBlockerRulesUserScript.swift
+++ b/Core/ContentBlockerRulesUserScript.swift
@@ -26,6 +26,7 @@ public class ContentBlockerRulesUserScript: NSObject, UserScript {
         static let url = "url"
         static let resourceType = "resourceType"
         static let blocked = "blocked"
+        static let pageUrl = "pageUrl"
     }
     
     public var source: String {
@@ -54,9 +55,20 @@ public class ContentBlockerRulesUserScript: NSObject, UserScript {
         guard let dict = message.body as? [String: Any] else { return }
         guard let blocked = dict[ContentBlockerKey.blocked] as? Bool else { return }
         guard let urlString = dict[ContentBlockerKey.url] as? String else { return }
+        guard let pageUrlStr = dict[ContentBlockerKey.pageUrl] as? String else { return }
         
+        Swift.print("PAGE: \(pageUrlStr)")
         if let tracker = trackerFromUrl(urlString, blocked: blocked) {
-            delegate.contentBlockerUserScript(self, detectedTracker: tracker)
+            guard let pageUrl = URL(string: pageUrlStr),
+               let pageHost = pageUrl.host,
+               let pageEntity = TrackerDataManager.shared.findEntity(forHost: pageHost) else {
+                delegate.contentBlockerUserScript(self, detectedTracker: tracker)
+                return
+            }
+            
+            if pageEntity.displayName != tracker.entity?.displayName {
+                delegate.contentBlockerUserScript(self, detectedTracker: tracker)
+            }
         }
     }
     

--- a/Core/ContentBlockerRulesUserScript.swift
+++ b/Core/ContentBlockerRulesUserScript.swift
@@ -57,7 +57,6 @@ public class ContentBlockerRulesUserScript: NSObject, UserScript {
         guard let urlString = dict[ContentBlockerKey.url] as? String else { return }
         guard let pageUrlStr = dict[ContentBlockerKey.pageUrl] as? String else { return }
         
-        Swift.print("PAGE: \(pageUrlStr)")
         if let tracker = trackerFromUrl(urlString, blocked: blocked) {
             guard let pageUrl = URL(string: pageUrlStr),
                let pageHost = pageUrl.host,

--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -92,10 +92,12 @@
 
     function sendMessage(url, resourceType) {
       if (url) {
+        const pageUrl = window.location.href
         webkit.messageHandlers.processRule.postMessage({ 
           url: url,
           resourceType: resourceType === undefined ? null : resourceType,
-          blocked: !unprotectedDomain
+          blocked: !unprotectedDomain,
+          pageUrl: pageUrl
         });
       }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1198500057425372/f
Tech Design URL:
CC: @brindy 

**Description**:
This PR checks if trackers are first party when reported by the content blocker rules script and excludes them from the report.

**Steps to test this PR**:
1. Vist yahoo.com
2. Verify no VM trackers are reported
3. Visit amazon.com
4. Verify no amazon trackers are reported
5. Visit some other sites (wayfair.com for example. not included in TR data)
6. Verify tracker blocking works as expected.


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

