### PR TITLE
Fix "UI API called on background thread" violation when updating content blocking rules

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -603,13 +603,15 @@ class TabViewController: UIViewController {
     
     @objc func onContentBlockerConfigurationChanged() {
         ContentBlockerRulesManager.shared.compiledRules { [weak self] rulesList in
-            guard let self = self else { return }
-            if let rulesList = rulesList {
-                self.webView.configuration.userContentController.remove(rulesList)
-                self.webView.configuration.userContentController.add(rulesList)
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if let rulesList = rulesList {
+                    self.webView.configuration.userContentController.remove(rulesList)
+                    self.webView.configuration.userContentController.add(rulesList)
+                }
+
+                self.reload(scripts: true)
             }
-            
-            self.reload(scripts: true)
         }
     }
 


### PR DESCRIPTION
**Description**:

Fixes "UI API called on background thread" violations that terminate the app. The violations are due to updating the web view on a background thread once content blocker rules are updated. This is fixes by dispatching web views to the main queue.

Crash report example: [DuckDuckGo  5-11-21, 9-21 PM.crash.zip](https://github.com/duckduckgo/iOS/files/6463464/DuckDuckGo.5-11-21.9-21.PM.crash.zip)
Runtime issues reported when running attached to Xcode:
<img width="286" alt="runtime-issues" src="https://user-images.githubusercontent.com/915431/117919235-7bb6fa00-b2a1-11eb-8bc3-bc6b376c9928.png">

**Steps to test this PR**:
1. Have a tab open
2. Have the content blocking rule recompile (an easy way to force this is to set `newData` to `true` in the [`AppConfigurationFetch.start` closure](https://github.com/duckduckgo/iOS/blob/develop/DuckDuckGo/AppDelegate.swift#L142-L146))

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

