### PR TITLE
additional hidden bars scrolling lock escape

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -130,7 +130,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             appIsLaunching = false
             onApplicationLaunch(application)
         }
-        
+
+        mainViewController?.showBars()
         mainViewController?.didReturnFromBackground()
         
         if !privacyStore.authenticationEnabled {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1276,12 +1276,7 @@ extension TabViewController: UIGestureRecognizerDelegate {
 
     private func isShowBarsTap(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         let y = gestureRecognizer.location(in: webView).y
-        return gestureRecognizer == showBarsTapGestureRecogniser && chromeDelegate?.isToolbarHidden == true &&
-            (isBottom(yPosition: y) || isTop(yPosition: y))
-    }
-
-    private func isTop(yPosition y: CGFloat) -> Bool {
-        return y < (view.safeAreaInsets.top + 25)
+        return gestureRecognizer == showBarsTapGestureRecogniser && chromeDelegate?.isToolbarHidden == true && isBottom(yPosition: y)
     }
 
     private func isBottom(yPosition y: CGFloat) -> Bool {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1276,7 +1276,12 @@ extension TabViewController: UIGestureRecognizerDelegate {
 
     private func isShowBarsTap(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         let y = gestureRecognizer.location(in: webView).y
-        return gestureRecognizer == showBarsTapGestureRecogniser && chromeDelegate?.isToolbarHidden == true && isBottom(yPosition: y)
+        return gestureRecognizer == showBarsTapGestureRecogniser && chromeDelegate?.isToolbarHidden == true &&
+            (isBottom(yPosition: y) || isTop(yPosition: y))
+    }
+
+    private func isTop(yPosition y: CGFloat) -> Bool {
+        return y < (view.safeAreaInsets.top + 25)
     }
 
     private func isBottom(yPosition y: CGFloat) -> Bool {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1199565285527972
Tech Design URL:
CC:

**Description**:

Sometimes the app can get stuck when the bars are hidden and a site shows a pay wall.  You can already exit that by tapping the bottom of the screen, but this adds a new way to escape by showing the bars when the app comes to the foreground.

**Steps to test this PR**:
1. Visit alternet.org and swipe up quickly to hide the bars
1. When the ad blocker popup appears try to swipe the bars back - you can't.
1. Swipe the app to the app launcher, then return it to the foreground - the bars will be shown.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 11
* [x] iOS 12
* [x] iOS 13
* [x] iOS 14

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

