### PR TITLE
Fix an issue causing integration test compilation problems

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -212,7 +212,7 @@ private class BarsAnimator {
         guard bottomRevealGestureState != .triggered else { return }
         
         // In case view has been "caught" in the middle of the animation above the (0.0, 0.0) offset,
-        //wait till user scrolls to the top before animating any transition.
+        // wait till user scrolls to the top before animating any transition.
         if draggingStartPosY < 0, scrollView.contentOffset.y <= 0 {
             return
         }

--- a/DuckDuckGo/GestureToolbarButton.swift
+++ b/DuckDuckGo/GestureToolbarButton.swift
@@ -81,7 +81,7 @@ class GestureToolbarButton: UIView {
         super.layoutSubviews()
         
         if #available(iOS 11.0, *) {
-            //no-op
+            // no-op
         } else if traitCollection.containsTraits(in: .init(verticalSizeClass: .compact)),
             traitCollection.containsTraits(in: .init(horizontalSizeClass: .compact)) {
             // adjust frame to toolbar height change

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -704,7 +704,7 @@ class MainViewController: UIViewController {
         notificationContainerHeight.constant = height
 
         if #available(iOS 11.0, *) {
-            //no-op
+            // no-op
         } else if traitCollection.containsTraits(in: .init(verticalSizeClass: .compact)),
             traitCollection.containsTraits(in: .init(horizontalSizeClass: .compact)) {
             // adjust frame to toolbar height change

--- a/DuckDuckGo/TabSwitcherButton.swift
+++ b/DuckDuckGo/TabSwitcherButton.swift
@@ -99,7 +99,7 @@ class TabSwitcherButton: UIView {
         super.layoutSubviews()
         
         if #available(iOS 11.0, *) {
-            //no-op
+            // no-op
         } else if traitCollection.containsTraits(in: .init(verticalSizeClass: .compact)),
             traitCollection.containsTraits(in: .init(horizontalSizeClass: .compact)) {
             // adjust frame to toolbar height change

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -424,7 +424,7 @@ extension TabSwitcherViewController: UICollectionViewDelegateFlowLayout {
 extension TabSwitcherViewController: TabObserver {
     
     func didChange(tab: Tab) {
-        //Reloading when updates are processed will result in a crash
+        // Reloading when updates are processed will result in a crash
         guard !isProcessingUpdates else { return }
         
         if let index = tabsModel.indexOf(tab: tab) {

--- a/DuckDuckGoTests/TabPreviewsSourceTests.swift
+++ b/DuckDuckGoTests/TabPreviewsSourceTests.swift
@@ -127,11 +127,11 @@ class TabPreviewsSourceTests: XCTestCase {
                                                     withIntermediateDirectories: false,
                                                     attributes: nil)
             
-            //Prepare png file
+            // Prepare png file
             let pngFile = fromUrl.appendingPathComponent("test.png")
             try "".write(to: pngFile, atomically: false, encoding: .utf8)
             
-            //Prepare random file
+            // Prepare random file
             let randomFile = fromUrl.appendingPathComponent("test.file")
             try "".write(to: randomFile, atomically: false, encoding: .utf8)
         } catch {

--- a/IntegrationTests/ContentBlockingRulesTests.swift
+++ b/IntegrationTests/ContentBlockingRulesTests.swift
@@ -18,7 +18,6 @@
 //
 
 import XCTest
-@testable import DuckDuckGo
 @testable import Core
 
 class ContentBlockingRulesTests: XCTestCase {

--- a/IntegrationTests/TrackerRadarIntegrationTests.swift
+++ b/IntegrationTests/TrackerRadarIntegrationTests.swift
@@ -18,7 +18,6 @@
 //
 
 import XCTest
-@testable import DuckDuckGo
 @testable import Core
 
 class TrackerRadarIntegrationTests: XCTestCase {


### PR DESCRIPTION
## Description

**Problem**:

This PR updates a couple of the integration test files which were throwing errors during compilation, triggered when importing the `DuckDuckGo` module.

An example failure can be [found on Bitrise](https://app.bitrise.io/build/f823b0837b3802db#?tab=log):

```
▸ Compiling TrackerRadarIntegrationTests.swift

❌  /Users/vagrant/git/IntegrationTests/TrackerRadarIntegrationTests.swift:21:18: missing required module 'Lottie'
@testable import DuckDuckGo
```

**Solution**:

It doesn't appear that the integration tests are using the `DuckDuckGo` module, so the fix is to remove these imports. I'm not sure what changed to cause this to start happening, but the fix works. 🙂 

## Steps to test this PR

1. Compile the integration test suite locally and check that everything works

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

