### PR TITLE
Add a default header comment template

### DIFF
--- a/DuckDuckGo.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/DuckDuckGo.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+//  ___FILENAME___
+//  DuckDuckGo
+//
+//  Copyright © ___YEAR___ DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1193940488017201
Tech Design URL:
CC: @brindy 

**Description**:

This PR adds a default header template with license information.

**Steps to test this PR**:
1. Create a new file in Xcode
1. Check that the header comment contains license info and matches other files