### PR TITLE
Force-clean additional data types

### DIFF
--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -247,9 +247,11 @@ extension WKWebsiteDataStore: WebCacheManagerDataStore {
     public func removeAllDataExceptCookies(completion: @escaping () -> Void) {
         var types = WKWebsiteDataStore.allWebsiteDataTypes()
 
-        // Force the HSTS cache to clear when using the Fire button.
+        // Force the HSTS, Media and Alt services cache to clear when using the Fire button.
         // https://github.com/WebKit/WebKit/blob/0f73b4d4350c707763146ff0501ab62425c902d6/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm#L47
         types.insert("_WKWebsiteDataTypeHSTSCache")
+        types.insert("_WKWebsiteDataTypeMediaKeys")
+        types.insert("_WKWebsiteDataTypeAlternativeServices")
 
         types.remove(WKWebsiteDataTypeCookies)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1201466349275489
Tech Design URL:
CC:

**Description**:
Force cleanup of WebKit's Media and AlternativeServices cache.

**Steps to test this PR**:

1. Visit some websites, and look at the app's data directory to verify that AlternativeServices DB and Media caches contain some data.
2. Invoke the Fire button
3. Check locations from point 1 again to validate that data has been removed.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
