### PR TITLE
Minor tweak to how GPC DOM property is set

### DIFF
--- a/Core/donotsell.js
+++ b/Core/donotsell.js
@@ -24,10 +24,10 @@
     }
     
     if (navigator.globalPrivacyControl === undefined) {
-        Object.defineProperty(navigator, 'globalPrivacyControl', {
-            value: true,
-            writable: false,
-            configurable: false
+        Object.defineProperty(Navigator.prototype, 'globalPrivacyControl', {
+            get: () => true,
+            configurable: true,
+            enumerable: true
         });
     } else {
         try {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1201168853446393/f
Tech Design URL:
CC:

**Description**:
Set GPC DOM signal on `Navigator.prototype` rather than `navigator`. Existing tests should still pass after this change--calling `navigator.globalPrivacyControl` will still return the signal value.

**Steps to test this PR**:
1. Visit test page and ensure that Client-side detection is passing: https://global-privacy-control.glitch.me/
2. Toggle GPC off and check that Client-side detection is no longer passing.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable. 
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**

