### PR TITLE
Use GROUP_ID_PREFIX in WidgetsExtension.entitlements

### DIFF
--- a/Widgets/WidgetsExtension.entitlements
+++ b/Widgets/WidgetsExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.duckduckgo.bookmarks</string>
+		<string>$(GROUP_ID_PREFIX).bookmarks</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This patch uses `$(GROUP_ID_PREFIX)` in the _Widgets_ extension similar to what is done in the other app extensions. This will allow a contributor to override the prefix through `Configuration/ExternalDeveloper.xcconfig` as described in the documentation.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:


**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

