### PR TITLE
Enable GPC header adding for select sites

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -47,6 +47,11 @@ public struct AppUrls {
         
         static let pixelBase = ProcessInfo.processInfo.environment["PIXEL_BASE_URL", default: "https://improving.duckduckgo.com"]
         static let pixel = "\(pixelBase)/t/%@"
+        
+        static let gpcGlitchBase = "http://global-privacy-control.glitch.me"
+        static let washingtonPostBase = "https://washingtonpost.com"
+        static let newYorkTimesBase = "https://nytimes.com"
+        static let gpcEnabled = [gpcGlitchBase, washingtonPostBase, newYorkTimesBase]
     }
     
     private enum DDGStaticURL: String {
@@ -130,6 +135,12 @@ public struct AppUrls {
             .addParam(name: Param.atb, value: atbWithVariant)
             .addParam(name: Param.setAtb, value: setAtb)
     }
+    
+    private var gpcEnabledURLs: [URL] {
+        return Url.gpcEnabled.map {
+            URL(string: $0)!
+        }
+    }
 
     public func isDuckDuckGo(domain: String?) -> Bool {
         guard let domain = domain, let url = URL(string: "https://\(domain)") else { return false }
@@ -191,6 +202,16 @@ public struct AppUrls {
         if !isDuckDuckGo(url: url) { return false }
         guard DDGStaticURL(rawValue: url.path) != nil else { return false }
         return true
+    }
+    
+    public func isGPCEnabled(url: URL) -> Bool {
+        for gpcURL in gpcEnabledURLs {
+            if let host = gpcURL.host,
+               url.isPart(ofDomain: host) {
+                return true
+            }
+        }
+        return false
     }
 
     public func applyStatsParams(for url: URL) -> URL {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1023,7 +1023,9 @@ extension TabViewController: WKNavigationDelegate {
     
     private func requestForDoNotSell(basedOn incomingRequest: URLRequest) -> URLRequest? {
         /*
-         For now, the GPC header is only applied to sites known to be honoring GPC (nytimes.com, washingtonpost.com), while the DOM signal is available to all websites. This is done to avoid an issue with back navigation when adding the header (e.g. with 't.co').
+         For now, the GPC header is only applied to sites known to be honoring GPC (nytimes.com, washingtonpost.com),
+         while the DOM signal is available to all websites.
+         This is done to avoid an issue with back navigation when adding the header (e.g. with 't.co').
          */
         guard let url = incomingRequest.url, appUrls.isGPCEnabled(url: url) else { return nil }
         

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1048,7 +1048,7 @@ extension TabViewController: WKNavigationDelegate {
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         
         if navigationAction.isTargetingMainFrame(),
-           !(navigationAction.request.url?.isCustomURLScheme() ?? false), // https://github.com/duckduckgo/iOS/pull/739/files
+           !(navigationAction.request.url?.isCustomURLScheme() ?? false),
            navigationAction.navigationType != .backForward,
            let request = requestForDoNotSell(basedOn: navigationAction.request) {
             

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -31,6 +31,8 @@ class TabViewController: UIViewController {
         static let frameLoadInterruptedErrorCode = 102
         
         static let trackerNetworksAnimationDelay: TimeInterval = 0.7
+        
+        static let secGPCHeader = "Sec-GPC"
     }
     
     @IBOutlet private(set) weak var error: UIView!
@@ -1022,10 +1024,43 @@ extension TabViewController: WKNavigationDelegate {
         detectedNewNavigation()
         checkLoginDetectionAfterNavigation()
     }
+    
+    private func requestForDoNotSell(basedOn incomingRequest: URLRequest) -> URLRequest? {
+        // For now, only enable for select sites, due to an issue with back navigation this can introduce
+        guard let url = incomingRequest.url, appUrls.isGPCEnabled(url: url) else { return nil }
+        
+        var request = incomingRequest
+        // Add Do Not sell header if needed
+        if appSettings.sendDoNotSell {
+            if let headers = request.allHTTPHeaderFields,
+               headers.firstIndex(where: { $0.key == Constants.secGPCHeader }) == nil {
+                request.addValue("1", forHTTPHeaderField: Constants.secGPCHeader)
+                return request
+            }
+        } else {
+            // Check if DN$ header is still there and remove it
+            if let headers = request.allHTTPHeaderFields, headers.firstIndex(where: { $0.key == Constants.secGPCHeader }) != nil {
+                request.setValue(nil, forHTTPHeaderField: Constants.secGPCHeader)
+                return request
+            }
+        }
+        return nil
+    }
             
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        
+        if navigationAction.isTargetingMainFrame(),
+           !(navigationAction.request.url?.isCustomURLScheme() ?? false), // https://github.com/duckduckgo/iOS/pull/739/files
+           lastCommittedURL != navigationAction.request.url,
+           navigationAction.navigationType != .backForward,
+           let request = requestForDoNotSell(basedOn: navigationAction.request) {
+            
+            decisionHandler(.cancel)
+            load(urlRequest: request)
+            return
+        }
 
         if navigationAction.navigationType == .linkActivated,
            let url = navigationAction.request.url,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -107,8 +107,6 @@ class TabViewController: UIViewController {
             checkLoginDetectionAfterNavigation()
         }
     }
-
-    private var lastCommittedURL: URL?
     
     override var title: String? {
         didSet {
@@ -508,7 +506,6 @@ class TabViewController: UIViewController {
     }
     
     private func reloadUserScripts() {
-        lastCommittedURL = nil
         removeMessageHandlers() // incoming config might be a copy of an existing confg with handlers
         webView.configuration.userContentController.removeAllUserScripts()
         
@@ -817,7 +814,6 @@ extension TabViewController: WKNavigationDelegate {
             instrumentation.willLoad(url: url)
         }
                 
-        lastCommittedURL = webView.url
         url = webView.url
         let tld = storageCache.tld
         let httpsForced = tld.domain(lastUpgradedURL?.host) == tld.domain(webView.url?.host)
@@ -1053,7 +1049,6 @@ extension TabViewController: WKNavigationDelegate {
         
         if navigationAction.isTargetingMainFrame(),
            !(navigationAction.request.url?.isCustomURLScheme() ?? false), // https://github.com/duckduckgo/iOS/pull/739/files
-           lastCommittedURL != navigationAction.request.url,
            navigationAction.navigationType != .backForward,
            let request = requestForDoNotSell(basedOn: navigationAction.request) {
             
@@ -1318,7 +1313,6 @@ extension TabViewController: UIGestureRecognizerDelegate {
 
     func refresh() {
         requeryLogic.onRefresh()
-        lastCommittedURL = nil
         if isError {
             if let url = URL(string: chromeDelegate?.omniBar.textField.text ?? "") {
                 load(url: url)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1022,7 +1022,9 @@ extension TabViewController: WKNavigationDelegate {
     }
     
     private func requestForDoNotSell(basedOn incomingRequest: URLRequest) -> URLRequest? {
-        // For now, only enable for select sites, due to an issue with back navigation this can introduce
+        /*
+         For now, the GPC header is only applied to sites known to be honoring GPC (nytimes.com, washingtonpost.com), while the DOM signal is available to all websites. This is done to avoid an issue with back navigation when adding the header (e.g. with 't.co').
+         */
         guard let url = incomingRequest.url, appUrls.isGPCEnabled(url: url) else { return nil }
         
         var request = incomingRequest

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -143,7 +143,43 @@ class AppUrlsTests: XCTestCase {
         let result = testee.isDuckDuckGo(url: URL(string: "http://www.duckduckgo.com")!)
         XCTAssertTrue(result)
     }
-
+    
+    func testWhenGPCEnableDomainIsHttpThenISGPCEnabledTrue() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.isGPCEnabled(url: URL(string: "https://www.washingtonpost.com")!)
+        XCTAssertTrue(result)
+    }
+    
+    func testWhenGPCEnableDomainIsHttpsThenISGPCEnabledTrue() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.isGPCEnabled(url: URL(string: "http://www.washingtonpost.com")!)
+        XCTAssertTrue(result)
+    }
+    
+    func testWhenGPCEnableDomainHasNoSubDomainThenISGPCEnabledTrue() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.isGPCEnabled(url: URL(string: "http://washingtonpost.com")!)
+        XCTAssertTrue(result)
+    }
+    
+    func testWhenGPCEnableDomainHasPathThenISGPCEnabledTrue() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.isGPCEnabled(url: URL(string: "http://www.washingtonpost.com/test/somearticle.html")!)
+        XCTAssertTrue(result)
+    }
+    
+    func testWhenGPCEnableDomainHasCorrectSubdomainThenISGPCEnabledTrue() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.isGPCEnabled(url: URL(string: "http://global-privacy-control.glitch.me")!)
+        XCTAssertTrue(result)
+    }
+    
+    func testWhenGPCEnableDomainHasWrongSubdomainThenISGPCEnabledFalse() {
+        let testee = AppUrls(statisticsStore: mockStatisticsStore)
+        let result = testee.isGPCEnabled(url: URL(string: "http://glitch.me")!)
+        XCTAssertFalse(result)
+    }
+    
     func testAutocompleteUrlCreatesCorrectUrlWithParams() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
         let actual = testee.autocompleteUrl(forText: "a term")

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -20,6 +20,7 @@
 import XCTest
 @testable import Core
 
+// swiftlint:disable type_body_length
 class AppUrlsTests: XCTestCase {
 
     var mockStatisticsStore: MockStatisticsStore!
@@ -313,3 +314,4 @@ class AppUrlsTests: XCTestCase {
         XCTAssertNil(result)
     }
 }
+// swiftlint:enable type_body_length


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1199654549449490/f
Tech Design URL:
CC: @brindy 

**Description**:
Due to an issue with back navigation with Twitter redirects, we disabled our GPC header injection. This adds it back, but only for select sites that support it. This should minimise the effect of the twitter issue, whilst still sending the header to sites that actually support it

**Steps to test this PR**:
1. Navigate to http://global-privacy-control.glitch.me, and check that it says the header is present
2. Manually inspect the webview via safari and check the header is included in the main document request when visiting any NYTimes or Washington Post page.
3. Do the same for any other site besides the three above and check the header isn't present in the request
4. Go to Twitter, and test that when clicking links on twitter to sites other than NYTimes or Washington Post that the back button navigation doesn't have a blank t.co page on the stack
5. Go to settings and turn off the "Global Privacy Control" setting. Ensure the header isn't sent to any site

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

