### PR TITLE
Fixed non-closing keyboard at closing tab on iPad (#943)

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -638,6 +638,7 @@ class MainViewController: UIViewController {
     fileprivate func updateCurrentTab() {
         if let currentTab = currentTab {
             select(tab: currentTab)
+            omniBar.resignFirstResponder()
         } else {
             attachHomeScreen()
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://github.com/duckduckgo/iOS/issues/943
Tech Design URL:
CC:

**Description**:
This PR fixes a bug with non-closing keyboard at closing tab on iPad. The problem was that when closing the tab on the iPad omnibar don't resign to be the responder

**Steps to test this PR**:
1. Open tab 1, load a website
2. Tap the "+", open tab 2
3. Load a website in tab 2
4. Tap the address bar of tab 2
5. Close tab 2

Previous behavior: 
I get tab 2, address bar retains focus, has tab 2 url, keyboard is present.
Actual behavior:
Address bar in new tab refreshes

The problem was solved by adding method resignFirstResponder to omnibar at updating current tab. 
 

iPad Pro (12.9 inch) 5th generation

Closes https://github.com/duckduckgo/iOS/issues/943.
