### PR TITLE
Stop web views from loading during Fire button calls

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -344,7 +344,7 @@ public class TimedPixel {
         self.date = date
     }
     
-    public func fire(_ fireDate: Date = Date(), withAdditionalParmaeters params: [String: String] = [:]) {
+    public func fire(_ fireDate: Date = Date(), withAdditionalParameters params: [String: String] = [:]) {
         let duration = String(fireDate.timeIntervalSince(date))
         var newParams = params
         newParams[PixelParameters.duration] = duration

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1552,7 +1552,6 @@ extension MainViewController: AutoClearWorker {
     func forgetData() {
         findInPageView?.done()
         
-        tabManager.stopLoadingInAllTabs()
         ServerTrustCache.shared.clear()
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
 
@@ -1567,6 +1566,7 @@ extension MainViewController: AutoClearWorker {
         Pixel.fire(pixel: .forgetAllExecuted)
         
         fireButtonAnimator?.animate {
+            self.tabManager.stopLoadingInAllTabs()
             self.forgetData()
             DaxDialogs.shared.resumeRegularFlow()
             self.forgetTabs()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1557,7 +1557,7 @@ extension MainViewController: AutoClearWorker {
 
         let pixel = TimedPixel(.forgetAllDataCleared)
         WebCacheManager.shared.clear {
-            pixel.fire(withAdditionalParmaeters: [PixelParameters.tabCount: "\(self.tabManager.count)"])
+            pixel.fire(withAdditionalParameters: [PixelParameters.tabCount: "\(self.tabManager.count)"])
         }
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1552,6 +1552,7 @@ extension MainViewController: AutoClearWorker {
     func forgetData() {
         findInPageView?.done()
         
+        tabManager.stopLoadingInAllTabs()
         ServerTrustCache.shared.clear()
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
 

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -226,6 +226,10 @@ class TabManager {
     func save() {
         model.save()
     }
+    
+    func stopLoadingInAllTabs() {
+        tabControllerCache.forEach { $0.stopLoading() }
+    }
 
 }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -353,6 +353,10 @@ class TabViewController: UIViewController {
         load(urlRequest: URLRequest(url: url))
     }
     
+    func stopLoading() {
+        webView.stopLoading()
+    }
+    
     private func load(urlRequest: URLRequest) {
         loadViewIfNeeded()
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201429846080703/f
Tech Design URL:
CC: @miasma13 

**Description**:

This PR tells each WKWebView to stop loading before the Fire button runs, to try to prevent cookies from sneaking through the `removeAllData` call.

**Steps to test this PR**:
1. Visit a few websites
2. Tap the Fire button
3. Check that it has worked as expected, using the debug menus

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
