### PR TITLE
Omit ATB for autofill pixels

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -293,13 +293,17 @@ public struct AppUrls {
         return URL(string: Url.emailLoginQuickLink)!
     }
     
-    public func pixelUrl(forPixelNamed pixelName: String, formFactor: String? = nil) -> URL {
+    public func pixelUrl(forPixelNamed pixelName: String, formFactor: String? = nil, includeATB: Bool = true) -> URL {
         var urlString = Url.pixel.format(arguments: pixelName)
         if let formFactor = formFactor {
             urlString.append("_ios_\(formFactor)")
         }
         var url = URL(string: urlString)!
-        url = url.addParam(name: Param.atb, value: statisticsStore.atbWithVariant ?? "")
+
+        if includeATB {
+            url = url.addParam(name: Param.atb, value: statisticsStore.atbWithVariant ?? "")
+        }
+
         return url
     }
     

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -261,6 +261,7 @@ public class Pixel {
                             forDeviceType deviceType: UIUserInterfaceIdiom? = UIDevice.current.userInterfaceIdiom,
                             withAdditionalParameters params: [String: String] = [:],
                             withHeaders headers: HTTPHeaders = APIHeaders().defaultHeaders,
+                            includeATB: Bool = true,
                             onComplete: @escaping (Error?) -> Void = {_ in }) {
         
         var newParams = params
@@ -272,9 +273,9 @@ public class Pixel {
         let url: URL
         if let deviceType = deviceType {
             let formFactor = deviceType == .pad ? Constants.tablet : Constants.phone
-            url = appUrls.pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor)
+            url = appUrls.pixelUrl(forPixelNamed: pixel.rawValue, formFactor: formFactor, includeATB: includeATB)
         } else {
-            url = appUrls.pixelUrl(forPixelNamed: pixel.rawValue)
+            url = appUrls.pixelUrl(forPixelNamed: pixel.rawValue, includeATB: includeATB)
         }
         
         APIRequest.request(url: url, parameters: newParams, headers: headers, callBackOnMainThread: true) { (_, error) in

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1430,18 +1430,18 @@ extension TabViewController: EmailManagerAliasPermissionDelegate {
             if let userEmail = emailManager.userEmail {
                 let actionTitle = String(format: UserText.emailAliasAlertUseUserAddress, userEmail)
                 alert.addAction(title: actionTitle) {
-                    Pixel.fire(pixel: .emailUserPressedUseAddress, withAdditionalParameters: pixelParameters)
+                    Pixel.fire(pixel: .emailUserPressedUseAddress, withAdditionalParameters: pixelParameters, includeATB: false)
                     completionHandler(.user)
                 }
             }
 
             alert.addAction(title: UserText.emailAliasAlertGeneratePrivateAddress) {
-                Pixel.fire(pixel: .emailUserPressedUseAlias, withAdditionalParameters: pixelParameters)
+                Pixel.fire(pixel: .emailUserPressedUseAlias, withAdditionalParameters: pixelParameters, includeATB: false)
                 completionHandler(.generated)
             }
 
             alert.addAction(title: UserText.emailAliasAlertDecline) {
-                Pixel.fire(pixel: .emailTooltipDismissed, withAdditionalParameters: pixelParameters)
+                Pixel.fire(pixel: .emailTooltipDismissed, withAdditionalParameters: pixelParameters, includeATB: false)
                 completionHandler(.none)
             }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200714585958659/f
Tech Design URL:
CC:

**Description**:

This PR updates the Pixel code to allow ATB to be excluded. This is done on Autofill pixels exclusively right now.

**Steps to test this PR**:
1. Test the Autofill feature and verify that ATB is excluded when you interact with each of the alias action sheet options (there are only three autofill pixels to test)
1. Test that other pixels include ATB

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

