### PR TITLE
increase hit areas for toolbar buttons

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 		856D57C720656A28000170B5 /* TLDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856D57C620656A28000170B5 /* TLDTests.swift */; };
 		8570656E1F6AAE270044DCB1 /* DetectedTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8570656A1F6AADDF0044DCB1 /* DetectedTrackerTests.swift */; };
 		857065701F6ABFA40044DCB1 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8570656F1F6ABFA40044DCB1 /* APIRequest.swift */; };
-		8577A1C5255D2C0D00D43FCD /* CustomToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577A1C4255D2C0D00D43FCD /* CustomToolbar.swift */; };
+		8577A1C5255D2C0D00D43FCD /* HitTestingToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577A1C4255D2C0D00D43FCD /* HitTestingToolbar.swift */; };
 		8577B0AE2225CA4F009CCC71 /* OnboardingPadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577B0AD2225CA4F009CCC71 /* OnboardingPadViewController.swift */; };
 		857D1DC9223A9E7D00833940 /* MockAppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D1DC8223A9E7D00833940 /* MockAppSettings.swift */; };
 		857EEB752095FFAC008A005C /* HomeRowInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857EEB742095FFAC008A005C /* HomeRowInstructionsViewController.swift */; };
@@ -876,7 +876,7 @@
 		856D57C620656A28000170B5 /* TLDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLDTests.swift; sourceTree = "<group>"; };
 		8570656A1F6AADDF0044DCB1 /* DetectedTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectedTrackerTests.swift; sourceTree = "<group>"; };
 		8570656F1F6ABFA40044DCB1 /* APIRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
-		8577A1C4255D2C0D00D43FCD /* CustomToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToolbar.swift; sourceTree = "<group>"; };
+		8577A1C4255D2C0D00D43FCD /* HitTestingToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitTestingToolbar.swift; sourceTree = "<group>"; };
 		8577B0AD2225CA4F009CCC71 /* OnboardingPadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPadViewController.swift; sourceTree = "<group>"; };
 		857D1DC8223A9E7D00833940 /* MockAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSettings.swift; sourceTree = "<group>"; };
 		857EEB742095FFAC008A005C /* HomeRowInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRowInstructionsViewController.swift; sourceTree = "<group>"; };
@@ -3584,7 +3584,7 @@
 				8540BD5323D8D5080057FDD2 /* PreserveLoginsAlert.swift */,
 				851DFD86212C39D300D95F20 /* TabSwitcherButton.swift */,
 				85864FBB24D31EF300E756FF /* SuggestionTrayViewController.swift */,
-				8577A1C4255D2C0D00D43FCD /* CustomToolbar.swift */,
+				8577A1C4255D2C0D00D43FCD /* HitTestingToolbar.swift */,
 			);
 			name = Main;
 			sourceTree = "<group>";
@@ -4461,7 +4461,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8528AE81212F15D600D0BD74 /* AppRatingPrompt.xcdatamodeld in Sources */,
-				8577A1C5255D2C0D00D43FCD /* CustomToolbar.swift in Sources */,
+				8577A1C5255D2C0D00D43FCD /* HitTestingToolbar.swift in Sources */,
 				853C5F5B21BFF0AE001F7A05 /* HomeCollectionView.swift in Sources */,
 				984E291922CD67B500EE7154 /* PrivacyProtectionHomeCell.swift in Sources */,
 				9820FF502244FECC008D4782 /* UIScrollViewExtension.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		856D57C720656A28000170B5 /* TLDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856D57C620656A28000170B5 /* TLDTests.swift */; };
 		8570656E1F6AAE270044DCB1 /* DetectedTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8570656A1F6AADDF0044DCB1 /* DetectedTrackerTests.swift */; };
 		857065701F6ABFA40044DCB1 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8570656F1F6ABFA40044DCB1 /* APIRequest.swift */; };
+		8577A1C5255D2C0D00D43FCD /* CustomToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577A1C4255D2C0D00D43FCD /* CustomToolbar.swift */; };
 		8577B0AE2225CA4F009CCC71 /* OnboardingPadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577B0AD2225CA4F009CCC71 /* OnboardingPadViewController.swift */; };
 		857D1DC9223A9E7D00833940 /* MockAppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857D1DC8223A9E7D00833940 /* MockAppSettings.swift */; };
 		857EEB752095FFAC008A005C /* HomeRowInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857EEB742095FFAC008A005C /* HomeRowInstructionsViewController.swift */; };
