### PR TITLE
Update the Privacy Leaderboard to have a scalable header UI

### DIFF
--- a/DuckDuckGo/Base.lproj/PrivacyProtection.storyboard
+++ b/DuckDuckGo/Base.lproj/PrivacyProtection.storyboard
@@ -1412,7 +1412,7 @@ many trackers we've blocked.</string>
                                                 <constraint firstItem="3j6-i6-nia" firstAttribute="top" secondItem="2vQ-S5-Xxv" secondAttribute="top" constant="8" id="kwt-rB-kzs"/>
                                                 <constraint firstItem="tGi-n5-HjD" firstAttribute="centerX" secondItem="2vQ-S5-Xxv" secondAttribute="centerX" id="lWb-xb-FEw"/>
                                                 <constraint firstAttribute="bottom" secondItem="3j6-i6-nia" secondAttribute="bottom" constant="8" id="mzD-PU-e9l"/>
-                                                <constraint firstAttribute="height" constant="75" id="xN7-nQ-eyz"/>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="75" id="xN7-nQ-eyz"/>
                                             </constraints>
                                         </view>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ict-Tf-vBn">


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200557316195160/f
Tech Design URL:
CC:

**Description**:

This PR updates the Privacy Leaderboard's header to scale its height. The fix it simple: previously, one of the views had a fixed height of 75 points. This PR changes it to be greater than or equal to 75 points.

**Steps to test this PR**:
1. Run the app as you would usually and check that the leaderboard looks correct
1. Run the app with the Double Length Pseudolanguage and check that it can wrap multiple lines

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

