### PR TITLE
Privacy reference unit tests for content blocker rules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/privacy-grade"]
 	path = submodules/privacy-grade
 	url = https://github.com/duckduckgo/privacy-grade
+[submodule "DuckDuckGoTests/MockFiles/reference-tests"]
+	path = DuckDuckGoTests/MockFiles/reference-tests
+	url = https://github.com/duckduckgo/privacy-reference-tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "submodules/privacy-grade"]
 	path = submodules/privacy-grade
 	url = https://github.com/duckduckgo/privacy-grade
-[submodule "DuckDuckGoTests/MockFiles/reference-tests"]
-	path = DuckDuckGoTests/MockFiles/reference-tests
+[submodule "submodules/privacy-reference-tests"]
+	path = submodules/privacy-reference-tests
 	url = https://github.com/duckduckgo/privacy-reference-tests

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -468,7 +468,8 @@
 		AAF2E28523E0496F00962AF8 /* AppIconGreen83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AAF2E28423E0496F00962AF8 /* AppIconGreen83.5x83.5@2x.png */; };
 		AAF2E28723E0498200962AF8 /* AppIconPurple83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AAF2E28623E0498100962AF8 /* AppIconPurple83.5x83.5@2x.png */; };
 		AAF2E28B23E049DF00962AF8 /* AppIconYellow83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AAF2E28A23E049DF00962AF8 /* AppIconYellow83.5x83.5@2x.png */; };
-		EA7EFE722677F62F0075464E /* domainMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA7EFE712677F62F0075464E /* domainMatching.swift */; };
+		EA39B7E2268A1A35000C62CD /* privacy-reference-tests in Resources */ = {isa = PBXBuildFile; fileRef = EA39B7E1268A1A35000C62CD /* privacy-reference-tests */; };
+		EAB19EDA268963510015D3EA /* DomainMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */; };
 		F10307391E7C5E310059FEC7 /* NoBookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10307381E7C5E310059FEC7 /* NoBookmarksCell.swift */; };
 		F103073B1E7C91330059FEC7 /* BookmarksDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */; };
 		F103076B1E800DC30059FEC7 /* BookmarksManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F103076A1E800DC30059FEC7 /* BookmarksManager.swift */; };
@@ -1902,7 +1903,8 @@
 		AAF2E28423E0496F00962AF8 /* AppIconGreen83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIconGreen83.5x83.5@2x.png"; sourceTree = "<group>"; };
 		AAF2E28623E0498100962AF8 /* AppIconPurple83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIconPurple83.5x83.5@2x.png"; sourceTree = "<group>"; };
 		AAF2E28A23E049DF00962AF8 /* AppIconYellow83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIconYellow83.5x83.5@2x.png"; sourceTree = "<group>"; };
-		EA7EFE712677F62F0075464E /* domainMatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = domainMatching.swift; sourceTree = "<group>"; };
+		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "privacy-reference-tests"; path = "submodules/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
+		EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainMatchingTests.swift; sourceTree = "<group>"; };
 		F10307381E7C5E310059FEC7 /* NoBookmarksCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoBookmarksCell.swift; sourceTree = "<group>"; };
 		F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksDataSource.swift; sourceTree = "<group>"; };
 		F103076A1E800DC30059FEC7 /* BookmarksManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksManager.swift; sourceTree = "<group>"; };
@@ -3080,7 +3082,8 @@
 		EA7EFE662677F5BD0075464E /* PrivacyReferenceTests */ = {
 			isa = PBXGroup;
 			children = (
-				EA7EFE712677F62F0075464E /* domainMatching.swift */,
+				EA39B7E1268A1A35000C62CD /* privacy-reference-tests */,
+				EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */,
 			);
 			name = PrivacyReferenceTests;
 			sourceTree = "<group>";
@@ -4455,6 +4458,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				85F1E9C11FB7D19A00A75AC1 /* ddgissuercert.der in Resources */,
+				EA39B7E2268A1A35000C62CD /* privacy-reference-tests in Resources */,
 				85F1E9BB1FB7D06300A75AC1 /* ddgcert.der in Resources */,
 				85F1E9B91FB7CB7100A75AC1 /* testcert.der in Resources */,
 				F17843E91F36226700390DCD /* MockFiles in Resources */,
@@ -4924,6 +4928,7 @@
 				F4560AC125B8926400597645 /* DaxDialogFireEducationTests.swift in Sources */,
 				85D2187024BF24DB004373D2 /* FaviconRequestModifierTests.swift in Sources */,
 				8570656E1F6AAE270044DCB1 /* DetectedTrackerTests.swift in Sources */,
+				EAB19EDA268963510015D3EA /* DomainMatchingTests.swift in Sources */,
 				85267D2D215286C500A0CE28 /* PrivacyPracticesTests.swift in Sources */,
 				8590CB632684F10F0089F6BF /* ContentBlockerProtectionStoreTests.swift in Sources */,
 				83EDCC411F86B89C005CDFCD /* StatisticsLoaderTests.swift in Sources */,
@@ -4987,7 +4992,6 @@
 				85C7438E2152A66D005CF998 /* EmbeddedTermsOfServiceStoreTests.swift in Sources */,
 				F1D477C91F2139410031ED49 /* SmallOmniBarStateTests.swift in Sources */,
 				85F1E9B71FB7C81C00A75AC1 /* NativeDisplayableCertificateBuilderDriverTests.swift in Sources */,
-				EA7EFE722677F62F0075464E /* domainMatching.swift in Sources */,
 				F198D7981E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift in Sources */,
 				8521FDE6238D414B00A44CC3 /* FileStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -468,6 +468,7 @@
 		AAF2E28523E0496F00962AF8 /* AppIconGreen83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AAF2E28423E0496F00962AF8 /* AppIconGreen83.5x83.5@2x.png */; };
 		AAF2E28723E0498200962AF8 /* AppIconPurple83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AAF2E28623E0498100962AF8 /* AppIconPurple83.5x83.5@2x.png */; };
 		AAF2E28B23E049DF00962AF8 /* AppIconYellow83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AAF2E28A23E049DF00962AF8 /* AppIconYellow83.5x83.5@2x.png */; };
