### PR TITLE
fix bad tab state and favicon flash

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1087,6 +1087,7 @@ extension MainViewController: TabDelegate {
              for navigationAction: WKNavigationAction) -> WKWebView? {
 
         showBars()
+        currentTab?.dismiss()
 
         let newTab = tabManager.addURLRequest(navigationAction.request, withConfiguration: configuration)
         newTab.openedByPage = true


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:

* https://app.asana.com/0/414709148257752/1199169232620084
* https://app.asana.com/0/414709148257752/1199169232620080 

Tech Design URL:
CC:

**Description**:

Fixes:
* the bad new tab state bug
* favicon icon flash

**Steps to test this PR**:

Bad tab state:

1. Add some favorites
1. Close all tabs (fire button)
1. Navigate to https://falkirkrpg.org.uk/noxwall/open.html
1. Click the open button
1. Long press the tab button to open a new tab

Favorites flash:

1. Add a lot of favorites (so the new tab page scrolls)
1. Ensure no performance problems when opening a new tab / showing home screen

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

