### PR TITLE
Improved site reports

### DIFF
--- a/Core/URLExtension.swift
+++ b/Core/URLExtension.swift
@@ -190,4 +190,13 @@ extension URL {
         guard let host = host else { return false }
         return host == domain || host.hasSuffix(".\(domain)")
     }
+
+    public func normalized() -> URL? {
+        var components = URLComponents(url: self, resolvingAgainstBaseURL: true)
+        components?.queryItems = nil
+        components?.fragment = nil
+
+        return components?.url
+    }
+
 }

--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -72,13 +72,7 @@ public struct BrokenSiteInfo {
     }
     
     private func normalize(_ url: URL?) -> String {
-        guard let url = url else { return "" }
-        
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
-        components?.queryItems = nil
-        
-        guard let nomalizedUrl = components?.url else { return "" }
-        return nomalizedUrl.absoluteString
+        return url?.normalized()?.absoluteString ?? ""
     }
     
 }

--- a/DuckDuckGo/FeedbackSender.swift
+++ b/DuckDuckGo/FeedbackSender.swift
@@ -65,10 +65,17 @@ struct FeedbackSubmitter: FeedbackSender {
                                 comment: String,
                                 model: Feedback.Model? = nil) {
 
+        let normalizedUrlString: String
+        if let urlString = url, let normalizedURL = URL(string: urlString)?.normalized() {
+            normalizedUrlString = normalizedURL.absoluteString
+        } else {
+            normalizedUrlString = url ?? ""
+        }
+
         let parameters = [
             "reason": "general",
             "rating": rating?.rawValue ?? "",
-            "url": url ?? "",
+            "url": normalizedUrlString,
             "comment": comment,
             "category": model?.category?.component ?? "",
             "subcategory": model?.subcategory?.component ?? "",

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -19,6 +19,7 @@
 
 import XCTest
 
+// swiftlint:disable type_body_length
 class URLExtensionTests: XCTestCase {
     
     func testWhenHostnameHasMultiplePunycodedPartsThenItIsConsideredValid() {
@@ -338,3 +339,4 @@ class URLExtensionTests: XCTestCase {
     }
 
 }
+// swiftlint:enable type_body_length

--- a/DuckDuckGoTests/URLExtensionTests.swift
+++ b/DuckDuckGoTests/URLExtensionTests.swift
@@ -299,4 +299,42 @@ class URLExtensionTests: XCTestCase {
         XCTAssertFalse(URL.isValidBookmarklet(url: invalidSyntax2))
     }
 
+    func testWhenNormalizingURLWithNoParametersThenURLIsUnchanged() {
+        let url = URL(string: "http://example.com/index.html")!
+        let normalized = url.normalized()
+
+        XCTAssertEqual(url, normalized)
+    }
+
+    func testWhenNormalizingURLWithParametersThenParametersAreRemoved() {
+        let url = URL(string: "https://example.com/Path?abc=xyz")!
+        let expected = URL(string: "https://example.com/Path")!
+        let normalized = url.normalized()
+
+        XCTAssertEqual(normalized, expected)
+    }
+
+    func testWhenNormalizingURLWithNoFragmentThenURLIsUnchanged() {
+        let url = URL(string: "http://example.com/index.html")!
+        let normalized = url.normalized()
+
+        XCTAssertEqual(url, normalized)
+    }
+
+    func testWhenNormalizingURLWithFragmentThenFragmentIsRemoved() {
+        let url = URL(string: "https://example.com/Path#fragment")!
+        let expected = URL(string: "https://example.com/Path")!
+        let normalized = url.normalized()
+
+        XCTAssertEqual(normalized, expected)
+    }
+
+    func testWhenNormalizingURLWithParametersAndFragmentThenBothAreRemoved() {
+        let url = URL(string: "https://example.com/Path#fragment&firstParam=1&secondParam=2")!
+        let expected = URL(string: "https://example.com/Path")!
+        let normalized = url.normalized()
+
+        XCTAssertEqual(normalized, expected)
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200378732322006/f
Tech Design URL:
CC:

**Description**:

This PR improves the way parameters are sent when providing site feedback. There are two changes:

1. There's a new URL extension which returns a normalized URL, stripping out the parameters and fragment
2. This new extension is used in `FeedbackSender.swift` and `BrokenSiteInfo.swift`

**Steps to test this PR**:
1. Test reporting a broken site which includes parameters and a fragment and verify that they are removed
1. Test sending a URL with parameters and fragment in the Negative Feedback form and verify that they are removed
1. Perform the same tests with a URL that does not include these and verify that it is unchanged

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

