### PR TITLE
Revert iOS app CSS injection

### DIFF
--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -36,7 +36,6 @@ extension WKWebViewConfiguration {
         }
         configuration.dataDetectorTypes = [.link, .phoneNumber]
 
-        configuration.installHideAtbModals()
         configuration.installContentBlockingRules()
 
         configuration.allowsAirPlayForMediaPlayback = true
@@ -45,28 +44,6 @@ extension WKWebViewConfiguration {
         configuration.ignoresViewportScaleLimits = true
 
         return configuration
-    }
-
-    private func installHideAtbModals() {
-        guard let store = WKContentRuleListStore.default() else { return }
-        let rules = """
-        [
-          {
-            "trigger": {
-              "url-filter": ".*",
-              "if-domain": ["*duckduckgo.com"]
-            },
-            "action": {
-              "type": "css-display-none",
-              "selector": ".ddg-extension-hide"
-            }
-          }
-        ]
-        """
-        store.compileContentRuleList(forIdentifier: "hide-extension-css", encodedContentRuleList: rules) { rulesList, _ in
-            guard let rulesList = rulesList else { return }
-            self.userContentController.add(rulesList)
-        }
     }
     
     private func installContentBlockingRules() {
@@ -87,7 +64,6 @@ extension WKWebViewConfiguration {
     }
     
     public func installContentRules(trackerProtection: Bool) {
-        self.installHideAtbModals()
         if trackerProtection {
             self.installContentBlockingRules()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1166471018013617/f
Tech Design URL: N/A
CC: @brindy 

**Description**:
This PR reverts previous logic setup to hide ATB modals. This logic is now handled on the front end.

**Steps to test this PR**:
1. Visit/search on duckduckgo.com
1. No modals appear

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->
**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

