### PR TITLE
Fix OmniBar horizontal padding in landscape mode

### DIFF
--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -60,6 +60,7 @@ class OmniBar: UIView {
     weak var omniDelegate: OmniBarDelegate?
     fileprivate var state: OmniBarState = SmallOmniBarState.HomeNonEditingState()
     private lazy var appUrls: AppUrls = AppUrls()
+    private var safeAreaInsetsObservation: NSKeyValueObservation?
     
     private(set) var trackersAnimator = TrackersAnimator()
     
@@ -78,6 +79,13 @@ class OmniBar: UIView {
         configureEditingMenu()
         refreshState(state)
         enableInteractionsWithPointer()
+        observeSafeAreaInsets()
+    }
+    
+    private func observeSafeAreaInsets() {
+        safeAreaInsetsObservation = self.observe(\.safeAreaInsets, options: .new) { [weak self] (_, _) in
+            self?.updateOmniBarPadding()
+        }
     }
     
     private func enableInteractionsWithPointer() {
@@ -214,12 +222,16 @@ class OmniBar: UIView {
         searchContainerMaxWidthConstraint.isActive = state.hasLargeWidth
         leftButtonsSpacingConstraint.constant = state.hasLargeWidth ? 24 : 0
         rightButtonsSpacingConstraint.constant = state.hasLargeWidth ? 24 : 14
-        omniBarLeadingConstraint.constant = state.hasLargeWidth ? 24 : 8
-        omniBarTrailingConstraint.constant = state.hasLargeWidth ? 24 : 14
 
+        updateOmniBarPadding()
         updateSearchBarBorder()
     }
 
+    private func updateOmniBarPadding() {
+        omniBarLeadingConstraint.constant = (state.hasLargeWidth ? 24 : 8) + safeAreaInsets.left
+        omniBarTrailingConstraint.constant = (state.hasLargeWidth ? 24 : 14) + safeAreaInsets.right
+    }
+    
     private func updateSearchBarBorder() {
         let theme = ThemeManager.shared.currentTheme
         if state.showBackground {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #788 
Tech Design URL:
CC:

**Description**:
Takes the safe area of the view into account when calculating leading & trailing constraints of OmniBar. Fixes duckduckgo/iOS#788

Before:
![Screenshot 2021-02-10 at 22 44 37](https://user-images.githubusercontent.com/1329970/107570130-cc12b300-6bf1-11eb-8f90-0c01055fc1b9.png)

After:
![Screenshot 2021-02-10 at 22 15 14](https://user-images.githubusercontent.com/1329970/107570161-d6cd4800-6bf1-11eb-82b9-5d0b44a2c81c.png)

**Steps to test this PR**:

- Ensure that the address bar has appropriately large horizontal padding when running on:
  - small screen devices with rounded corners in landscape mode
- Ensure that the address bar layout is the same as before when running on:
  - small screen devices with rounded corners in portrait mode
  - large screen devices
  - devices without rounded corners

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone 8
* [x] iPhone X
* [x] iPad
* [x] iPad Pro (11 inch)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

