### PR TITLE
Add background refresh stat safeguards

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -59,7 +59,6 @@ public struct UserDefaultsWrapper<T> {
         
         case doNotSell = "com.duckduckgo.ios.sendDoNotSell"
 
-        case backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
         case backgroundFetchTaskDuration = "com.duckduckgo.app.bgFetchTaskDuration"
         case downloadedHTTPSBloomFilterSpecCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterSpecCount"
         case downloadedHTTPSBloomFilterCount = "com.duckduckgo.app.downloadedHTTPSBloomFilterCount"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		4B0295192537BC6700E00CEF /* ConfigurationDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */; };
 		4B60AC97252EC07B00E8D219 /* fullscreenvideo.js in Resources */ = {isa = PBXBuildFile; fileRef = 4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */; };
 		4B60ACA1252EC0B100E8D219 /* FullScreenVideoUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */; };
+		4B62C4BA25B930DD008912C6 /* AppConfigurationFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B62C4B925B930DD008912C6 /* AppConfigurationFetchTests.swift */; };
 		4B82E98025B634B800656FE7 /* TrackerRadarKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4B82E97F25B634B800656FE7 /* TrackerRadarKit */; };
 		83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */; };
 		83004E862193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */; };
@@ -721,6 +722,7 @@
 		4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationDebugViewController.swift; sourceTree = "<group>"; };
 		4B60AC96252EC07B00E8D219 /* fullscreenvideo.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = fullscreenvideo.js; sourceTree = "<group>"; };
 		4B60ACA0252EC0B100E8D219 /* FullScreenVideoUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenVideoUserScript.swift; sourceTree = "<group>"; };
+		4B62C4B925B930DD008912C6 /* AppConfigurationFetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurationFetchTests.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
 		83004E832193E14C00DA013C /* UIAlertControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtension.swift; path = ../Core/UIAlertControllerExtension.swift; sourceTree = "<group>"; };
@@ -3372,6 +3374,7 @@
 				F1134EC21F40E24600B73467 /* AppVersionExtensionTests.swift */,
 				85BA58561F34F61C00C6E8CA /* AppUserDefaultsTests.swift */,
 				983EABB923619986003948D1 /* DatabaseMigrationTests.swift */,
+				4B62C4B925B930DD008912C6 /* AppConfigurationFetchTests.swift */,
 			);
 			name = Application;
 			sourceTree = "<group>";
@@ -4757,6 +4760,7 @@
 				859C5FBA2147E6E200E2A43D /* GradeTests.swift in Sources */,
 				8565A34D1FC8DFE400239327 /* LaunchTabNotificationTests.swift in Sources */,
 				F1134EC41F40E25800B73467 /* AppVersionExtensionTests.swift in Sources */,
