### PR TITLE
Break loop when embedded Trackers list fails to compile

### DIFF
--- a/Core/ContentBlockerRulesManager.swift
+++ b/Core/ContentBlockerRulesManager.swift
@@ -231,17 +231,22 @@ public class ContentBlockerRulesManager {
                 // We failed compilation for non-embedded TDS, marking as broken.
                 etagForFailedTDSCompilation = tdsEtag
                 Pixel.fire(pixel: .contentBlockingTDSCompilationFailed,
+                           error: error,
                            withAdditionalParameters: [PixelParameters.etag: tdsEtag])
             } else if tempListEtag != nil {
                 etagForFailedTempListCompilation = tempListEtag
                 Pixel.fire(pixel: .contentBlockingTempListCompilationFailed,
+                           error: error,
                            withAdditionalParameters: [PixelParameters.etag: tempListEtag ?? "empty"])
             } else if !unprotectedSitesHash.isEmpty {
                 hashForFailedUnprotectedSitesCompilation = unprotectedSitesHash
-                Pixel.fire(pixel: .contentBlockingUnpSitesCompilationFailed)
+                Pixel.fire(pixel: .contentBlockingUnpSitesCompilationFailed,
+                           error: error)
             } else {
                 // We failed for embedded data, this is unlikely.
-                Pixel.fire(pixel: .contentBlockingFallbackCompilationFailed)
+                Pixel.fire(pixel: .contentBlockingFallbackCompilationFailed) { _ in
+                    assertionFailure("Could not compile rules list")
+                }
             }
         }
         

--- a/Core/ContentBlockerRulesManager.swift
+++ b/Core/ContentBlockerRulesManager.swift
@@ -245,7 +245,7 @@ public class ContentBlockerRulesManager {
             } else {
                 // We failed for embedded data, this is unlikely.
                 Pixel.fire(pixel: .contentBlockingFallbackCompilationFailed) { _ in
-                    assertionFailure("Could not compile rules list")
+                    fatalError("Could not compile embedded rules list")
                 }
             }
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1200685603965597
Tech Design URL:
CC:

**Description**:

When embedded list fails to compile (that should never happen on production) break the loop with assertion failure.

**Steps to test this PR**:

General smoke tests for Content Blocker and unprotected sites.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->


**Device Testing**:

* [x] iPhone
* [x] iPad

**OS Testing**:

* [x] iOS 13
* [x] iOS 14


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

