### PR TITLE
Fix potential memory leak in BloomFilterWrapper

### DIFF
--- a/Core/BloomFilterWrapper.h
+++ b/Core/BloomFilterWrapper.h
@@ -21,6 +21,7 @@
 @interface BloomFilterWrapper : NSObject
 - (instancetype)initFromPath:(NSString*)path withBitCount:(int)bitCount andTotalItems:(int)totalItems;
 - (instancetype)initWithTotalItems:(int)count errorRate:(double)errorRate;
+- (void)dealloc;
 - (void)add:(NSString*) entry;
 - (BOOL)contains:(NSString*) entry;
 @end

--- a/Core/BloomFilterWrapper.mm
+++ b/Core/BloomFilterWrapper.mm
@@ -44,6 +44,10 @@
     return self;
 }
 
+- (void)dealloc {
+	delete filter;
+}
+
 - (void)add:(NSString*)entry {
     if (filter != nil) {
         filter->add([entry UTF8String]);


### PR DESCRIPTION
**Description**:

As best I can tell, this is mostly theoretical
at this point---the BloomFilterWrapper is currently
retained for the lifetime of the program. If this
ever were *not* the case, though, we'd be leaking
the allocated BloomFilter object without a `delete`
corresponding to its `new`.

**Steps to test this PR**:

You can observe the leak in the test suite, which
*does* create temporary `BloomFilterWrapper`s: just
add a destructor to BloomFilter.hpp in the submodule
like this:

    ~BloomFilter() { printf("Destroyed Bloom\n"); }

...and observe that it's never called without this
patch, and consistently called with it.

Issue URL: https://github.com/duckduckgo/iOS/issues/806
Internal URL:  https://app.asana.com/0/392891325557410/1199935106721785