+				4B62C4BA25B930DD008912C6 /* AppConfigurationFetchTests.swift in Sources */,
 				8598F67B2405EB8D00FBC70C /* KeyboardSettingsTests.swift in Sources */,
 				85D2187224BF24F2004373D2 /* NotFoundCachingDownloaderTests.swift in Sources */,
 				85081A031FE03154006561FD /* SiteRatingPrivacyProtectionExtensionTests.swift in Sources */,

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -101,7 +101,7 @@ class AppConfigurationFetch {
         case newData
 
         var success: Bool {
-            self == .noData || self == .newData
+            self != .expired
         }
     }
     

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -256,6 +256,7 @@ class AppConfigurationFetch {
                           Keys.fgFetchNoData: String(store.foregroundNoDataCount),
                           Keys.fgFetchWithData: String(store.foregroundNewDataCount),
                           Keys.bgFetchType: backgroundFetchType,
+                          Keys.bgFetchTaskExpiration: String(store.backgroundFetchTaskExpirationCount),
                           Keys.bgFetchTaskDuration: String(Self.backgroundFetchTaskDuration),
                           Keys.fetchHTTPSBloomFilterSpec: String(downloadedHTTPSBloomFilterSpecCount),
                           Keys.fetchHTTPSBloomFilter: String(downloadedHTTPSBloomFilterCount),
@@ -289,6 +290,7 @@ class AppConfigurationFetch {
         store.foregroundStartCount = 0
         store.foregroundNoDataCount = 0
         store.foregroundNewDataCount = 0
+        store.backgroundFetchTaskExpirationCount = 0
 
         Self.backgroundFetchTaskDuration = 0
 

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -36,7 +36,6 @@ protocol AppConfigurationFetchStatistics {
     var backgroundFetchTaskExpirationCount: Int { get set }
 }
 
-// swiftlint:disable type_body_length
 class AppConfigurationFetch {
     
     private struct Constants {
@@ -301,7 +300,6 @@ class AppConfigurationFetch {
         downloadedTrackerDataSetCount = 0
     }
 }
-// swiftlint:enable type_body_length
 
 extension AppConfigurationFetch {
 

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -121,7 +121,7 @@ class AppConfigurationFetch {
 
         type(of: self).fetchQueue.async {
             let taskID = UIApplication.shared.beginBackgroundTask(withName: Constants.backgroundTaskName)
-            let newData = self.fetchConfigurationFiles(isBackground: isBackgroundFetch)
+            let fetchedNewData = self.fetchConfigurationFiles(isBackground: isBackgroundFetch)
 
             if !isBackgroundFetch {
                 type(of: self).fetchQueue.async {
@@ -133,7 +133,7 @@ class AppConfigurationFetch {
                 UIApplication.shared.endBackgroundTask(taskID)
             }
 
-            completion?(newData)
+            completion?(fetchedNewData)
         }
     }
 
@@ -362,13 +362,13 @@ extension AppConfigurationFetch {
         }
 
         queue.async {
-            let newData = configurationFetcher.fetchConfigurationFiles(isBackground: true)
+            let fetchedNewData = configurationFetcher.fetchConfigurationFiles(isBackground: true)
 
             DispatchQueue.main.async {
                 lastCompletionStatus = backgroundRefreshTaskCompletionHandler(store: store,
                                                                               refreshStartDate: refreshStartDate,
                                                                               task: task,
-                                                                              status: newData ? .newData : .noData,
+                                                                              status: fetchedNewData ? .newData : .noData,
                                                                               previousStatus: lastCompletionStatus)
             }
         }

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -352,21 +352,25 @@ extension AppConfigurationFetch {
             var mutableStore = store
             mutableStore.backgroundFetchTaskExpirationCount += 1
 
-            lastCompletionStatus = backgroundRefreshTaskCompletionHandler(store: store,
-                                                                          refreshStartDate: refreshStartDate,
-                                                                          task: task,
-                                                                          status: .expired,
-                                                                          previousStatus: lastCompletionStatus)
+            DispatchQueue.main.async {
+                lastCompletionStatus = backgroundRefreshTaskCompletionHandler(store: store,
+                                                                              refreshStartDate: refreshStartDate,
+                                                                              task: task,
+                                                                              status: .expired,
+                                                                              previousStatus: lastCompletionStatus)
+            }
         }
 
         queue.async {
             let newData = configurationFetcher.fetchConfigurationFiles(isBackground: true)
 
-            lastCompletionStatus = backgroundRefreshTaskCompletionHandler(store: store,
-                                                                          refreshStartDate: refreshStartDate,
-                                                                          task: task,
-                                                                          status: newData ? .newData : .noData,
-                                                                          previousStatus: lastCompletionStatus)
+            DispatchQueue.main.async {
+                lastCompletionStatus = backgroundRefreshTaskCompletionHandler(store: store,
+                                                                              refreshStartDate: refreshStartDate,
+                                                                              task: task,
+                                                                              status: newData ? .newData : .noData,
+                                                                              previousStatus: lastCompletionStatus)
+            }
         }
     }
 

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -46,7 +46,7 @@ public class AppUserDefaults: AppSettings {
         static let backgroundFetchNoDataCount = "com.duckduckgo.app.bgFetchNoDataCount"
         static let backgroundFetchNewDataCount = "com.duckduckgo.app.bgFetchNewDataCount"
 
-        static let backgroundFetchTaskExpirationCount = "backgroundFetchTaskExpirationCount"
+        static let backgroundFetchTaskExpirationCount = "com.duckduckgo.app.bgFetchTaskExpirationCount"
         
         static let notificationsEnabled = "com.duckduckgo.app.notificationsEnabled"
         static let allowUniversalLinks = "com.duckduckgo.app.allowUniversalLinks"

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -45,6 +45,8 @@ public class AppUserDefaults: AppSettings {
         static let backgroundFetchStartCount = "com.duckduckgo.app.bgFetchStartCount"
         static let backgroundFetchNoDataCount = "com.duckduckgo.app.bgFetchNoDataCount"
         static let backgroundFetchNewDataCount = "com.duckduckgo.app.bgFetchNewDataCount"
+
+        static let backgroundFetchTaskExpirationCount = "backgroundFetchTaskExpirationCount"
         
         static let notificationsEnabled = "com.duckduckgo.app.notificationsEnabled"
         static let allowUniversalLinks = "com.duckduckgo.app.allowUniversalLinks"
@@ -218,6 +220,15 @@ extension AppUserDefaults: AppConfigurationFetchStatistics {
         }
         set {
             userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchNewDataCount)
+        }
+    }
+
+    var backgroundFetchTaskExpirationCount: Int {
+        get {
+            return userDefaults?.integer(forKey: Keys.backgroundFetchTaskExpirationCount) ?? 0
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.backgroundFetchTaskExpirationCount)
         }
     }
 }

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -90,6 +90,30 @@ class AppConfigurationFetchTests: XCTestCase {
     }
 
     @available(iOS 13.0, *)
+    func testWhenTheCompletionHandlerTriesToUpdateStatisticsThenTheCountCannotBeNegative() {
+        let store = AppUserDefaults(groupName: testGroupName)
+        let task = MockBackgroundTask()
+
+        store.backgroundFetchTaskExpirationCount = 0
+        store.backgroundNoDataCount = 0
+        store.backgroundNewDataCount = 0
+
+        var previousStatus: AppConfigurationFetch.BackgroundRefreshCompletionStatus? = .expired
+
+        MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
+                                                                         refreshStartDate: Date(),
+                                                                         task: task,
+                                                                         status: .noData,
+                                                                         previousStatus: &previousStatus)
+
+        XCTAssertEqual(previousStatus, .noData)
+
+        XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
+        XCTAssertEqual(store.backgroundNoDataCount, 0)
+        XCTAssertEqual(store.backgroundNewDataCount, 0)
+    }
+
+    @available(iOS 13.0, *)
     private func assert(current: AppConfigurationFetch.BackgroundRefreshCompletionStatus,
                         previous: AppConfigurationFetch.BackgroundRefreshCompletionStatus?) {
 

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -89,8 +89,13 @@ class AppConfigurationFetchTests: XCTestCase {
         assert(current: .newData, previous: .newData)
     }
 
-    @available(iOS 13.0, *)
     func testWhenTheCompletionHandlerTriesToUpdateStatisticsThenTheCountCannotBeNegative() {
+
+        // Using @available at the function/class level still allowed these unit tests to run pre iOS 13, so a guard statement is used.
+        guard #available(iOS 13.0, *) else {
+            return
+        }
+
         let store = AppUserDefaults(groupName: testGroupName)
         let task = MockBackgroundTask()
 
@@ -109,11 +114,16 @@ class AppConfigurationFetchTests: XCTestCase {
         XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
         XCTAssertEqual(store.backgroundNoDataCount, 0)
         XCTAssertEqual(store.backgroundNewDataCount, 0)
+
     }
 
-    @available(iOS 13.0, *)
     private func assert(current: AppConfigurationFetch.BackgroundRefreshCompletionStatus,
                         previous: AppConfigurationFetch.BackgroundRefreshCompletionStatus?) {
+
+        // Using @available at the function/class level still allowed these unit tests to run pre iOS 13, so a guard statement is used.
+        guard #available(iOS 13.0, *) else {
+            return
+        }
 
         let store = AppUserDefaults(groupName: testGroupName)
         let task = MockBackgroundTask()
@@ -147,21 +157,26 @@ class AppConfigurationFetchTests: XCTestCase {
         XCTAssertEqual(store.backgroundFetchTaskExpirationCount, current == .expired ? 1 : 0)
         XCTAssertEqual(store.backgroundNoDataCount, current == .noData ? 1 : 0)
         XCTAssertEqual(store.backgroundNewDataCount, current == .newData ? 1 : 0)
+
     }
 }
 
 private class MockAppConfigurationFetch: AppConfigurationFetch {
+
     func fetchConfigurationFiles(isBackground: Bool) -> Bool {
         return true
     }
+
 }
 
 @available(iOS 13.0, *)
 private class MockBackgroundTask: BGTask {
+
     /// Used to instantiate background tasks, as `BGTask` marks its `init` unavailable.
     init(_ unusedValue: String? = nil) {}
 
     override func setTaskCompleted(success: Bool) {
         // no-op
     }
+
 }

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -98,13 +98,11 @@ class AppConfigurationFetchTests: XCTestCase {
         store.backgroundNoDataCount = 0
         store.backgroundNewDataCount = 0
 
-        var previousStatus: AppConfigurationFetch.BackgroundRefreshCompletionStatus? = .expired
-
         let newStatus = MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
                                                                                          refreshStartDate: Date(),
                                                                                          task: task,
                                                                                          status: .noData,
-                                                                                         previousStatus: previousStatus)
+                                                                                         previousStatus: .expired)
 
         XCTAssertEqual(newStatus, .noData)
 

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -100,13 +100,13 @@ class AppConfigurationFetchTests: XCTestCase {
 
         var previousStatus: AppConfigurationFetch.BackgroundRefreshCompletionStatus? = .expired
 
-        MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
-                                                                         refreshStartDate: Date(),
-                                                                         task: task,
-                                                                         status: .noData,
-                                                                         previousStatus: &previousStatus)
+        let newStatus = MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
+                                                                                         refreshStartDate: Date(),
+                                                                                         task: task,
+                                                                                         status: .noData,
+                                                                                         previousStatus: previousStatus)
 
