### PR TITLE
Fix dynamic text on settings headers and footers

### DIFF
--- a/DuckDuckGo/Base.lproj/Settings.storyboard
+++ b/DuckDuckGo/Base.lproj/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="w88-u3-TgK">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="w88-u3-TgK">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -1130,10 +1130,17 @@ After all, the internet shouldn’t feel so creepy, and getting the privacy you 
                             <rect key="frame" x="0.0" y="0.0" width="414" height="72"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="These sites will not be enhanced by Privacy Protection." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zvh-2e-Wmz" userLabel="Info Label">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zvh-2e-Wmz" userLabel="Info Label">
                                     <rect key="frame" x="60" y="20" width="294" height="32"/>
-                                    <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="14"/>
-                                    <color key="textColor" red="0.7434888482093811" green="0.76165848970413208" blue="0.79455751180648804" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <attributedString key="attributedText">
+                                        <fragment content="These sites will not be enhanced by Privacy Protection.">
+                                            <attributes>
+                                                <color key="NSColor" red="0.7434888482093811" green="0.76165848970413208" blue="0.79455751180648804" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <font key="NSFont" size="14" name="ProximaNova-Regular"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SWM-CB-n4U">

--- a/DuckDuckGo/DoNotSellSettingsViewController.swift
+++ b/DuckDuckGo/DoNotSellSettingsViewController.swift
@@ -31,21 +31,20 @@ class DoNotSellSettingsViewController: UITableViewController {
     @IBOutlet weak var disclaimerTextView: UITextView!
     
     private lazy var appSettings = AppDependencyProvider.shared.appSettings
-    
-    let learnMoreStr = "Learn More"
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         
         doNotSellToggle.isOn = appSettings.sendDoNotSell
         
+        let fontSize = SettingsViewController.fontSizeForHeaderView
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineHeightMultiple = 1.16
         infoTextView.attributedText = NSAttributedString(string: UserText.doNotSellInfoText,
                                                          attributes: [
                                                             NSAttributedString.Key.kern: -0.08,
                                                             NSAttributedString.Key.paragraphStyle: paragraphStyle,
-                                                            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 13)
+                                                            NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)
                                                          ])
         
         infoTextView.backgroundColor = .clear
@@ -93,28 +92,30 @@ extension DoNotSellSettingsViewController: Themable {
     func applyAtributes(theme: Theme) {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineHeightMultiple = 1.16
+        let fontSize = SettingsViewController.fontSizeForHeaderView
         let tempStr = NSMutableAttributedString(string: UserText.doNotSellDisclaimerBold,
                                                 attributes: [
                                                     NSAttributedString.Key.kern: -0.08,
                                                     NSAttributedString.Key.paragraphStyle: paragraphStyle,
-                                                    NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 13),
+                                                    NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: fontSize),
                                                     NSAttributedString.Key.foregroundColor: theme.tableHeaderTextColor
                                                 ])
         tempStr.append(NSAttributedString(string: UserText.doNotSellDisclaimerSuffix,
                                           attributes: [
                                               NSAttributedString.Key.kern: -0.08,
                                               NSAttributedString.Key.paragraphStyle: paragraphStyle,
-                                              NSAttributedString.Key.font: UIFont.systemFont(ofSize: 13),
+                                              NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize),
                                               NSAttributedString.Key.foregroundColor: theme.tableHeaderTextColor
                                           ]))
         tempStr.append(NSAttributedString(string: UserText.doNotSellLearnMore,
                                           attributes: [
-                                            NSAttributedString.Key.link: "ddgQuickLink://duckduckgo.com/global-privacy-control-learn-more"
+                                            NSAttributedString.Key.link: "ddgQuickLink://duckduckgo.com/global-privacy-control-learn-more",
+                                            NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)
                                           ]))
         let linkAttributes: [NSAttributedString.Key: Any] = [
             NSAttributedString.Key.kern: -0.08,
             NSAttributedString.Key.paragraphStyle: paragraphStyle,
-            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 13),
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize),
             NSAttributedString.Key.foregroundColor: theme.searchBarTextColor,
             NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue
         ]

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -327,3 +327,37 @@ extension MFMailComposeViewController {
         return MFMailComposeViewController()
     }
 }
+
+extension SettingsViewController {
+    static var fontSizeForHeaderView: CGFloat {
+        let contentSize = UIApplication.shared.preferredContentSizeCategory
+        switch contentSize {
+        case .extraSmall:
+            return 12
+        case .small:
+            return 12
+        case .medium:
+            return 12
+        case .large:
+            return 13
+        case .extraLarge:
+            return 15
+        case .extraExtraLarge:
+            return 17
+        case .extraExtraExtraLarge:
+            return 19
+        case .accessibilityMedium:
+            return 23
+        case .accessibilityLarge:
+            return 27
+        case .accessibilityExtraLarge:
+            return 33
+        case .accessibilityExtraExtraLarge:
+            return 38
+        case .accessibilityExtraExtraExtraLarge:
+            return 44
+        default:
+            return 13
+        }
+    }
+}

--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -45,6 +45,12 @@ class UnprotectedSitesViewController: UITableViewController {
         refreshToolbarItems(animated: false)
         
         configureBackButton()
+        
+        let fontSize = SettingsViewController.fontSizeForHeaderView
+        let text = NSAttributedString(string: infoText.text ?? "", attributes: [
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)
+        ])
+        infoText.attributedText = text
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199241778510997/f
Tech Design URL:
CC:

**Description**:
Fixes the text sizes of the headers on footers on the GPC settings page, and the Unprotected sites pages

**Steps to test this PR**:
1. Test both pages with a variety of text sizes

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

