### PR TITLE
Fix Fingerprinting UI test failures

### DIFF
--- a/FingerprintingUITests/FingerprintUITest.swift
+++ b/FingerprintingUITests/FingerprintUITest.swift
@@ -104,8 +104,9 @@ class FingerprintUITest: XCTestCase {
         } else {
             XCTFail("Could not find bookmark")
         }
-        app.alerts["Edit Bookmark"].scrollViews.otherElements.collectionViews.textFields["www.example.com"].tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        app.alerts["Edit Bookmark"].scrollViews.otherElements.collectionViews.textFields["www.example.com"]
+        
+        app.alerts["Edit Bookmark"].textFields["Bookmark Address"].clear()
+        app.alerts["Edit Bookmark"].textFields["Bookmark Address"]
             .typeText("javascript:(function(){const values = {'screen.availTop': 0,'screen.availLeft': 0,'screen.availWidth': screen.width,'screen.availHeight': screen.height,'screen.colorDepth': 24,'screen.pixelDepth': 24,'window.screenY': 0,'window.screenLeft': 0,'navigator.doNotTrack': undefined};var passed = true;var reason = null;for (const test of results.results) {if (values[test.id] !== undefined) {if (values[test.id] !== test.value) {console.log(test.id, values[test.id]);reason = test.id;passed = false;break;}}}var elem = document.createElement('p');elem.innerHTML = (passed) ? 'TEST PASSED' : 'TEST FAILED: ' + reason;document.body.insertBefore(elem, document.body.childNodes[0]);}());")
         app.alerts["Edit Bookmark"].scrollViews.otherElements.buttons["Save"].tap()
         bookmarksNavigationBar.buttons["Done"].tap()
@@ -138,6 +139,24 @@ class FingerprintUITest: XCTestCase {
         
         // Verify the test passed
         XCTAssertTrue(webview.staticTexts["TEST PASSED"].waitForExistence(timeout: 25), "Test not run")
+    }
+
+}
+
+extension XCUIElement {
+    
+    // https://stackoverflow.com/a/38523252
+    public func clear() {
+        guard let stringValue = self.value as? String else {
+            XCTFail("Tried to clear and enter text into a non string value")
+            return
+        }
+
+        let lowerRightCorner = self.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.9))
+        lowerRightCorner.tap()
+
+        let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: stringValue.count)
+        self.typeText(deleteString)
     }
 
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201466059456360/f
Tech Design URL:
CC: @brindy @miasma13 

**Description**:

This PR fixes issues with the Fingerprinting UI test suite on Xcode 13.

This fix **requires** running against Xcode 13.2, as it contains a fix for an issue with the `typeText` method. Xcode 13.2 has been set as the stack for these test runs on Bitrise already.

**Steps to test this PR**:
1. Check this branch out and open it in Xcode 13.2
2. Run the FingerprintingUITests suite
3. Verify that this change passes on Bitrise (I ran this already [here](https://app.bitrise.io/build/3b54f336-d7a0-4b66-a006-d595c9757379), which has passed)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
