### PR TITLE
Only add the web-browser entitlement to DDG team builds

### DIFF
--- a/DuckDuckGo/DuckDuckGo.entitlements
+++ b/DuckDuckGo/DuckDuckGo.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.web-browser</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(GROUP_ID_PREFIX).bookmarks</string>

--- a/add_entitlement.sh
+++ b/add_entitlement.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+/usr/libexec/PlistBuddy -c "Add :com.apple.developer.web-browser bool true" DuckDuckGo/DuckDuckGo.entitlements
+


### PR DESCRIPTION
The `com.apple.developer.web-browser` entitlement is only available to applications that have been granted this special entitlement. Contributors are unable to use this entitlement in their builds because they cannot actually set this up: there is no option to add `com.apple.developer.web-browser` manually in the developer portal and when _Automatically Manage Signing_ is used in Xcode, Xcode is unable to generate an App ID or Provisioning profile with this special entitlement.

To make things a little simpler for contributors, this patch removes the entitlement from `DuckDuckGo/DuckDuckGo.entitlements` and adds a `add_entitlement.sh` script that can be called to add it back. The idea is that the script can be called on the DDG CI after a code checkout so that _Ad-Hoc_ and _Release_ builds have it properly set.

Of course I do not know what the DDG CI infrastructure looks like - so if this is not practical just close it. I'm also happy to submit a PR to the [README.md](README.md) instead that explains how contributors must delete the entitlement manually to test their builds locally.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:


**Steps to test this PR**:
1.
1.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

