### PR TITLE
Fix new tab opened via window.open()

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1271,6 +1271,8 @@ extension MainViewController: TabDelegate {
 
         let newTab = tabManager.addURLRequest(navigationAction.request, withConfiguration: configuration)
         newTab.openedByPage = true
+        newTab.openingTab = tab
+        
         newTabAnimation {
             self.dismissOmniBar()
             self.addToView(tab: newTab)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1201593282800220/f

**Description**:
Fix back button when tab is opened via window.open()

**Steps to test this PR**:

**Window.open**
1. Open https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_win_open
2. Tap on try it
3. On the new tab, tap on the back button.
4. It should go back to the page on step 1

**Target _blank**
1. Open https://www.w3docs.com/tools/code-editor/51
2. Tap on "hyperlink"
3. On the new tab, tap on the back button.
4. It should go back to the page on step 1

**OS Testing**:

* [ ] iOS 13
* [x] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
