### PR TITLE
Correct the memory management of the launchTabObserver

### DIFF
--- a/DuckDuckGo/LaunchTabNotification.swift
+++ b/DuckDuckGo/LaunchTabNotification.swift
@@ -29,6 +29,10 @@ class LaunchTabNotification {
             self.observer = observer
         }
 
+        deinit {
+            remove()
+        }
+
         func remove() {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -90,7 +90,7 @@ class MainViewController: UIViewController {
     private let previewsSource = TabPreviewsSource()
     fileprivate lazy var bookmarkStore: BookmarkUserDefaults = BookmarkUserDefaults()
     fileprivate lazy var appSettings: AppSettings = AppUserDefaults()
-    private weak var launchTabObserver: LaunchTabNotification.Observer?
+    private var launchTabObserver: LaunchTabNotification.Observer?
 
     weak var tabSwitcherController: TabSwitcherViewController?
     let tabSwitcherButton = TabSwitcherButton()
@@ -432,8 +432,8 @@ class MainViewController: UIViewController {
     }
 
     private func addLaunchTabNotificationObserver() {
-        launchTabObserver = LaunchTabNotification.addObserver(handler: { urlString in
-            guard let url = URL(string: urlString) else { return }
+        launchTabObserver = LaunchTabNotification.addObserver(handler: { [weak self] urlString in
+            guard let self = self, let url = URL(string: urlString) else { return }
 
             self.loadUrlInNewTab(url)
         })

--- a/DuckDuckGoTests/LaunchTabNotificationTests.swift
+++ b/DuckDuckGoTests/LaunchTabNotificationTests.swift
@@ -34,11 +34,12 @@ class LaunchTabNotificationTests: XCTestCase {
 
     func testWhenNotificationPostedItIsHandled() {
         var x: String?
-        _ = LaunchTabNotification.addObserver { urlString in
+        let observer = LaunchTabNotification.addObserver { urlString in
             x = urlString
         }
         LaunchTabNotification.postLaunchTabNotification(urlString: "y")
         XCTAssertEqual(x, "y")
+        observer.remove()
     }
 
 }


### PR DESCRIPTION
**Asana:** https://app.asana.com/0/414235014887631/1200335662767805/f

The observer reference should be strong, while the capture of self within the closure should be weak

**Description**:

I found this issue when the memory profiler reported a leak on app start. The `LaunchTabNotification.Observer` object is being immediately deallocated since the property was marked as `weak` and there is nothing else retaining the object. Without an observer reference to unregister the observation will never stop - keeping the view controller alive forever.

<img width="770" alt="memory-leak-profiler" src="https://user-images.githubusercontent.com/915431/117926027-f5a0b080-b2ac-11eb-8f4f-ecd465979ad7.png">

This is technically a memory leak, but since the `MainViewController` has a lifecycle tied to the app's lifecycle, it's not a major issue. 

The leak is fixed by following the [guidelines from the `NotificationCenter.addObserver(forName:object:queue:using:)`](https://developer.apple.com/documentation/foundation/notificationcenter/1411723-addobserver#discussion)

> To avoid a retain cycle, use a weak reference to `self` inside the block when `self` contains the observer as a strong reference.
>
> You must invoke `removeObserver(_:)` or `removeObserver(_:name:object:)` before the system deallocates any object that `addObserver(forName:object:queue:using:)` specifies.

**Steps to test this PR**:
1. Start a memory leak profiling session
2. Launch the app with the profiler attached
3. Test that the memory leak caused by the observer is gone
4. Test that the launch tab observer still functions correctly (ex opening the ToS;DR link)

**OS Testing**:

* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**