### PR TITLE
Extract SQLite error info from CoreData errors

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -281,6 +281,9 @@ extension Pixel {
         if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
             newParams[PixelParameters.underlyingErrorCode] = "\(underlyingError.code)"
             newParams[PixelParameters.underlyingErrorDesc] = underlyingError.domain
+        } else if let sqlErrorCode =  nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {
+            newParams[PixelParameters.underlyingErrorCode] = "\(sqlErrorCode.intValue)"
+            newParams[PixelParameters.underlyingErrorDesc] = "NSSQLiteErrorDomain"
         }
         fire(pixel: pixel, withAdditionalParameters: newParams)
     }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -281,7 +281,7 @@ extension Pixel {
         if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
             newParams[PixelParameters.underlyingErrorCode] = "\(underlyingError.code)"
             newParams[PixelParameters.underlyingErrorDesc] = underlyingError.domain
-        } else if let sqlErrorCode =  nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {
+        } else if let sqlErrorCode = nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {
             newParams[PixelParameters.underlyingErrorCode] = "\(sqlErrorCode.intValue)"
             newParams[PixelParameters.underlyingErrorDesc] = "NSSQLiteErrorDomain"
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1200085531904129
Tech Design URL:
CC:

**Description**:
If present, extract additional information from CoreData error.

**Steps to test this PR**:
Regular flow - should just work. :)

To trigger an error:
- Locate DB file.
- Corrupt it in some way.
- Try running the app - Pixel should contain SQLite error info.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [x] iOS 14


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

