### PR TITLE
Add email protection waitlist pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -152,6 +152,10 @@ public enum PixelName: String {
     case emailUserCreatedAlias = "email_generated_button"
     case emailTooltipDismissed = "email_tooltip_dismissed"
     
+    case emailDidShowWaitlistDialog = "email_did_show_waitlist_dialog"
+    case emailDidPressWaitlistDialogDismiss = "email_did_press_waitlist_dialog_dismiss"
+    case emailDidPressWaitlistDialogNotifyMe = "email_did_press_waitlist_dialog_notify_me"
+    
     case textSizeSettingsShown = "m_text_size_settings_shown"
     case textSizeSettingsChanged = "m_text_size_settings_changed"
 

--- a/DuckDuckGo/EmailWaitlistViewController.swift
+++ b/DuckDuckGo/EmailWaitlistViewController.swift
@@ -210,17 +210,21 @@ class EmailWaitlistViewController: UIViewController {
                                                         preferredStyle: .alert)
 
                 alertController.addAction(title: UserText.emailWaitlistNotificationPermissionNoThanks, style: .cancel) {
+                    Pixel.fire(pixel: .emailDidPressWaitlistDialogDismiss)
                     EmailWaitlist.shared.showWaitlistNotification = false
                     self.renderCurrentWaitlistState()
                 }
 
                 alertController.addAction(title: UserText.emailWaitlistNotificationPermissionNotifyMe, style: .default) {
+                    Pixel.fire(pixel: .emailDidPressWaitlistDialogNotifyMe)
                     EmailWaitlist.shared.showWaitlistNotification = true
                     self.renderCurrentWaitlistState()
                     self.promptForUserNotificationAuthorization()
                 }
-
-                self.present(alertController, animated: true)
+                
+                self.present(alertController, animated: true) {
+                    Pixel.fire(pixel: .emailDidShowWaitlistDialog)
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201455494500114/f
Tech Design URL:
CC: @samsymons 

**Description**:
Add analytics pixels around joining email protection waitlist flow.

**Steps to test this PR**:
Fresh app install
1. Open Settings -> Email Protection
2. Tap "Join the Private Waitlist"
3. Upon presentation the alert dialog the **email_did_show_waitlist_dialog**

Fresh app install
1. Open Settings -> Email Protection
2. Tap "Join the Private Waitlist"
3. Tap "No Thanks"
4. The **email_did_press_waitlist_dialog_dismiss** pixel should be fired

Fresh app install
1. Open Settings -> Email Protection
2. Tap "Join the Private Waitlist"
3. Tap "Notify Me"
4. The **email_did_press_waitlist_dialog_notify_me** pixel should be fired


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


**Device Testing**:

* [x] iPhone
* [x] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
