### PR TITLE
Content blocker rule compilation threading tweaks

### DIFF
--- a/Core/ContentBlockerRulesManager.swift
+++ b/Core/ContentBlockerRulesManager.swift
@@ -55,7 +55,10 @@ public class ContentBlockerRulesManager {
 
         store.lookUpContentRuleList(forIdentifier: Self.rulesIdentifier) { list, _ in
             guard list == nil else {
-                completion?(list)
+                DispatchQueue.main.async {
+                    completion?(list)
+                }
+
                 return
             }
 
@@ -91,7 +94,10 @@ fileprivate extension WKContentRuleListStore {
 
         let ruleList = String(data: data, encoding: .utf8)!
         compileContentRuleList(forIdentifier: rulesIdentifier, encodedContentRuleList: ruleList) { ruleList, error in
-            completion?(ruleList)
+            DispatchQueue.main.async {
+                completion?(ruleList)
+            }
+
             if let error = error {
                 os_log("Failed to compile rules %{public}s", log: generalLog, type: .error, error.localizedDescription)
             }

--- a/Core/ContentBlockerRulesManager.swift
+++ b/Core/ContentBlockerRulesManager.swift
@@ -75,7 +75,10 @@ fileprivate extension WKContentRuleListStore {
     func compileRules(withIdentifier rulesIdentifier: String, completion: ((WKContentRuleList?) -> Void)?) {
 
         guard let trackerData = TrackerDataManager.shared.trackerData else {
-            completion?(nil)
+            DispatchQueue.main.async {
+                completion?(nil)
+            }
+
             return
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200320427092735/f
Tech Design URL:
CC: @brindy

**Description**:

This PR updates the content blocker rule manager to call its completion handlers on the main thread.

The core of the issue is that `ContentBlockerProtectionChangedNotification.name` was being called on a background thread, which was then interacting with UI classes and upsetting the Main Thread Checker.

**TODO:**

* [ ] Verify that this doesn't impact background refresh

**Steps to test this PR**:
1. Check out the `develop` branch, go to a website and toggle privacy protection
1. Verify that main thread warnings appear after a short period (this may take a few seconds due to rule compilation)
1. Check out this PR and then toggle privacy protection
1. Verify that main thread warnings no longer appear

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

