### PR TITLE
handle launching external apps better

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -677,9 +677,16 @@ class TabViewController: UIViewController {
     }
     
     private func openExternally(url: URL) {
+        self.url = webView.url
+        delegate?.tabLoadingStateDidChange(tab: self)
         UIApplication.shared.open(url, options: [:]) { opened in
             if !opened {
                 self.view.showBottomToast(UserText.failedToOpenExternally)
+            }
+
+            // just showing a blank tab at this point, so close it
+            if self.webView.url == nil {
+                self.delegate?.tabDidRequestClose(self)
             }
         }
     }
@@ -692,7 +699,13 @@ class TabViewController: UIViewController {
         
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.overrideUserInterfaceStyle()
-        alert.addAction(UIAlertAction(title: dontOpen, style: .cancel))
+        alert.addAction(UIAlertAction(title: dontOpen, style: .cancel, handler: { _ in
+            if self.webView.url == nil {
+                self.delegate?.tabDidRequestClose(self)
+            } else {
+                self.url = self.webView.url
+            }
+        }))
         alert.addAction(UIAlertAction(title: open, style: .destructive, handler: { _ in
             self.openExternally(url: url)
         }))
@@ -970,20 +983,23 @@ extension TabViewController: WKNavigationDelegate {
         hideProgressIndicator()
         lastError = error
         let error = error as NSError
-        
+
         // prevent loops where a site keeps redirecting to itself (e.g. bbc)
         if let url = url,
             let domain = url.host,
             error.code == Constants.frameLoadInterruptedErrorCode {
             failingUrls.insert(domain)
+
+            // Reset the URL
+            self.url = webView.url
         }
-        
+
         // wait before showing errors in case they recover automatically
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             self.showErrorNow()
         }
     }
-    
+
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         guard let url = webView.url else { return }
         self.url = url


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1198953673392557
Tech Design URL:
CC:

**Description**:

Previously launching an external app would sometimes leave the app in a weird state; a blank screen or with the wrong URL.

Now when clicking a link that opens in an external app we make sure the URL is correct for the current page.  If the launch was triggered from the home screen, we close the tab and go back to the home screen.

**Steps to test this PR**:

From the home screen:
1. Paste https://itunes.apple.com/us/app/duckduckgo 
1. Will redirect to a scheme which launches externally
1. Tab will close back to the home screen
1. Clicking No in the prompt shows the home screen
1. Clicking Yes in the prompt launches the app (or shows the message saying that it couldn't be opened)

From a web page
1. Paste https://itunes.apple.com/us/app/duckduckgo 
1. Will redirect to a scheme which launches externally
1. URL will be updated to reflect the current page, not the pasted link
1. Clicking No in the prompt returns to the page
1. Clicking Yes in the prompt launches the app 

Following links
1. Navigate here https://falkirkrpg.org.uk/noxwall/schemes.html
1. Try the links on the page, ensure browser stays in a reasonable state
1. Some links might result in a search for the URL, that's OK

Errors
1. Paste https://thisisgibberish.url in to the address bar
1. The error screen should display with the url entered
1. Visit https://badssl.com and browse around 
1. The error pages should have the URL of the URL navigated to

Smoke testing
1. Use the browser in a general way and ensure nothing out of order

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

