### PR TITLE
Fix history API goBack not working (#901)

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -479,7 +479,8 @@ class TabViewController: UIViewController {
             url = webView.url
             onWebpageDidStartLoading(httpsForced: false)
             onWebpageDidFinishLoading()
-        } else if webView.canGoBack && webView.goBack() != nil {
+        } else if webView.canGoBack {
+            webView.goBack()
             chromeDelegate?.omniBar.resignFirstResponder()
         } else if openingTab != nil {
             delegate?.tabDidRequestClose(self)


### PR DESCRIPTION
(sorry, had to remove the template since it was all internal, please feel free to ask if you need more information).

Task/Issue URL: https://github.com/duckduckgo/iOS/issues/901

This PR fixes a bug with opening new tabs, and then clicking the back button for websites that use the History API (pushState, replaceState). It closed the tab instead of going back. You can read the details in #901

The issue orginates in the following part of the code (TabViewController.swift):
```swift
    func goBack() {
        if isError {
            hideErrorMessage()
            url = webView.url
            onWebpageDidStartLoading(httpsForced: false)
            onWebpageDidFinishLoading()
        } else if webView.canGoBack && webView.goBack() != -1 {
            webView.backForwardList.backList
            chromeDelegate?.omniBar.resignFirstResponder()
        } else if openingTab != nil {
            delegate?.tabDidRequestClose(self)
        }
    }
```

During testing with the steps described in #901 (so pressing the back button when there was some navigation on a website using pushState instead of normal anchor text):
- the backlist (`webView.backForwardList.backList`) is filled
- `webView.canGoBack` returns `true`.
- `webView.goBack()` returns nil.

In every case, `webView.goBack()` is always executed. Which is good. The webView does go to the previous page in the new tab. The problem is, when the current tab has been opened by another one, it skips to the next `else if` statement and also closes the tab. 

I don't know why `webView.goBack()` returns nil when `webView.canGoBack` returns `true`. This might be a bug or inconsitency in the API or it could just mean than when the History API is used, there is no `WKNavigation` instance that could be returned (since there is no navigation). In fact, the only thing that has happend is some JavaScript that is executed on the page. This might be intended behaviour.

So I propose the following change. In case of `webView.canGoBack` returning true, `webView.goBack()` should always get executed and handled as if it succeeded. This should not have any impact on other parts of the code. For now, I still execute `chromeDelegate?.omniBar.resignFirstResponder()` afterwards, you might want to correct that if needed (I think it should work that way). For consistency, you might also want to change the `goForward` method.

```swift
    func goForward() {
        if webView.goForward() != nil {
            chromeDelegate?.omniBar.resignFirstResponder()
        }
    }
```

to

```swift
    func goForward() {
        if webView.canGoForward {
            webView.goForward()
            chromeDelegate?.omniBar.resignFirstResponder()
        }
    }
```