### PR TITLE
Fix class protocol deprecation warnings

### DIFF
--- a/Core/ContentBlockerConfigurationStore.swift
+++ b/Core/ContentBlockerConfigurationStore.swift
@@ -23,7 +23,7 @@ public struct ContentBlockerProtectionChangedNotification {
     public static let name = Notification.Name(rawValue: "com.duckduckgo.contentblocker.storeChanged")
 }
 
-public protocol ContentBlockerProtectionStore: class {
+public protocol ContentBlockerProtectionStore: AnyObject {
 
     var unprotectedDomains: Set<String> { get }
 

--- a/Core/StatisticsStore.swift
+++ b/Core/StatisticsStore.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-public protocol StatisticsStore: class {
+public protocol StatisticsStore: AnyObject {
 
     var hasInstallStatistics: Bool { get }
     var installDate: Date? { get set }

--- a/DuckDuckGo/AutocompleteViewControllerDelegate.swift
+++ b/DuckDuckGo/AutocompleteViewControllerDelegate.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-protocol AutocompleteViewControllerDelegate: class {
+protocol AutocompleteViewControllerDelegate: AnyObject {
 
     func autocomplete(selectedSuggestion suggestion: Suggestion)
 
@@ -30,7 +30,7 @@ protocol AutocompleteViewControllerDelegate: class {
     func autocompleteWasDismissed()
 }
 
-protocol AutocompleteViewControllerPresentationDelegate: class {
+protocol AutocompleteViewControllerPresentationDelegate: AnyObject {
     
     func autocompleteDidChangeContentHeight(height: CGFloat)
 

--- a/DuckDuckGo/BookmarksDelegate.swift
+++ b/DuckDuckGo/BookmarksDelegate.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Core
 
-protocol BookmarksDelegate: class {
+protocol BookmarksDelegate: AnyObject {
 
     func bookmarksDidSelect(link: Link)
     

--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-protocol BrowserChromeDelegate: class {
+protocol BrowserChromeDelegate: AnyObject {
 
     func setBarsHidden(_ hidden: Bool, animated: Bool)
     func setNavigationBarHidden(_ hidden: Bool)

--- a/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Core
 
-protocol FavoritesHomeViewSectionRendererDelegate: class {
+protocol FavoritesHomeViewSectionRendererDelegate: AnyObject {
     
     func favoritesRenderer(_ renderer: FavoritesHomeViewSectionRenderer,
                            didSelect link: Link)

--- a/DuckDuckGo/FavoritesOverlay.swift
+++ b/DuckDuckGo/FavoritesOverlay.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Core
 
-protocol FavoritesOverlayDelegate: class {
+protocol FavoritesOverlayDelegate: AnyObject {
     
     func favoritesOverlay(_ overlay: FavoritesOverlay, didSelect link: Link)
 }

--- a/DuckDuckGo/HomeControllerDelegate.swift
+++ b/DuckDuckGo/HomeControllerDelegate.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-protocol HomeControllerDelegate: class {
+protocol HomeControllerDelegate: AnyObject {
 
     func home(_ home: HomeViewController, didRequestUrl url: URL)
 

--- a/DuckDuckGo/HomeMessageCell.swift
+++ b/DuckDuckGo/HomeMessageCell.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-protocol HomeMessageCellDelegate: class {
+protocol HomeMessageCellDelegate: AnyObject {
     func homeMessageCellDismissButtonWasPressed(_ cell: HomeMessageCell)
     func homeMessageCellMainButtonWaspressed(_ cell: HomeMessageCell)
 }

--- a/DuckDuckGo/HomeMessageViewSectionRenderer.swift
+++ b/DuckDuckGo/HomeMessageViewSectionRenderer.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Core
 
-protocol HomeMessageViewSectionRendererDelegate: class {
+protocol HomeMessageViewSectionRendererDelegate: AnyObject {
     
     func homeMessageRenderer(_ renderer: HomeMessageViewSectionRenderer,
                              didDismissHomeMessage homeMessage: HomeMessage)

--- a/DuckDuckGo/OmniBarDelegate.swift
+++ b/DuckDuckGo/OmniBarDelegate.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-protocol OmniBarDelegate: class {
+protocol OmniBarDelegate: AnyObject {
 
     func onOmniQueryUpdated(_ query: String)
     

--- a/DuckDuckGo/PrivacyProtectionController.swift
+++ b/DuckDuckGo/PrivacyProtectionController.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Core
 
-protocol PrivacyProtectionDelegate: class {
+protocol PrivacyProtectionDelegate: AnyObject {
 
     func omniBarTextTapped()
 

--- a/DuckDuckGo/PrivacyProtectionErrorController.swift
+++ b/DuckDuckGo/PrivacyProtectionErrorController.swift
@@ -21,7 +21,7 @@ import Foundation
 import UIKit
 import Core
 
-protocol PrivacyProtectionErrorDelegate: class {
+protocol PrivacyProtectionErrorDelegate: AnyObject {
 
     func canTryAgain(controller: PrivacyProtectionErrorController) -> Bool
 

--- a/DuckDuckGo/Tab.swift
+++ b/DuckDuckGo/Tab.swift
@@ -19,7 +19,7 @@
 
 import Core
 
-protocol TabObserver: class {
+protocol TabObserver: AnyObject {
  
     func didChange(tab: Tab)
     

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -20,7 +20,7 @@
 import WebKit
 import Core
 
-protocol TabDelegate: class {
+protocol TabDelegate: AnyObject {
 
     func tabWillRequestNewTab(_ tab: TabViewController) -> UIKeyModifierFlags?
 

--- a/DuckDuckGo/TabSwitcherDelegate.swift
+++ b/DuckDuckGo/TabSwitcherDelegate.swift
@@ -19,7 +19,7 @@
 
 import Core
 
-protocol TabSwitcherDelegate: class {
+protocol TabSwitcherDelegate: AnyObject {
 
     func tabSwitcherDidRequestNewTab(tabSwitcher: TabSwitcherViewController)
 

--- a/DuckDuckGo/TabViewCell.swift
+++ b/DuckDuckGo/TabViewCell.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Core
 
-protocol TabViewCellDelegate: class {
+protocol TabViewCellDelegate: AnyObject {
 
     func deleteTab(tab: Tab)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200282795494791/f
Tech Design URL:
CC:

**Description**:

This PR fixes warnings introduced in Xcode 12.5. This change has no functional impact, as `AnyObject` behaves the same as `class`. See the [relevant Swift proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md).

> To reduce source-breakage to a minimum, class could be redefined as typealias class = AnyObject and give a deprecation warning on class for the first version of Swift this proposal is implemented in. Later, class could be removed in a subsequent version of Swift.

**Steps to test this PR**:
1. Build the app locally and verify that no warnings appear

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

