### PR TITLE
Revert user agent change

### DIFF
--- a/Core/UserAgentManager.swift
+++ b/Core/UserAgentManager.swift
@@ -82,9 +82,11 @@ struct UserAgent {
         static let osVersion = " OS ([0-9_]+)"
     }
     
-    private static let sitesThatIncludeApplication = [
-        "duckduckgo.com",
-        "wikipedia.org"
+    private static let sitesThatOmitApplication = [
+        "cvs.com",
+        "sovietgames.su",
+        "accounts.google.com",
+        "facebook.com"
     ]
     
     private let baseAgent: String
@@ -101,11 +103,11 @@ struct UserAgent {
     }
     
     public func agent(forUrl url: URL?, isDesktop: Bool) -> String {
-        let includeApplicationComponent = UserAgent.sitesThatIncludeApplication.contains { domain in
+        let omitApplicationComponent = UserAgent.sitesThatOmitApplication.contains { domain in
             url?.isPart(ofDomain: domain) ?? false
         }
         
-        let resolvedApplicationComponent = includeApplicationComponent ? applicationComponent : nil
+        let resolvedApplicationComponent = !omitApplicationComponent ? applicationComponent : nil
         if isDesktop {
             return concatWithSpaces(baseDesktopAgent, resolvedApplicationComponent, safariComponent)
         } else {

--- a/DuckDuckGoTests/FaviconRequestModifierTests.swift
+++ b/DuckDuckGoTests/FaviconRequestModifierTests.swift
@@ -30,7 +30,7 @@ class FaviconRequestModifierTests: XCTestCase {
     func test() {
         let request = URLRequest(url: URL(string: "https://www.example.com")!)
         let result = FaviconRequestModifier().modified(for: request)
-        XCTAssertFalse(result?.allHTTPHeaderFields?["User-Agent"]?.contains("DuckDuckGo") ?? false)
+        XCTAssertTrue(result?.allHTTPHeaderFields?["User-Agent"]?.contains("DuckDuckGo") ?? false)
     }
     
 }

--- a/DuckDuckGoTests/UserAgentTests.swift
+++ b/DuckDuckGoTests/UserAgentTests.swift
@@ -32,15 +32,15 @@ class UserAgentTests: XCTestCase {
         // swiftlint:disable line_length
         
         // Based on DefaultAgent values
-        static let mobile = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 Mobile/15E148 Safari/605.1.15"
-        static let tablet = "Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 Mobile/15E148 Safari/605.1.15"
-        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 Safari/605.1.15"
+        static let mobile = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15"
+        static let tablet = "Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15"
+        static let desktop = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 DuckDuckGo/7 Safari/605.1.15"
         
         static let mobileNoApplication = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.4 Mobile/15E148 Safari/605.1.15"
         
         // Based on fallback constants in UserAgent
-        static let mobileFallback = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.5 Mobile/15E148 Safari/605.1.15"
-        static let desktopFallback = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.5 Safari/605.1.15"
+        static let mobileFallback = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.5 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15"
+        static let desktopFallback = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.5 DuckDuckGo/7 Safari/605.1.15"
         
         // swiftlint:enable line_length
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1200312503998341/f
Tech Design URL:
CC: @bwaresiak 

**Description**:

This PR reverts #870 to re-enable the default user agent.

**Steps to test this PR**:
1. Test that the user agent is sent with requests
1. Test that the autofill feature works as expected

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

