### PR TITLE
add follow up pixels for no trackers dax dialog

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -128,6 +128,7 @@ public enum PixelName: String {
     
     case daxDialogsSerp = "m_dx_s"
     case daxDialogsWithoutTrackers = "m_dx_wo"
+    case daxDialogsWithoutTrackersFollowUp = "m_dx_wof"
     case daxDialogsWithTrackers = "m_dx_wt"
     case daxDialogsSiteIsMajor = "m_dx_sm"
     case daxDialogsSiteOwnedByMajor = "m_dx_so"

--- a/DuckDuckGo/FullscreenDaxDialogViewController.swift
+++ b/DuckDuckGo/FullscreenDaxDialogViewController.swift
@@ -50,6 +50,7 @@ class FullscreenDaxDialogViewController: UIViewController {
     weak var delegate: FullscreenDaxDialogDelegate?
 
     var spec: DaxDialogs.BrowsingSpec?
+    var woShown: Bool = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -81,7 +82,7 @@ class FullscreenDaxDialogViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if let spec = spec {
-            Pixel.fire(pixel: spec.pixelName)
+            Pixel.fire(pixel: spec.pixelName, withAdditionalParameters: [ "wo": woShown ? "1" : "0" ])
         }
         containerHeight.constant = daxDialogViewController?.calculateHeight() ?? 0
         daxDialogViewController?.start()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1199214002677583
Tech Design URL:
CC:

**Description**:

After firing the without trackers pixel, monitor the current page and see if trackers were eventually loaded.  If so, fire another pixel.

Add a parameter to dax dialog pixels to show if the without trackers dialog was shown during this browsing session (specifically if they stayed on this tab)

**Steps to test this PR**:

Same browsing session:

1. Clean install. 
1. Visit techcrunch.com - will be redirected to accept terms interstitial and "no trackers found" dax dialog will show - pixel fired will have "wo" = "0" parameter.
1. Accept and wait for page to redirect to main techcrunch site.  "trackers found" dialog will show - pixel fired will have "wo" = "1" parameter.

Different browsing session:

1. Clean install. 
1. Visit techcrunch.com - will be redirected to accept terms interstitial and "no trackers found" dax dialog will show - pixel fired will have "wo" = "0" parameter.
1. Do one of the following: Fire button, background the app, visit the tab switcher, visit bookmarks 
1. Visit techcrunch.com again and proceed until "trackers shown" dax dialog appears - pixel fired will have "wo" = "0" parameter.

Deferred trackers:

1. Clean install
1. Visit https://falkirkrpg.org.uk/noxwall/delayed-tracker.html
1. No trackers dax dialog will appear
1. Click the button
1. Check dashboard - one tracker blocked
1. `wof` Pixel should have fired 

Smoke testing:

1. General browsing should not fire any additional pixels when dax dialogs are not shown.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

