### PR TITLE
Improvements to background refresh

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -60,6 +60,7 @@ public struct UserDefaultsWrapper<T> {
         case doNotSell = "com.duckduckgo.ios.sendDoNotSell"
 
         case backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
+        case backgroundFetchTaskDuration = "com.duckduckgo.app.bgFetchTaskDuration"
         case downloadedHTTPSBloomFilterSpecCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterSpecCount"
         case downloadedHTTPSBloomFilterCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterCount"
         case downloadedHTTPSExcludedDomainsCount = "com.duckduckgo.app.downloadedHTTPSExcludedDomainsCount"

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -128,7 +128,7 @@ class AppConfigurationFetch {
     static func registerBackgroundRefreshTaskHandler() {
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: AppConfigurationFetch.Constants.backgroundProcessingTaskIdentifier,
-            using: fetchQueue) { (task) in
+            using: nil) { (task) in
 
             guard shouldRefresh else {
                 task.setTaskCompleted(success: true)
@@ -138,13 +138,15 @@ class AppConfigurationFetch {
 
             task.expirationHandler = {
                 backgroundFetchTaskExpirationCount += 1
+                task.setTaskCompleted(success: false)
                 scheduleBackgroundRefreshTask()
             }
 
-            AppConfigurationFetch().fetchConfigurationFiles(isBackground: true)
-
-            task.setTaskCompleted(success: true)
-            scheduleBackgroundRefreshTask()
+            fetchQueue.async {
+                AppConfigurationFetch().fetchConfigurationFiles(isBackground: true)
+                task.setTaskCompleted(success: true)
+                scheduleBackgroundRefreshTask()
+            }
         }
     }
 

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -142,9 +142,8 @@ class AppConfigurationFetch {
 
             let refreshStartDate = Date()
 
-            task.expirationHandler = {
-                backgroundFetchTaskExpirationCount += 1
-                task.setTaskCompleted(success: false)
+            let taskCompletion = { (success: Bool) in
+                task.setTaskCompleted(success: success)
                 scheduleBackgroundRefreshTask()
 
                 let refreshEndDate = Date()
@@ -152,14 +151,14 @@ class AppConfigurationFetch {
                 backgroundFetchTaskDuration += Int(difference)
             }
 
+            task.expirationHandler = {
+                backgroundFetchTaskExpirationCount += 1
+                taskCompletion(false)
+            }
+
             fetchQueue.async {
                 AppConfigurationFetch().fetchConfigurationFiles(isBackground: true)
-                task.setTaskCompleted(success: true)
-                scheduleBackgroundRefreshTask()
-
-                let refreshEndDate = Date()
-                let difference = refreshEndDate.timeIntervalSince(refreshStartDate)
-                backgroundFetchTaskDuration += Int(difference)
+                taskCompletion(true)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1193060753475688/1199215093917749
Task/Issue URL: https://app.asana.com/0/1193060753475688/1199238993752719
CC: @brindy 

## Description

This PR makes three changes to the background refresh process:

1. The background refresh call now checks `shouldRefresh` to ensure that it can only run once every 12 hours; this wasn't likely to be happening before since the background tasks themselves are set to run at minimum every 12 hours, but it's here now as a safeguard
1. Background tasks are run on their default queue, with the refresh process taking place on the fetch queue. Having the refresh take place on the same queue as the task itself was preventing the `expirationHandler` from running except if you manually trigger the expiration yourself via lldb
1. A parameter for average background refresh duration has been added to the config refresh pixel

## Steps to test this PR

**Note:** This has to be run on a physical device, as background tasks can't be run in the simulator. 😭 

This PR can be tested by manually triggering the background refresh APIs. The app has multiple safeguards in place that prevent tasks from being submitted/run too frequently, which will need to be commented out to test this multiple times. There are two to comment out:

1. The call to `getPendingTaskRequests` in `AppDelegate` needs its guard statement commented, otherwise it will not schedule a task if one has already been scheduled
1. The static var `shouldRefresh` in `AppConfigurationFetch` can be changed to return `true` every time, to bypass the 12 hour time gate. Alternatively you can change the duration to something shorter, like 60 seconds, which will help with testing the time gating itself

**Testing the regular flow:**

1. Place a breakpoint on `try BGTaskScheduler.shared.submit(task)` in `AppConfigurationFetch`
1. Run the app; if you have commented out the safeguards then it will trip that breakpoint on launch
1. Step over the `submit(task)` breakpoint via the debugger
1. Run `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]` via LLDB to launch the task
1. Resume app execution
1. Verify that the task handler in `registerBackgroundRefreshTaskHandler` is run. You could set a breakpoint in there, watch the console logs, or observe via Charles/Proxyman to verify that network calls are made to the config endpoints

**Testing the new duration pixel:**

After running through the steps for the regular flow above, the duration and background refresh pixel param counters will have been incremented. We want to verify that the pixel values are accurate, which can be tested like so:

1. Undo any changes made to the `shouldRefresh` computed var, as this value is used to determine whether the app should refresh or send pixels instead
1. Launch the app
1. The `m_d_cfgfetch` pixel should fire with params matching those you expect after running the background task. You should see a count matching however many times you ran the background task for `bgfs` and a non-zero value for `bgtd`, lining up with however long the background task ran for

**Testing task expiry:**

Task expiry is tested by launching the task manually and then telling the OS to expire it _while the task is running_. If you try to force expire a task before it's run then you'll get an error in the console, even if you've just run the command to launch it. You have to wait until you know the task is running, by adding a breakpoint to it.

1. Place a breakpoint on `try BGTaskScheduler.shared.submit(task)` in `AppConfigurationFetch`
1. Place a breakpoint inside the `task.expirationHandler` block
1. Place a breakpoint inside the background task handler itself, a good spot is on the line `let refreshStartDate = Date()`
1. Run the app. If you have commented out the safeguards then it will trip the `submit(task)` breakpoint on launch
1. Step over the `submit(task)` breakpoint via the debugger
1. Run `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]` via LLDB to launch the task
1. Resume the app, which should then hit the `let refreshStartDate = Date()` breakpoint, and the task is now active
1. Run the command to expire the task: `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateExpirationForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]`
1. Resume the app, and verify that the breakpoint in the expiry handler is triggered

## Device Testing

* [ ] iPhone X
* [ ] iPad

## OS Testing

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

