### PR TITLE
Complete text animation on tapping outside Dax dialog

### DIFF
--- a/DuckDuckGo/ActionSheetDaxDialogViewController.swift
+++ b/DuckDuckGo/ActionSheetDaxDialogViewController.swift
@@ -94,6 +94,11 @@ class ActionSheetDaxDialogViewController: UIViewController {
     }
 
     @IBAction func onTapOutside(_ sender: Any) {
+        guard daxDialogViewController?.isFinished ?? true else {
+            daxDialogViewController?.finish()
+            return
+        }
+        
         self.dismiss(animated: true)
         if let spec = spec {
             Pixel.fire(pixel: spec.cancelActionPixelName)

--- a/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
+++ b/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
@@ -37,7 +37,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lvy-9G-3gr">
-                                <rect key="frame" x="20" y="182" width="984" height="81"/>
+                                <rect key="frame" x="20" y="182" width="984" height="70"/>
                                 <attributedString key="attributedText">
                                     <fragment>
                                         <string key="content">Welcome to
@@ -176,7 +176,7 @@ DuckDuckGo!</string>
                                 <rect key="frame" x="10" y="82" width="355" height="113"/>
                                 <subviews>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDm-rv-vek">
-                                        <rect key="frame" x="16" y="10" width="323" height="25.5"/>
+                                        <rect key="frame" x="16" y="10" width="323" height="22"/>
                                         <attributedString key="attributedText">
                                             <fragment content="Label">
                                                 <attributes>
@@ -257,6 +257,7 @@ DuckDuckGo!</string>
                         <outlet property="icon" destination="UzU-6y-Vfa" id="h5u-VZ-4uc"/>
                         <outlet property="label" destination="UDm-rv-vek" id="E3z-rn-qvh"/>
                         <outlet property="pointer" destination="eh6-ce-Ivv" id="Pyj-WK-6C6"/>
+                        <outlet property="tapToCompleteGestureRecognizer" destination="o8q-3z-33o" id="VHC-Wy-gPT"/>
                         <outlet property="textArea" destination="Ix6-dq-RAh" id="UTU-sm-jn7"/>
                         <outlet property="topSpacing" destination="Gmu-7B-dTI" id="8mg-Zw-YAm"/>
                     </connections>
@@ -265,6 +266,11 @@ DuckDuckGo!</string>
                 <tapGestureRecognizer id="1gA-Oe-qi9">
                     <connections>
                         <action selector="onTap" destination="UUS-R7-a2i" id="rL5-bR-JzA"/>
+                    </connections>
+                </tapGestureRecognizer>
+                <tapGestureRecognizer id="o8q-3z-33o">
+                    <connections>
+                        <action selector="onTap" destination="UUS-R7-a2i" id="Eh7-ke-WPO"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>
@@ -293,7 +299,7 @@ DuckDuckGo!</string>
                                 </connections>
                             </containerView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgy-75-OvJ">
-                                <rect key="frame" x="966" y="72" width="34" height="31"/>
+                                <rect key="frame" x="966" y="72" width="34" height="28"/>
                                 <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="16"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Hide"/>

--- a/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
+++ b/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
@@ -267,11 +267,6 @@ DuckDuckGo!</string>
                         <action selector="onTapText" destination="UUS-R7-a2i" id="QGR-gw-YBK"/>
                     </connections>
                 </tapGestureRecognizer>
-                <tapGestureRecognizer id="IpT-mY-clw">
-                    <connections>
-                        <action selector="onTapText" destination="UUS-R7-a2i" id="E04-X1-lJT"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="1273" y="391"/>
         </scene>

--- a/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
+++ b/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
@@ -161,7 +161,7 @@ DuckDuckGo!</string>
             <objects>
                 <viewController storyboardIdentifier="DaxDialog" id="UUS-R7-a2i" customClass="DaxDialogViewController" customModule="DuckDuckGo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="im0-JF-Sin">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="195"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="DaxIcon" translatesAutoresizingMaskIntoConstraints="NO" id="UzU-6y-Vfa">
@@ -173,7 +173,7 @@ DuckDuckGo!</string>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ix6-dq-RAh" userLabel="Background">
-                                <rect key="frame" x="10" y="82" width="355" height="318"/>
+                                <rect key="frame" x="10" y="82" width="355" height="113"/>
                                 <subviews>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDm-rv-vek">
                                         <rect key="frame" x="16" y="10" width="323" height="25.5"/>
@@ -189,7 +189,7 @@ DuckDuckGo!</string>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zJt-F9-L48">
-                                        <rect key="frame" x="16" y="250" width="323" height="44"/>
+                                        <rect key="frame" x="16" y="45" width="323" height="44"/>
                                         <color key="backgroundColor" red="0.40392156862745099" green="0.5607843137254902" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="Gta-qP-xcx"/>
@@ -222,9 +222,6 @@ DuckDuckGo!</string>
                                         <integer key="value" value="16"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="1gA-Oe-qi9" appends="YES" id="2hE-O7-Jy6"/>
-                                </connections>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eh6-ce-Ivv" userLabel="Pointer">
                                 <rect key="frame" x="56.5" y="77" width="10" height="10"/>
@@ -251,6 +248,9 @@ DuckDuckGo!</string>
                             <constraint firstItem="Ix6-dq-RAh" firstAttribute="width" secondItem="im0-JF-Sin" secondAttribute="width" constant="-20" id="ifK-1a-KrV"/>
                             <constraint firstItem="Ix6-dq-RAh" firstAttribute="centerX" secondItem="im0-JF-Sin" secondAttribute="centerX" id="sl4-7u-0ho"/>
                         </constraints>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="1gA-Oe-qi9" appends="YES" id="QQQ-bZ-CVH"/>
+                        </connections>
                     </view>
                     <connections>
                         <outlet property="button" destination="zJt-F9-L48" id="RMQ-DD-jZK"/>
@@ -264,7 +264,7 @@ DuckDuckGo!</string>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="61G-0Y-elT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="1gA-Oe-qi9">
                     <connections>
-                        <action selector="onTapText" destination="UUS-R7-a2i" id="QGR-gw-YBK"/>
+                        <action selector="onTap" destination="UUS-R7-a2i" id="rL5-bR-JzA"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>
@@ -437,7 +437,7 @@ DuckDuckGo!</string>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="x63-BY-KWY"/>
+        <segue reference="Z8u-vf-YsD"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="DaxIcon" width="86" height="86"/>

--- a/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
+++ b/DuckDuckGo/Base.lproj/DaxOnboarding.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YXw-O5-LLS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YXw-O5-LLS">
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -37,7 +37,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lvy-9G-3gr">
-                                <rect key="frame" x="20" y="182" width="984" height="70"/>
+                                <rect key="frame" x="20" y="182" width="984" height="81"/>
                                 <attributedString key="attributedText">
                                     <fragment>
                                         <string key="content">Welcome to
@@ -176,7 +176,7 @@ DuckDuckGo!</string>
                                 <rect key="frame" x="10" y="82" width="355" height="318"/>
                                 <subviews>
                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UDm-rv-vek">
-                                        <rect key="frame" x="16" y="10" width="323" height="22"/>
+                                        <rect key="frame" x="16" y="10" width="323" height="25.5"/>
                                         <attributedString key="attributedText">
                                             <fragment content="Label">
                                                 <attributes>
@@ -298,7 +298,7 @@ DuckDuckGo!</string>
                                 </connections>
                             </containerView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgy-75-OvJ">
-                                <rect key="frame" x="966" y="72" width="34" height="28"/>
+                                <rect key="frame" x="966" y="72" width="34" height="31"/>
                                 <fontDescription key="fontDescription" name="ProximaNova-Bold" family="Proxima Nova" pointSize="16"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Hide"/>

--- a/DuckDuckGo/DaxDialogViewController.swift
+++ b/DuckDuckGo/DaxDialogViewController.swift
@@ -29,6 +29,8 @@ class DaxDialogViewController: UIViewController {
     @IBOutlet weak var button: UIButton!
     @IBOutlet weak var label: UILabel!
     
+    @IBOutlet weak var tapToCompleteGestureRecognizer: UIGestureRecognizer!
+    
     var message: String? {
         didSet {
             initLabel()

--- a/DuckDuckGo/DaxDialogViewController.swift
+++ b/DuckDuckGo/DaxDialogViewController.swift
@@ -118,7 +118,7 @@ class DaxDialogViewController: UIViewController {
         updateMessage()
     }
     
-    @IBAction func onTapText() {
+    @IBAction func onTap() {
         finish()
     }
     

--- a/DuckDuckGo/DaxDialogViewController.swift
+++ b/DuckDuckGo/DaxDialogViewController.swift
@@ -74,6 +74,8 @@ class DaxDialogViewController: UIViewController {
         return position >= chars.count
     }
     
+    var isFinished: Bool { atEnd(position) }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/DuckDuckGo/DaxOnboardingViewController.swift
+++ b/DuckDuckGo/DaxOnboardingViewController.swift
@@ -78,8 +78,9 @@ class DaxOnboardingViewController: UIViewController, Onboarding {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: nil)
         
-        if let controller = segue.destination as? DaxDialogViewController {
-            self.daxDialog = controller
+        if let daxDialog = segue.destination as? DaxDialogViewController {
+            self.daxDialog = daxDialog
+            view.addGestureRecognizer(daxDialog.tapToCompleteGestureRecognizer)
         } else if let controller = segue.destination as? DaxOnboardingPadViewController {
             controller.delegate = self
         } else if let navController = segue.destination as? UINavigationController,

--- a/DuckDuckGo/FullscreenDaxDialogViewController.swift
+++ b/DuckDuckGo/FullscreenDaxDialogViewController.swift
@@ -87,8 +87,10 @@ class FullscreenDaxDialogViewController: UIViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
-        if segue.destination is DaxDialogViewController {
-            daxDialogViewController = segue.destination as? DaxDialogViewController
+        
+        if let daxDialog = segue.destination as? DaxDialogViewController {
+            daxDialogViewController = daxDialog
+            highlightCutOutView.addGestureRecognizer(daxDialog.tapToCompleteGestureRecognizer)
         }
     }
     

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -143,14 +143,19 @@ class HomeViewController: UIViewController {
     func showNextDaxDialog() {
 
         guard !isShowingDax else { return }
-        guard let spec = DaxDialogs.shared.nextHomeScreenMessage() else { return }
+        guard let spec = DaxDialogs.shared.nextHomeScreenMessage(),
+              let daxDialogViewController = daxDialogViewController else { return }
         collectionView.isHidden = true
         daxDialogContainer.isHidden = false
         daxDialogContainer.alpha = 0.0
-        daxDialogViewController?.loadViewIfNeeded()
-        daxDialogViewController?.message = spec.message
-        daxDialogViewController?.accessibleMessage = spec.accessibilityLabel
-        daxDialogContainerHeight.constant = daxDialogViewController?.calculateHeight() ?? 0
+        
+        daxDialogViewController.loadViewIfNeeded()
+        daxDialogViewController.message = spec.message
+        daxDialogViewController.accessibleMessage = spec.accessibilityLabel
+        
+        view.addGestureRecognizer(daxDialogViewController.tapToCompleteGestureRecognizer)
+        
+        daxDialogContainerHeight.constant = daxDialogViewController.calculateHeight()
         hideLogo()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1199405563917481/f
Tech Design URL:
CC:

**Description**:
Tapping on a Dax dialog while the text is animated completes it. Tapping anywhere outside the dialog also should finish the animation. 

**Steps to test this PR**:
On fresh app install navigate through: 
1. initial onboarding
2. empty home with Dax dialog
3. navigate to webpage with trackers to Dax dialog appear
4. tap Fire button to trigger Dax dialog shown over action sheet

**Device Testing**:
* [ ] iPhone
* [ ] iPad

**OS Testing**:
* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