@@ -875,6 +876,7 @@
 		856D57C620656A28000170B5 /* TLDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLDTests.swift; sourceTree = "<group>"; };
 		8570656A1F6AADDF0044DCB1 /* DetectedTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectedTrackerTests.swift; sourceTree = "<group>"; };
 		8570656F1F6ABFA40044DCB1 /* APIRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
+		8577A1C4255D2C0D00D43FCD /* CustomToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToolbar.swift; sourceTree = "<group>"; };
 		8577B0AD2225CA4F009CCC71 /* OnboardingPadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPadViewController.swift; sourceTree = "<group>"; };
 		857D1DC8223A9E7D00833940 /* MockAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppSettings.swift; sourceTree = "<group>"; };
 		857EEB742095FFAC008A005C /* HomeRowInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRowInstructionsViewController.swift; sourceTree = "<group>"; };
@@ -3582,6 +3584,7 @@
 				8540BD5323D8D5080057FDD2 /* PreserveLoginsAlert.swift */,
 				851DFD86212C39D300D95F20 /* TabSwitcherButton.swift */,
 				85864FBB24D31EF300E756FF /* SuggestionTrayViewController.swift */,
+				8577A1C4255D2C0D00D43FCD /* CustomToolbar.swift */,
 			);
 			name = Main;
 			sourceTree = "<group>";
@@ -4458,6 +4461,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8528AE81212F15D600D0BD74 /* AppRatingPrompt.xcdatamodeld in Sources */,
+				8577A1C5255D2C0D00D43FCD /* CustomToolbar.swift in Sources */,
 				853C5F5B21BFF0AE001F7A05 /* HomeCollectionView.swift in Sources */,
 				984E291922CD67B500EE7154 /* PrivacyProtectionHomeCell.swift in Sources */,
 				9820FF502244FECC008D4782 /* UIScrollViewExtension.swift in Sources */,

--- a/DuckDuckGo/Base.lproj/Main.storyboard
+++ b/DuckDuckGo/Base.lproj/Main.storyboard
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="C1X-Zd-UbA">
-    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -22,21 +20,21 @@
             <objects>
                 <viewController definesPresentationContext="YES" id="C1X-Zd-UbA" customClass="MainViewController" customModule="DuckDuckGo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Vxt-xD-aBt">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EJw-WC-cX3" userLabel="Logo Container">
-                                <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" translatesAutoresizingMaskIntoConstraints="NO" id="KGS-6D-8Qu">
-                                        <rect key="frame" x="147" y="302" width="96" height="96"/>
+                                        <rect key="frame" x="252" y="180" width="96" height="96"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="KGS-6D-8Qu" secondAttribute="height" multiplier="1:1" id="8Sj-qV-mg4"/>
                                             <constraint firstAttribute="width" constant="96" id="cmA-xS-5w3"/>
                                         </constraints>
                                     </imageView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TextDuckDuckGo" translatesAutoresizingMaskIntoConstraints="NO" id="x0w-JG-l7a">
-                                        <rect key="frame" x="114" y="410" width="162" height="21"/>
+                                        <rect key="frame" x="219" y="288" width="162" height="21"/>
                                     </imageView>
                                 </subviews>
                                 <constraints>
@@ -47,28 +45,28 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ylj-oJ-fqD">
-                                <rect key="frame" x="0.0" y="96" width="390" height="670"/>
+                                <rect key="frame" x="0.0" y="52" width="600" height="504"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </containerView>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0vw-jR-X6Q" userLabel="Suggestion Tray">
-                                <rect key="frame" x="0.0" y="96" width="390" height="670"/>
+                                <rect key="frame" x="0.0" y="52" width="600" height="504"/>
                                 <connections>
                                     <segue destination="j6c-LM-dZE" kind="embed" id="1ri-Fa-CEp"/>
                                 </connections>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lJT-0B-l2J">
-                                <rect key="frame" x="0.0" y="96" width="390" height="0.0"/>
+                                <rect key="frame" x="0.0" y="52" width="600" height="0.0"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="g5u-N0-iSI"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iiL-6e-jxs" userLabel="Status BG">
-                                <rect key="frame" x="0.0" y="0.0" width="390" height="96"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="52"/>
                                 <color key="backgroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="agl-Nk-nUH" userLabel="Tabs Container">
