### PR TITLE
Add String to silence iTC warning

### DIFF
--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -228,6 +228,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>This is required to use voice search. DuckDuckGo never records what you say.</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Note, this string will never be displayed to the user since we only use local speech recognizer  and when local speech recognizer is used on iOS 15+ no alert permission dialog is displayed. This is being added to silence the "Missing Purpose String in Info.plist" warning when submitting to the app store.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->


**Description**:


**Steps to test this PR**:
1. Tap on the mic in the search bar
2. Check the permissions alert
3. Make sure that `This is required to use voice search. DuckDuckGo never records what you say.` is NOT called. But make sure that `This is required to use voice features. DuckDuckGo never records what you say.` is (One says voice search, another voice features).
**OS Testing**:

* [ ] iOS 13
* [x] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
