### PR TITLE
Clean up naming of the dev & ad hoc provisioning profiles

### DIFF
--- a/Configuration/DuckDuckGoDeveloper.xcconfig
+++ b/Configuration/DuckDuckGoDeveloper.xcconfig
@@ -26,4 +26,4 @@ GROUP_ID_PREFIX = group.com.duckduckgo
 CODE_SIGN_STYLE = Manual
 
 // The manualy specified provisioning profile
-PROVISIONING_PROFILE_SPECIFIER = iOS 14 - Dev - App
+PROVISIONING_PROFILE_SPECIFIER = Development - App

--- a/adhocExportOptions.plist
+++ b/adhocExportOptions.plist
@@ -11,22 +11,22 @@
     <key>provisioningProfiles</key>
     <dict>
         <key>com.duckduckgo.mobile.ios</key>
-        <string>iOS 14 - Ad Hoc - App</string>
+        <string>Ad Hoc - App</string>
 
         <key>com.duckduckgo.mobile.ios.ShareExtension</key>
-        <string>iOS 14 - Ad Hoc - Share</string>
+        <string>Ad Hoc - Share</string>
 
         <key>com.duckduckgo.mobile.ios.BookmarksTodayExtension</key>
-        <string>iOS 14 - Ad Hoc - Bookmarks</string>
+        <string>Ad Hoc - Bookmarks</string>
 
         <key>com.duckduckgo.mobile.ios.QuickActionsTodayExtension</key>
-        <string>iOS 14 - Ad Hoc - Quick Actions</string>
+        <string>Ad Hoc - Quick Actions</string>
 
         <key>com.duckduckgo.mobile.ios.OpenAction2</key>
-        <string>iOS 14 - Ad Hoc - Open Action</string>
+        <string>Ad Hoc - Open Action</string>
 
         <key>com.duckduckgo.mobile.ios.Widgets</key>
-        <string>iOS 14 - Ad Hoc - Widgets</string>
+        <string>Ad Hoc - Widgets</string>
     </dict>
 
 </dict>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1201038135952664/f
Tech Design URL:
CC:

**Description**:
The names for the development and ad hoc provisioning profiles were prefixed with "iOS 14 - " string. This change is for renaming them without that prefix and updating appropriate references for them (for the development profile in the project and in the ad hoc build script).

**Steps to test this PR**:
1. Refresh provisioning profiles, the default development provisioning profile should be matching.
2. Ad hoc build should successfully complete signing with new provisioning profiles. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

