### PR TITLE
Use privacy config for GPC enabled hosts

### DIFF
--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -47,11 +47,6 @@ public struct AppUrls {
         
         static let pixelBase = ProcessInfo.processInfo.environment["PIXEL_BASE_URL", default: "https://improving.duckduckgo.com"]
         static let pixel = "\(pixelBase)/t/%@"
-        
-        static let gpcGlitchBase = "http://global-privacy-control.glitch.me"
-        static let washingtonPostBase = "https://washingtonpost.com"
-        static let newYorkTimesBase = "https://nytimes.com"
-        static let gpcEnabled = [gpcGlitchBase, washingtonPostBase, newYorkTimesBase]
 
         static var loginQuickLink = "https://duckduckgo.com/email/login"
         static var emailPrivacyGuarantees = "https://duckduckgo.com/email/privacy-guarantees"
@@ -148,12 +143,6 @@ public struct AppUrls {
             .addParam(name: Param.atb, value: atbWithVariant)
             .addParam(name: Param.setAtb, value: setAtb)
     }
-    
-    private var gpcEnabledURLs: [URL] {
-        return Url.gpcEnabled.map {
-            URL(string: $0)!
-        }
-    }
 
     public func isBlog(url: URL) -> Bool {
         guard let host = url.host else { return false }
@@ -222,12 +211,17 @@ public struct AppUrls {
     }
     
     public func isGPCEnabled(url: URL) -> Bool {
-        for gpcURL in gpcEnabledURLs {
-            if let host = gpcURL.host,
-               url.isPart(ofDomain: host) {
+        guard let gpcFeature = PrivacyConfigurationManager.shared.privacyConfig.feature(forKey: .gpc),
+              let gpcUrls = gpcFeature.settings["gpcHeaderEnabledSites"] as? [String] else {
+            return false
+        }
+        
+        for gpcHost in gpcUrls {
+            if url.isPart(ofDomain: gpcHost) {
                 return true
             }
         }
+        
         return false
     }
 

--- a/Core/AppUrls.swift
+++ b/Core/AppUrls.swift
@@ -210,8 +210,9 @@ public struct AppUrls {
         return true
     }
     
-    public func isGPCEnabled(url: URL) -> Bool {
-        guard let gpcFeature = PrivacyConfigurationManager.shared.privacyConfig.feature(forKey: .gpc),
+    public func isGPCEnabled(url: URL,
+                             config: PrivacyConfiguration = PrivacyConfigurationManager.shared.privacyConfig) -> Bool {
+        guard let gpcFeature = config.feature(forKey: .gpc),
               let gpcUrls = gpcFeature.settings["gpcHeaderEnabledSites"] as? [String] else {
             return false
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1200890834746050/1201481892398403/f
Tech Design URL:
CC:

**Description**:
We've included hosts which we send the GPC header to the privacy configuration. This PR uses the configuration to get the enabled hosts rather than the hard-coded URLs.

**Steps to test this PR**:
1. Visit https://privacy-test-pages.glitch.me/privacy-protections/gpc/
2. Tap "Start Test"
3. Expand the results. "top frame header" should display "1".

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
