### PR TITLE
Add a debug pixel to check the tab preview count

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -185,6 +185,8 @@ public enum PixelName: String {
     case blankOverlayNotDismissed = "m_d_ovs"
 
     case cookieDeletionTimedOut = "m_d_csto"
+
+    case cachedTabPreviewsExceedsTabCount = "m_d_tpetc"
 }
 // swiftlint:enable identifier_name
 
@@ -218,6 +220,8 @@ public struct PixelParameters {
 
     static let removeCookiesTimedOut = "rc"
     static let clearWebDataTimedOut = "cd"
+
+    public static let tabPreviewCountDelta = "cd"
 }
 
 public struct PixelValues {

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -44,6 +44,10 @@ class TabManager {
         registerForNotifications()
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     private func buildController(forTab tab: Tab) -> TabViewController {
         let url = tab.link?.url
         return buildController(forTab: tab, url: url)

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -40,6 +40,8 @@ class TabManager {
             let controller = buildController(forTab: tab)
             tabControllerCache.append(controller)
         }
+
+        registerForNotifications()
     }
 
     private func buildController(forTab tab: Tab) -> TabViewController {
@@ -224,6 +226,33 @@ class TabManager {
 
     func save() {
         model.save()
+    }
+
+}
+
+extension TabManager: Themable {
+    
+    func decorate(with theme: Theme) {
+        for tabController in tabControllerCache {
+            tabController.decorate(with: theme)
+        }
+    }
+    
+}
+
+// MARK: - Debugging Pixels
+
+extension TabManager {
+
+    fileprivate func registerForNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(onApplicationBecameActive),
+                                               name: UIApplication.didBecomeActiveNotification,
+                                               object: nil)
+    }
+
+    @objc
+    private func onApplicationBecameActive(_ notification: NSNotification) {
         assertTabPreviewCount()
     }
 
@@ -237,14 +266,4 @@ class TabManager {
             ])
         }
     }
-}
-
-extension TabManager: Themable {
-    
-    func decorate(with theme: Theme) {
-        for tabController in tabControllerCache {
-            tabController.decorate(with: theme)
-        }
-    }
-    
 }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -224,6 +224,18 @@ class TabManager {
 
     func save() {
         model.save()
+        assertTabPreviewCount()
+    }
+
+    private func assertTabPreviewCount() {
+        let totalStoredPreviews = previewsSource.totalStoredPreviews()
+        let totalTabs = model.tabs.count
+
+        if totalStoredPreviews > totalTabs {
+            Pixel.fire(pixel: .cachedTabPreviewsExceedsTabCount, withAdditionalParameters: [
+                PixelParameters.tabPreviewCountDelta: "\(totalStoredPreviews - totalTabs)"
+            ])
+        }
     }
 }
 

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -231,9 +231,9 @@ class TabManager {
         let totalStoredPreviews = previewsSource.totalStoredPreviews()
         let totalTabs = model.tabs.count
 
-        if totalStoredPreviews > totalTabs {
+        if let storedPreviews = totalStoredPreviews, storedPreviews > totalTabs {
             Pixel.fire(pixel: .cachedTabPreviewsExceedsTabCount, withAdditionalParameters: [
-                PixelParameters.tabPreviewCountDelta: "\(totalStoredPreviews - totalTabs)"
+                PixelParameters.tabPreviewCountDelta: "\(storedPreviews - totalTabs)"
             ])
         }
     }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -44,10 +44,6 @@ class TabManager {
         registerForNotifications()
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     private func buildController(forTab tab: Tab) -> TabViewController {
         let url = tab.link?.url
         return buildController(forTab: tab, url: url)

--- a/DuckDuckGo/TabPreviewsSource.swift
+++ b/DuckDuckGo/TabPreviewsSource.swift
@@ -89,6 +89,13 @@ class TabPreviewsSource {
             }
         }
     }
+
+    func totalStoredPreviews() -> Int {
+        guard let directory = previewStoreDir else { return 0 }
+
+        let contents = try? FileManager.default.contentsOfDirectory(atPath: directory.path)
+        return contents?.count ?? 0
+    }
     
     static private var previewStoreDir: URL? {
         guard var cachesDirURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return nil }

--- a/DuckDuckGo/TabPreviewsSource.swift
+++ b/DuckDuckGo/TabPreviewsSource.swift
@@ -90,11 +90,11 @@ class TabPreviewsSource {
         }
     }
 
-    func totalStoredPreviews() -> Int {
-        guard let directory = previewStoreDir else { return 0 }
+    func totalStoredPreviews() -> Int? {
+        guard let directory = previewStoreDir else { return nil }
 
         let contents = try? FileManager.default.contentsOfDirectory(atPath: directory.path)
-        return contents?.count ?? 0
+        return contents?.count
     }
     
     static private var previewStoreDir: URL? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200123805767782/f
Tech Design URL:
CC: @bwaresiak 

**Description**:

This PR adds a debug pixel to check the stored tab preview count vs the total tab count, reporting the pixel if the preview count is higher than the tab count.

One question about this change is: are there any situations where we would expect the tab preview count to be higher, even briefly? In the implementation I've added the pixel check after tab previews and the tab model are updated, but I want to be certain that we won't fire false positives.

**Steps to test this PR**:
1. Open and close tabs, checking that the pixel check is performed (but that the pixel does not fire)
1. Check that there are no other places where tab previews are stored, so that we're sure the pixel is checking all cases
1. Background and foreground the app, checking that the pixel check is performed (but that the pixel does not fire)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

