### PR TITLE
Release fire education experiment (i.e. remove experiment and make always on)

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -134,7 +134,6 @@ public enum PixelName: String {
     case daxDialogsFireEducationShown = "m_dx_fe_s"
     case daxDialogsFireEducationConfirmed = "m_dx_fe_co"
     case daxDialogsFireEducationCancelled = "m_dx_fe_ca"
-    case daxDialogsFireEducationCancelledOutsideOfButton = "m_dx_fe_ca_o"
     
     case widgetFavoriteLaunch = "m_w_fl"
     case widgetNewSearch = "m_w_ns"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -135,11 +135,6 @@ public enum PixelName: String {
     case daxDialogsFireEducationConfirmed = "m_dx_fe_co"
     case daxDialogsFireEducationCancelled = "m_dx_fe_ca"
     case daxDialogsFireEducationCancelledOutsideOfButton = "m_dx_fe_ca_o"
-    case fireEducationPulseShown = "m_fe_p_s"
-    case fireEducationPulseCancelledBecauseTabOpened = "m_fe_p_c_ta"
-    case fireEducationPulseCancelledBecauseTimeout = "m_fe_p_c_to"
-    case fireEducationFireButtonPressedWhilstPulseShowing = "m_fe_p_b"
-    case fireEducationFireButtonOnTabSwitcherScreenPressedWhilstPulseShowing = "m_fe_p_ts_b"
     
     case widgetFavoriteLaunch = "m_w_fl"
     case widgetNewSearch = "m_w_ns"

--- a/Core/VariantManager.swift
+++ b/Core/VariantManager.swift
@@ -60,10 +60,7 @@ public struct Variant {
         // SERP testing
         Variant(name: "sc", weight: 1, isIncluded: When.always, features: []),
         Variant(name: "sd", weight: doNotAllocate, isIncluded: When.always, features: []),
-        Variant(name: "se", weight: 1, isIncluded: When.always, features: []),
-        
-        Variant(name: "mn", weight: doNotAllocate, isIncluded: When.always, features: []),
-        Variant(name: "me", weight: doNotAllocate, isIncluded: When.always, features: [.fireButtonEducationIteration])
+        Variant(name: "se", weight: 1, isIncluded: When.always, features: [])
     ]
     
     public let name: String

--- a/DuckDuckGo/ActionSheetDaxDialogViewController.swift
+++ b/DuckDuckGo/ActionSheetDaxDialogViewController.swift
@@ -96,7 +96,7 @@ class ActionSheetDaxDialogViewController: UIViewController {
     @IBAction func onTapOutside(_ sender: Any) {
         self.dismiss(animated: true)
         if let spec = spec {
-            Pixel.fire(pixel: spec.cancelOutsideOfButtonPixelName)
+            Pixel.fire(pixel: spec.cancelActionPixelName)
         }
     }
 }

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -180,15 +180,11 @@ class DaxDialogs {
     func fireButtonPulseStarted() {
         if settings.fireButtonPulseDateShown == nil {
             settings.fireButtonPulseDateShown = Date()
-            Pixel.fire(pixel: .fireEducationPulseShown)
         }
         if fireButtonPulseTimer == nil, let date = settings.fireButtonPulseDateShown {
             let timeSinceShown = Date().timeIntervalSince(date)
             let timerTime = DaxDialogs.timeToFireButtonExpire - timeSinceShown
             fireButtonPulseTimer = Timer(timeInterval: timerTime, repeats: false) { _ in
-                if !self.settings.fireButtonEducationShownOrExpired {
-                    Pixel.fire(pixel: .fireEducationPulseCancelledBecauseTimeout)
-                }
                 self.settings.fireButtonEducationShownOrExpired = true
                 ViewHighlighter.hideAll()
             }
@@ -198,9 +194,6 @@ class DaxDialogs {
     
     func fireButtonPulseCancelled() {
         fireButtonPulseTimer?.invalidate()
-        if !self.settings.fireButtonEducationShownOrExpired {
-            Pixel.fire(pixel: .fireEducationPulseCancelledBecauseTabOpened)
-        }
         settings.fireButtonEducationShownOrExpired = true
     }
     

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -97,8 +97,7 @@ class DaxDialogs {
                                                          isConfirmActionDestructive: true,
                                                          displayedPixelName: .daxDialogsFireEducationShown,
                                                          confirmActionPixelName: .daxDialogsFireEducationConfirmed,
-                                                         cancelActionPixelName: .daxDialogsFireEducationCancelled,
-                                                         cancelOutsideOfButtonPixelName: .daxDialogsFireEducationCancelledOutsideOfButton)
+                                                         cancelActionPixelName: .daxDialogsFireEducationCancelled)
         
         let message: String
         let confirmAction: String
@@ -108,7 +107,6 @@ class DaxDialogs {
         let displayedPixelName: PixelName
         let confirmActionPixelName: PixelName
         let cancelActionPixelName: PixelName
-        let cancelOutsideOfButtonPixelName: PixelName
     }
 
     public static let shared = DaxDialogs()

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -152,12 +152,8 @@ class DaxDialogs {
         return nextHomeScreenMessageOverride == .addFavorite
     }
     
-    var isFireButtonEducationEnabled: Bool {
-        return variantManager.isSupported(feature: .fireButtonEducationIteration)
-    }
-    
     var shouldShowFireButtonPulse: Bool {
-        return nonDDGBrowsingMessageSeen && !fireButtonBrowsingMessageSeenOrExpired && isFireButtonEducationEnabled && isEnabled
+        return nonDDGBrowsingMessageSeen && !fireButtonBrowsingMessageSeenOrExpired && isEnabled
     }
 
     func dismiss() {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -502,7 +502,6 @@ class MainViewController: UIViewController {
         Pixel.fire(pixel: .forgetAllPressedBrowsing)
         
         if let spec = DaxDialogs.shared.fireButtonEducationMessage() {
-            Pixel.fire(pixel: .fireEducationFireButtonPressedWhilstPulseShowing)
             performSegue(withIdentifier: "ActionSheetDaxDialog", sender: spec)
         } else {
             let alert = ForgetDataAlert.buildAlert(forgetTabsAndDataHandler: { [weak self] in

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -300,7 +300,6 @@ class TabSwitcherViewController: UIViewController {
         Pixel.fire(pixel: .forgetAllPressedTabSwitching)
         
         if DaxDialogs.shared.shouldShowFireButtonPulse {
-            Pixel.fire(pixel: .fireEducationFireButtonOnTabSwitcherScreenPressedWhilstPulseShowing)
             let spec = DaxDialogs.shared.fireButtonEducationMessage()
             performSegue(withIdentifier: "ActionSheetDaxDialog", sender: spec)
         } else {

--- a/DuckDuckGo/TabsBarViewController.swift
+++ b/DuckDuckGo/TabsBarViewController.swift
@@ -314,7 +314,6 @@ extension MainViewController: TabsBarDelegate {
     }
     
     func tabsBarDidRequestFireEducationDialog(_ controller: TabsBarViewController) {
-        Pixel.fire(pixel: .fireEducationFireButtonPressedWhilstPulseShowing)
         let spec = DaxDialogs.shared.fireButtonEducationMessage()
         performSegue(withIdentifier: "ActionSheetDaxDialog", sender: spec)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1179359141574181/f
Tech Design URL:
CC:

**Description**:
Turns the fire education experiment to always on and cleans up the experiment code. 
Removes the now unnecessary pixels:
```
fireEducationPulseShown = "m_fe_p_s"
fireEducationPulseCancelledBecauseTabOpened = "m_fe_p_c_ta"
fireEducationPulseCancelledBecauseTimeout = "m_fe_p_c_to"
fireEducationFireButtonPressedWhilstPulseShowing = "m_fe_p_b"
fireEducationFireButtonOnTabSwitcherScreenPressedWhilstPulseShowing = "m_fe_p_ts_b"
```

And consolidates 
```
daxDialogsFireEducationCancelled = "m_dx_fe_ca" 
daxDialogsFireEducationCancelledOutsideOfButton = "m_dx_fe_ca_o" 
```
into just m_dx_fe_ca

It **keeps**:
``` 
daxDialogsFireEducationShown = "m_dx_fe_s"
daxDialogsFireEducationConfirmed = "m_dx_fe_co"
daxDialogsFireEducationCancelled = "m_dx_fe_ca"
```
largely because it's consistent with the other dax dialogs, but if you think we should remove these too, I wouldn't have much opposition to changing the ActionSheet specs to make pixels optional.

**Steps to test this PR**:
1. Test that fire button education shows when onboarding every time (but otherwise doesn't show)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

