### PR TITLE
Fix iOS 15 image favicon rendering

### DIFF
--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -392,7 +392,6 @@ public class Favicons {
         return [
             .downloader(Constants.downloader),
             .requestModifier(Constants.requestModifier),
-            .cacheSerializer(FormatIndicatedCacheSerializer.jpeg),
             .targetCache(cache),
             expiry,
             .alternativeSources(sources)

--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -392,6 +392,7 @@ public class Favicons {
         return [
             .downloader(Constants.downloader),
             .requestModifier(Constants.requestModifier),
+            .cacheSerializer(FormatIndicatedCacheSerializer.jpeg),
             .targetCache(cache),
             expiry,
             .alternativeSources(sources)

--- a/Widgets/Widgets.swift
+++ b/Widgets/Widgets.swift
@@ -98,7 +98,7 @@ struct Provider: TimelineProvider {
 
         guard let data = (try? Data(contentsOf: imageUrl)) else { return nil }
 
-        return UIImage(data: data)
+        return UIImage(data: data)?.toSRGB()
     }
 
 }
@@ -150,6 +150,16 @@ struct Widgets: WidgetBundle {
     var body: some Widget {
         SearchWidget()
         FavoritesWidget()
+    }
+
+}
+
+extension UIImage {
+
+    func toSRGB() -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
     }
 
 }


### PR DESCRIPTION
This is to work around issues with indexed color spaces failing to render correctly in widgets.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201002203177706/f
Tech Design URL:
CC: @bwaresiak 

**Description**:

This PR fixes an issue where favicons in widgets on iOS 15 can sometimes fail to render correctly. 

**Steps to test this PR**:
1. Favorite some websites that exhibit this issue and verify that they're broken before swapping to this branch (see task for examples and steps on how to reproduce the issue)
1. Swap to this branch, and then clear the image cache
1. Visit each favorite website to re-fetch their favicons
1. Try to reproduce the issue again

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 13
* [x] iOS 14

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

