### PR TITLE
fix long press menu on iOS 12

### DIFF
--- a/Core/document.js
+++ b/Core/document.js
@@ -22,7 +22,9 @@
         Object.defineProperty(window, "__ddg__", {
             enumerable: false,
             configurable: false,
-            writable: false
+            writable: false,
+            value: {
+            }
         });
     }
     

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -50,9 +50,6 @@ extension TabViewController {
         alert.addAction(title: UserText.actionOpen) { [weak self] in
             self?.onOpenAction(forUrl: url)
         }
-        alert.addAction(title: UserText.actionReadingList) { [weak self] in
-            self?.onReadingAction(forUrl: url)
-        }
         alert.addAction(title: UserText.actionCopy) { [weak self] in
             self?.onCopyAction(forUrl: url)
         }
@@ -87,11 +84,7 @@ extension TabViewController {
             webView.load(URLRequest(url: url))
         }
     }
-    
-    private func onReadingAction(forUrl url: URL) {
-        try? SSReadingList.default()?.addItem(with: url, title: nil, previewText: nil)
-    }
-    
+
     private func onCopyAction(forUrl url: URL) {
         let copyText = url.absoluteString
         UIPasteboard.general.string = copyText

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -42,7 +42,6 @@ public struct UserText {
     public static let actionForgetAll = NSLocalizedString("action.title.forgetAll", value: "Close Tabs and Clear Data", comment: "")
     public static let actionForgetAllDone = NSLocalizedString("action.title.forgetAllDone", value: "Tabs and data cleared", comment: "Confirmation message")
     public static let actionOpen = NSLocalizedString("action.title.open", value: "Open", comment: "Open action")
-    public static let actionReadingList = NSLocalizedString("action.title.readingList", value: "Add to Reading List", comment: "Reading List action")
     public static let actionCopy = NSLocalizedString("action.title.copy", value: "Copy", comment: "Copy action")
     public static let actionShare = NSLocalizedString("action.title.share", value: "Share...", comment: "Share action")
     public static let actionEnableProtection = NSLocalizedString("action.title.enable.protection", value: "Enable Privacy Protection", comment: "Enable protection action")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -37,9 +37,6 @@
 /* Paste and Go action */
 "action.title.pasteAndGo" = "Paste & Go";
 
-/* Reading List action */
-"action.title.readingList" = "Add to Reading List";
-
 /* Refresh action - button shown in alert */
 "action.title.refresh" = "Refresh";
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199561262947046
Tech Design URL:
CC:

**Description**:

Fix long press menu on iOS 12 and remove add to reading list to match iOS 13+

**Steps to test this PR**:
1. Using iOS 12, check that long press menu still works (for reason only shows after the long press event), e.g. open in new tab, etc are present
1. Regression test on iOS 13+

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [x] iPhone 8
* [x] iPad

**OS Testing**:

* [x] iOS 12
* [x] iOS 13

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

