### PR TITLE
Display link titles when sharing via email

### DIFF
--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -51,9 +51,14 @@ extension UIViewController {
         present(controller: shareController, fromButtonItem: buttonItem)
     }
 
-    public func presentShareSheet(withItems activityItems: [Any], fromView sourceView: UIView, atPoint point: Point? = nil) {
+    public func presentShareSheet(withItems activityItems: [Any], fromView sourceView: UIView, subject: String? = nil, atPoint point: Point? = nil) {
         let activities = buildActivities()
         let shareController = UIActivityViewController(activityItems: activityItems, applicationActivities: activities)
+
+        if let subject = subject {
+            shareController.setValue(subject, forKey: "Subject")
+        }
+
         shareController.overrideUserInterfaceStyle()
         shareController.excludedActivityTypes = [.markupAsPDF]
         present(controller: shareController, fromView: sourceView, atPoint: point)

--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -51,14 +51,9 @@ extension UIViewController {
         present(controller: shareController, fromButtonItem: buttonItem)
     }
 
-    public func presentShareSheet(withItems activityItems: [Any], fromView sourceView: UIView, subject: String? = nil, atPoint point: Point? = nil) {
+    public func presentShareSheet(withItems activityItems: [Any], fromView sourceView: UIView, atPoint point: Point? = nil) {
         let activities = buildActivities()
         let shareController = UIActivityViewController(activityItems: activityItems, applicationActivities: activities)
-
-        if let subject = subject {
-            shareController.setValue(subject, forKey: "Subject")
-        }
-
         shareController.overrideUserInterfaceStyle()
         shareController.excludedActivityTypes = [.markupAsPDF]
         present(controller: shareController, fromView: sourceView, atPoint: point)
@@ -78,4 +73,22 @@ extension UIViewController {
         }
         present(controller, animated: true, completion: nil)
     }
+}
+
+extension Core.Link: UIActivityItemSource {
+
+    public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        AppUrls().removeATBAndSource(fromUrl: url)
+    }
+
+    public func activityViewController(_ activityViewController: UIActivityViewController,
+                                       itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        AppUrls().removeATBAndSource(fromUrl: url)
+    }
+
+    public func activityViewController(_ activityViewController: UIActivityViewController,
+                                       subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+        title ?? ""
+    }
+
 }

--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -78,17 +78,17 @@ extension UIViewController {
 extension Core.Link: UIActivityItemSource {
 
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        AppUrls().removeATBAndSource(fromUrl: url)
+        return AppUrls().removeATBAndSource(fromUrl: url)
     }
 
     public func activityViewController(_ activityViewController: UIActivityViewController,
                                        itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        AppUrls().removeATBAndSource(fromUrl: url)
+        return AppUrls().removeATBAndSource(fromUrl: url)
     }
 
     public func activityViewController(_ activityViewController: UIActivityViewController,
                                        subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
-        title ?? ""
+        return title ?? ""
     }
 
 }

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -128,8 +128,7 @@ extension TabViewController {
 
     func onShareAction(forLink link: Link, fromView view: UIView) {
         Pixel.fire(pixel: .browsingMenuShare)
-        let url = appUrls.removeATBAndSource(fromUrl: link.url)
-        presentShareSheet(withItems: [ url, link, webView.viewPrintFormatter() ], fromView: view, subject: link.title)
+        presentShareSheet(withItems: [ link, webView.viewPrintFormatter() ], fromView: view)
     }
     
     private func onToggleDesktopSiteAction(forUrl url: URL) {

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -129,7 +129,7 @@ extension TabViewController {
     func onShareAction(forLink link: Link, fromView view: UIView) {
         Pixel.fire(pixel: .browsingMenuShare)
         let url = appUrls.removeATBAndSource(fromUrl: link.url)
-        presentShareSheet(withItems: [ url, link, webView.viewPrintFormatter() ], fromView: view)
+        presentShareSheet(withItems: [ url, link, webView.viewPrintFormatter() ], fromView: view, subject: link.title)
     }
     
     private func onToggleDesktopSiteAction(forUrl url: URL) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199667555122426
Tech Design URL:
CC:

**Description**:

This PR updates `Link` to provide the URL and title/subject to the activity view controller directly, by extending `Link` to conform to `UIActivityItemSource`.

The first commit on this branch achieved the same thing by setting a value for the `Subject` key on the activity view controller, but the current way is the proper way to do it.

**Steps to test this PR**:
1. Open a new tab
1. Go through Settings  -> Share and select the Mail icon
1. Verify that the link's subject is present, matching the title of the tab

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

