### PR TITLE
fixes crash on long press for amp links

### DIFF
--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -101,25 +101,22 @@ extension TabViewController {
 
 extension TabViewController {
 
-        func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
-                     completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
+    func webView(_ webView: WKWebView, contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+                 completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
 
         guard let url = elementInfo.linkURL else {
             completionHandler(nil)
             return
         }
 
-        getCleanUrl(url, showLoadingIndicator: false) { cleanUrl in
-            let config = UIContextMenuConfiguration(identifier: nil, previewProvider: {
-                return AppUserDefaults().longPressPreviews ? self.buildOpenLinkPreview(for: cleanUrl) : nil
-            }, actionProvider: { _ in
-                // We don't use provided elements as they are not built with correct URL in case of AMP links
+        let config = UIContextMenuConfiguration(identifier: nil, previewProvider: {
+            return AppUserDefaults().longPressPreviews ? self.buildOpenLinkPreview(for: url) : nil
+        }, actionProvider: { _ in
+            // We don't use provided elements as they are not built with correct URL in case of AMP links
+            return self.buildLinkPreviewMenu(for: url, withProvided: [])
+        })
 
-                return self.buildLinkPreviewMenu(for: cleanUrl, withProvided: [])
-            })
-
-            completionHandler(config)
-        }
+        completionHandler(config)
     }
 
     func webView(_ webView: WKWebView, contextMenuForElement elementInfo: WKContextMenuElementInfo,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1201466703593882
Tech Design URL:
CC: @SlayterDev @miasma13 @samsymons 

**Description**:

Fix crash on long press by letting the preview tab worry about de-amping the URL (which it was doing anyway).  Also add code to add confidence around completion handler being called.

**Steps to test this PR**:
1.  Visit https://privacy-test-pages.glitch.me/privacy-protections/amp/
2. Long press (more than a tap, but ideally less than a full long press)
3. Either nothing should happen or the preview will show (might be difficult to not show the preview now)
4. Use the fire button and try it a few times

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
