### PR TITLE
Fix back button is not working

### DIFF
--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -106,6 +106,7 @@ class PrivacyProtectionScoreCardController: UITableViewController {
         PrivacyProtectionHeaderConfigurator.configure(cell: cell, siteRating: siteRating, config: privacyConfig)
         cell.disclosureImage.isHidden = true
         cell.backImage.isHidden = !AppWidthObserver.shared.isLargeWidth
+        cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.onBack)))
         
         return cell
     }

--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -105,7 +105,7 @@ class PrivacyProtectionScoreCardController: UITableViewController {
         
         PrivacyProtectionHeaderConfigurator.configure(cell: cell, siteRating: siteRating, config: privacyConfig)
         cell.disclosureImage.isHidden = true
-        cell.backImage.isHidden = !AppWidthObserver.shared.isLargeWidth
+        cell.backImage.isHidden = !isPad
         cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.onBack)))
         
         return cell


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #1025
Tech Design URL:
CC:

**Description**:
It seems that the `UITapGestureRecognizer` defined in `PrivacyProtection.storyboard` is not applied to the score card header cell, so clicking the back button in the header trigger nothing.

**Steps to test this PR**:
1. Go to https://apple.com
2. Open privacy protection overview 
3. Click overview header to go to privacy protection score card
4. Click score card header to go back to privacy protection overview

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [*] iPadOS 15

**Theme Testing**:

* [*] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
