### PR TITLE
Pixel cleanup

### DIFF
--- a/BookmarksTodayExtension/TodayViewController.swift
+++ b/BookmarksTodayExtension/TodayViewController.swift
@@ -118,7 +118,6 @@ class TodayViewController: UIViewController, NCWidgetProviding, UITableViewDeleg
     private func launchBookmark(at index: Int) {
         let selection = bookmarks[index].url
         if let url = URL(string: "\(AppDeepLinks.quickLink)\(selection)") {
-            Pixel.fire(pixel: .bookmarksExtensionBookmark)
             extensionContext?.open(url, completionHandler: nil)
         }
     }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -137,8 +137,6 @@ public enum PixelName: String {
     case feedbackNegativePerformanceVideo = "mfbs_negative_performance_video"
     case feedbackNegativePerformanceOther = "mfbs_negative_performance_other"
     
-    case brokenSiteReported = "m_bsr"
-    
     case brokenSiteReport = "epbf"
 
     case preserveLoginsSettingsSwitchOn = "m_pl_s_on"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -137,9 +137,6 @@ public enum PixelName: String {
     case feedbackNegativePerformanceVideo = "mfbs_negative_performance_video"
     case feedbackNegativePerformanceOther = "mfbs_negative_performance_other"
     
-    case notificationOptIn = "m_ne"
-    case notificationOptOut = "m_nd"
-    
     case brokenSiteReported = "m_bsr"
     
     case brokenSiteReport = "epbf"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -59,15 +59,6 @@ public enum PixelName: String {
     case settingsOpened = "ms"
     case settingsHomeRowInstructionsRequested = "ms_hr"
 
-    case settingsAppIconShown = "ms_ais"
-    case settingsAppIconChangedPrefix = "ms_aic_"
-    case settingsAppIconChangedRed = "ms_aic_red"
-    case settingsAppIconChangedYellow = "ms_aic_yellow"
-    case settingsAppIconChangedGreen = "ms_aic_green"
-    case settingsAppIconChangedBlue = "ms_aic_blue"
-    case settingsAppIconChangedPurple = "ms_aic_purple"
-    case settingsAppIconChangedBlack = "ms_aic_black"
-
     case settingsKeyboardShown = "ms_ks"
     case settingsKeyboardNewTabOn = "ms_ks_nt_on"
     case settingsKeyboardNewTabOff = "ms_ks_nt_off"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -138,13 +138,6 @@ public enum PixelName: String {
     case feedbackNegativePerformanceOther = "mfbs_negative_performance_other"
     
     case brokenSiteReport = "epbf"
-
-    case preserveLoginsSettingsSwitchOn = "m_pl_s_on"
-    case preserveLoginsSettingsSwitchOff = "m_pl_s_off"
-    case preserveLoginsSettingsEdit = "m_pl_s_c_e"
-    case preserveLoginsSettingsDeleteEditing = "m_pl_s_c_ie"
-    case preserveLoginsSettingsDeleteNotEditing = "m_pl_s_c_in"
-    case preserveLoginsSettingsClearAll = "m_pl_s_c_a"
     
     case daxDialogsSerp = "m_dx_s"
     case daxDialogsWithoutTrackers = "m_dx_wo"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -51,9 +51,6 @@ public enum PixelName: String {
     case tabSwitcherListEnabled = "m_ts_l"
     case tabSwitcherGridEnabled = "m_ts_g"
     
-    case settingsOpened = "ms"
-    case settingsHomeRowInstructionsRequested = "ms_hr"
-    
     case settingsDoNotSellShown = "ms_dns"
     case settingsDoNotSellOn = "ms_dns_on"
     case settingsDoNotSellOff = "ms_dns_off"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -47,11 +47,6 @@ public enum PixelName: String {
     case httpsLocalUpgrade = "m_https_lu"
     case httpsNoUpgrade = "m_https_nu"
     
-    case quickActionExtensionSearch = "mqe_s"
-    case quickActionExtensionFire = "mqe_f"
-    case quickActionExtensionBookmarks = "mqe_b"
-    case bookmarksExtensionBookmark = "mbe_b"
-    
     case bookmarkTapped = "m_b_t"
     case bookmarkRemoved = "m_b_r"
     case bookmarksEditPressed = "m_b_e"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -67,16 +67,6 @@ public enum PixelName: String {
     case settingsDoNotSellOn = "ms_dns_on"
     case settingsDoNotSellOff = "ms_dns_off"
 
-    case autoClearSettingsShown = "mac_s"
-    case autoClearActionOptionNone = "macwhat_n"
-    case autoClearActionOptionTabs = "macwhat_t"
-    case autoClearActionOptionTabsAndData = "macwhat_td"
-    case autoClearTimingOptionExit = "macwhen_x"
-    case autoClearTimingOptionExitOr5Mins = "macwhen_5"
-    case autoClearTimingOptionExitOr15Mins = "macwhen_15"
-    case autoClearTimingOptionExitOr30Mins = "macwhen_30"
-    case autoClearTimingOptionExitOr60Mins = "macwhen_60"
-
     case browsingMenuOpened = "mb"
     case browsingMenuRefresh = "mb_rf"
     case browsingMenuNewTab = "mb_tb"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -58,12 +58,6 @@ public enum PixelName: String {
     
     case settingsOpened = "ms"
     case settingsHomeRowInstructionsRequested = "ms_hr"
-
-    case settingsKeyboardShown = "ms_ks"
-    case settingsKeyboardNewTabOn = "ms_ks_nt_on"
-    case settingsKeyboardNewTabOff = "ms_ks_nt_off"
-    case settingsKeyboardAppLaunchOn = "ms_ks_al_on"
-    case settingsKeyboardAppLaunchOff = "ms_ks_pl_off"
     
     case settingsUnprotectedSites = "ms_mw"
     case settingsLinkPreviewsOff = "ms_lp_f"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -63,11 +63,6 @@ public enum PixelName: String {
     
     case settingsOpened = "ms"
     case settingsHomeRowInstructionsRequested = "ms_hr"
-    
-    case settingsThemeShown = "ms_tp"
-    case settingsThemeChangedSystemDefault = "ms_ts"
-    case settingsThemeChangedLight = "ms_tl"
-    case settingsThemeChangedDark = "ms_td"
 
     case settingsAppIconShown = "ms_ais"
     case settingsAppIconChangedPrefix = "ms_aic_"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -84,13 +84,9 @@ public enum PixelName: String {
     case homeScreenAddFavoriteCancel = "mh_af_c"
     case homeScreenEditFavorite = "mh_ef"
     case homeScreenDeleteFavorite = "mh_df"
-    
-    case homeRowCTAReminderTapped = "m_hc"
-    case homeRowCTAReminderDismissed = "m_hd"
-    
-    case homeRowInstructionsReplayed = "m_hv"
+
     case homeRowOnboardingMovedToBackground = "m_o_h_b"
-    
+
     case feedbackPositive = "mfbs_positive_submit"
     case feedbackNegativePrefix = "mfbs_negative_"
     

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -47,14 +47,6 @@ public enum PixelName: String {
     case httpsLocalUpgrade = "m_https_lu"
     case httpsNoUpgrade = "m_https_nu"
     
-    case longPressMenuOpened = "mlp"
-    case longPressMenuNewBackgroundTabItem = "mlp_b"
-    case longPressMenuNewTabItem = "mlp_t"
-    case longPressMenuOpenItem = "mlp_o"
-    case longPressMenuReadingListItem = "mlp_r"
-    case longPressMenuCopyItem = "mlp_c"
-    case longPressMenuShareItem = "mlp_s"
-    
     case quickActionExtensionSearch = "mqe_s"
     case quickActionExtensionFire = "mqe_f"
     case quickActionExtensionBookmarks = "mqe_b"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -47,11 +47,6 @@ public enum PixelName: String {
     case httpsLocalUpgrade = "m_https_lu"
     case httpsNoUpgrade = "m_https_nu"
     
-    case bookmarkTapped = "m_b_t"
-    case bookmarkRemoved = "m_b_r"
-    case bookmarksEditPressed = "m_b_e"
-    case overlayFavoriteLaunched = "m_ov_f"
-    
     case tabSwitcherNewLayoutSeen = "m_ts_n"
     case tabSwitcherListEnabled = "m_ts_l"
     case tabSwitcherGridEnabled = "m_ts_g"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -59,10 +59,6 @@ public enum PixelName: String {
     case settingsOpened = "ms"
     case settingsHomeRowInstructionsRequested = "ms_hr"
     
-    case settingsUnprotectedSites = "ms_mw"
-    case settingsLinkPreviewsOff = "ms_lp_f"
-    case settingsLinkPreviewsOn = "ms_lp_n"
-    
     case settingsDoNotSellShown = "ms_dns"
     case settingsDoNotSellOn = "ms_dns_on"
     case settingsDoNotSellOff = "ms_dns_off"

--- a/DuckDuckGo/AppIconSettingsViewController.swift
+++ b/DuckDuckGo/AppIconSettingsViewController.swift
@@ -87,22 +87,12 @@ class AppIconWorker {
                 return
             }
 
-            self.firePixel(with: appIcon)
             DispatchQueue.main.async {
                 completion(false)
             }
         }
     }
 
-    private func firePixel(with appIcon: AppIcon) {
-        let pixelNameString = PixelName.settingsAppIconChangedPrefix.rawValue + appIcon.rawValue
-
-        guard let pixel = PixelName(rawValue: pixelNameString) else {
-            fatalError("Could not match AppIcon with Pixel")
-        }
-        
-        Pixel.fire(pixel: pixel)
-    }
 }
 
 extension AppIconSettingsViewController: Themable {

--- a/DuckDuckGo/AutoClearSettingsViewController.swift
+++ b/DuckDuckGo/AutoClearSettingsViewController.swift
@@ -58,7 +58,6 @@ class AutoClearSettingsViewController: UITableViewController {
         
         let oldSettings = loadClearDataSettings()
         if oldSettings != clearDataSettings {
-            sendPixels(oldState: oldSettings)
             store()
         }
     }
@@ -70,35 +69,6 @@ class AutoClearSettingsViewController: UITableViewController {
         } else {
             appSettings.autoClearAction = AutoClearSettingsModel.Action()
             appSettings.autoClearTiming = AutoClearSettingsModel.Timing.termination
-        }
-    }
-    
-    private func sendPixels(oldState: AutoClearSettingsModel?) {
-        if let settings = clearDataSettings {
-            if settings.action != oldState?.action {
-                if settings.action.contains(.clearData) {
-                    Pixel.fire(pixel: .autoClearActionOptionTabsAndData)
-                } else if settings.action.contains(.clearTabs) {
-                    Pixel.fire(pixel: .autoClearActionOptionTabs)
-                }
-            }
-            
-            if settings.timing != oldState?.timing {
-                switch settings.timing {
-                case .termination:
-                    Pixel.fire(pixel: .autoClearTimingOptionExit)
-                case .delay5min:
-                    Pixel.fire(pixel: .autoClearTimingOptionExitOr5Mins)
-                case .delay15min:
-                    Pixel.fire(pixel: .autoClearTimingOptionExitOr15Mins)
-                case .delay30min:
-                    Pixel.fire(pixel: .autoClearTimingOptionExitOr30Mins)
-                case .delay60min:
-                    Pixel.fire(pixel: .autoClearTimingOptionExitOr60Mins)
-                }
-            }
-        } else {
-            Pixel.fire(pixel: .autoClearActionOptionNone)
         }
     }
     

--- a/DuckDuckGo/BookmarksDataSource.swift
+++ b/DuckDuckGo/BookmarksDataSource.swift
@@ -100,8 +100,6 @@ class BookmarksDataSource: NSObject, UITableViewDataSource {
         guard editingStyle == .delete else { return }
         var reload = false
         
-        Pixel.fire(pixel: .bookmarkRemoved)
-        
         if indexPath.section == 0 {
             bookmarksManager.deleteFavorite(at: indexPath.row)
             reload = bookmarksManager.favoritesCount == 0

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -46,7 +46,6 @@ class BookmarksViewController: UITableViewController {
         if tableView.isEditing {
             showEditBookmarkAlert(for: indexPath)
         } else if let link = dataSource.link(at: indexPath) {
-            Pixel.fire(pixel: .bookmarkTapped)
             selectLink(link)
         }
     }
@@ -84,7 +83,6 @@ class BookmarksViewController: UITableViewController {
     }
 
     @IBAction func onEditPressed(_ sender: UIBarButtonItem) {
-        Pixel.fire(pixel: .bookmarksEditPressed)
         startEditing()
     }
 

--- a/DuckDuckGo/FavoritesOverlay.swift
+++ b/DuckDuckGo/FavoritesOverlay.swift
@@ -104,7 +104,6 @@ class FavoritesOverlay: UIViewController {
 extension FavoritesOverlay: FavoritesHomeViewSectionRendererDelegate {
     
     func favoritesRenderer(_ renderer: FavoritesHomeViewSectionRenderer, didSelect link: Link) {
-        Pixel.fire(pixel: .overlayFavoriteLaunched)
         delegate?.favoritesOverlay(self, didSelect: link)
     }
     

--- a/DuckDuckGo/HomeRowInstructionsViewController.swift
+++ b/DuckDuckGo/HomeRowInstructionsViewController.swift
@@ -34,8 +34,6 @@ class HomeRowInstructionsViewController: UIViewController {
 
     var layer: AVPlayerLayer?
     var player: AVPlayer?
-    
-    private var userInteracted = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,12 +47,7 @@ class HomeRowInstructionsViewController: UIViewController {
 
     @IBAction func playVideo() {
         guard let player = player else { return }
-        
-        if !userInteracted {
-            userInteracted = true
-            Pixel.fire(pixel: .homeRowInstructionsReplayed)
-        }
-        
+
         player.seek(to: CMTime(seconds: 0.0, preferredTimescale: player.currentTime().timescale))
         startVideo()
     }

--- a/DuckDuckGo/KeyboardSettingsViewController.swift
+++ b/DuckDuckGo/KeyboardSettingsViewController.swift
@@ -45,12 +45,10 @@ class KeyboardSettingsViewController: UITableViewController {
     
     @IBAction func onNewTabValueChanged(_ sender: Any) {
         settings.onNewTab = newTabToggle.isOn
-        Pixel.fire(pixel: newTabToggle.isOn ? .settingsKeyboardNewTabOn : .settingsKeyboardNewTabOff)
     }
         
     @IBAction func onAppLaunchValueChanged(_ sender: Any) {
         settings.onAppLaunch = appLaunchToggle.isOn
-        Pixel.fire(pixel: appLaunchToggle.isOn ? .settingsKeyboardAppLaunchOn : .settingsKeyboardAppLaunchOff)
     }
     
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -747,10 +747,7 @@ class MainViewController: UIViewController {
 
         showNotification(title: UserText.homeRowReminderTitle, message: UserText.homeRowReminderMessage) { tapped in
             if tapped {
-                Pixel.fire(pixel: .homeRowCTAReminderTapped)
                 self.launchInstructions()
-            } else {
-                Pixel.fire(pixel: .homeRowCTAReminderDismissed)
             }
 
             self.hideNotification()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -680,7 +680,6 @@ class MainViewController: UIViewController {
     }
     
     fileprivate func launchSettings() {
-        Pixel.fire(pixel: .settingsOpened)
         performSegue(withIdentifier: "Settings", sender: self)
     }
 

--- a/DuckDuckGo/OnboardingHomeRowViewController.swift
+++ b/DuckDuckGo/OnboardingHomeRowViewController.swift
@@ -27,8 +27,6 @@ class OnboardingHomeRowViewController: OnboardingContentViewController {
     
     @IBOutlet weak var playButton: UIImageView!
     
-    private var userInteracted = false
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         addVideo()
@@ -67,11 +65,6 @@ class OnboardingHomeRowViewController: OnboardingContentViewController {
     
     @IBAction func playVideo() {
         guard let player = player else { return }
-        
-        if !userInteracted {
-            userInteracted = true
-            Pixel.fire(pixel: .homeRowInstructionsReplayed)
-        }
         
         player.seek(to: CMTime(seconds: 0.0, preferredTimescale: player.currentTime().timescale))
         startVideo()

--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -45,8 +45,6 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     }
     
     @IBAction func startEditing() {
-        Pixel.fire(pixel: .preserveLoginsSettingsEdit)
-        
         navigationItem.setHidesBackButton(true, animated: true)
         navigationItem.setRightBarButton(doneButton, animated: true)
         
@@ -142,9 +140,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         guard editingStyle == .delete else { return }
-        
-        Pixel.fire(pixel: tableView.isEditing ? .preserveLoginsSettingsDeleteEditing : .preserveLoginsSettingsDeleteNotEditing)
-        
+
         let domain = model.remove(at: indexPath.row)
         PreserveLogins.shared.remove(domain: domain)
         Favicons.shared.removeFireproofFavicon(forDomain: domain)
@@ -163,7 +159,6 @@ class PreserveLoginsSettingsViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section == Section.removeAll.rawValue {
-            Pixel.fire(pixel: .preserveLoginsSettingsClearAll)
             clearAll()
             tableView.deselectRow(at: indexPath, animated: true)
         }
@@ -251,7 +246,6 @@ class PreserveLoginsSwitchCell: UITableViewCell {
     weak var controller: PreserveLoginsSettingsViewController!
 
     @IBAction func onToggle() {
-        Pixel.fire(pixel: toggle.isOn ? .preserveLoginsSettingsSwitchOn : .preserveLoginsSettingsSwitchOff)
         PreserveLogins.shared.loginDetectionEnabled = toggle.isOn
     }
 

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -91,11 +91,6 @@ class SettingsViewController: UITableViewController {
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.destination is HomeRowInstructionsViewController {
-            Pixel.fire(pixel: .settingsHomeRowInstructionsRequested)
-            return
-        }
-        
         if segue.destination is DoNotSellSettingsViewController {
             Pixel.fire(pixel: .settingsDoNotSellShown)
             return

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -91,11 +91,6 @@ class SettingsViewController: UITableViewController {
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.destination is AutoClearSettingsViewController {
-            Pixel.fire(pixel: .autoClearSettingsShown)
-            return
-        }
-
         if segue.destination is UnprotectedSitesViewController {
             Pixel.fire(pixel: .settingsUnprotectedSites)
             return

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -95,11 +95,6 @@ class SettingsViewController: UITableViewController {
             Pixel.fire(pixel: .autoClearSettingsShown)
             return
         }
-
-        if segue.destination is AppIconSettingsViewController {
-            Pixel.fire(pixel: .settingsAppIconShown)
-            return
-        }
  
         if segue.destination is KeyboardSettingsViewController {
             Pixel.fire(pixel: .settingsKeyboardShown)

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -95,11 +95,6 @@ class SettingsViewController: UITableViewController {
             Pixel.fire(pixel: .autoClearSettingsShown)
             return
         }
- 
-        if segue.destination is KeyboardSettingsViewController {
-            Pixel.fire(pixel: .settingsKeyboardShown)
-            return
-        }
 
         if segue.destination is UnprotectedSitesViewController {
             Pixel.fire(pixel: .settingsUnprotectedSites)

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -95,11 +95,6 @@ class SettingsViewController: UITableViewController {
             Pixel.fire(pixel: .autoClearSettingsShown)
             return
         }
-        
-        if segue.destination is ThemeSettingsViewController {
-            Pixel.fire(pixel: .settingsThemeShown)
-            return
-        }
 
         if segue.destination is AppIconSettingsViewController {
             Pixel.fire(pixel: .settingsAppIconShown)

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -91,11 +91,6 @@ class SettingsViewController: UITableViewController {
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.destination is UnprotectedSitesViewController {
-            Pixel.fire(pixel: .settingsUnprotectedSites)
-            return
-        }
-        
         if segue.destination is HomeRowInstructionsViewController {
             Pixel.fire(pixel: .settingsHomeRowInstructionsRequested)
             return
@@ -291,7 +286,6 @@ class SettingsViewController: UITableViewController {
 
     @IBAction func onLinkPreviewsToggle(_ sender: UISwitch) {
         appSettings.longPressPreviews = sender.isOn
-        Pixel.fire(pixel: appSettings.longPressPreviews ? .settingsLinkPreviewsOn : .settingsLinkPreviewsOff)
     }
 }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -672,7 +672,6 @@ class TabViewController: UIViewController {
     }
     
     private func launchLongPressMenu(atPoint point: Point, forUrl url: URL) {
-        Pixel.fire(pixel: .longPressMenuOpened)
         let alert = buildLongPressMenu(atPoint: point, forUrl: url)
         present(controller: alert, fromView: webView, atPoint: point)
     }

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -75,35 +75,29 @@ extension TabViewController {
     }
     
     private func onNewTabAction(url: URL) {
-        Pixel.fire(pixel: .longPressMenuNewTabItem)
         delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false)
     }
     
     private func onBackgroundTabAction(url: URL) {
-        Pixel.fire(pixel: .longPressMenuNewBackgroundTabItem)
         delegate?.tab(self, didRequestNewBackgroundTabForUrl: url)
     }
     
     private func onOpenAction(forUrl url: URL) {
         if let webView = webView {
-            Pixel.fire(pixel: .longPressMenuOpenItem)
             webView.load(URLRequest(url: url))
         }
     }
     
     private func onReadingAction(forUrl url: URL) {
-        Pixel.fire(pixel: .longPressMenuReadingListItem)
         try? SSReadingList.default()?.addItem(with: url, title: nil, previewText: nil)
     }
     
     private func onCopyAction(forUrl url: URL) {
         let copyText = url.absoluteString
-        Pixel.fire(pixel: .longPressMenuCopyItem)
         UIPasteboard.general.string = copyText
     }
     
     private func onShareAction(forUrl url: URL, atPoint point: Point?) {
-        Pixel.fire(pixel: .longPressMenuShareItem)
         guard let webView = webView else { return }
         presentShareSheet(withItems: [url], fromView: webView, atPoint: point)
     }

--- a/DuckDuckGo/ThemeSettingsViewController.swift
+++ b/DuckDuckGo/ThemeSettingsViewController.swift
@@ -45,25 +45,6 @@ class ThemeSettingsViewController: UITableViewController {
         applyTheme(ThemeManager.shared.currentTheme)
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        
-        sendPixel()
-    }
-    
-    private func sendPixel() {
-        guard appSettings.currentThemeName != previousTheme else { return }
-        
-        switch appSettings.currentThemeName {
-        case .systemDefault:
-            Pixel.fire(pixel: .settingsThemeChangedSystemDefault)
-        case .light:
-            Pixel.fire(pixel: .settingsThemeChangedLight)
-        case .dark:
-            Pixel.fire(pixel: .settingsThemeChangedDark)
-        }
-    }
-    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return availableThemes.count
     }

--- a/QuickActionsTodayExtension/TodayViewController.swift
+++ b/QuickActionsTodayExtension/TodayViewController.swift
@@ -69,19 +69,16 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     @IBAction func onSearchTapped(_ sender: Any) {
         let url = URL(string: AppDeepLinks.newSearch)!
         extensionContext?.open(url, completionHandler: nil)
-        Pixel.fire(pixel: .quickActionExtensionSearch)
     }
 
     @IBAction func onBookmarksTapped(_ sender: Any) {
         let url = URL(string: AppDeepLinks.bookmarks)!
         extensionContext?.open(url, completionHandler: nil)
-        Pixel.fire(pixel: .quickActionExtensionBookmarks)
     }
     
     @IBAction func onFireTapped(_ sender: Any) {
         let url = URL(string: AppDeepLinks.fire)!
         extensionContext?.open(url, completionHandler: nil)
-        Pixel.fire(pixel: .quickActionExtensionFire)
     }
   
     func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1193060753475688/1184561590740026/f
CC: @brindy

**Description**:

This PR removes many pixels that are no longer being monitored. Only feedback, debug, and core functionality pixels have been kept, in additional to some which may be used in the near future.

Pixels listed [here](https://app.asana.com/0/72649045549333/1195170401658396/f) have been kept.

I've also kept Smarter Encryption pixels, and will add those to the list of @subsymbolic agrees that they should be kept. I suspect they will, now that Smarter Encryption happens entirely locally, but want to confirm.

**Steps to test this PR**:
1. Test flows such as settings and check that no Pixel HTTP request has been fired
1. Verify that the new `Pixel.swift` files matches the internal list of pixels to keep in the Asana task linked above
1. Verify that any remaining pixels should not need to be removed

**Device Testing**:

* [x] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

