### PR TITLE
Re-order data / tab clearing and delete HSTS cache

### DIFF
--- a/Core/HSTSCache.swift
+++ b/Core/HSTSCache.swift
@@ -1,0 +1,31 @@
+//
+//  HSTSCache.swift
+//  DuckDuckGo
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public class HSTSCache {
+
+    public static func delete() {
+        if let hstsCache = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first?
+            .appendingPathComponent("com.apple.WebKit.Networking/HSTS.plist") {
+            try? FileManager.default.removeItem(at: hstsCache)
+        }
+    }
+
+}

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		85482D992462F1C600EDEDD1 /* ActionIcons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85482D982462F1C600EDEDD1 /* ActionIcons.xcassets */; };
 		8548D95E25262B1B005AAE49 /* ViewHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8548D95D25262B1B005AAE49 /* ViewHighlighter.swift */; };
 		8548D96825262C33005AAE49 /* view_highlight.json in Resources */ = {isa = PBXBuildFile; fileRef = 8548D96725262C33005AAE49 /* view_highlight.json */; };
+		854AAE0A26B19C8800B90BC8 /* HSTSCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 854AAE0926B19C8800B90BC8 /* HSTSCache.swift */; };
 		85514FFD2372DA0100DBC528 /* ios13-home-row.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 85514FFC2372DA0000DBC528 /* ios13-home-row.mp4 */; };
 		8551912724746EDC0010FDD0 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8551912624746EDC0010FDD0 /* SnapshotHelper.swift */; };
 		855D914D2063EF6A00C4B448 /* TabSwitcherTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855D914C2063EF6A00C4B448 /* TabSwitcherTransition.swift */; };
@@ -918,6 +919,7 @@
 		85482D982462F1C600EDEDD1 /* ActionIcons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ActionIcons.xcassets; sourceTree = "<group>"; };
 		8548D95D25262B1B005AAE49 /* ViewHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHighlighter.swift; sourceTree = "<group>"; };
 		8548D96725262C33005AAE49 /* view_highlight.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = view_highlight.json; sourceTree = "<group>"; };
+		854AAE0926B19C8800B90BC8 /* HSTSCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HSTSCache.swift; sourceTree = "<group>"; };
 		85514FFC2372DA0000DBC528 /* ios13-home-row.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ios13-home-row.mp4"; sourceTree = "<group>"; };
 		85519124247468580010FDD0 /* TrackerRadarIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerRadarIntegrationTests.swift; sourceTree = "<group>"; };
 		8551912624746EDC0010FDD0 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = fastlane/SnapshotHelper.swift; sourceTree = SOURCE_ROOT; };
@@ -3446,6 +3448,7 @@
 				F159BDA61F0C073D00B4A01D /* WebCacheSummary.swift */,
 				83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */,
 				830381BF1F850AAF00863075 /* WKWebViewConfigurationExtension.swift */,
+				854AAE0926B19C8800B90BC8 /* HSTSCache.swift */,
 			);
 			name = Web;
 			sourceTree = "<group>";
@@ -5100,6 +5103,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				854AAE0A26B19C8800B90BC8 /* HSTSCache.swift in Sources */,
 				8533133F1F98EA7900E061A5 /* UnprotectedSitesManager.swift in Sources */,
 				8328AAB5212A3D7C00293140 /* BloomFilter.cpp in Sources */,
 				F16393FF1ECCB9CC00DDD653 /* FileLoader.swift in Sources */,

--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -44,13 +44,13 @@ class AutoClear {
     
     private func clearData() {
         guard let settings = AutoClearSettingsModel(settings: appSettings) else { return }
-        
-        if settings.action.contains(.clearData) {
-            worker.forgetData()
-        }
-        
+
         if settings.action.contains(.clearTabs) {
             worker.forgetTabs()
+        }
+
+        if settings.action.contains(.clearData) {
+            worker.forgetData()
         }
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1531,11 +1531,10 @@ extension MainViewController: AutoClearWorker {
         ServerTrustCache.shared.clear()
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
 
-        HSTSCache.delete()
-
         let pixel = TimedPixel(.forgetAllDataCleared)
         WebCacheManager.shared.clear {
             pixel.fire(withAdditionalParmaeters: [PixelParameters.tabCount: "\(self.tabManager.count)"])
+            HSTSCache.delete()
         }
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1531,6 +1531,8 @@ extension MainViewController: AutoClearWorker {
         ServerTrustCache.shared.clear()
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
 
+        HSTSCache.delete()
+
         let pixel = TimedPixel(.forgetAllDataCleared)
         WebCacheManager.shared.clear {
             pixel.fire(withAdditionalParmaeters: [PixelParameters.tabCount: "\(self.tabManager.count)"])
@@ -1542,9 +1544,9 @@ extension MainViewController: AutoClearWorker {
         Pixel.fire(pixel: .forgetAllExecuted)
         
         fireButtonAnimator?.animate {
-            self.forgetData()
-            DaxDialogs.shared.resumeRegularFlow()
             self.forgetTabs()
+            DaxDialogs.shared.resumeRegularFlow()
+            self.forgetData()
         } onTransitionCompleted: {
             ActionMessageView.present(message: UserText.actionForgetAllDone)
             transitionCompletion?()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/69071770703008/1200664593509351
Tech Design URL:
CC:

**Description**:

Re-order data and tab clearing to ensure that webview has been dispoed first.  explicitly remove the HSTS cache file.

**Steps to test this PR**:
1. In a simulator open a bunch of tabs and browse around in each.
1. cd to the Library folder of your app on disk
1. Run `find .` to get an idea of the files stored
1. Run `plutil -p ./Caches/com.apple.WebKit.Networking/HSTS.plist` - there will be a few entries probably
1. Use the fire button 
1. Run `find .` a lot of the files should gone
1. Run `plutil -p ./Caches/com.apple.WebKit.Networking/HSTS.plist` - it should complain the file does not exist
1. Repeat the test to confirm that the WebView/WebKit is still behaving after having that file deleted
1. Check data clearing using the auto clear functionality 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

