### PR TITLE
Prevent tabs from opening all links in the background

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -33,13 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private struct ShortcutKey {
         static let clipboard = "com.duckduckgo.mobile.ios.clipboard"
     }
-    
-    static var shared: AppDelegate {
-        // swiftlint:disable force_cast
-        return UIApplication.shared.delegate as! AppDelegate
-        // swiftlint:enable force_cast
-    }
-    
+
     private var testing = false
     var appIsLaunching = false
     var overlayWindow: UIWindow?

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -100,7 +100,7 @@ class MainViewController: UIViewController {
         return tabManager?.current
     }
 
-    var tapLinkDestination: TabViewController.LinkDestination = .currentTab
+    var keyModifierFlags: UIKeyModifierFlags?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -386,15 +386,7 @@ class MainViewController: UIViewController {
 
     @available(iOS 13.4, *)
     func handlePressEvent(event: UIPressesEvent?) {
-        self.tapLinkDestination = .currentTab
-
-        if event?.modifierFlags.contains(.command) ?? false {
-            if event?.modifierFlags.contains(.shift) ?? false {
-                self.tapLinkDestination = .newTab
-            } else {
-                self.tapLinkDestination = .backgroundTab
-            }
-        }
+        keyModifierFlags = event?.modifierFlags
     }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
@@ -1125,8 +1117,8 @@ extension MainViewController: TabDelegate {
         previewsSource.update(preview: preview, forTab: tab.tabModel)
     }
 
-    func tabWillRequestNewTab(_ tab: TabViewController) -> TabViewController.LinkDestination {
-        tapLinkDestination
+    func tabWillRequestNewTab(_ tab: TabViewController) -> UIKeyModifierFlags? {
+        keyModifierFlags
     }
 
     func tabDidRequestNewTab(_ tab: TabViewController) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -99,6 +99,8 @@ class MainViewController: UIViewController {
     var currentTab: TabViewController? {
         return tabManager?.current
     }
+
+    var tapLinkDestination: TabViewController.LinkDestination = .currentTab
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -384,13 +386,13 @@ class MainViewController: UIViewController {
 
     @available(iOS 13.4, *)
     func handlePressEvent(event: UIPressesEvent?) {
-        tabManager.tabControllerCache.forEach { $0.tapLinkDestination = .currentTab }
+        self.tapLinkDestination = .currentTab
 
         if event?.modifierFlags.contains(.command) ?? false {
             if event?.modifierFlags.contains(.shift) ?? false {
-                tabManager.tabControllerCache.forEach { $0.tapLinkDestination = .newTab }
+                self.tapLinkDestination = .newTab
             } else {
-                tabManager.tabControllerCache.forEach { $0.tapLinkDestination = .backgroundTab }
+                self.tapLinkDestination = .backgroundTab
             }
         }
     }
@@ -1121,6 +1123,10 @@ extension MainViewController: TabDelegate {
     
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage) {
         previewsSource.update(preview: preview, forTab: tab.tabModel)
+    }
+
+    func tabWillRequestNewTab(_ tab: TabViewController) -> TabViewController.LinkDestination {
+        tapLinkDestination
     }
 
     func tabDidRequestNewTab(_ tab: TabViewController) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -384,12 +384,13 @@ class MainViewController: UIViewController {
 
     @available(iOS 13.4, *)
     func handlePressEvent(event: UIPressesEvent?) {
-        currentTab?.tapLinkDestination = .currentTab
+        tabManager.tabControllerCache.forEach { $0.tapLinkDestination = .currentTab }
+
         if event?.modifierFlags.contains(.command) ?? false {
             if event?.modifierFlags.contains(.shift) ?? false {
-                currentTab?.tapLinkDestination = .newTab
+                tabManager.tabControllerCache.forEach { $0.tapLinkDestination = .newTab }
             } else {
-                currentTab?.tapLinkDestination = .backgroundTab
+                tabManager.tabControllerCache.forEach { $0.tapLinkDestination = .backgroundTab }
             }
         }
     }

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -22,6 +22,8 @@ import Core
 
 protocol TabDelegate: class {
 
+    func tabWillRequestNewTab(_ tab: TabViewController) -> TabViewController.LinkDestination
+
     func tabDidRequestNewTab(_ tab: TabViewController)
 
     func tab(_ tab: TabViewController,

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -22,7 +22,7 @@ import Core
 
 protocol TabDelegate: class {
 
-    func tabWillRequestNewTab(_ tab: TabViewController) -> TabViewController.LinkDestination
+    func tabWillRequestNewTab(_ tab: TabViewController) -> UIKeyModifierFlags?
 
     func tabDidRequestNewTab(_ tab: TabViewController)
 

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -25,7 +25,7 @@ class TabManager {
 
     private(set) var model: TabsModel
     
-    private(set) var tabControllerCache = [TabViewController]()
+    private var tabControllerCache = [TabViewController]()
 
     private var previewsSource: TabPreviewsSource
     weak var delegate: TabDelegate?

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -25,7 +25,7 @@ class TabManager {
 
     private(set) var model: TabsModel
     
-    private var tabControllerCache = [TabViewController]()
+    private(set) var tabControllerCache = [TabViewController]()
 
     private var previewsSource: TabPreviewsSource
     weak var delegate: TabDelegate?

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -35,14 +35,6 @@ class TabViewController: UIViewController {
         static let secGPCHeader = "Sec-GPC"
     }
     
-    enum LinkDestination {
-        
-        case currentTab
-        case newTab
-        case backgroundTab
-        
-    }
-    
     @IBOutlet private(set) weak var error: UIView!
     @IBOutlet private(set) weak var errorInfoImage: UIImageView!
     @IBOutlet private(set) weak var errorHeader: UILabel!
@@ -1044,20 +1036,18 @@ extension TabViewController: WKNavigationDelegate {
         }
 
         if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
-            let destination = delegate?.tabWillRequestNewTab(self) ?? .currentTab
+            let modifierFlags = delegate?.tabWillRequestNewTab(self)
 
-            switch destination {
-            case .newTab:
-                decisionHandler(.cancel)
-                delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false)
-                return
-
-            case .backgroundTab:
-                decisionHandler(.cancel)
-                delegate?.tab(self, didRequestNewBackgroundTabForUrl: url)
-                return
-                
-            default: break
+            if modifierFlags?.contains(.command) ?? false {
+                if modifierFlags?.contains(.shift) ?? false {
+                    decisionHandler(.cancel)
+                    delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false)
+                    return
+                } else {
+                    decisionHandler(.cancel)
+                    delegate?.tab(self, didRequestNewBackgroundTabForUrl: url)
+                    return
+                }
             }
         }
         

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -43,8 +43,6 @@ class TabViewController: UIViewController {
         
     }
     
-    var tapLinkDestination: LinkDestination = .currentTab
-    
     @IBOutlet private(set) weak var error: UIView!
     @IBOutlet private(set) weak var errorInfoImage: UIImageView!
     @IBOutlet private(set) weak var errorHeader: UILabel!
@@ -1046,7 +1044,9 @@ extension TabViewController: WKNavigationDelegate {
         }
 
         if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
-            switch tapLinkDestination {
+            let destination = delegate?.tabWillRequestNewTab(self) ?? .currentTab
+
+            switch destination {
             case .newTab:
                 decisionHandler(.cancel)
                 delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1035,11 +1035,12 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
 
-        if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
-            let modifierFlags = delegate?.tabWillRequestNewTab(self)
+        if navigationAction.navigationType == .linkActivated,
+           let url = navigationAction.request.url,
+           let modifierFlags = delegate?.tabWillRequestNewTab(self) {
 
-            if modifierFlags?.contains(.command) ?? false {
-                if modifierFlags?.contains(.shift) ?? false {
+            if modifierFlags.contains(.command) {
+                if modifierFlags.contains(.shift) {
                     decisionHandler(.cancel)
                     delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false)
                     return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1199224141509182

**Description**:

This PR fixes a bug where tabs could have their `tapLinkDestination` property get out of sync when the current tab changes.

If you use Command+T to open a new tab, then pressing the Command key puts a tab into the `.backgroundTab` state, and releasing it after the new tab is created means that `currentTab` has changed – the original tab never gets reset to the `.currentTab` state.

The fix is to propagate these events to all active `TabViewController` instances.

**Steps to test this PR**:
1. Open a tab on a device with a physical keyboard, for example the iPad keyboard case
1. Use Command+T to open a new tab
1. Go back to the original tab and tap any link and verify that it does not get opened as a background tab

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

