### PR TITLE
Switch from beforeload to load event handler

### DIFF
--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -484,6 +484,8 @@ _utf8_encode : function (string) {
             return new URL(location.href)
         }
     }
+    
+    var loadedSurrogates = {}
 
     // private
     function loadSurrogate(surrogatePattern) {
@@ -531,7 +533,10 @@ _utf8_encode : function (string) {
         // Tracker blocking is dealt with by content rules
         // Only handle surrogates here
         if (blocked && result.matchedRule && result.matchedRule.surrogate) {
-            loadSurrogate(result.matchedRule.surrogate)
+            if (!loadedSurrogates[trackerUrl]) {
+                loadSurrogate(result.matchedRule.surrogate)
+                loadedSurrogates[trackerUrl] = true
+            }
 
             duckduckgoDebugMessaging.signpostEvent({event: "Tracker Blocked",
                                                    url: trackerUrl,
@@ -549,50 +554,60 @@ _utf8_encode : function (string) {
         
         return false
     }
+    
+    function processPage() {
+        [].slice.apply(document.scripts).forEach(function(el) {
+            if (shouldBlock(el.src, 'SCRIPT')) {
+                duckduckgoDebugMessaging.log("blocking load")
+            } else {
+                duckduckgoDebugMessaging.log("don't block " + el.src);
+                return
+            }
+            
+        });
+        [].slice.apply(document.images).forEach(function(el) {
+          // If the image's natural width is zero, then it has not loaded so we
+          // can assume that it may have been blocked.
+          if (el.naturalWidth === 0) {
+              if (shouldBlock(el.src, 'IMG')) {
+                  duckduckgoDebugMessaging.log("blocking load")
+              } else {
+                  duckduckgoDebugMessaging.log("don't block " + el.src);
+                  return
+              }
+          }
+        });
+        [].slice.apply(document.querySelectorAll('link')).forEach(function(el) {
+            if (shouldBlock(el.src, 'LINK')) {
+                duckduckgoDebugMessaging.log("blocking load")
+            } else {
+                duckduckgoDebugMessaging.log("don't block " + el.src);
+                return
+            }
+        });
+        [].slice.apply(document.querySelectorAll('iframe')).forEach(function(el) {
+          if (shouldBlock(el.src, 'IFRAME')) {
+              duckduckgoDebugMessaging.log("blocking load")
+          } else {
+              duckduckgoDebugMessaging.log("don't block " + el.src);
+              return
+          }
+        });
+        scheduleProcessPage()
+    }
+    
+    var interval = 1
+    function scheduleProcessPage() {
+        interval *= 2
+        setTimeout(processPage, interval * 1000)
+    }
 
     // Init
     (function() {
         
         duckduckgoDebugMessaging.log("installing load detection")
         window.addEventListener("load", function(event) {
-            [].slice.apply(document.scripts).forEach(function(el) {
-                if (shouldBlock(el.src, 'SCRIPT')) {
-                    duckduckgoDebugMessaging.log("blocking load")
-                } else {
-                    duckduckgoDebugMessaging.log("don't block " + el.src);
-                    return
-                }
-                
-            });
-            [].slice.apply(document.images).forEach(function(el) {
-              // If the image's natural width is zero, then it has not loaded so we
-              // can assume that it may have been blocked.
-              if (el.naturalWidth === 0) {
-                  if (shouldBlock(el.src, 'IMG')) {
-                      duckduckgoDebugMessaging.log("blocking load")
-                  } else {
-                      duckduckgoDebugMessaging.log("don't block " + el.src);
-                      return
-                  }
-              }
-            });
-            [].slice.apply(document.querySelectorAll('link')).forEach(function(el) {
-                if (shouldBlock(el.src, 'LINK')) {
-                    duckduckgoDebugMessaging.log("blocking load")
-                } else {
-                    duckduckgoDebugMessaging.log("don't block " + el.src);
-                    return
-                }
-            });
-            [].slice.apply(document.querySelectorAll('iframe')).forEach(function(el) {
-              if (shouldBlock(el.src, 'IFRAME')) {
-                  duckduckgoDebugMessaging.log("blocking load")
-              } else {
-                  duckduckgoDebugMessaging.log("don't block " + el.src);
-                  return
-              }
-            });
-            
+            processPage()
         }, false)
 
 

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -576,6 +576,14 @@ _utf8_encode : function (string) {
                   }
               }
             });
+            [].slice.apply(document.querySelectorAll('link')).forEach(function(el) {
+                if (shouldBlock(el.src, 'LINK')) {
+                    duckduckgoDebugMessaging.log("blocking load")
+                } else {
+                    duckduckgoDebugMessaging.log("don't block " + el.src);
+                    return
+                }
+            });
             [].slice.apply(document.querySelectorAll('iframe')).forEach(function(el) {
               if (shouldBlock(el.src, 'IFRAME')) {
                   duckduckgoDebugMessaging.log("blocking load")

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -533,9 +533,9 @@ _utf8_encode : function (string) {
         // Tracker blocking is dealt with by content rules
         // Only handle surrogates here
         if (blocked && result.matchedRule && result.matchedRule.surrogate) {
-            if (!loadedSurrogates[trackerUrl]) {
+            if (!loadedSurrogates[result.matchedRule.surrogate]) {
                 loadSurrogate(result.matchedRule.surrogate)
-                loadedSurrogates[trackerUrl] = true
+                loadedSurrogates[result.matchedRule.surrogate] = true
             }
 
             duckduckgoDebugMessaging.signpostEvent({event: "Tracker Blocked",

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -581,7 +581,7 @@ _utf8_encode : function (string) {
             if (shouldBlock(el.src, 'LINK')) {
                 duckduckgoDebugMessaging.log("blocking load")
             } else {
-                duckduckgoDebugMessaging.log("don't block " + el.src);
+                duckduckgoDebugMessaging.log("don't block " + el.href);
                 return
             }
         });

--- a/Core/contentblocker.js
+++ b/Core/contentblocker.js
@@ -553,29 +553,39 @@ _utf8_encode : function (string) {
     // Init
     (function() {
         
-        duckduckgoDebugMessaging.log("installing beforeload detection")
-        document.addEventListener("beforeload", function(event) {
-
-            if (event.target.nodeName == "LINK") {
-                type = event.target.rel
-            } else if (event.target.nodeName == "IMG") {
-                type = "image"
-            } else if (event.target.nodeName == "IFRAME") {
-                type = "subdocument"
-            } else {
-                type = event.target.nodeName
-            }
-
-            duckduckgoDebugMessaging.log("checking " + event.url + " (" + type + ")");
-            if (shouldBlock(event.url, type)) {
-                duckduckgoDebugMessaging.log("blocking beforeload")
-                event.preventDefault()
-                event.stopPropagation()
-            } else {
-                duckduckgoDebugMessaging.log("don't block " + event.url);
-                return
-            }
-        }, true)
+        duckduckgoDebugMessaging.log("installing load detection")
+        window.addEventListener("load", function(event) {
+            [].slice.apply(document.scripts).forEach(function(el) {
+                if (shouldBlock(el.src, 'SCRIPT')) {
+                    duckduckgoDebugMessaging.log("blocking load")
+                } else {
+                    duckduckgoDebugMessaging.log("don't block " + el.src);
+                    return
+                }
+                
+            });
+            [].slice.apply(document.images).forEach(function(el) {
+              // If the image's natural width is zero, then it has not loaded so we
+              // can assume that it may have been blocked.
+              if (el.naturalWidth === 0) {
+                  if (shouldBlock(el.src, 'IMG')) {
+                      duckduckgoDebugMessaging.log("blocking load")
+                  } else {
+                      duckduckgoDebugMessaging.log("don't block " + el.src);
+                      return
+                  }
+              }
+            });
+            [].slice.apply(document.querySelectorAll('iframe')).forEach(function(el) {
+              if (shouldBlock(el.src, 'IFRAME')) {
+                  duckduckgoDebugMessaging.log("blocking load")
+              } else {
+                  duckduckgoDebugMessaging.log("don't block " + el.src);
+                  return
+              }
+            });
+            
+        }, false)
 
 
         try {

--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -115,7 +115,7 @@
     function onLoadNativeCallback() {
       // Send back the sources of every script and image in the DOM back to the host application.
       [].slice.apply(document.scripts).forEach(function(el) { sendMessage(el.src, "script"); });
-      [].slice.apply(document.links).forEach(function(el) { sendMessage(el.src, "link"); });
+      [].slice.apply(document.querySelectorAll('link')).forEach(function(el) { sendMessage(el.src, "link"); });
       [].slice.apply(document.images).forEach(function(el) {
         // If the image's natural width is zero, then it has not loaded so we
         // can assume that it may have been blocked.

--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -115,7 +115,7 @@
     function onLoadNativeCallback() {
       // Send back the sources of every script and image in the DOM back to the host application.
       [].slice.apply(document.scripts).forEach(function(el) { sendMessage(el.src, "script"); });
-      [].slice.apply(document.querySelectorAll('link')).forEach(function(el) { sendMessage(el.src, "link"); });
+      [].slice.apply(document.querySelectorAll('link')).forEach(function(el) { sendMessage(el.href, "link"); });
       [].slice.apply(document.images).forEach(function(el) {
         // If the image's natural width is zero, then it has not loaded so we
         // can assume that it may have been blocked.

--- a/Core/contentblockerrules.js
+++ b/Core/contentblockerrules.js
@@ -112,24 +112,10 @@
       }
     }
 
-    document.addEventListener("beforeload", function(event) {
-        if (event.target.nodeName == "LINK") {
-            type = event.target.rel
-        } else if (event.target.nodeName == "IMG") {
-            type = "image"
-        } else if (event.target.nodeName == "IFRAME") {
-            type = "subdocument"
-        } else {
-            type = event.target.nodeName
-        }
-
-        sendMessage(event.url, type)
-    }, false)
-
-
     function onLoadNativeCallback() {
       // Send back the sources of every script and image in the DOM back to the host application.
       [].slice.apply(document.scripts).forEach(function(el) { sendMessage(el.src, "script"); });
+      [].slice.apply(document.links).forEach(function(el) { sendMessage(el.src, "link"); });
       [].slice.apply(document.images).forEach(function(el) {
         // If the image's natural width is zero, then it has not loaded so we
         // can assume that it may have been blocked.
@@ -137,6 +123,7 @@
           sendMessage(el.src, "image");
         }
       });
+      [].slice.apply(document.querySelectorAll('iframe')).forEach(function(el) { sendMessage(el.src, "iframe" )})
     }
 
     let originalOpen = null;


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1200134317948619/f
Tech Design URL: N/A
CC: @bwaresiak @catehstn 

**Description**:
This PR fixes surrogate loading after `beforeload` was deprecated in iOS 14. This solution has been tested to work with iOS 14 and below.

**Steps to test this PR**:
1. Add log or breakpoint to this line to show when a surrogate is loaded: https://github.com/duckduckgo/iOS/blob/714450d4c59c604eb41150addda676f088beb814/Core/contentblocker.js#L490
2. Visit https://nytimes.com/wirecutter/deals/
1. Your breakpoint should trigger or log should be displayed

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