-                                <rect key="frame" x="0.0" y="44" width="390" height="40"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="vZY-9N-j4a"/>
                                 </constraints>
@@ -77,21 +75,21 @@
                                 </connections>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nQT-PV-ULm" userLabel="Navigation Bar">
-                                <rect key="frame" x="0.0" y="44" width="390" height="52"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="52"/>
                                 <color key="backgroundColor" red="0.0" green="0.56031829119999998" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="52" id="XOq-1B-9oE"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kFG-OX-YkL" customClass="ProgressView" customModule="DuckDuckGo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="93" width="390" height="3"/>
+                                <rect key="frame" x="0.0" y="49" width="600" height="3"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="3" id="ysF-8z-Vg0"/>
                                 </constraints>
                             </view>
-                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Krm-hA-s9u" customClass="CustomToolbar" customModule="DuckDuckGo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="766" width="390" height="44"/>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Krm-hA-s9u" customClass="HitTestingToolbar" customModule="DuckDuckGo" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="556" width="600" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="ACG-Ld-ZlG">
                                         <variation key="heightClass=compact-widthClass=compact" constant="32"/>
@@ -138,36 +136,36 @@
                                 <color key="barTintColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </toolbar>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPc-P1-sCk" customClass="FindInPageView" customModule="DuckDuckGo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="695" width="390" height="149"/>
+                                <rect key="frame" x="0.0" y="451" width="600" height="149"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vrw-HM-EuC" userLabel="Container">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="49"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8N-Ee-U1n">
-                                                <rect key="frame" x="341" y="9.6666666666666288" width="37" height="30"/>
+                                                <rect key="frame" x="551" y="9.5" width="37" height="30"/>
                                                 <state key="normal" title="Done"/>
                                                 <connections>
                                                     <action selector="done" destination="yPc-P1-sCk" eventType="touchUpInside" id="QkN-1x-ae0"/>
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="piX-Du-shO" customClass="RoundedRectangleView" customModule="DuckDuckGo" customModuleProvider="target">
-                                                <rect key="frame" x="76" y="6.6666666666666288" width="253" height="36"/>
+                                                <rect key="frame" x="76" y="6.5" width="463" height="36"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="SearchLoupeMini" translatesAutoresizingMaskIntoConstraints="NO" id="5Nz-IB-Q70">
-                                                        <rect key="frame" x="9" y="6.3333333333333712" width="23" height="23"/>
+                                                        <rect key="frame" x="9" y="6.5" width="23" height="23"/>
                                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="23" id="N5c-Lx-OZW"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 of 12" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rSE-zZ-iud">
-                                                        <rect key="frame" x="207" y="11" width="37" height="14"/>
+                                                        <rect key="frame" x="410.5" y="10" width="43.5" height="16.5"/>
                                                         <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="14"/>
                                                         <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="16" translatesAutoresizingMaskIntoConstraints="NO" id="IBB-TQ-d5c">
-                                                        <rect key="frame" x="38" y="0.0" width="161" height="36"/>
+                                                        <rect key="frame" x="38" y="0.0" width="364.5" height="36"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
@@ -197,7 +195,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kT9-LB-Wus">
-                                                <rect key="frame" x="40" y="3.6666666666666288" width="28" height="42"/>
+                                                <rect key="frame" x="40" y="3.5" width="28" height="42"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="42" id="IJF-lN-s24"/>
                                                     <constraint firstAttribute="width" constant="28" id="Ser-WX-vmN"/>
@@ -209,7 +207,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FwE-sE-qcT">
-                                                <rect key="frame" x="8" y="3.6666666666666288" width="28" height="42"/>
+                                                <rect key="frame" x="8" y="3.5" width="28" height="42"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="42" id="H60-Hy-MZi"/>
                                                     <constraint firstAttribute="width" constant="28" id="t58-lc-LAp"/>
@@ -221,7 +219,7 @@
                                                 </connections>
                                             </button>
                                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="NKG-8h-dYm">
-                                                <rect key="frame" x="300" y="14.666666666666629" width="20" height="20"/>
+                                                <rect key="frame" x="510" y="14.5" width="20" height="20"/>
                                             </activityIndicatorView>
                                         </subviews>
                                         <constraints>

