### PR TITLE
Add a short threshold before the keyboard is shown on app foreground

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -28,7 +28,7 @@ import BackgroundTasks
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    private static let ShowKeyboardOnLaunchThreshold = TimeInterval(45)
+    private static let ShowKeyboardOnLaunchThreshold = TimeInterval(20)
     
     private struct ShortcutKey {
         static let clipboard = "com.duckduckgo.mobile.ios.clipboard"

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -28,6 +28,8 @@ import BackgroundTasks
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    private static let ShowKeyboardOnLaunchThreshold = TimeInterval(45)
+    
     private struct ShortcutKey {
         static let clipboard = "com.duckduckgo.mobile.ios.clipboard"
     }
@@ -47,6 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private lazy var privacyStore = PrivacyUserDefaults()
     private var autoClear: AutoClear?
     private var showKeyboardIfSettingOn = true
+    private var lastBackgroundDate: Date?
 
     // MARK: lifecycle
 
@@ -168,9 +171,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
     }
+    
+    private func shouldShowKeyboardOnLaunch() -> Bool {
+        guard let date = lastBackgroundDate else { return true }
+        return Date().timeIntervalSince(date) > AppDelegate.ShowKeyboardOnLaunchThreshold
+    }
 
     private func showKeyboardOnLaunch() {
-        guard KeyboardSettings().onAppLaunch && showKeyboardIfSettingOn else { return }
+        guard KeyboardSettings().onAppLaunch && showKeyboardIfSettingOn && shouldShowKeyboardOnLaunch() else { return }
         self.mainViewController?.enterSearch()
         showKeyboardIfSettingOn = false
     }
@@ -197,6 +205,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidEnterBackground(_ application: UIApplication) {
         autoClear?.applicationDidEnterBackground()
+        lastBackgroundDate = Date()
     }
 
     func application(_ application: UIApplication,


### PR DESCRIPTION
> I am probably skipping a few steps with this patch, which is why I marked it as a draft. I am submitting this because it fixes a small itch that I had. If you are interesting in picking this up then I'd love to get it into a state that makes sense for the product. I've been running this in my local build.

This patch introduces a time interval that is used to determine whether the keyboard should be shown on _App Foreground_ when the _Show Keyboard on App Launch_ setting is enabled.

I like that feature, because it is what I want when I open the browser for first time. Or after not using it for a long time. 

However in my day to day use I often am in the situation where I switch back and forth between the browser and another app in a very short time interval and in those cases I do not want the keyboard to show up. My intent then is mostly is to continue browsing the same site or reading the page I already had open in the current tab - and not to visit a new page.

I settled on a pretty low threshold of 45 seconds. This works for me but may not be representative in general. I'm not sure if this application has telemetry events, but those could be used to look at user behaviour to determine if this is a change that makes sense for a bigger audience or to determine a better threshold.

No proper testing has been done - I've only used this on an iPhone X running iOS 14.1.

## TODO

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1198923366005691
Tech Design URL:
CC:

**Description**:


**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

