### PR TITLE
Fix back button doesn't trigger back action

### DIFF
--- a/DuckDuckGo/Base.lproj/PrivacyProtection.storyboard
+++ b/DuckDuckGo/Base.lproj/PrivacyProtection.storyboard
@@ -2547,6 +2547,7 @@ many trackers we've blocked.</string>
                         <outlet property="isMajorNetworkCell" destination="YWf-b0-9Jx" id="sHo-Ui-l1Y"/>
                         <outlet property="majorNetworksCell" destination="bLw-VQ-f8g" id="hLd-p7-KCA"/>
                         <outlet property="networksCell" destination="8qZ-Eh-VsF" id="eLZ-iJ-obV"/>
+                        <outlet property="onHeaderCellTapped" destination="ons-8k-ZtF" id="or6-Bc-KER"/>
                         <outlet property="privacyGradeCell" destination="THl-q3-0pd" id="aXs-ho-6oc"/>
                         <outlet property="privacyPracticesCell" destination="Djq-pK-0ll" id="Wtr-kX-v5D"/>
                     </connections>

--- a/DuckDuckGo/PrivacyProtectionScoreCardController.swift
+++ b/DuckDuckGo/PrivacyProtectionScoreCardController.swift
@@ -30,6 +30,8 @@ class PrivacyProtectionScoreCardController: UITableViewController {
     @IBOutlet weak var enhancedGradeCell: PrivacyProtectionScoreCardCell!
     @IBOutlet weak var isMajorNetworkCell: PrivacyProtectionScoreCardCell!
 
+    @IBOutlet var onHeaderCellTapped: UITapGestureRecognizer!
+    
     private var siteRating: SiteRating!
     private var privacyConfig: PrivacyConfiguration = PrivacyConfigurationManager.shared.privacyConfig
 
@@ -106,6 +108,7 @@ class PrivacyProtectionScoreCardController: UITableViewController {
         PrivacyProtectionHeaderConfigurator.configure(cell: cell, siteRating: siteRating, config: privacyConfig)
         cell.disclosureImage.isHidden = true
         cell.backImage.isHidden = !AppWidthObserver.shared.isLargeWidth
+        cell.addGestureRecognizer(onHeaderCellTapped)
         
         return cell
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: #1025
Tech Design URL:
CC:

**Description**:
It seems that the `UITapGestureRecognizer` defined in `PrivacyProtection.storyboard` is not applied to the score card header cell, so clicking the back button in the header trigger nothing.

**Steps to test this PR**:
1. Go to https://apple.com
2. Open privacy protection overview 
3. Click overview header to go to privacy protection score card
4. Click score card header to go back to privacy protection overview

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15
* [x] iPadOS 15

**Theme Testing**:

* [x] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
