### PR TITLE
prompt for external link that isn't link activated

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1109,6 +1109,8 @@ extension TabViewController: WKNavigationDelegate {
         case .unknown:
             if navigationAction.navigationType == .linkActivated {
                 openExternally(url: url)
+            } else {
+                presentOpenInExternalAppAlert(url: url)
             }
             completion(.cancel)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/inbox/392891325557408/1198850012047869/1199390439822440
Tech Design URL:
CC:

**Description**:

Prompt for external link that isn't link activated.

**Steps to test this PR**:
1. Visit https://duckduckgo.github.io/privacy-test-pages/features/url-schemes.html and tap the zoom link.  Should open directly in Zoom.
1. With the app as default browser, sign in to zoom.  The last step should show a button to launch zoom.  Tapping this should prompt the user to open the external link and then open it.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