+		EA7EFE722677F62F0075464E /* domainMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA7EFE712677F62F0075464E /* domainMatching.swift */; };
 		F10307391E7C5E310059FEC7 /* NoBookmarksCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10307381E7C5E310059FEC7 /* NoBookmarksCell.swift */; };
 		F103073B1E7C91330059FEC7 /* BookmarksDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */; };
 		F103076B1E800DC30059FEC7 /* BookmarksManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F103076A1E800DC30059FEC7 /* BookmarksManager.swift */; };
@@ -1901,6 +1902,7 @@
 		AAF2E28423E0496F00962AF8 /* AppIconGreen83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIconGreen83.5x83.5@2x.png"; sourceTree = "<group>"; };
 		AAF2E28623E0498100962AF8 /* AppIconPurple83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIconPurple83.5x83.5@2x.png"; sourceTree = "<group>"; };
 		AAF2E28A23E049DF00962AF8 /* AppIconYellow83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIconYellow83.5x83.5@2x.png"; sourceTree = "<group>"; };
+		EA7EFE712677F62F0075464E /* domainMatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = domainMatching.swift; sourceTree = "<group>"; };
 		F10307381E7C5E310059FEC7 /* NoBookmarksCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoBookmarksCell.swift; sourceTree = "<group>"; };
 		F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksDataSource.swift; sourceTree = "<group>"; };
 		F103076A1E800DC30059FEC7 /* BookmarksManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksManager.swift; sourceTree = "<group>"; };
@@ -3075,6 +3077,14 @@
 			name = Red;
 			sourceTree = "<group>";
 		};
+		EA7EFE662677F5BD0075464E /* PrivacyReferenceTests */ = {
+			isa = PBXGroup;
+			children = (
+				EA7EFE712677F62F0075464E /* domainMatching.swift */,
+			);
+			name = PrivacyReferenceTests;
+			sourceTree = "<group>";
+		};
 		F11044FE1ECFD6AF00C5E3D3 /* Parser */ = {
 			isa = PBXGroup;
 			children = (
@@ -3787,6 +3797,7 @@
 		F1E092B31E92A6B900732CCC /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				EA7EFE662677F5BD0075464E /* PrivacyReferenceTests */,
 				83EDCC3E1F86B363005CDFCD /* API */,
 				830FA79B1F8E81FB00FCE105 /* ContentBlocker */,
 				F17D722C1E8B3563003E8B0E /* Domain */,
@@ -4976,6 +4987,7 @@
 				85C7438E2152A66D005CF998 /* EmbeddedTermsOfServiceStoreTests.swift in Sources */,
 				F1D477C91F2139410031ED49 /* SmallOmniBarStateTests.swift in Sources */,
 				85F1E9B71FB7C81C00A75AC1 /* NativeDisplayableCertificateBuilderDriverTests.swift in Sources */,
+				EA7EFE722677F62F0075464E /* domainMatching.swift in Sources */,
 				F198D7981E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift in Sources */,
 				8521FDE6238D414B00A44CC3 /* FileStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,

--- a/DuckDuckGoTests/DomainMatchingTests.swift
+++ b/DuckDuckGoTests/DomainMatchingTests.swift
@@ -1,5 +1,5 @@
 //
-//  domainMatching.swift
+//  DomainMatchingTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2021 DuckDuckGo. All rights reserved.
@@ -21,6 +21,7 @@ import XCTest
 @testable import TrackerRadarKit
 @testable import Core
 import Foundation
+import os.log
 
 struct RefTests: Decodable {
     
@@ -46,12 +47,12 @@ struct RefTests: Decodable {
     let domainTests: DomainTests
 }
 
-class DomainMatching: XCTestCase {
+class DomainMatchingTests: XCTestCase {
     private var data = JsonTestDataLoader()
 
     func testDomainMatchingRules() throws {
-        let trackerJSON = data.fromJsonFile("MockFiles/reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json")
-        let testJSON = data.fromJsonFile("MockFiles/reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json")
+        let trackerJSON = data.fromJsonFile("privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json")
+        let testJSON = data.fromJsonFile("privacy-reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json")
 
         let trackerData = try JSONDecoder().decode(TrackerData.self, from: trackerJSON)
         
@@ -62,16 +63,16 @@ class DomainMatching: XCTestCase {
                 andTemporaryUnprotectedDomains: [])
 
         for test in tests {
-            print("TEST: ", test.name)
+            os_log("TEST: %s", test.name)
             let requestURL = URL(string: test.requestURL)
             let siteURL = URL(string: test.siteURL)
             let requestType = ContentBlockerRulesBuilder.resourceMapping[test.requestType]
             let rule = rules.matchURL(url: requestURL!, topLevel: siteURL!, resourceType: requestType!)
             let result = rule?.action
             if test.expectAction == "block" {
-                XCTAssert(result == .block())
+                XCTAssertEqual(result, .block())
             } else {
-                XCTAssert(result == nil || result == .ignorePreviousRules())
+                XCTAssertTrue(result == nil || result == .ignorePreviousRules())
             }
         }
     }

--- a/DuckDuckGoTests/domainMatching.swift
+++ b/DuckDuckGoTests/domainMatching.swift
@@ -1,0 +1,89 @@
+//
+//  domainMatching.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import TrackerRadarKit
+@testable import Core
+import Foundation
+
+struct RefTests: Decodable {
+    
+    struct Test: Decodable {
+        
+        let name: String
+        let siteURL: String
+        let requestURL: String
+        let requestType: String
+        let expectAction: String?
+        let exceptPlatforms: [String]?
+        
+    }
+    
+    struct DomainTests: Decodable {
+        
+        let name: String
+        let desc: String
+        let tests: [Test]
+        
+    }
+    
+    let domainTests: DomainTests
+}
+
+class DomainMatching: XCTestCase {
+    private var data = JsonTestDataLoader()
+
+    func test() throws {
+        let trackerJSON = data.fromJsonFile("MockFiles/reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json")
+        let testJSON = data.fromJsonFile("MockFiles/reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json")
+
+        let trackerData = try JSONDecoder().decode(TrackerData.self, from: trackerJSON)
+        
+        let refTests = try JSONDecoder().decode(RefTests.self, from: testJSON)
+        let tests = refTests.domainTests.tests
+
+        let rules = ContentBlockerRulesBuilder(trackerData: trackerData).buildRules(withExceptions: ["duckduckgo.com"],
+                andTemporaryUnprotectedDomains: [])
+
+        for test in tests {
+            print("TEST: ", test.name)
+            let requestURL = URL(string: test.requestURL)
+            let siteURL = URL(string: test.siteURL)
+            let requestType = ContentBlockerRulesBuilder.resourceMapping[test.requestType]
+            let rule = rules.matchURL(url: requestURL!, topLevel: siteURL!, resourceType: requestType!)
+            let result = rule?.action
+            if test.expectAction == "block" {
+                XCTAssert(result == .block())
+            } else {
+                XCTAssert(result == nil || result == .ignorePreviousRules())
+            }
+        }
+    }
+}
+
+extension Array where Element == ContentBlockerRule {
+    func matchURL(url: URL, topLevel: URL, resourceType: ContentBlockerRule.Trigger.ResourceType) -> ContentBlockerRule? {
+        var result: ContentBlockerRule?
+        for rule in self where rule.matches(resourceUrl: url, onPageWithUrl: topLevel, ofType: resourceType) {
+            result = rule
+        }
+        
+        return result
+    }
+}

--- a/DuckDuckGoTests/domainMatching.swift
+++ b/DuckDuckGoTests/domainMatching.swift
@@ -49,7 +49,7 @@ struct RefTests: Decodable {
 class DomainMatching: XCTestCase {
     private var data = JsonTestDataLoader()
 
-    func test() throws {
+    func testDomainMatchingRules() throws {
         let trackerJSON = data.fromJsonFile("MockFiles/reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json")
         let testJSON = data.fromJsonFile("MockFiles/reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json")
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1171671347221384/1200272854466885/f
Tech Design URL: https://app.asana.com/0/1171671347221384/1200501100360630
CC:

**Description**:
Adds reference tests for domain matching rules.  Test definitions pulled as git submodule from https://github.com/duckduckgo/privacy-reference-tests

**Steps to test this PR**:
1. update git submodules
2. cmd-U in Xcode, or run the test in `domainMatching.swift` directly 

Note CI seems to be failing but for seemingly unrelated reasons (`comscore` tests), will retry again later.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

