### PR TITLE
Prevent sharing two links from the Bookmarks share button

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -261,9 +261,9 @@ public struct AppUrls {
         return url
     }
     
-    public func removeATBAndSource(fromUrl url: URL) -> URL {
+    public func removeInternalSearchParameters(fromUrl url: URL) -> URL {
         guard isDuckDuckGoSearch(url: url) else { return url }
-        return url.removeParam(name: Param.atb).removeParam(name: Param.source)
+        return url.removeParam(name: Param.atb).removeParam(name: Param.source).removeParam(name: Param.searchHeader)
     }
 
 }

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -263,7 +263,7 @@ public struct AppUrls {
     
     public func removeInternalSearchParameters(fromUrl url: URL) -> URL {
         guard isDuckDuckGoSearch(url: url) else { return url }
-        return url.removeParam(name: Param.atb).removeParam(name: Param.source).removeParam(name: Param.searchHeader)
+        return url.removeParams(named: [Param.atb, Param.source, Param.searchHeader])
     }
 
 }

--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -78,12 +78,12 @@ extension UIViewController {
 extension Core.Link: UIActivityItemSource {
 
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        return AppUrls().removeATBAndSource(fromUrl: url)
+        return AppUrls().removeInternalSearchParameters(fromUrl: url)
     }
 
     public func activityViewController(_ activityViewController: UIActivityViewController,
                                        itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        return AppUrls().removeATBAndSource(fromUrl: url)
+        return AppUrls().removeInternalSearchParameters(fromUrl: url)
     }
 
     public func activityViewController(_ activityViewController: UIActivityViewController,

--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -88,6 +88,14 @@ extension URL {
         return components.url ?? self
     }
 
+    public func removeParams(named parameters: [String]) -> URL {
+        var url = self
+        for param in parameters {
+            url = url.removeParam(name: param)
+        }
+        return url
+    }
+
     public func isHttps() -> Bool {
         return absoluteString.hasPrefix(URLProtocol.https.scheme)
     }

--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -76,24 +76,19 @@ extension URL {
     }
 
     public func removeParam(name: String) -> URL {
+        return self.removeParams(named: [name])
+    }
+
+    public func removeParams(named parametersToRemove: Set<String>) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
         guard let encodedQuery = components.percentEncodedQuery else { return self }
         components.percentEncodedQuery = switchWebSpacesToSystemEncoding(text: encodedQuery)
         guard var query = components.queryItems else { return self }
-        
-        for (index, param) in query.enumerated() where param.name == name {
-            query.remove(at: index)
-        }
+
+        query.removeAll { parametersToRemove.contains($0.name) }
+
         components.queryItems = query
         return components.url ?? self
-    }
-
-    public func removeParams(named parameters: [String]) -> URL {
-        var url = self
-        for param in parameters {
-            url = url.removeParam(name: param)
-        }
-        return url
     }
 
     public func isHttps() -> Bool {

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -191,9 +191,7 @@ class BookmarksViewController: UITableViewController {
     fileprivate func showShareSheet(for indexPath: IndexPath) {
 
         if let link = currentDataSource.link(at: indexPath) {
-            let appUrls: AppUrls = AppUrls()
-            let url = appUrls.removeATBAndSource(fromUrl: link.url)
-            presentShareSheet(withItems: [ link ], fromView: self.view)
+            presentShareSheet(withItems: [link], fromView: self.view)
         } else {
             os_log("Invalid share link found", log: generalLog, type: .debug)
         }

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -193,7 +193,7 @@ class BookmarksViewController: UITableViewController {
         if let link = currentDataSource.link(at: indexPath) {
             let appUrls: AppUrls = AppUrls()
             let url = appUrls.removeATBAndSource(fromUrl: link.url)
-            presentShareSheet(withItems: [ url, link ], fromView: self.view)
+            presentShareSheet(withItems: [ link ], fromView: self.view)
         } else {
             os_log("Invalid share link found", log: generalLog, type: .debug)
         }

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -30,7 +30,7 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
-    func testWhenRemoveInternalSearchParametersFromSearchUrlThenUrlIsUnchanged() {
+    func testWhenRemoveInternalSearchParametersFromSearchUrlThenUrlIsChanged() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
 
         let searchUrl = testee.searchUrl(text: "example")

--- a/DuckDuckGoTests/AppUrlsTests.swift
+++ b/DuckDuckGoTests/AppUrlsTests.swift
@@ -30,18 +30,22 @@ class AppUrlsTests: XCTestCase {
         mockStatisticsStore = MockStatisticsStore()
     }
 
-    func testWhenRemoveATBAndSourceFromSearchUrlThenUrlIsUnchanged() {
+    func testWhenRemoveInternalSearchParametersFromSearchUrlThenUrlIsUnchanged() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
+
         let searchUrl = testee.searchUrl(text: "example")
-        let result = testee.removeATBAndSource(fromUrl: searchUrl)
+        let searchUrlWithSearchHeader = testee.applySearchHeaderParams(for: searchUrl)
+        let result = testee.removeInternalSearchParameters(fromUrl: searchUrlWithSearchHeader)
+
         XCTAssertNil(result.getParam(name: "atb"))
         XCTAssertNil(result.getParam(name: "t"))
+        XCTAssertNil(result.getParam(name: "ko"))
     }
 
-    func testWhenRemoveATBAndSourceFromNonSearchUrlThenUrlIsUnchanged() {
+    func testWhenRemoveInternalSearchParametersFromNonSearchUrlThenUrlIsUnchanged() {
         let testee = AppUrls(statisticsStore: mockStatisticsStore)
-        let example = "https://duckduckgo.com?atb=x&t=y"
-        let result = testee.removeATBAndSource(fromUrl: URL(string: example)!)
+        let example = "https://duckduckgo.com?atb=x&t=y&ko=z"
+        let result = testee.removeInternalSearchParameters(fromUrl: URL(string: example)!)
         XCTAssertEqual(example, result.absoluteString)
     }
     

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -216,7 +216,7 @@ class URLExtensionTests: XCTestCase {
 
     func testWhenEmptyParamArrayIsUsedThenRemovingReturnsSameUrl() {
         let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
-        let actual = url?.removeParams(named: ["someParam", "someOtherParam"])
+        let actual = url?.removeParams(named: [])
         XCTAssertEqual(actual, url)
     }
 

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -214,6 +214,12 @@ class URLExtensionTests: XCTestCase {
         XCTAssertEqual(actual, url)
     }
 
+    func testWhenEmptyParamArrayIsUsedThenRemovingReturnsSameUrl() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let actual = url?.removeParams(named: ["someParam", "someOtherParam"])
+        XCTAssertEqual(actual, url)
+    }
+
     func testWhenRemovingParamsThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
         let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
         let expected = URL(string: "http://test.com?secondParam=45%20+%205")

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -201,6 +201,26 @@ class URLExtensionTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testWhenRemovingParamsThenRemovingReturnsUrlWithoutParams() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue&thirdParam=thirdValue")
+        let expected = URL(string: "http://test.com?secondParam=secondValue")
+        let actual = url?.removeParams(named: ["firstParam", "thirdParam"])
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testWhenParamsDoNotExistThenRemovingReturnsSameUrl() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=secondValue")
+        let actual = url?.removeParams(named: ["someParam", "someOtherParam"])
+        XCTAssertEqual(actual, url)
+    }
+
+    func testWhenRemovingParamsThenRemainingUrlWebPlusesAreEncodedToEnsureTheyAreMaintainedAsSpaces_bugFix() {
+        let url = URL(string: "http://test.com?firstParam=firstValue&secondParam=45+%2B+5")
+        let expected = URL(string: "http://test.com?secondParam=45%20+%205")
+        let actual = url?.removeParams(named: ["firstParam"])
+        XCTAssertEqual(actual, expected)
+    }
+
     func testWhenNoParamsThenAddingAppendsQuery() {
         let url = URL(string: "http://test.com")
         let expected = URL(string: "http://test.com?aParam=aValue")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1200190888218943/f
Tech Design URL:
CC:

**Description**:

This PR fixes a bug where the Share button in the Bookmarks view controller would share the same link twice.

This began happening after `Core.Link` was made to conform to `UIActivityItemSource`, at which point it was capable of publishing its own URL directly.

**Steps to test this PR**:
1. Favorite or bookmark a page
1. Go the bookmarks screen and swipe right on a row to reveal the Share button
1. Tap Share and verify that only one link is present, and that sharing works as expected to various sources (iMessage, Mail, AirDrop, etc.)
1. Verify that the shared link has removed ATB and source parameters

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 11
* [ ] iOS 12
* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

