### PR TITLE
Add conditional ActionMessageView width

### DIFF
--- a/DuckDuckGo/ActionMessageView.swift
+++ b/DuckDuckGo/ActionMessageView.swift
@@ -27,6 +27,9 @@ class ActionMessageView: UIView {
     
     private enum Constants {
         static var maxWidth: CGFloat = 346
+        static var minimumHorizontalPadding: CGFloat = 20
+        static var cornerRadius: CGFloat = 10
+        static var windowBottomPadding: CGFloat = 70
         
         static var animationDuration: TimeInterval = 0.2
         static var duration: TimeInterval = 3.0
@@ -49,7 +52,7 @@ class ActionMessageView: UIView {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        layer.cornerRadius = 10
+        layer.cornerRadius = Constants.cornerRadius
     }
     
     static func present(message: String, actionTitle: String? = nil, onAction: @escaping () -> Void = {}) {
@@ -70,9 +73,10 @@ class ActionMessageView: UIView {
         }
         
         window.addSubview(messageView)
+        window.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: messageView.bottomAnchor, constant: Constants.windowBottomPadding).isActive = true
         
-        window.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: messageView.bottomAnchor, constant: 70).isActive = true
-        messageView.widthAnchor.constraint(equalToConstant: Constants.maxWidth).isActive = true
+        let messageViewWidth = window.frame.width <= Constants.maxWidth ? window.frame.width - Constants.minimumHorizontalPadding : Constants.maxWidth
+        messageView.widthAnchor.constraint(equalToConstant: messageViewWidth).isActive = true
         messageView.centerXAnchor.constraint(equalTo: window.centerXAnchor).isActive = true
         
         window.layoutIfNeeded()


### PR DESCRIPTION


Task/Issue URL: https://github.com/duckduckgo/iOS/issues/907

**Description**:
In order to respect devices that have a smaller width than the maxWidth constant  I've added a conditional messageViewWidth that calculates if the window width is wider than maxWidth, if it is then we set a minimumHorizontalPadding to it.

I've also moved cornerRadius and windowBottomPadding to the Constants struct.

**Steps to test this PR**:
1. Open the app on a smaller device like an iPod touch or iPhone SE
2. Tap on the bottom 3 dots at bottom right
3. Favorite a web page

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPod touch (7th Gen)
* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone 11
* [x] iPhone 12 mini
* [x] iPad

**OS Testing**:

* [x] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

