### PR TITLE
skip reference tests that are disabled for this platform

### DIFF
--- a/DuckDuckGoTests/DomainMatchingTests.swift
+++ b/DuckDuckGoTests/DomainMatchingTests.swift
@@ -63,6 +63,11 @@ class DomainMatchingTests: XCTestCase {
                 andTemporaryUnprotectedDomains: [])
 
         for test in tests {
+            let skip = test.exceptPlatforms?.contains("ios-browser")
+            if skip == true {
+                os_log("!!SKIPPING TEST: %s", test.name)
+                continue
+            }
             os_log("TEST: %s", test.name)
             let requestURL = URL(string: test.requestURL)
             let siteURL = URL(string: test.siteURL)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1171671347221384/1200272854466885/f
Tech Design URL: https://app.asana.com/0/1171671347221384/1200351023709985/f
CC:

**Description**:
Add support for the "except_platforms" array in the reference test definition.  It allows us to exempt individual tests on specific platforms 

**Steps to test this PR**:
1. If you want to test this against a dataset containing this field, you can checkout  `la/cnames` in your local `submodules/privacy-reference-tests`  which contains a test that is exempted for iOS.  The tests should pass.
2. If you manually remove the `"exceptPlatforms": [ "ios-browser" ]` exception from `tracker_radar_reference.json`, that test should fail.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

