### PR TITLE
Fixed to use isDebugBuild

### DIFF
--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -387,11 +387,7 @@ public class Favicons {
         }
 
         // Explicity set the expiry
-        #if DEBUG
-        let expiry = KingfisherOptionsInfoItem.diskCacheExpiration(.seconds(60))
-        #else
-        let expiry = KingfisherOptionsInfoItem.diskCacheExpiration(.days(7))
-        #endif
+        let expiry = KingfisherOptionsInfoItem.diskCacheExpiration(isDebugBuild ? .seconds(60) : .days(7))
 
         return [
             .downloader(Constants.downloader),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200965596521822/f
Tech Design URL:
CC:

**Description**:

It is more consistent to use `isDebugBuild` instead of the `DEBUG` preprocessor.

**Steps to test this PR**:
1. Confirm that the expiration of the favicon cache changes with Debug / Release.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [x] iPhone 8

**OS Testing**:

* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

