### PR TITLE
Fix `Unprotected Sites` toolbar was kept hidden.

### DIFF
--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -53,8 +53,8 @@ class UnprotectedSitesViewController: UITableViewController {
         infoText.attributedText = text
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         
         navigationController?.setToolbarHidden(true, animated: false)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
Hi,

When the user moved the `Unprotected Sites` view down a little, the toolbar was kept hidden. I fixed it.

Thanks.

https://user-images.githubusercontent.com/45647069/138539366-c649fb3b-23d3-42c8-93c2-731f63adf7dc.mov


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [x] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait

**Device Testing**:

* [x] iPhone 8

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
