### PR TITLE
Only return a subject when sharing via Mail.

### DIFF
--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -88,7 +88,11 @@ extension Core.Link: UIActivityItemSource {
 
     public func activityViewController(_ activityViewController: UIActivityViewController,
                                        subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
-        return title ?? ""
+        if let title = title, activityType == .mail {
+            return title
+        } else {
+            return ""
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199667555122426
Tech Design URL:
CC: @brindy as the reviewer of the original PR

**Description**:

This PR is a small followup to https://github.com/duckduckgo/iOS/pull/837 which limits the addition of the subject to the Mail app only. While adding the subject is fairly harmless for most activity types, it's only really necessary for Mail and it impacts AirDrop by forcing it to share a .txt file instead of the URL.

**Steps to test this PR**:
1. Share a URL via AirDrop and verify that it opens the link in Safari
1. Share a URL with Mail and verify that the title of the page appears as the subject
1. Test other share destinations, like iMessage

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

