### PR TITLE
Remove m_n and m_https pixels

### DIFF
--- a/Core/HTTPSUpgrade.swift
+++ b/Core/HTTPSUpgrade.swift
@@ -38,19 +38,16 @@ public class HTTPSUpgrade {
     public func isUgradeable(url: URL, completion: @escaping UpgradeCheckCompletion) {
         
         guard url.scheme == "http" else {
-            Pixel.fire(pixel: .httpsNoLookup)
             completion(false)
             return
         }
         
         guard let host = url.host else {
-            Pixel.fire(pixel: .httpsNoLookup)
             completion(false)
             return
         }
         
         if store.shouldExcludeDomain(host) {
-            Pixel.fire(pixel: .httpsNoLookup)
             completion(false)
             return
         }
@@ -58,7 +55,6 @@ public class HTTPSUpgrade {
         waitForAnyReloadsToComplete()
         let isUpgradable = isInUpgradeList(host: host)
         os_log("%s %s upgradable", log: generalLog, type: .debug, host, isUpgradable ? "is" : "is not")
-        Pixel.fire(pixel: isUpgradable ? .httpsLocalUpgrade : .httpsNoUpgrade)
         completion(isUpgradable)
            
     }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -43,10 +43,6 @@ public enum PixelName: String {
     case privacyDashboardManageProtection = "mp_mw"
     case privacyDashboardReportBrokenSite = "mp_rb"
     
-    case httpsNoLookup = "m_https_nl"
-    case httpsLocalUpgrade = "m_https_lu"
-    case httpsNoUpgrade = "m_https_nu"
-    
     case tabSwitcherNewLayoutSeen = "m_ts_n"
     case tabSwitcherListEnabled = "m_ts_l"
     case tabSwitcherGridEnabled = "m_ts_g"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -25,7 +25,6 @@ public enum PixelName: String {
     
     case appLaunch = "ml"
     case defaultBrowserLaunch = "m_dl"
-    case navigationDetected = "m_n"
     case refreshPressed = "m_r"
 
     case forgetAllPressedBrowsing = "mf_bp"

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -868,8 +868,6 @@ extension TabViewController: WKNavigationDelegate {
         hideErrorMessage()
         showProgressIndicator()
         chromeDelegate?.omniBar.startLoadingAnimation(for: webView.url)
-        
-        detectedNewNavigation()
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -960,10 +958,6 @@ extension TabViewController: WKNavigationDelegate {
         trackersInfoWorkItem = nil
     }
     
-    private func detectedNewNavigation() {
-        Pixel.fire(pixel: .navigationDetected)
-    }
-    
     private func checkLoginDetectionAfterNavigation() {
         if preserveLoginsWorker?.handleLoginDetection(detectedURL: detectedLoginURL, currentURL: url) ?? false {
             detectedLoginURL = nil
@@ -1013,7 +1007,6 @@ extension TabViewController: WKNavigationDelegate {
         self.url = url
         self.siteRating = makeSiteRating(url: url)
         updateSiteRating()
-        detectedNewNavigation()
         checkLoginDetectionAfterNavigation()
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200123805767793/f
Tech Design URL:
CC: @bwaresiak 

**Description**:

This PR removes `m_https_*` and `m_n` pixels.

**Steps to test this PR**:
1. Check that there are no other instances of the removed pixels in the app
1. Test navigation and Smarter Encryption features to verify that no pixel is fired
1. Verify that no other pixels need to be removed per the Asana task listed

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

