### PR TITLE
add facebook to ua exclusions

### DIFF
--- a/Core/UserAgentManager.swift
+++ b/Core/UserAgentManager.swift
@@ -81,7 +81,8 @@ struct UserAgent {
     private static let sitesThatOmitApplication = [
         "cvs.com",
         "sovietgames.su",
-        "accounts.google.com"
+        "accounts.google.com",
+        "facebook.com"
     ]
     
     private let baseAgent: String


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1199155469132411
Tech Design URL:
CC:

**Description**:

Facebook shows an error sometimes when our UA is present so exclude Facebook from seeing our UA.

**Steps to test this PR**:
1. Visit Facebook.com via the SERP or autocomplete (problem doesn't happen if you go straight to it) 
1. Shouldn't see any message about browser compatibility


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

