### PR TITLE
Fix request cancelling bugs (GPC header injection)

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		85A1B3B220C6CD9900C18F15 /* CookieStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B3B120C6CD9900C18F15 /* CookieStorage.swift */; };
 		85A1B3B420C6D07100C18F15 /* CookieStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A1B3B320C6D07100C18F15 /* CookieStorageTests.swift */; };
 		85A313972028E78A00327D00 /* release_notes.txt in Resources */ = {isa = PBXBuildFile; fileRef = 85A313962028E78A00327D00 /* release_notes.txt */; };
+		85A34DA825712BBE001895E6 /* DDGWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A34DA725712BBE001895E6 /* DDGWebView.swift */; };
 		85A53ECA200D1FA20010D13F /* FileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A53EC9200D1FA20010D13F /* FileStore.swift */; };
 		85A9C37920E0E00C00073340 /* HomeRow.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85A9C37820E0E00C00073340 /* HomeRow.xcassets */; };
 		85AE668E2097206E0014CF04 /* NotificationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 85AE668D2097206E0014CF04 /* NotificationView.xib */; };
@@ -902,6 +903,7 @@
 		85A1B3B120C6CD9900C18F15 /* CookieStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieStorage.swift; sourceTree = "<group>"; };
 		85A1B3B320C6D07100C18F15 /* CookieStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieStorageTests.swift; sourceTree = "<group>"; };
 		85A313962028E78A00327D00 /* release_notes.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = release_notes.txt; path = fastlane/metadata/default/release_notes.txt; sourceTree = "<group>"; };
+		85A34DA725712BBE001895E6 /* DDGWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDGWebView.swift; sourceTree = "<group>"; };
 		85A53EC9200D1FA20010D13F /* FileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileStore.swift; sourceTree = "<group>"; };
 		85A9C37820E0E00C00073340 /* HomeRow.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = HomeRow.xcassets; sourceTree = "<group>"; };
 		85AE668D2097206E0014CF04 /* NotificationView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NotificationView.xib; sourceTree = "<group>"; };
@@ -3160,9 +3162,10 @@
 		F13B4BF41F18C74500814661 /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
+				85A34DA725712BBE001895E6 /* DDGWebView.swift */,
 				8565A34A1FC8D96B00239327 /* LaunchTabNotification.swift */,
-				F1617C141E57336D00DEDCAF /* TabManager.swift */,
 				F13B4BF51F18C75D00814661 /* Model */,
+				F1617C141E57336D00DEDCAF /* TabManager.swift */,
 				F13B4BF61F18C76600814661 /* UI */,
 			);
 			name = Tabs;
@@ -4489,6 +4492,7 @@
 				F1F5337C1F26A9EF00D80D4F /* UserText.swift in Sources */,
 				853C5F6121C277C7001F7A05 /* global.swift in Sources */,
 				F13B4BD31F1822C700814661 /* Tab.swift in Sources */,
+				85A34DA825712BBE001895E6 /* DDGWebView.swift in Sources */,
 				F1BE54581E69DE1000FCF649 /* TutorialSettings.swift in Sources */,
 				858650D12469BCDE00C36F8A /* DaxDialogs.swift in Sources */,
 				98196CFA23AA75D0007809AC /* OnboardingHomeRowViewController.swift in Sources */,

--- a/DuckDuckGo/DDGWebView.swift
+++ b/DuckDuckGo/DDGWebView.swift
@@ -1,0 +1,53 @@
+//
+//  DDGWebView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2020 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+
+class DDGWebView: WKWebView {
+
+    struct GPC {
+
+        static let headerName = "Sec-GPC"
+        static let signalOn = "1"
+
+    }
+
+    let appSettings = AppUserDefaults()
+
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        var updatedRequest = request
+
+        // No need to worry about removing as the header won't be in the request anyway so
+        //  long as this is not called with a reused URLRequest object.
+        if appSettings.sendDoNotSell {
+            updatedRequest.addValue(GPC.signalOn, forHTTPHeaderField: GPC.headerName)
+        }
+
+        return super.load(updatedRequest)
+    }
+
+    override func reload() -> WKNavigation? {
+        guard let url = url else {
+            // returning nil would probably ok here too, but just let WKWebView do it's thing
+            return super.reload()
+        }
+        return load(URLRequest(url: url))
+    }
+
+}

