### PR TITLE
prevent div0 crash if pages visited is zero

### DIFF
--- a/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
+++ b/DuckDuckGo/PrivacyProtectionNetworkLeaderboardController.swift
@@ -199,7 +199,7 @@ extension PrivacyProtectionNetworkLeaderboardController: UITableViewDataSource {
         }
 
         let network = networksDetected[indexPath.row]
-        let percent = drama ? 0 : 100 * Int(network.detectedOnCount) / pagesVisited
+        let percent = pagesVisited == 0 || drama ? 0 : 100 * Int(network.detectedOnCount) / pagesVisited
 
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "Cell") as? PrivacyProtectionNetworkLeaderboardCell else {
             fatalError("Failed to dequeue cell as PrivacyProtectionNetworkLeaderboardCell")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1200590152293113
Tech Design URL:
CC:

**Description**:

Fixes an edge case div0 crash.

**Steps to test this PR**:
1. Visit network leaderboard on the dashboard
1. Reset the leaderboard (think is what causes the crash)
1. Check the privacy dashboard, network leaderboard 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone X

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

