### PR TITLE
Fix issue with alerts being presented while the tab is in the background

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1410,6 +1410,9 @@ extension MainViewController: TabDelegate {
         }
     }
 
+    func tabCheckIfItsBeingCurrentlyPresented(_ tab: TabViewController) -> Bool {
+        return tabManager.current === tab
+    }
 }
 
 extension MainViewController: TabSwitcherDelegate {

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -67,6 +67,8 @@ protocol TabDelegate: AnyObject {
     
     func tab(_ tab: TabViewController, didRequestPresentingAlert alert: UIAlertController)
 
+    func tabCheckIfItsBeingCurrentlyPresented(_ tab: TabViewController) -> Bool
+    
     func showBars()
 
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -180,7 +180,7 @@ class TabViewController: UIViewController {
     private var userScripts: [UserScript] = []
     
     private var canDisplayJavaScriptAlert: Bool {
-        return presentedViewController == nil
+        return presentedViewController == nil && delegate?.tabCheckIfItsBeingCurrentlyPresented(self) ?? false
     }
 
     static func loadFromStoryboard(model: Tab) -> TabViewController {


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/0/414709148257752/1201233289756560
Tech Design URL:
CC:

**Description**:


**Steps to test this PR**:
1. Open demo page (in asana)
2. Select "Alert With 4s Delay"
3. Change Tabs - Crash


**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
