### PR TITLE
Clear out the HSTS cache when invoking the Fire button

### DIFF
--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -180,6 +180,11 @@ extension WKWebsiteDataStore: WebCacheManagerDataStore {
 
     public func removeAllDataExceptCookies(completion: @escaping () -> Void) {
         var types = WKWebsiteDataStore.allWebsiteDataTypes()
+
+        // Force the HSTS cache to clear when using the Fire button.
+        // https://github.com/WebKit/WebKit/blob/0f73b4d4350c707763146ff0501ab62425c902d6/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm#L47
+        types.insert("_WKWebsiteDataTypeHSTSCache")
+
         types.remove(WKWebsiteDataTypeCookies)
 
         removeData(ofTypes: types,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200850028728616/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:

This PR forces the HSTS cache to clear when invoking the Fire button.

**Steps to test this PR**:
1. Visit some websites, and look at the app's data directory to verify that HSTS.plist contains some of these domains
1. Invoke the Fire button
1. Check the HSTS.plist file and verify that all domains have been removed

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

