### PR TITLE
Remove onboarding experiment and rollout default browser variant

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -88,8 +88,6 @@ public enum PixelName: String {
     case autocompleteSelectedLocal = "m_au_l"
     case autocompleteSelectedRemote = "m_au_r"
 
-    case homeRowOnboardingMovedToBackground = "m_o_h_b"
-
     case feedbackPositive = "mfbs_positive_submit"
     case feedbackNegativePrefix = "mfbs_negative_"
     
@@ -138,8 +136,6 @@ public enum PixelName: String {
     case widgetNewSearch = "m_w_ns"
     case widgetAddFavoriteLaunch = "m_w_af"
 
-    case defaultBrowserButtonPressedOnboarding = "m_db_o"
-    case defaultBroswerOnboardingDeclineOptionPressed = "m_db_o_d"
     case defaultBrowserButtonPressedSettings = "m_db_s"
     case defaultBrowserButtonPressedHome = "m_db_h"
     case defaultBrowserHomeMessageShown = "m_db_h_s"

--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -24,11 +24,6 @@ public enum FeatureName: String {
 
     // Used for unit tests
     case dummy
-     
-    // Onboarding
-    case onboardingHomeRow
-    case onboardingDefaultBrowser
-    case onboardingWidgets
 }
 
 public struct Variant {
@@ -62,12 +57,7 @@ public struct Variant {
         // SERP testing
         Variant(name: "sc", weight: doNotAllocate, isIncluded: When.inRequiredCountry, features: []),
         Variant(name: "sd", weight: doNotAllocate, isIncluded: When.always, features: []),
-        Variant(name: "se", weight: doNotAllocate, isIncluded: When.inRequiredCountry, features: []),
-
-        // Onboarding
-        Variant(name: "mh", weight: 1, isIncluded: When.inEnglishAndIOS14, features: [ .onboardingHomeRow ]),
-        Variant(name: "md", weight: 1, isIncluded: When.inEnglishAndIOS14, features: [ .onboardingDefaultBrowser ]),
-        Variant(name: "mw", weight: 1, isIncluded: When.inEnglishAndIOS14, features: [ .onboardingWidgets ])
+        Variant(name: "se", weight: doNotAllocate, isIncluded: When.inRequiredCountry, features: [])
     ]
     
     public let name: String

--- a/DuckDuckGo/OnboardingDefaultBroswerViewController.swift
+++ b/DuckDuckGo/OnboardingDefaultBroswerViewController.swift
@@ -39,15 +39,9 @@ class OnboardingDefaultBroswerViewController: OnboardingContentViewController {
     }
     
     override func onContinuePressed(navigationHandler: @escaping () -> Void) {
-        Pixel.fire(pixel: .defaultBrowserButtonPressedOnboarding)
         if let url = URL(string: UIApplication.openSettingsURLString) {
             UIApplication.shared.open(url)
         }
         super.onContinuePressed(navigationHandler: navigationHandler)
-    }
-    
-    override func onSkipPressed(navigationHandler: @escaping () -> Void) {
-        Pixel.fire(pixel: .defaultBroswerOnboardingDeclineOptionPressed)
-        super.onSkipPressed(navigationHandler: navigationHandler)
     }
 }

--- a/DuckDuckGo/OnboardingHomeRowViewController.swift
+++ b/DuckDuckGo/OnboardingHomeRowViewController.swift
@@ -35,20 +35,7 @@ class OnboardingHomeRowViewController: OnboardingContentViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didEnterBackground(notification:)),
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil)
         startVideo()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil)
     }
     
     override var header: String {
@@ -104,10 +91,6 @@ class OnboardingHomeRowViewController: OnboardingContentViewController {
     @objc func playerDidFinishPlaying(note: NSNotification) {
         HomeRowReminder().setShown()
         playButton.isHidden = false
-    }
-    
-    @objc func didEnterBackground(notification: NSNotification) {
-        Pixel.fire(pixel: .homeRowOnboardingMovedToBackground)
     }
     
     deinit {

--- a/DuckDuckGo/OnboardingViewController.swift
+++ b/DuckDuckGo/OnboardingViewController.swift
@@ -23,12 +23,8 @@ import Core
 class OnboardingViewController: UIViewController, Onboarding {
         
     private lazy var controllerNames: [String] = {
-        if variantManager.isSupported(feature: .onboardingHomeRow) {
-            return ["onboardingHomeRow"]
-        } else if variantManager.isSupported(feature: .onboardingDefaultBrowser) {
+        if #available(iOS 14, *) {
             return ["onboardingDefaultBrowser"]
-        } else if variantManager.isSupported(feature: .onboardingWidgets) {
-            return ["onboardingWidget"]
         } else {
             return ["onboardingHomeRow"]
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1194681707917578/f
Tech Design URL:
CC: @brindy 

**Description**:
Remove onboarding experiment and rollout default browser variant

I've left the widget variant in the code base since we may want to reuse it for https://app.asana.com/0/715106103902962/1199513908085605/f , although let me know if we want to be more aggressive with clean up.

**Steps to test this PR**:
1. Test that devices running iOS 14 only ever see the default browser onboarding, and test the skip and default browser buttons still work
1. Test that devices running <iOS 14 only ever see the home row onboarding

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [x] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

