### PR TITLE
exclude accounts.google.com UA

### DIFF
--- a/Core/UserAgentManager.swift
+++ b/Core/UserAgentManager.swift
@@ -80,7 +80,8 @@ struct UserAgent {
     
     private static let sitesThatOmitApplication = [
         "cvs.com",
-        "sovietgames.su"
+        "sovietgames.su",
+        "accounts.google.com"
     ]
     
     private let baseAgent: String

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1124,7 +1124,7 @@ extension TabViewController: WKNavigationDelegate {
 
         // From iOS 12 we can set the UA dynamically, this lets us update it as needed for specific sites
         if #available(iOS 12, *) {
-            if allowPolicy == WKNavigationActionPolicy.allow {
+            if allowPolicy != WKNavigationActionPolicy.cancel {
                 UserAgentManager.shared.update(webView: webView, isDesktop: tabModel.isDesktop, url: url)
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1198978223513065/1198984670982837
Tech Design URL:
CC:

**Description**:

Exclude accounts.google.com from the ua and fix bug which prevented the UA being applied when disabling links opening in other sites.

**Steps to test this PR**:
1. Visit home.next.com and try to login with Google (doesn't matter if you have a Nest, but you do need a Google account)
1. Without the fix you'd see a message about the browser not being supported
1. With the fix you should be able to login
1. Disable "Open in Associated Apps"
1. You should still be able to login

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

