### PR TITLE
Allow settings to be displayed when another view controller is presented

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -448,25 +448,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     func presentWaitlistSettingsModal() {
-        guard let window = window, let rootViewController = window.rootViewController as? MainViewController else {
-            return
-        }
+        guard let window = window, let rootViewController = window.rootViewController as? MainViewController else { return }
 
+        rootViewController.clearNavigationStack()
+        rootViewController.performSegue(withIdentifier: "Settings", sender: nil)
+        let navigationController = rootViewController.presentedViewController as? UINavigationController
         let waitlist = EmailWaitlistViewController.loadFromStoryboard()
 
-        if let presentedViewController = rootViewController.presentedViewController {
-            let settings = SettingsViewController.loadFromStoryboard()
-            let settingsNavigationController = settings as? UINavigationController
-
-            presentedViewController.present(settings, animated: true, completion: nil)
-            settingsNavigationController?.pushViewController(waitlist, animated: true)
-        } else {
-            rootViewController.performSegue(withIdentifier: "Settings", sender: nil)
-
-            let settingsNavigationController = rootViewController.presentedViewController as? UINavigationController
-            settingsNavigationController?.popToRootViewController(animated: false)
-            settingsNavigationController?.pushViewController(waitlist, animated: true)
-        }
+        navigationController?.popToRootViewController(animated: false)
+        navigationController?.pushViewController(waitlist, animated: true)
     }
 
 }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -440,7 +440,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
-        presentWaitlistSettingsModal()
+        if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
+            presentWaitlistSettingsModal()
+        }
+
         completionHandler()
     }
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -447,15 +447,26 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler()
     }
 
-    private func presentWaitlistSettingsModal() {
-        guard let window = window, let rootViewController = window.rootViewController as? MainViewController else { return }
+    func presentWaitlistSettingsModal() {
+        guard let window = window, let rootViewController = window.rootViewController as? MainViewController else {
+            return
+        }
 
-        rootViewController.performSegue(withIdentifier: "Settings", sender: nil)
-        let navigationController = rootViewController.presentedViewController as? UINavigationController
         let waitlist = EmailWaitlistViewController.loadFromStoryboard()
 
-        navigationController?.popToRootViewController(animated: false)
-        navigationController?.pushViewController(waitlist, animated: true)
+        if let presentedViewController = rootViewController.presentedViewController {
+            let settings = SettingsViewController.loadFromStoryboard()
+            let settingsNavigationController = settings as? UINavigationController
+
+            presentedViewController.present(settings, animated: true, completion: nil)
+            settingsNavigationController?.pushViewController(waitlist, animated: true)
+        } else {
+            rootViewController.performSegue(withIdentifier: "Settings", sender: nil)
+
+            let settingsNavigationController = rootViewController.presentedViewController as? UINavigationController
+            settingsNavigationController?.popToRootViewController(animated: false)
+            settingsNavigationController?.pushViewController(waitlist, animated: true)
+        }
     }
 
 }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -451,12 +451,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let window = window, let rootViewController = window.rootViewController as? MainViewController else { return }
 
         rootViewController.clearNavigationStack()
-        rootViewController.performSegue(withIdentifier: "Settings", sender: nil)
-        let navigationController = rootViewController.presentedViewController as? UINavigationController
-        let waitlist = EmailWaitlistViewController.loadFromStoryboard()
 
-        navigationController?.popToRootViewController(animated: false)
-        navigationController?.pushViewController(waitlist, animated: true)
+        // Give the `clearNavigationStack` call time to complete.
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            rootViewController.performSegue(withIdentifier: "Settings", sender: nil)
+            let navigationController = rootViewController.presentedViewController as? UINavigationController
+            let waitlist = EmailWaitlistViewController.loadFromStoryboard()
+
+            navigationController?.popToRootViewController(animated: false)
+            navigationController?.pushViewController(waitlist, animated: true)
+        }
     }
 
 }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -447,7 +447,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler()
     }
 
-    func presentWaitlistSettingsModal() {
+    private func presentWaitlistSettingsModal() {
         guard let window = window, let rootViewController = window.rootViewController as? MainViewController else { return }
 
         rootViewController.clearNavigationStack()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200719636818678/f
Tech Design URL:
CC:

**Description**:

This PR updates the waitlist notification logic to present settings even when another view controller has been presented.

It does this by changing the previous logic from trying to present the settings segue (with the risk of failure) to first checking if another view controller has been presented, and if it has then just create the settings VC and display it from there.

**Steps to test this PR**:
1. Go into Settings -> Version -> Email Waitlist -> tap Fire Waitlist Notification, then quickly close settings and background the app
1. Tap the notification when it appears
1. Check that settings is presented

Do the same steps above, but before the waitlist notification fires, open the tab switcher and then background the app. Check that settings opens as expected. Test that the same works on iPad.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