--- a/DuckDuckGo/Base.lproj/Main.storyboard
+++ b/DuckDuckGo/Base.lproj/Main.storyboard
@@ -90,7 +90,7 @@
                                     <constraint firstAttribute="height" constant="3" id="ysF-8z-Vg0"/>
                                 </constraints>
                             </view>
-                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Krm-hA-s9u">
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Krm-hA-s9u" customClass="CustomToolbar" customModule="DuckDuckGo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="766" width="390" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="ACG-Ld-ZlG">
@@ -161,13 +161,13 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 of 12" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rSE-zZ-iud">
-                                                        <rect key="frame" x="200.66666666666669" y="9.6666666666667407" width="43.333333333333343" height="16.333333333333329"/>
+                                                        <rect key="frame" x="207" y="11" width="37" height="14"/>
                                                         <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="14"/>
                                                         <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="16" translatesAutoresizingMaskIntoConstraints="NO" id="IBB-TQ-d5c">
-                                                        <rect key="frame" x="38" y="0.0" width="154.66666666666666" height="36"/>
+                                                        <rect key="frame" x="38" y="0.0" width="161" height="36"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>

--- a/DuckDuckGo/CustomToolbar.swift
+++ b/DuckDuckGo/CustomToolbar.swift
@@ -21,13 +21,19 @@ import UIKit
 
 class CustomToolbar: UIToolbar {
 
+    static let hitWidth: CGFloat = 45
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
 
         let item = items?.first(where: {
             guard let customView = $0.customView else { return false }
             let location = convert(point, to: customView)
-            print(location, "vs", $0.customView)
-            return location.x > 0 && location.x <= 45 && location.y > 0 && location.y <= 45
+
+            let extra = 45 - customView.frame.width
+            print(location, "vs", $0.customView as Any, extra)
+
+            return location.x >= -extra && location.x <= Self.hitWidth
+                && location.y > 0 && location.y <= customView.frame.height
         })
         print("---")
         return item?.customView ?? super.hitTest(point, with: event)

--- a/DuckDuckGo/CustomToolbar.swift
+++ b/DuckDuckGo/CustomToolbar.swift
@@ -22,17 +22,14 @@ import UIKit
 class CustomToolbar: UIToolbar {
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        print(#function, event)
-
-        guard let touch = event?.allTouches?.first else { return super.hitTest(point, with: event) }
 
         let item = items?.first(where: {
             guard let customView = $0.customView else { return false }
-            let location = touch.location(in: customView)
-            print($0, location)
-            return false
+            let location = convert(point, to: customView)
+            print(location, "vs", $0.customView)
+            return location.x > 0 && location.x <= 45 && location.y > 0 && location.y <= 45
         })
-
+        print("---")
         return item?.customView ?? super.hitTest(point, with: event)
     }
 

--- a/DuckDuckGo/CustomToolbar.swift
+++ b/DuckDuckGo/CustomToolbar.swift
@@ -1,0 +1,39 @@
+//
+//  CustomToolbar.swift
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+class CustomToolbar: UIToolbar {
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        print(#function, event)
+
+        guard let touch = event?.allTouches?.first else { return super.hitTest(point, with: event) }
+
+        let item = items?.first(where: {
+            guard let customView = $0.customView else { return false }
+            let location = touch.location(in: customView)
+            print($0, location)
+            return false
+        })
+
+        return item?.customView ?? super.hitTest(point, with: event)
+    }
+
+}

--- a/DuckDuckGo/GestureToolbarButton.swift
+++ b/DuckDuckGo/GestureToolbarButton.swift
@@ -128,14 +128,7 @@ class GestureToolbarButton: UIView {
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let touch = touches.first else {
-            imposeReleaseAnimation()
-            return
-        }
-        guard point(inside: touch.location(in: self), with: event) else {
-            imposeReleaseAnimation()
-            return
-        }
+        imposeReleaseAnimation()
         delegate?.singleTapDetected(in: self)
         imposeReleaseAnimation()
     }

--- a/DuckDuckGo/HitTestingToolbar.swift
+++ b/DuckDuckGo/HitTestingToolbar.swift
@@ -1,5 +1,5 @@
 //
-//  CustomToolbar.swift
+//  HitTestingToolbar.swift
 //  DuckDuckGo
 //
 //  Copyright © 2020 DuckDuckGo. All rights reserved.
@@ -19,7 +19,7 @@
 
 import UIKit
 
-class CustomToolbar: UIToolbar {
+class HitTestingToolbar: UIToolbar {
 
     static let hitWidth: CGFloat = 45
 
@@ -28,14 +28,10 @@ class CustomToolbar: UIToolbar {
         let item = items?.first(where: {
             guard let customView = $0.customView else { return false }
             let location = convert(point, to: customView)
-
-            let extra = 45 - customView.frame.width
-            print(location, "vs", $0.customView as Any, extra)
-
+            let extra = max(0, Self.hitWidth - customView.frame.width)
             return location.x >= -extra && location.x <= Self.hitWidth
                 && location.y > 0 && location.y <= customView.frame.height
         })
-        print("---")
         return item?.customView ?? super.hitTest(point, with: event)
     }
 

--- a/DuckDuckGo/TabSwitcherButton.swift
+++ b/DuckDuckGo/TabSwitcherButton.swift
@@ -155,10 +155,6 @@ class TabSwitcherButton: UIView {
 
         workItem?.cancel()
         guard workItem != nil else { return }
-
-        // unncessary because if it's a long press it'll happen anyway, if it's a tap it needs to happen
-//        guard let touch = touches.first else { return }
-        // guard point(inside: touch.location(in: self), with: event) else { return }
         delegate?.showTabSwitcher(self)
     }
     

--- a/DuckDuckGo/TabSwitcherButton.swift
+++ b/DuckDuckGo/TabSwitcherButton.swift
@@ -157,7 +157,7 @@ class TabSwitcherButton: UIView {
         guard workItem != nil else { return }
 
         guard let touch = touches.first else { return }
-        guard point(inside: touch.location(in: self), with: event) else { return }
+        // guard point(inside: touch.location(in: self), with: event) else { return }
         delegate?.showTabSwitcher(self)
     }
     

--- a/DuckDuckGo/TabSwitcherButton.swift
+++ b/DuckDuckGo/TabSwitcherButton.swift
@@ -156,7 +156,8 @@ class TabSwitcherButton: UIView {
         workItem?.cancel()
         guard workItem != nil else { return }
 
-        guard let touch = touches.first else { return }
+        // unncessary because if it's a long press it'll happen anyway, if it's a tap it needs to happen
+//        guard let touch = touches.first else { return }
         // guard point(inside: touch.location(in: self), with: event) else { return }
         delegate?.showTabSwitcher(self)
     }

--- a/adhocExportOptions.plist
+++ b/adhocExportOptions.plist
@@ -4,9 +4,30 @@
 <dict>
 
 	<key>teamID</key>
-        <string>HKE973VLUW</string>
-        <key>method</key>
-        <string>ad-hoc</string>
+    <string>HKE973VLUW</string>
+    <key>method</key>
+    <string>ad-hoc</string>
+
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.duckduckgo.mobile.ios</key>
+        <string>iOS 14 - Ad Hoc - App</string>
+
+        <key>com.duckduckgo.mobile.ios.ShareExtension</key>
+        <string>iOS 14 - Ad Hoc - Share</string>
+
+        <key>com.duckduckgo.mobile.ios.BookmarksTodayExtension</key>
+        <string>iOS 14 - Ad Hoc - Bookmarks</string>
+
+        <key>com.duckduckgo.mobile.ios.QuickActionsTodayExtension</key>
+        <string>iOS 14 - Ad Hoc - Quick Actions</string>
+
+        <key>com.duckduckgo.mobile.ios.OpenAction2</key>
+        <string>iOS 14 - Ad Hoc - Open Action</string>
+
+        <key>com.duckduckgo.mobile.ios.Widgets</key>
+        <string>iOS 14 - Ad Hoc - Widgets</string>
+    </dict>
 
 </dict>
 </plist>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1198872510442766
Tech Design URL:
CC:

**Description**:

Use a toolbar subclass to handle hit tests.

Increasing the actual size of the buttons causes the buttons to not be laid out correctly due to the custom views.

Not worrying about iPad layout at this stage.

**Steps to test this PR**:

1. Launch the app on a phone (or iPad with phone layout), ensure tab switcher and bookmarks button work as planned and are not triggered when they shouldn't be (e.g. browsing, scrolling, etc).

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

