### PR TITLE
Fix height calculation on onboarding messages

### DIFF
--- a/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
+++ b/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YXw-O5-LLS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YXw-O5-LLS">
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -37,14 +37,14 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lvy-9G-3gr">
-                                <rect key="frame" x="20" y="182" width="984" height="70"/>
+                                <rect key="frame" x="20" y="182" width="984" height="82.5"/>
                                 <attributedString key="attributedText">
                                     <fragment>
                                         <string key="content">Welcome to
 DuckDuckGo!</string>
                                         <attributes>
                                             <color key="NSColor" red="0.1333333333" green="0.1333333333" blue="0.1333333333" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <font key="NSFont" size="32" name="ProximaNova-Bold"/>
+                                            <font key="NSFont" metaFont="system" size="32"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="6" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -161,7 +161,7 @@ DuckDuckGo!</string>
             <objects>
                 <viewController storyboardIdentifier="DaxDialog" id="UUS-R7-a2i" customClass="DaxDialogViewController" customModule="DuckDuckGo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="im0-JF-Sin">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="DaxIcon" translatesAutoresizingMaskIntoConstraints="NO" id="UzU-6y-Vfa">
@@ -173,15 +173,15 @@ DuckDuckGo!</string>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ix6-dq-RAh" userLabel="Background">
-                                <rect key="frame" x="10" y="82" width="355" height="318"/>
+                                <rect key="frame" x="10" y="82" width="300" height="318"/>
                                 <subviews>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDm-rv-vek">
-                                        <rect key="frame" x="16" y="10" width="323" height="22"/>
+                                        <rect key="frame" x="16" y="10" width="268" height="26"/>
                                         <attributedString key="attributedText">
                                             <fragment content="Label">
                                                 <attributes>
                                                     <color key="NSColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <font key="NSFont" size="16" name="ProximaNova-Regular"/>
+                                                    <font key="NSFont" metaFont="system" size="16"/>
                                                     <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineHeightMultiple="1.3500000000000001" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
@@ -189,7 +189,7 @@ DuckDuckGo!</string>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zJt-F9-L48">
-                                        <rect key="frame" x="16" y="250" width="323" height="44"/>
+                                        <rect key="frame" x="16" y="250" width="268" height="44"/>
                                         <color key="backgroundColor" red="0.40392156862745099" green="0.5607843137254902" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="Gta-qP-xcx"/>
@@ -288,17 +288,17 @@ DuckDuckGo!</string>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XmT-SX-w7H">
-                                <rect key="frame" x="324.5" y="309" width="375" height="400"/>
+                                <rect key="frame" x="352" y="309" width="320" height="400"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="400" id="V8D-Hc-dLK"/>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="375" id="eK0-5h-FDJ"/>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="320" id="eK0-5h-FDJ"/>
                                 </constraints>
                                 <connections>
                                     <segue destination="UUS-R7-a2i" kind="embed" id="WM8-Xy-pab"/>
                                 </connections>
                             </containerView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgy-75-OvJ">
-                                <rect key="frame" x="966" y="72" width="34" height="28"/>
+                                <rect key="frame" x="966" y="72" width="34" height="31"/>
                                 <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="16"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Hide"/>
@@ -395,9 +395,9 @@ DuckDuckGo!</string>
                                 </connections>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OaR-Oy-k45">
-                                <rect key="frame" x="324.5" y="276" width="375" height="400"/>
+                                <rect key="frame" x="352" y="276" width="320" height="400"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="375" id="RWw-1w-Uhi"/>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="320" id="RWw-1w-Uhi"/>
                                     <constraint firstAttribute="height" constant="400" id="yAP-iu-Hwg"/>
                                 </constraints>
                                 <connections>


### PR DESCRIPTION
Task/Issue URL: Fix issue https://github.com/duckduckgo/iOS/issues/910
Asana: https://app.asana.com/0/414709148257752/1200623609427972


**Description**:
The storyboard containing the layout of the onboarding screen was considering the minimum width to be 375 instead of 320. The Fix was just a change on 2 views on the storyboard width's constant.

Code reviews for StoryBoards are generally not straightforward so in case the reviewer wants to just close the PR and do the changes on the reviewer's machine here are the only changes made:

<img width="500" alt="Screen Shot 2021-06-27 at 19 45 54" src="https://user-images.githubusercontent.com/782316/123559177-5bc89080-d792-11eb-9b32-5f4b2439894c.png">


**Steps to test this PR**:
- On an iPhone SE or iPod touch
- Open the app for the first time
- See first onboarding message
- Open a website
- Open a new tab
- See the subsequent onboarding message

Here's a video illustrating the steps to reproduce:

https://user-images.githubusercontent.com/782316/123559230-af3ade80-d792-11eb-8f32-c9fd24f29c52.mp4

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone 11
* [x] iPod touch (7th Gen)

**Test screenshots and video**

https://user-images.githubusercontent.com/782316/123559316-283a3600-d793-11eb-913d-1946eaa91f79.mp4


<img width="500" alt="Screen Shot 2021-06-27 at 19 48 37" src="https://user-images.githubusercontent.com/782316/123559277-f32de380-d792-11eb-944f-6ab8cb9a536b.png">
<img width="500" alt="Screen Shot 2021-06-27 at 19 48 50" src="https://user-images.githubusercontent.com/782316/123559279-f6c16a80-d792-11eb-8af7-3d87fd7436e8.png">
<img width="500" alt="Screen Shot 2021-06-27 at 19 49 11" src="https://user-images.githubusercontent.com/782316/123559281-f7f29780-d792-11eb-9be5-fe0b237ede85.png">
<img width="500" alt="Screen Shot 2021-06-27 at 19 49 28" src="https://user-images.githubusercontent.com/782316/123559282-f923c480-d792-11eb-9dc5-816f34561391.png">