--- a/DuckDuckGo/DDGWebView.swift
+++ b/DuckDuckGo/DDGWebView.swift
@@ -44,7 +44,7 @@ class DDGWebView: WKWebView {
 
     override func reload() -> WKNavigation? {
         guard let url = url else {
-            // returning nil would probably ok here too, but just let WKWebView do it's thing
+            // returning nil would probably ok here too, but just let WKWebView do its thing
             return super.reload()
         }
         return load(URLRequest(url: url))

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -267,7 +267,7 @@ class TabViewController: UIViewController {
 
     func attachWebView(configuration: WKWebViewConfiguration, andLoadRequest request: URLRequest?, consumeCookies: Bool) {
         instrumentation.willPrepareWebView()
-        webView = WKWebView(frame: view.bounds, configuration: configuration)
+        webView = DDGWebView(frame: view.bounds, configuration: configuration)
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         
         if #available(iOS 13, *) {
@@ -1001,39 +1001,10 @@ extension TabViewController: WKNavigationDelegate {
         detectedNewNavigation()
         checkLoginDetectionAfterNavigation()
     }
-    
-    private func requestForDoNotSell(basedOn incomingRequest: URLRequest) -> URLRequest? {
-        var request = incomingRequest
-        // Add Do Not sell header if needed
-        if appSettings.sendDoNotSell {
-            if let headers = request.allHTTPHeaderFields,
-               headers.firstIndex(where: { $0.key == Constants.secGPCHeader }) == nil {
-                request.addValue("1", forHTTPHeaderField: Constants.secGPCHeader)
-                return request
-            }
-        } else {
-            // Check if DN$ header is still there and remove it
-            if let headers = request.allHTTPHeaderFields, headers.firstIndex(where: { $0.key == Constants.secGPCHeader }) != nil {
-                request.setValue(nil, forHTTPHeaderField: Constants.secGPCHeader)
-                return request
-            }
-        }
-        
-        return nil
-    }
             
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-
-        if navigationAction.isTargetingMainFrame(),
-           !(navigationAction.request.url?.isCustomURLScheme() ?? false),
-           navigationAction.navigationType != .backForward,
-           let request = requestForDoNotSell(basedOn: navigationAction.request) {
-            decisionHandler(.cancel)
-            load(urlRequest: request)
-            return
-        }
 
         if navigationAction.navigationType == .linkActivated,
            let url = navigationAction.request.url,

--- a/DuckDuckGo/WebContainerViewController.swift
+++ b/DuckDuckGo/WebContainerViewController.swift
@@ -48,7 +48,7 @@ class WebContainerViewController: UIViewController {
 
         applyTheme(ThemeManager.shared.currentTheme)
 
-        let webView = WKWebView(frame: view.frame)
+        let webView = DDGWebView(frame: view.frame)
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
         view.addSubview(webView)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1199370790017886/1198740529455819
Tech Design URL:
CC:

**Description**:

Use a subclass to inject gpc header without having to cancel and re-issue the request

**Steps to test this PR**:
1. Visit https://global-privacy-control.glitch.me/ and enable/disable the GPC setting.  Ensure the website reflects the setting correctly.
1. Visit https://github.com/globalprivacycontrol/gpc-spec/issues/11#issuecomment-732504580 ensure the page loads as expected (no reload cycle)
1. Visit https://twitter.com/CodeClanScot/status/1332275491726831616?s=20 (or any other tweet with a link to a URL) 
    1. Ensure page loads.
    1. Tap link ensure page loads (in a new tab)
    1. Tap back, should close tab and show Twitter
1. Smoke test by browsing the web hitting up other big sites like Facebook and Google amongst others.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

