### PR TITLE
sync the currently set user interface style to the selected app theme

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -67,8 +67,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
-        updateUserInterfaceStyle()
-
         DispatchQueue.global(qos: .background).async {
             ContentBlockerStringCache.removeLegacyData()
         }
@@ -106,7 +104,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func updateUserInterfaceStyle() {
         guard #available(iOS 13.0, *) else { return }
-        switch ThemeManager.shared.currentTheme.name {
+        switch AppUserDefaults().currentThemeName {
 
         case .dark:
             window?.overrideUserInterfaceStyle = .dark
@@ -131,7 +129,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
-        
+
         if !(overlayWindow?.rootViewController is AuthenticationViewController) {
             removeOverlay()
         }
@@ -218,6 +216,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
+        updateUserInterfaceStyle()
+
         beginAuthentication()
         autoClear?.applicationWillMoveToForeground()
         showKeyboardIfSettingOn = true

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -67,6 +67,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
+        updateUserInterfaceStyle()
+
         DispatchQueue.global(qos: .background).async {
             ContentBlockerStringCache.removeLegacyData()
         }
@@ -100,6 +102,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         appIsLaunching = true
         return true
+    }
+
+    func updateUserInterfaceStyle() {
+        guard #available(iOS 13.0, *) else { return }
+        switch ThemeManager.shared.currentTheme.name {
+
+        case .dark:
+            window?.overrideUserInterfaceStyle = .dark
+
+        case .light:
+            window?.overrideUserInterfaceStyle = .light
+
+        default:
+            window?.overrideUserInterfaceStyle = .unspecified
+
+        }
     }
 
     private func clearLegacyAllowedDomainCookies() {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -102,22 +102,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func updateUserInterfaceStyle() {
-        guard #available(iOS 13.0, *) else { return }
-        switch AppUserDefaults().currentThemeName {
-
-        case .dark:
-            window?.overrideUserInterfaceStyle = .dark
-
-        case .light:
-            window?.overrideUserInterfaceStyle = .light
-
-        default:
-            window?.overrideUserInterfaceStyle = .unspecified
-
-        }
-    }
-
     private func clearLegacyAllowedDomainCookies() {
         let domains = PreserveLogins.shared.legacyAllowedDomains
         guard !domains.isEmpty else { return }
@@ -216,7 +200,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        updateUserInterfaceStyle()
+        ThemeManager.shared.updateUserInterfaceStyle()
 
         beginAuthentication()
         autoClear?.applicationWillMoveToForeground()

--- a/DuckDuckGo/ThemeManager.swift
+++ b/DuckDuckGo/ThemeManager.swift
@@ -100,5 +100,21 @@ class ThemeManager {
             currentTheme = systemTheme
         }
     }
-    
+
+    func updateUserInterfaceStyle(window: UIWindow? = UIApplication.shared.keyWindow) {
+        guard #available(iOS 13.0, *) else { return }
+        switch appSettings.currentThemeName {
+
+        case .dark:
+            window?.overrideUserInterfaceStyle = .dark
+
+        case .light:
+            window?.overrideUserInterfaceStyle = .light
+
+        default:
+            window?.overrideUserInterfaceStyle = .unspecified
+
+        }
+    }
+
 }

--- a/DuckDuckGo/ThemeSettingsViewController.swift
+++ b/DuckDuckGo/ThemeSettingsViewController.swift
@@ -79,6 +79,8 @@ class ThemeSettingsViewController: UITableViewController {
         appSettings.currentThemeName = theme
 
         ThemeManager.shared.enableTheme(with: theme)
+
+        (UIApplication.shared.delegate as? AppDelegate)?.updateUserInterfaceStyle()
     }
 }
 

--- a/DuckDuckGo/ThemeSettingsViewController.swift
+++ b/DuckDuckGo/ThemeSettingsViewController.swift
@@ -80,7 +80,7 @@ class ThemeSettingsViewController: UITableViewController {
 
         ThemeManager.shared.enableTheme(with: theme)
 
-        (UIApplication.shared.delegate as? AppDelegate)?.updateUserInterfaceStyle()
+        ThemeManager.shared.updateUserInterfaceStyle()
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199923842924964
Tech Design URL:
CC:

**Description**:

If the user selects light or dark mode in our app then the web view still selects the system selection, and can cause some dissonance for the user.

**Steps to test this PR**:
1. Load the SERP - it will match the current system theme.
1. Change the in-app theme to `dark`, the SERP will automatically reflect the setting
1. Change the in-app theme to `light`, the SERP will automatically reflect the setting
1. Change the in-app theme to `system`, the SERP will automatically reflect the setting
1. Change the system theme to a different color, the SERP will automatically reflect the setting

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [x] iOS 13
* [x] iOS 14

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)