-        XCTAssertEqual(previousStatus, .noData)
+        XCTAssertEqual(newStatus, .noData)
 
         XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
         XCTAssertEqual(store.backgroundNoDataCount, 0)
@@ -138,15 +138,13 @@ class AppConfigurationFetchTests: XCTestCase {
         updateStore(current)
         updateStore(previous)
 
-        var previousStatus: AppConfigurationFetch.BackgroundRefreshCompletionStatus? = previous
+        let newStatus = MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
+                                                                                         refreshStartDate: Date(),
+                                                                                         task: task,
+                                                                                         status: current,
+                                                                                         previousStatus: previous)
 
-        MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
-                                                                         refreshStartDate: Date(),
-                                                                         task: task,
-                                                                         status: current,
-                                                                         previousStatus: &previousStatus)
-
-        XCTAssertEqual(previousStatus, current)
+        XCTAssertEqual(newStatus, current)
 
         XCTAssertEqual(store.backgroundFetchTaskExpirationCount, current == .expired ? 1 : 0)
         XCTAssertEqual(store.backgroundNoDataCount, current == .noData ? 1 : 0)

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -1,0 +1,161 @@
+//
+//  AppConfigurationFetchTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import BackgroundTasks
+@testable import DuckDuckGo
+
+class AppConfigurationFetchTests: XCTestCase {
+
+    let testGroupName = "configurationFetchTestGroup"
+
+    override func setUp() {
+        UserDefaults(suiteName: testGroupName)?.removePersistentDomain(forName: testGroupName)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_expired_noPreviousStatus() {
+        assert(current: .expired, previous: nil)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_expired_previouslyExpired() {
+        assert(current: .expired, previous: .expired)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_expired_previouslySucceededWithNoData() {
+        assert(current: .expired, previous: .noData)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_expired_previouslySucceededWithNewData() {
+        assert(current: .expired, previous: .newData)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_noData_noPreviousStatus() {
+        assert(current: .noData, previous: nil)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_noData_previouslyExpired() {
+        assert(current: .noData, previous: .expired)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_noData_previouslySucceededWithNoData() {
+        assert(current: .noData, previous: .noData)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_noData_previouslySucceededWithNewData() {
+        assert(current: .noData, previous: .newData)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_newData_noPreviousStatus() {
+        assert(current: .newData, previous: nil)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_newData_previouslyExpired() {
+        assert(current: .newData, previous: .expired)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_newData_previouslySucceededWithNoData() {
+        assert(current: .newData, previous: .noData)
+    }
+
+    @available(iOS 13.0, *)
+    func testBackgroundRefreshCompletionHandler_newData_previouslySucceededWithNewData() {
+        assert(current: .newData, previous: .newData)
+    }
+
+    @available(iOS 13.0, *)
+    private func assert(current: AppConfigurationFetch.BackgroundRefreshCompletionStatus,
+                        previous: AppConfigurationFetch.BackgroundRefreshCompletionStatus?) {
+
+        let store = AppUserDefaults(groupName: testGroupName)
+        let task = MockBackgroundTask()
+
+        // Set up the counts for the current and previous statuses. The completion handler expects that the statistic counts have already been
+        // updated before completion.
+        switch current {
+        case .expired:
+            store.backgroundFetchTaskExpirationCount += 1
+        case .noData:
+            store.backgroundNoDataCount += 1
+        case .newData:
+            store.backgroundNewDataCount += 1
+        }
+
+        switch previous {
+        case .expired:
+            store.backgroundFetchTaskExpirationCount += 1
+        case .noData:
+            store.backgroundNoDataCount += 1
+        case .newData:
+            store.backgroundNewDataCount += 1
+        case .none: break
+        }
+
+        var previousStatus: AppConfigurationFetch.BackgroundRefreshCompletionStatus? = previous
+
+        MockAppConfigurationFetch.backgroundRefreshTaskCompletionHandler(store: store,
+                                                                         refreshStartDate: Date(),
+                                                                         task: task,
+                                                                         status: current,
+                                                                         previousStatus: &previousStatus)
+
+        XCTAssertEqual(previousStatus, current)
+
+        switch current {
+        case .expired:
+            XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 1)
+            XCTAssertEqual(store.backgroundNoDataCount, 0)
+            XCTAssertEqual(store.backgroundNewDataCount, 0)
+        case .noData:
+            XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
+            XCTAssertEqual(store.backgroundNoDataCount, 1)
+            XCTAssertEqual(store.backgroundNewDataCount, 0)
+        case .newData:
+            XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
+            XCTAssertEqual(store.backgroundNoDataCount, 0)
+            XCTAssertEqual(store.backgroundNewDataCount, 1)
+        }
+    }
+}
+
+private class MockAppConfigurationFetch: AppConfigurationFetch {
+    func fetchConfigurationFiles(isBackground: Bool) -> Bool {
+        return true
+    }
+}
+
+@available(iOS 13.0, *)
+private class MockBackgroundTask: BGTask {
+    /// Used to instantiate background tasks, as `BGTask` marks its `init` unavailable.
+    init(_ unusedValue: String? = nil) {}
+
+    override func setTaskCompleted(success: Bool) {
+        // no-op
+    }
+}

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -96,26 +96,23 @@ class AppConfigurationFetchTests: XCTestCase {
         let store = AppUserDefaults(groupName: testGroupName)
         let task = MockBackgroundTask()
 
-        // Set up the counts for the current and previous statuses. The completion handler expects that the statistic counts have already been
-        // updated before completion.
-        switch current {
-        case .expired:
-            store.backgroundFetchTaskExpirationCount += 1
-        case .noData:
-            store.backgroundNoDataCount += 1
-        case .newData:
-            store.backgroundNewDataCount += 1
+        let updateStore: (AppConfigurationFetch.BackgroundRefreshCompletionStatus?) -> Void = { status in
+            switch status {
+            case .expired:
+                store.backgroundFetchTaskExpirationCount += 1
+            case .noData:
+                store.backgroundNoDataCount += 1
+            case .newData:
+                store.backgroundNewDataCount += 1
+            case .none: break
+            }
         }
 
-        switch previous {
-        case .expired:
-            store.backgroundFetchTaskExpirationCount += 1
-        case .noData:
-            store.backgroundNoDataCount += 1
-        case .newData:
-            store.backgroundNewDataCount += 1
-        case .none: break
-        }
+        // Set up the counts for the current and previous statuses. The completion handler expects that the statistic counts have already been
+        // updated before completion.
+
+        updateStore(current)
+        updateStore(previous)
 
         var previousStatus: AppConfigurationFetch.BackgroundRefreshCompletionStatus? = previous
 
@@ -127,20 +124,9 @@ class AppConfigurationFetchTests: XCTestCase {
 
         XCTAssertEqual(previousStatus, current)
 
-        switch current {
-        case .expired:
-            XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 1)
-            XCTAssertEqual(store.backgroundNoDataCount, 0)
-            XCTAssertEqual(store.backgroundNewDataCount, 0)
-        case .noData:
-            XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
-            XCTAssertEqual(store.backgroundNoDataCount, 1)
-            XCTAssertEqual(store.backgroundNewDataCount, 0)
-        case .newData:
-            XCTAssertEqual(store.backgroundFetchTaskExpirationCount, 0)
-            XCTAssertEqual(store.backgroundNoDataCount, 0)
-            XCTAssertEqual(store.backgroundNewDataCount, 1)
-        }
+        XCTAssertEqual(store.backgroundFetchTaskExpirationCount, current == .expired ? 1 : 0)
+        XCTAssertEqual(store.backgroundNoDataCount, current == .noData ? 1 : 0)
+        XCTAssertEqual(store.backgroundNewDataCount, current == .newData ? 1 : 0)
     }
 }
 

--- a/DuckDuckGoTests/AppConfigurationFetchTests.swift
+++ b/DuckDuckGoTests/AppConfigurationFetchTests.swift
@@ -29,6 +29,12 @@ class AppConfigurationFetchTests: XCTestCase {
         UserDefaults(suiteName: testGroupName)?.removePersistentDomain(forName: testGroupName)
     }
 
+    func testBackgroundRefreshCompletionStatusSuccess() {
+        XCTAssertFalse(AppConfigurationFetch.BackgroundRefreshCompletionStatus.expired.success)
+        XCTAssertTrue(AppConfigurationFetch.BackgroundRefreshCompletionStatus.noData.success)
+        XCTAssertTrue(AppConfigurationFetch.BackgroundRefreshCompletionStatus.newData.success)
+    }
+
     // MARK: - Test Expired
 
     @available(iOS 13.0, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199333091098016/1199644311779247
CC: @bwaresiak 

**Description**:

This PR introduces a mechanism which checks whether a background task's completion handler has been called previously, and corrects the background refresh metrics if so.

**Steps to test this PR**:
1. Test the background refresh flow on a device through Xcode and verify that the typical flows work as expected; there are instructions inside `AppConfigurationFetch` for manually triggering background tasks

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

