### PR TITLE
Fix missing unprotected domains injection.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 #These people are listed as being the code owners for this project. As such, they will be automatically added as a reviewer when a PR is created.
 #For more details on how this is configured, see https://help.github.com/articles/about-code-owners/
 
-*       @bwaresiak @brindy @samsymons @THISISDINOUSAUR
+*       @bwaresiak @brindy @samsymons @THISISDINOSAUR

--- a/Core/ContentBlockerRulesManager.swift
+++ b/Core/ContentBlockerRulesManager.swift
@@ -26,9 +26,7 @@ public class ContentBlockerRulesManager {
     public static let shared = ContentBlockerRulesManager()
     
     public var blockingRules: WKContentRuleList?
-    
-    public weak var storageCache: StorageCache?
-    
+
     private init() {}
 
     public func compileRules(completion: ((WKContentRuleList?) -> Void)?) {
@@ -37,8 +35,10 @@ public class ContentBlockerRulesManager {
             return
         }
 
+        let storageCache = StorageCacheProvider().current
         let unprotectedSites = UnprotectedSitesManager().domains
-        let tempUnprotectedDomains = storageCache?.fileStore.loadAsArray(forConfiguration: .temporaryUnprotectedSites)
+        let tempUnprotectedDomains = storageCache.fileStore.loadAsArray(forConfiguration: .temporaryUnprotectedSites)
+            .filter { !$0.trimWhitespace().isEmpty }
 
         let rules = ContentBlockerRulesBuilder(trackerData: trackerData).buildRules(withExceptions: unprotectedSites,
                                                                                     andTemporaryUnprotectedDomains: tempUnprotectedDomains)

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -460,9 +460,19 @@ _utf8_encode : function (string) {
 
     let topLevelUrl = getTopLevelURL();
 
-    let unprotectedDomain = `
-        ${unprotectedDomains}
-    `.split("\n").filter(domain => domain.trim() == topLevelUrl.host).length > 0;
+    var unprotectedDomain = false;
+    var domainParts = topLevelUrl && topLevelUrl.host ? topLevelUrl.host.split(".") : [];
+
+    // walk up the domain to see if it's unprotected
+    while (domainParts && domainParts.length > 1 && !unprotectedDomain) {
+      let partialDomain = domainParts.join(".")
+
+      unprotectedDomain = `
+          ${unprotectedDomains}
+          `.split("\n").filter(domain => domain.trim() == partialDomain).length > 0;
+
+      domainParts.shift()
+    }
 
     // private
     function getTopLevelURL() {

--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -23,10 +23,20 @@
 
   let topLevelUrl = getTopLevelURL();
     
-  let unprotectedDomain = `
+  var unprotectedDomain = false;
+  var domainParts = topLevelUrl && topLevelUrl.host ? topLevelUrl.host.split(".") : [];
+
+  // walk up the domain to see if it's unprotected
+  while (domainParts && domainParts.length > 1 && !unprotectedDomain) {
+    let partialDomain = domainParts.join(".")
+
+    unprotectedDomain = `
         ${unprotectedDomains}
-    `.split("\n").filter(domain => domain.trim() == topLevelUrl.host).length > 0;
+        `.split("\n").filter(domain => domain.trim() == partialDomain).length > 0;
     
+    domainParts.shift()
+  }
+
   // private
   function getTopLevelURL() {
       try {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -258,7 +258,6 @@ class TabViewController: UIViewController {
         debugScript.instrumentation = instrumentation
         contentBlockerScript.storageCache = storageCache
         contentBlockerScript.delegate = self
-        ContentBlockerRulesManager.shared.storageCache = storageCache
         contentBlockerRulesScript.delegate = self
         contentBlockerRulesScript.storageCache = storageCache
     }
@@ -606,8 +605,6 @@ class TabViewController: UIViewController {
 
     @objc func onStorageCacheChange() {
         DispatchQueue.main.async {
-            self.storageCache = AppDependencyProvider.shared.storageCache.current
-            ContentBlockerRulesManager.shared.storageCache = self.storageCache
             self.reload(scripts: true)
         }
     }

--- a/DuckDuckGoTests/FileStoreTests.swift
+++ b/DuckDuckGoTests/FileStoreTests.swift
@@ -27,7 +27,7 @@ class FileStoreTests: XCTestCase {
         try? FileManager.default.removeItem(at: FileStore().persistenceLocation(forConfiguration: .surrogates))
         try? FileManager.default.removeItem(at: FileStore().persistenceLocation(forConfiguration: .temporaryUnprotectedSites))
     }
-    
+
     func testWhenFileExistsThenHasDataReturnsTrue() {
         let store = FileStore()
         XCTAssertFalse(store.hasData(forConfiguration: .surrogates))


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1198928368416160
Tech Design URL:
CC:

**Description**:

Fix bug where temporary unprotected domains weren't injected and weren't being checked against the domain correctly.

**Steps to test this PR**:
1.  Load the app and make sure "trackers-whitelist-temporary.txt" has been updated to include "theguardian.com" 
 * In-app Settings > About > Configuration Refresh Info > Etag starting `c75c91da`
1. Visit theguardian.com - it should not be blocking trackers (none should appear in the dashboard and no 'blocking' messages should appear in the console.
1. Visit other sites and ensure blocking still works as expected.


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

