### PR TITLE
Add additional configuration refresh stats

### DIFF
--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -115,13 +115,13 @@ public class ContentBlockerLoader {
             guard case ContentBlockerRequest.Response.success(_, let data) = response,
                 let specification = try? HTTPSUpgradeParser.convertBloomFilterSpecification(fromJSONData: data)
                 else {
+                    progress?(.httpsBloomFilter)
                     semaphore.signal()
                     return
             }
             
             if let storedSpecification = self.httpsUpgradeStore.bloomFilterSpecification(), storedSpecification == specification {
                 os_log("Bloom filter already downloaded", log: generalLog, type: .debug)
-                // Mark the Bloom Filter as downloaded if the current version already exists locally.
                 progress?(.httpsBloomFilter)
                 semaphore.signal()
                 return

--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -21,7 +21,7 @@ import Foundation
 import os.log
 
 public class ContentBlockerLoader {
-    typealias ContentBlockerConfigurationProgress = (ContentBlockerRequest.Configuration) -> Void
+    typealias ContentBlockerLoaderProgress = (ContentBlockerRequest.Configuration) -> Void
 
     private typealias DataDict = [ContentBlockerRequest.Configuration: Any]
     private typealias EtagDict = [ContentBlockerRequest.Configuration: String]
@@ -38,7 +38,7 @@ public class ContentBlockerLoader {
         self.fileStore = fileStore
     }
 
-    func checkForUpdates(progress: ContentBlockerConfigurationProgress? = nil, dataSource: ContentBlockerRemoteDataSource? = nil) -> Bool {
+    func checkForUpdates(progress: ContentBlockerLoaderProgress? = nil, dataSource: ContentBlockerRemoteDataSource? = nil) -> Bool {
         let dataSource = dataSource ?? ContentBlockerRequest(etagStorage: etagStorage)
 
         self.newData.removeAll()
@@ -68,7 +68,7 @@ public class ContentBlockerLoader {
     
     private func startRequests(with semaphore: DispatchSemaphore,
                                dataSource: ContentBlockerRemoteDataSource,
-                               progress: ContentBlockerConfigurationProgress? = nil) -> Int {
+                               progress: ContentBlockerLoaderProgress? = nil) -> Int {
         
         request(.surrogates, with: dataSource, semaphore, progress)
         request(.trackerDataSet, with: dataSource, semaphore, progress)
@@ -82,7 +82,7 @@ public class ContentBlockerLoader {
     fileprivate func request(_ configuration: ContentBlockerRequest.Configuration,
                              with contentBlockerRequest: ContentBlockerRemoteDataSource,
                              _ semaphore: DispatchSemaphore,
-                             _ progress: ContentBlockerConfigurationProgress? = nil) {
+                             _ progress: ContentBlockerLoaderProgress? = nil) {
         contentBlockerRequest.request(configuration) { response in
             defer {
                 progress?(configuration)
@@ -106,7 +106,7 @@ public class ContentBlockerLoader {
     
     private func requestHttpsUpgrade(_ contentBlockerRequest: ContentBlockerRemoteDataSource,
                                      _ semaphore: DispatchSemaphore,
-                                     _ progress: ContentBlockerConfigurationProgress? = nil) {
+                                     _ progress: ContentBlockerLoaderProgress? = nil) {
         contentBlockerRequest.request(.httpsBloomFilterSpec) { response in
             defer {
                 progress?(.httpsBloomFilterSpec)
@@ -145,7 +145,7 @@ public class ContentBlockerLoader {
     
     private func requestHttpsExcludedDomains(_ contentBlockerRequest: ContentBlockerRemoteDataSource,
                                              _ semaphore: DispatchSemaphore,
-                                             _ progress: ContentBlockerConfigurationProgress? = nil) {
+                                             _ progress: ContentBlockerLoaderProgress? = nil) {
         contentBlockerRequest.request(.httpsExcludedDomains) { response in
             defer {
                 progress?(.httpsExcludedDomains)

--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -21,7 +21,8 @@ import Foundation
 import os.log
 
 public class ContentBlockerLoader {
-    
+    typealias ContentBlockerConfigurationProgress = (ContentBlockerRequest.Configuration) -> Void
+
     private typealias DataDict = [ContentBlockerRequest.Configuration: Any]
     private typealias EtagDict = [ContentBlockerRequest.Configuration: String]
 
@@ -37,14 +38,14 @@ public class ContentBlockerLoader {
         self.fileStore = fileStore
     }
 
-    func checkForUpdates(dataSource: ContentBlockerRemoteDataSource? = nil) -> Bool {
+    func checkForUpdates(progress: ContentBlockerConfigurationProgress? = nil, dataSource: ContentBlockerRemoteDataSource? = nil) -> Bool {
         let dataSource = dataSource ?? ContentBlockerRequest(etagStorage: etagStorage)
 
         self.newData.removeAll()
         self.etags.removeAll()
         
         let semaphore = DispatchSemaphore(value: 0)
-        let numberOfRequests = startRequests(with: semaphore, dataSource: dataSource)
+        let numberOfRequests = startRequests(with: semaphore, dataSource: dataSource, progress: progress)
         
         for _ in 0 ..< numberOfRequests {
             semaphore.wait()
@@ -66,22 +67,27 @@ public class ContentBlockerLoader {
     }
     
     private func startRequests(with semaphore: DispatchSemaphore,
-                               dataSource: ContentBlockerRemoteDataSource) -> Int {
+                               dataSource: ContentBlockerRemoteDataSource,
+                               progress: ContentBlockerConfigurationProgress? = nil) -> Int {
         
-        request(.surrogates, with: dataSource, semaphore)
-        request(.trackerDataSet, with: dataSource, semaphore)
-        request(.temporaryUnprotectedSites, with: dataSource, semaphore)
-        requestHttpsUpgrade(dataSource, semaphore)
-        requestHttpsExcludedDomains(dataSource, semaphore)
+        request(.surrogates, with: dataSource, semaphore, progress)
+        request(.trackerDataSet, with: dataSource, semaphore, progress)
+        request(.temporaryUnprotectedSites, with: dataSource, semaphore, progress)
+        requestHttpsUpgrade(dataSource, semaphore, progress)
+        requestHttpsExcludedDomains(dataSource, semaphore, progress)
         
         return dataSource.requestCount
     }
     
     fileprivate func request(_ configuration: ContentBlockerRequest.Configuration,
                              with contentBlockerRequest: ContentBlockerRemoteDataSource,
-                             _ semaphore: DispatchSemaphore) {
+                             _ semaphore: DispatchSemaphore,
+                             _ progress: ContentBlockerConfigurationProgress? = nil) {
         contentBlockerRequest.request(configuration) { response in
-            
+            defer {
+                progress?(configuration)
+            }
+
             guard case ContentBlockerRequest.Response.success(let etag, let data) = response else {
                 semaphore.signal()
                 return
@@ -98,8 +104,14 @@ public class ContentBlockerLoader {
         }
     }
     
-    private func requestHttpsUpgrade(_ contentBlockerRequest: ContentBlockerRemoteDataSource, _ semaphore: DispatchSemaphore) {
+    private func requestHttpsUpgrade(_ contentBlockerRequest: ContentBlockerRemoteDataSource,
+                                     _ semaphore: DispatchSemaphore,
+                                     _ progress: ContentBlockerConfigurationProgress? = nil) {
         contentBlockerRequest.request(.httpsBloomFilterSpec) { response in
+            defer {
+                progress?(.httpsBloomFilterSpec)
+            }
+
             guard case ContentBlockerRequest.Response.success(_, let data) = response,
                 let specification = try? HTTPSUpgradeParser.convertBloomFilterSpecification(fromJSONData: data)
                 else {
@@ -109,11 +121,17 @@ public class ContentBlockerLoader {
             
             if let storedSpecification = self.httpsUpgradeStore.bloomFilterSpecification(), storedSpecification == specification {
                 os_log("Bloom filter already downloaded", log: generalLog, type: .debug)
+                // Mark the Bloom Filter as downloaded if the current version already exists locally.
+                progress?(.httpsBloomFilter)
                 semaphore.signal()
                 return
             }
             
             contentBlockerRequest.request(.httpsBloomFilter) { response in
+                defer {
+                    progress?(.httpsBloomFilter)
+                }
+
                 guard case ContentBlockerRequest.Response.success(_, let data) = response else {
                     semaphore.signal()
                     return
@@ -125,8 +143,14 @@ public class ContentBlockerLoader {
         }
     }
     
-    private func requestHttpsExcludedDomains(_ contentBlockerRequest: ContentBlockerRemoteDataSource, _ semaphore: DispatchSemaphore) {
+    private func requestHttpsExcludedDomains(_ contentBlockerRequest: ContentBlockerRemoteDataSource,
+                                             _ semaphore: DispatchSemaphore,
+                                             _ progress: ContentBlockerConfigurationProgress? = nil) {
         contentBlockerRequest.request(.httpsExcludedDomains) { response in
+            defer {
+                progress?(.httpsExcludedDomains)
+            }
+
             guard case ContentBlockerRequest.Response.success(let etag, let data) = response else {
                 semaphore.signal()
                 return

--- a/Core/ContentBlockerRequest.swift
+++ b/Core/ContentBlockerRequest.swift
@@ -26,14 +26,13 @@ protocol ContentBlockerRemoteDataSource {
     func request(_ configuration: ContentBlockerRequest.Configuration, completion:@escaping (ContentBlockerRequest.Response) -> Void)
 }
 
-class ContentBlockerRequest: ContentBlockerRemoteDataSource {
-    
+public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
     enum Response {
         case error
         case success(etag: String?, data: Data)
     }
 
-    enum Configuration: String {
+    public enum Configuration: String {
         case httpsBloomFilterSpec
         case httpsBloomFilter
         case httpsExcludedDomains
@@ -50,7 +49,7 @@ class ContentBlockerRequest: ContentBlockerRemoteDataSource {
         self.etagStorage = etagStorage
     }
     
-    func request(_ configuration: Configuration, completion:@escaping (Response) -> Void) {
+    func request(_ configuration: Configuration, completion: @escaping (Response) -> Void) {
         requestCount += 1
         
         let spid = Instruments.shared.startTimedEvent(.fetchingContentBlockerData, info: configuration.rawValue)

--- a/Core/StorageCacheProvider.swift
+++ b/Core/StorageCacheProvider.swift
@@ -22,7 +22,8 @@ import Foundation
 public class StorageCacheProvider {
     
     public static let didUpdateStorageCacheNotification = NSNotification.Name(rawValue: "com.duckduckgo.storageCacheProvider.notifications.didUpdate")
-    
+
+    public typealias StorageCacheUpdateProgress = (ContentBlockerRequest.Configuration) -> Void
     public typealias StorageCacheUpdateCompletion = (StorageCache?) -> Void
     
     private static let updateQueue = DispatchQueue(label: "StorageCache update queue", qos: .utility)
@@ -47,13 +48,13 @@ public class StorageCacheProvider {
     
     public init() {}
     
-    public func update(completion: @escaping StorageCacheUpdateCompletion) {
-    
+    public func update(progress: StorageCacheUpdateProgress? = nil, completion: @escaping StorageCacheUpdateCompletion) {
+
         Self.updateQueue.async {
             let loader = ContentBlockerLoader()
             let currentCache = self.current
             
-            guard loader.checkForUpdates() else {
+            guard loader.checkForUpdates(progress: progress) else {
                 completion(nil)
                 return
             }

--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -58,6 +58,14 @@ public struct UserDefaultsWrapper<T> {
         case lastConfigurationRefreshDate = "com.duckduckgo.ios.lastConfigurationRefreshDate"
         
         case doNotSell = "com.duckduckgo.ios.sendDoNotSell"
+
+        case backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
+        case downloadedHTTPSBloomFilterSpecCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterSpecCount"
+        case downloadedHTTPSBloomFilterCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterCount"
+        case downloadedHTTPSExcludedDomainsCount = "com.duckduckgo.app.downloadedHTTPSExcludedDomainsCount"
+        case downloadedSurrogatesCount = "com.duckduckgo.app.downloadedSurrogatesCount"
+        case downloadedTrackerDataSetCount = "com.duckduckgo.app.downloadedTrackerDataSetCount"
+        case downloadedTemporaryUnprotectedSitesCount = "com.duckduckgo.app.downloadedTemporaryUnprotectedSitesCount"
     }
 
     private let key: Key

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -32,6 +32,8 @@ protocol AppConfigurationFetchStatistics {
     var backgroundStartCount: Int { get set }
     var backgroundNoDataCount: Int { get set }
     var backgroundNewDataCount: Int { get set }
+
+    var backgroundTaskExpirationCount: Int { get set }
 }
 
 class AppConfigurationFetch {
@@ -46,6 +48,7 @@ class AppConfigurationFetch {
         static let bgFetchType = "bgft"
         static let bgFetchTypeBackgroundTasks = "bgbt"
         static let bgFetchTypeLegacy = "bgl"
+        static let bgFetchTaskExpiration = "bgte"
         static let bgFetchStart = "bgfs"
         static let bgFetchNoData = "bgnd"
         static let bgFetchWithData = "bgwd"
@@ -102,6 +105,9 @@ class AppConfigurationFetch {
             using: fetchQueue) { (task) in
 
             task.expirationHandler = {
+                var store: AppConfigurationFetchStatistics = AppUserDefaults()
+                store.backgroundTaskExpirationCount += 1
+
                 scheduleBackgroundRefreshTask()
             }
 
@@ -200,7 +206,8 @@ class AppConfigurationFetch {
                           Keys.fgFetchStart: String(store.foregroundStartCount),
                           Keys.fgFetchNoData: String(store.foregroundNoDataCount),
                           Keys.fgFetchWithData: String(store.foregroundNewDataCount),
-                          Keys.bgFetchType: backgroundFetchType]
+                          Keys.bgFetchType: backgroundFetchType,
+                          Keys.bgFetchTaskExpiration: String(store.backgroundTaskExpirationCount)]
         
         let semaphore = DispatchSemaphore(value: 0)
         
@@ -227,5 +234,6 @@ class AppConfigurationFetch {
         store.foregroundStartCount = 0
         store.foregroundNoDataCount = 0
         store.foregroundNewDataCount = 0
+        store.backgroundTaskExpirationCount = 0
     }
 }

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -127,6 +127,10 @@ class AppConfigurationFetch {
         // Background tasks can be debugged by breaking on the `submit` call, stepping over, then running the following LLDB command, before resuming:
         //
         // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]
+        //
+        // Task expiration can be simulated similarly:
+        //
+        // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateExpirationForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]
 
         do {
             try BGTaskScheduler.shared.submit(task)

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -258,6 +258,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func initialiseBackgroundFetch(_ application: UIApplication) {
         if #available(iOS 13.0, *) {
+            guard UIApplication.shared.backgroundRefreshStatus == .available else {
+                return
+            }
+            
             // BackgroundTasks will automatically replace an existing task in the queue if one with the same identifier is queued, so we should only
             // schedule a task if there are none pending in order to avoid the config task getting perpetually replaced.
             BGTaskScheduler.shared.getPendingTaskRequests { tasks in

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -46,6 +46,13 @@ public class AppUserDefaults: AppSettings {
         static let backgroundFetchNewDataCount = "com.duckduckgo.app.bgFetchNewDataCount"
 
         static let backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
+
+        static let downloadedHTTPSBloomFilterSpecCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterSpecCount"
+        static let downloadedHTTPSBloomFilterCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterCount"
+        static let downloadedHTTPSExcludedDomainsCount = "com.duckduckgo.app.downloadedHTTPSExcludedDomainsCount"
+        static let downloadedSurrogatesCount = "com.duckduckgo.app.downloadedSurrogatesCount"
+        static let downloadedTrackerDataSetCount = "com.duckduckgo.app.downloadedTrackerDataSetCount"
+        static let downloadedTemporaryUnprotectedSitesCount = "com.duckduckgo.app.downloadedTemporaryUnprotectedSitesCount"
         
         static let notificationsEnabled = "com.duckduckgo.app.notificationsEnabled"
         static let allowUniversalLinks = "com.duckduckgo.app.allowUniversalLinks"
@@ -211,6 +218,60 @@ extension AppUserDefaults: AppConfigurationFetchStatistics {
         }
         set {
             userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchTaskExpirationCount)
+        }
+    }
+
+    var downloadedHTTPSBloomFilterSpecCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.downloadedHTTPSBloomFilterSpecCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.downloadedHTTPSBloomFilterSpecCount)
+        }
+    }
+
+    var downloadedHTTPSBloomFilterCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.downloadedHTTPSBloomFilterCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.downloadedHTTPSBloomFilterCount)
+        }
+    }
+
+    var downloadedHTTPSExcludedDomainsCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.downloadedHTTPSExcludedDomainsCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.downloadedHTTPSExcludedDomainsCount)
+        }
+    }
+
+    var downloadedSurrogatesCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.downloadedSurrogatesCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.downloadedSurrogatesCount)
+        }
+    }
+
+    var downloadedTrackerDataSetCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.downloadedTrackerDataSetCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.downloadedTrackerDataSetCount)
+        }
+    }
+
+    var downloadedTemporaryUnprotectedSitesCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.downloadedTemporaryUnprotectedSitesCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.downloadedTemporaryUnprotectedSitesCount)
         }
     }
 }

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -44,15 +44,6 @@ public class AppUserDefaults: AppSettings {
         static let backgroundFetchStartCount = "com.duckduckgo.app.bgFetchStartCount"
         static let backgroundFetchNoDataCount = "com.duckduckgo.app.bgFetchNoDataCount"
         static let backgroundFetchNewDataCount = "com.duckduckgo.app.bgFetchNewDataCount"
-
-        static let backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
-
-        static let downloadedHTTPSBloomFilterSpecCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterSpecCount"
-        static let downloadedHTTPSBloomFilterCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterCount"
-        static let downloadedHTTPSExcludedDomainsCount = "com.duckduckgo.app.downloadedHTTPSExcludedDomainsCount"
-        static let downloadedSurrogatesCount = "com.duckduckgo.app.downloadedSurrogatesCount"
-        static let downloadedTrackerDataSetCount = "com.duckduckgo.app.downloadedTrackerDataSetCount"
-        static let downloadedTemporaryUnprotectedSitesCount = "com.duckduckgo.app.downloadedTemporaryUnprotectedSitesCount"
         
         static let notificationsEnabled = "com.duckduckgo.app.notificationsEnabled"
         static let allowUniversalLinks = "com.duckduckgo.app.allowUniversalLinks"
@@ -209,69 +200,6 @@ extension AppUserDefaults: AppConfigurationFetchStatistics {
         }
         set {
             userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchNewDataCount)
-        }
-    }
-
-    var backgroundTaskExpirationCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.backgroundFetchTaskExpirationCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchTaskExpirationCount)
-        }
-    }
-
-    var downloadedHTTPSBloomFilterSpecCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.downloadedHTTPSBloomFilterSpecCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.downloadedHTTPSBloomFilterSpecCount)
-        }
-    }
-
-    var downloadedHTTPSBloomFilterCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.downloadedHTTPSBloomFilterCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.downloadedHTTPSBloomFilterCount)
-        }
-    }
-
-    var downloadedHTTPSExcludedDomainsCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.downloadedHTTPSExcludedDomainsCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.downloadedHTTPSExcludedDomainsCount)
-        }
-    }
-
-    var downloadedSurrogatesCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.downloadedSurrogatesCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.downloadedSurrogatesCount)
-        }
-    }
-
-    var downloadedTrackerDataSetCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.downloadedTrackerDataSetCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.downloadedTrackerDataSetCount)
-        }
-    }
-
-    var downloadedTemporaryUnprotectedSitesCount: Int {
-        get {
-            return userDefaults?.integer(forKey: Keys.downloadedTemporaryUnprotectedSitesCount) ?? 0
-        }
-        set {
-            userDefaults?.setValue(newValue, forKey: Keys.downloadedTemporaryUnprotectedSitesCount)
         }
     }
 }

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -44,6 +44,8 @@ public class AppUserDefaults: AppSettings {
         static let backgroundFetchStartCount = "com.duckduckgo.app.bgFetchStartCount"
         static let backgroundFetchNoDataCount = "com.duckduckgo.app.bgFetchNoDataCount"
         static let backgroundFetchNewDataCount = "com.duckduckgo.app.bgFetchNewDataCount"
+
+        static let backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
         
         static let notificationsEnabled = "com.duckduckgo.app.notificationsEnabled"
         static let allowUniversalLinks = "com.duckduckgo.app.allowUniversalLinks"
@@ -200,6 +202,15 @@ extension AppUserDefaults: AppConfigurationFetchStatistics {
         }
         set {
             userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchNewDataCount)
+        }
+    }
+
+    var backgroundTaskExpirationCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.backgroundFetchTaskExpirationCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchTaskExpirationCount)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1193060753475688/1198516960588141
CC: @bwaresiak 

**Description**:

This PR adds extra stats to the configuration refresh process, to better understand where errors may be occurring.

1. An early return has been added when scheduling a background task on a device which doesn't have permission, to avoid sending needless error pixels
1. A new stat has been added which is tracked when a background task is expired by the device
1. Stats have been added on a per-config file basis to help us understand if any files are causing problems

**Steps to test this PR**:
1. Manually trigger a configuration refresh and check the parameters being sent with the pixel call
1. Schedule a background task and manually force it to expire (instructions can be found via a comment in the code) to check that the expiration stat is tracked

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [x] iOS 14



