### PR TITLE
override lookup and open a new tab instead

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		85F2FFCF2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F2FFCE2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift */; };
 		85F2FFFD2215C020006BB258 /* findinpage.js in Resources */ = {isa = PBXBuildFile; fileRef = 85F2FFFC2215C020006BB258 /* findinpage.js */; };
 		85F45B2A1F875DFF00DB1978 /* ContentBlockerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F45B291F875DFF00DB1978 /* ContentBlockerRequest.swift */; };
+		85F6266325CE0E73006C0E7A /* DDGWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F6266225CE0E73006C0E7A /* DDGWebView.swift */; };
 		8C4724502217A14B004C9B2D /* TabViewControllerLongPressBookmarkExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C47244F2217A14B004C9B2D /* TabViewControllerLongPressBookmarkExtension.swift */; };
 		8C4838B5221C8F7F008A6739 /* GestureToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4838B4221C8F7F008A6739 /* GestureToolbarButton.swift */; };
 		980891A222369ADB00313A70 /* FeedbackUserText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980891A122369ADB00313A70 /* FeedbackUserText.swift */; };
@@ -996,6 +997,7 @@
 		85F2FFFC2215C020006BB258 /* findinpage.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = findinpage.js; path = "submodules/ios-js-support/src/findinpage.js"; sourceTree = SOURCE_ROOT; };
 		85F2FFFF2215C17B006BB258 /* FindInPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindInPage.swift; sourceTree = "<group>"; };
 		85F45B291F875DFF00DB1978 /* ContentBlockerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerRequest.swift; sourceTree = "<group>"; };
+		85F6266225CE0E73006C0E7A /* DDGWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDGWebView.swift; sourceTree = "<group>"; };
 		8C47244F2217A14B004C9B2D /* TabViewControllerLongPressBookmarkExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerLongPressBookmarkExtension.swift; sourceTree = "<group>"; };
 		8C4838B4221C8F7F008A6739 /* GestureToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureToolbarButton.swift; sourceTree = "<group>"; };
 		98056C77251EABC000298AF6 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -3223,6 +3225,7 @@
 				8540BBA12440857A00017FE4 /* PreserveLoginsWorker.swift */,
 				8548D95D25262B1B005AAE49 /* ViewHighlighter.swift */,
 				8548D96725262C33005AAE49 /* view_highlight.json */,
+				85F6266225CE0E73006C0E7A /* DDGWebView.swift */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -4723,6 +4726,7 @@
 				9820EAF522613CD30089094D /* WebProgressWorker.swift in Sources */,
 				F1C4A70E1E57725800A6CA1B /* OmniBar.swift in Sources */,
 				8565A3431FC5995900239327 /* PrivacyProtectionTrackerNetworksController.swift in Sources */,
+				85F6266325CE0E73006C0E7A /* DDGWebView.swift in Sources */,
 				9872D205247DCAC100CEF398 /* TabPreviewsSource.swift in Sources */,
 				F130D73A1E5776C500C45811 /* OmniBarDelegate.swift in Sources */,
 				85DFEDEF24C7EA3B00973FE7 /* SmallOmniBarState.swift in Sources */,

--- a/DuckDuckGo/DDGWebView.swift
+++ b/DuckDuckGo/DDGWebView.swift
@@ -1,0 +1,43 @@
+//
+//  DDGWebView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+
+class DDGWebView: WKWebView {
+
+    weak var ddgWebViewDelegate: DDGWebViewDelegate?
+
+    // swiftlint:disable identifier_name
+    @IBAction func _lookup(_ sender: Any?) {
+        print("***", #function, sender)
+        evaluateJavaScript("window.getSelection().toString()") { [weak self] result, _ in
+            guard let self = self,
+                  let text = result as? String else { return }
+            self.ddgWebViewDelegate?.webView(self, didRequestLookupText: text)
+        }
+    }
+    // swiftlint:enable identifier_name
+
+}
+
+protocol DDGWebViewDelegate: AnyObject {
+
+    func webView(_ webView: WKWebView, didRequestLookupText text: String)
+
+}

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -65,7 +65,7 @@ class TabViewController: UIViewController {
     
     let progressWorker = WebProgressWorker()
 
-    private(set) var webView: WKWebView!
+    private(set) var webView: DDGWebView!
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt()
     private weak var privacyController: PrivacyProtectionController?
     
@@ -275,7 +275,7 @@ class TabViewController: UIViewController {
 
     func attachWebView(configuration: WKWebViewConfiguration, andLoadRequest request: URLRequest?, consumeCookies: Bool) {
         instrumentation.willPrepareWebView()
-        webView = WKWebView(frame: view.bounds, configuration: configuration)
+        webView = DDGWebView(frame: view.bounds, configuration: configuration)
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         
         if #available(iOS 13, *) {
@@ -292,6 +292,7 @@ class TabViewController: UIViewController {
         
         webView.navigationDelegate = self
         webView.uiDelegate = self
+        webView.ddgWebViewDelegate = self
         webViewContainer.addSubview(webView)
 
         reloadUserScripts()
@@ -1245,6 +1246,14 @@ extension TabViewController: PrivacyProtectionDelegate {
     func omniBarTextTapped() {
         chromeDelegate?.omniBar.becomeFirstResponder()
     }
+}
+
+extension TabViewController: DDGWebViewDelegate {
+
+    func webView(_ webView: WKWebView, didRequestLookupText text: String) {
+        delegate?.tab(self, didRequestNewTabForUrl: appUrls.url(forQuery: text), openedByPage: true)
+    }
+
 }
 
 extension TabViewController: WKUIDelegate {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1199890390771052
Tech Design URL:
CC:

**Description**:

Override "lookup" in the menu that pops up when long pressing a text selection and do a search in a new tab instead.

**Steps to test this PR**:
1. Open a page
1. Select some text
1. Select lookup from the popup menu
1. New tab should open with selected text as the search

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

