### PR TITLE
cancel show keyboard when favorite launched from home screen

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -103,6 +103,7 @@ class MainViewController: UIViewController {
     }
 
     var keyModifierFlags: UIKeyModifierFlags?
+    var showKeyboardAfterFireButton: DispatchWorkItem?
     
     // Skip SERP flow (focusing on autocomplete logic) and prepare for new navigation when selecting search bar
     private var skipSERPFlow = true
@@ -1080,7 +1081,8 @@ extension MainViewController: HomeControllerDelegate {
     }
 
     func home(_ home: HomeViewController, didRequestUrl url: URL) {
-       loadUrl(url)
+        showKeyboardAfterFireButton?.cancel()
+        loadUrl(url)
     }
     
     func home(_ home: HomeViewController, didRequestContentOverflow shouldOverflow: Bool) -> CGFloat {
@@ -1376,9 +1378,11 @@ extension MainViewController: AutoClearWorker {
         } completion: {
             Instruments.shared.endTimedEvent(for: spid)
             if KeyboardSettings().onNewTab {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                let showKeyboardAfterFireButton = DispatchWorkItem {
                     self.enterSearch()
                 }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: showKeyboardAfterFireButton)
+                self.showKeyboardAfterFireButton = showKeyboardAfterFireButton
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199613512009688
Tech Design URL:
CC:

**Description**:

Cancel showing keyboard when favorite launched from home screen.

**Steps to test this PR**:
1. Create a favorite
1. Enable "new tab" under Keyboard in settings
1. Use the fire button and wait
1. The keyboard should launch
1. Press cancel
1. Use the fire button but quickly tap the favorite
1. The page should load but the keyboard should not be launched

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

