### PR TITLE
Fix Alerts not being show if current tab is not yet presented

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1100,7 +1100,7 @@ extension MainViewController: HomeControllerDelegate {
 }
 
 extension MainViewController: TabDelegate {
-
+    
     func tab(_ tab: TabViewController,
              didRequestNewWebViewWithConfiguration configuration: WKWebViewConfiguration,
              for navigationAction: WKNavigationAction) -> WKWebView? {
@@ -1238,6 +1238,10 @@ extension MainViewController: TabDelegate {
             view.removeFromSuperview()
             completion()
         })
+    }
+    
+    func tab(_ tab: TabViewController, didRequestPresentingAlert alert: UIAlertController) {
+        present(alert, animated: true)
     }
 
     func selectTab(_ tab: Tab) {

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -54,6 +54,8 @@ protocol TabDelegate: class {
     func tabDidRequestFireButtonLocation(tab: TabViewController) -> CGPoint?
     
     func tabDidRequestSearchBarRect(tab: TabViewController) -> CGRect
+    
+    func tab(_ tab: TabViewController, didRequestPresentingAlert alert: UIAlertController)
 
     func showBars()
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -716,7 +716,7 @@ class TabViewController: UIViewController {
         alert.addAction(UIAlertAction(title: open, style: .destructive, handler: { _ in
             self.openExternally(url: url)
         }))
-        show(alert, sender: self)
+        delegate?.tab(self, didRequestPresentingAlert: alert)
     }
 
     func dismiss() {
@@ -809,7 +809,7 @@ extension TabViewController: WKNavigationDelegate {
             completionHandler(.rejectProtectionSpace, nil)
         })
         
-        present(alert, animated: true)
+        delegate?.tab(self, didRequestPresentingAlert: alert)
     }
     
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1199711975971605
Tech Design URL:
CC:

**Description**:
In case current tab is not yet attached to view hierarchy presenting alerts won't work. So instead of doing that, delegate presentation to MainViewController.

**Steps to test this PR**:

1. Visit https://blog.penbook.app/p/beautifying-your-penbook
2. Ensure tapping on App Store link works.

Other than that general regression tests.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [x] iPhone 
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

