### PR TITLE
Fix dax dialog presentation 

### DIFF
--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -44,7 +44,7 @@ class DaxDialogs {
         let accessibilityLabel: String?
     }
     
-    func overrideShownFlagForSpec(spec: BrowsingSpec, flag: Bool) {
+    func overrideShownFlagFor(_ spec: BrowsingSpec, flag: Bool) {
         switch spec.type {
         case .withMultipleTrackers, .withOneTracker :
             settings.browsingWithTrackersShown = flag

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -46,7 +46,7 @@ class DaxDialogs {
     
     func overrideShownFlagForSpec(spec: BrowsingSpec, flag: Bool) {
         switch spec.type {
-        case .withMutipleTrackers, .withOneTracker :
+        case .withMultipleTrackers, .withOneTracker :
             settings.browsingWithTrackersShown = flag
         case .afterSearch:
             settings.browsingAfterSearchShown = flag
@@ -67,7 +67,7 @@ class DaxDialogs {
             case siteIsMajorTracker
             case siteOwnedByMajorTracker
             case withOneTracker
-            case withMutipleTrackers
+            case withMultipleTrackers
         }
         // swiftlint:enable nesting
 
@@ -96,10 +96,10 @@ class DaxDialogs {
                                                  highlightAddressBar: true,
                                                  pixelName: .daxDialogsWithTrackers, type: .withOneTracker)
         
-        static let withMutipleTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithMultipleTrackers,
+        static let withMultipleTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithMultipleTrackers,
                                                       cta: UserText.daxDialogBrowsingWithMultipleTrackersCTA,
                                                       highlightAddressBar: true,
-                                                      pixelName: .daxDialogsWithTrackers, type: .withMutipleTrackers)
+                                                      pixelName: .daxDialogsWithTrackers, type: .withMultipleTrackers)
         
         let message: String
         let cta: String
@@ -323,7 +323,7 @@ class DaxDialogs {
             
         default:
             settings.browsingWithTrackersShown = true
-            return BrowsingSpec.withMutipleTrackers.format(args: entitiesBlocked.count - 2,
+            return BrowsingSpec.withMultipleTrackers.format(args: entitiesBlocked.count - 2,
                                                            entitiesBlocked[0].displayName ?? "",
                                                            entitiesBlocked[1].displayName ?? "")
         }

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -21,6 +21,8 @@ import Foundation
 import Core
 import TrackerRadarKit
 
+// swiftlint:disable type_body_length
+
 class DaxDialogs {
     
     struct MajorTrackers {
@@ -33,7 +35,6 @@ class DaxDialogs {
     }
     
     struct HomeScreenSpec: Equatable {
-
         static let initial = HomeScreenSpec(message: UserText.daxDialogHomeInitial, accessibilityLabel: nil)
         static let subsequent = HomeScreenSpec(message: UserText.daxDialogHomeSubsequent, accessibilityLabel: nil)
         static let addFavorite = HomeScreenSpec(message: UserText.daxDialogHomeAddFavorite,
@@ -41,53 +42,78 @@ class DaxDialogs {
 
         let message: String
         let accessibilityLabel: String?
-
+    }
+    
+    func overrideShownFlagForSpec(spec: BrowsingSpec, flag: Bool) {
+        switch spec.type {
+        case .withMutipleTrackers, .withOneTracker :
+            settings.browsingWithTrackersShown = flag
+        case .afterSearch:
+            settings.browsingAfterSearchShown = flag
+        case .withoutTrackers:
+            settings.browsingWithoutTrackersShown = flag
+        case .siteIsMajorTracker, .siteOwnedByMajorTracker:
+            settings.browsingMajorTrackingSiteShown = flag
+            settings.browsingWithoutTrackersShown = flag
+         }
     }
     
     struct BrowsingSpec: Equatable {
-        
+        // swiftlint:disable nesting
+
+        enum SpecType {
+            case afterSearch
+            case withoutTrackers
+            case siteIsMajorTracker
+            case siteOwnedByMajorTracker
+            case withOneTracker
+            case withMutipleTrackers
+        }
+        // swiftlint:enable nesting
+
         static let afterSearch = BrowsingSpec(message: UserText.daxDialogBrowsingAfterSearch,
                                               cta: UserText.daxDialogBrowsingAfterSearchCTA,
                                               highlightAddressBar: false,
-                                              pixelName: .daxDialogsSerp)
+                                              pixelName: .daxDialogsSerp, type: .afterSearch)
         
         static let withoutTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithoutTrackers,
                                                   cta: UserText.daxDialogBrowsingWithoutTrackersCTA,
                                                   highlightAddressBar: false,
-                                                  pixelName: .daxDialogsWithoutTrackers)
+                                                  pixelName: .daxDialogsWithoutTrackers, type: .withoutTrackers)
         
         static let siteIsMajorTracker = BrowsingSpec(message: UserText.daxDialogBrowsingSiteIsMajorTracker,
                                                      cta: UserText.daxDialogBrowsingSiteIsMajorTrackerCTA,
                                                      highlightAddressBar: false,
-                                                     pixelName: .daxDialogsSiteIsMajor)
+                                                     pixelName: .daxDialogsSiteIsMajor, type: .siteIsMajorTracker)
         
         static let siteOwnedByMajorTracker = BrowsingSpec(message: UserText.daxDialogBrowsingSiteOwnedByMajorTracker,
                                                           cta: UserText.daxDialogBrowsingSiteOwnedByMajorTrackerCTA,
                                                           highlightAddressBar: false,
-                                                          pixelName: .daxDialogsSiteOwnedByMajor)
+                                                          pixelName: .daxDialogsSiteOwnedByMajor, type: .siteOwnedByMajorTracker)
         
         static let withOneTracker = BrowsingSpec(message: UserText.daxDialogBrowsingWithOneTracker,
                                                  cta: UserText.daxDialogBrowsingWithOneTrackerCTA,
                                                  highlightAddressBar: true,
-                                                 pixelName: .daxDialogsWithTrackers)
+                                                 pixelName: .daxDialogsWithTrackers, type: .withOneTracker)
         
         static let withMutipleTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithMultipleTrackers,
                                                       cta: UserText.daxDialogBrowsingWithMultipleTrackersCTA,
                                                       highlightAddressBar: true,
-                                                      pixelName: .daxDialogsWithTrackers)
+                                                      pixelName: .daxDialogsWithTrackers, type: .withMutipleTrackers)
         
         let message: String
         let cta: String
         let highlightAddressBar: Bool
         let pixelName: PixelName
+        let type: SpecType
         
         func format(args: CVarArg...) -> BrowsingSpec {
             return BrowsingSpec(message: String(format: message, arguments: args),
                                 cta: cta,
                                 highlightAddressBar: highlightAddressBar,
-                                pixelName: pixelName)
+                                pixelName: pixelName,
+                                type: type)
         }
-        
     }
     
     struct ActionSheetSpec: Equatable {
@@ -228,7 +254,6 @@ class DaxDialogs {
     }
     
     func nextHomeScreenMessage() -> HomeScreenSpec? {
-
         if nextHomeScreenMessageOverride != nil {
             return nextHomeScreenMessageOverride
         }
@@ -302,7 +327,6 @@ class DaxDialogs {
                                                            entitiesBlocked[0].displayName ?? "",
                                                            entitiesBlocked[1].displayName ?? "")
         }
-
     }
  
     private func entitiesBlocked(_ siteRating: SiteRating) -> [Entity]? {
@@ -322,5 +346,5 @@ class DaxDialogs {
               let entity = currentTrackerData.findEntity(forHost: host) else { return nil }
         return entity.domains?.contains(where: { MajorTrackers.domains.contains($0) }) ?? false ? entity : nil
     }
-    
 }
+// swiftlint:enable type_body_length

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1000,7 +1000,14 @@ extension TabViewController: WKNavigationDelegate {
         
         isShowingFullScreenDaxDialog = true
         scheduleTrackerNetworksAnimation(collapsing: !spec.highlightAddressBar)
+        let currentURL = self.url
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            // https://app.asana.com/0/414709148257752/1201620790053163/f
+            if self?.url != currentURL {
+                return
+            }
+            
             self?.chromeDelegate?.omniBar.resignFirstResponder()
             self?.chromeDelegate?.setBarsHidden(false, animated: true)
             self?.performSegue(withIdentifier: "DaxDialog", sender: spec)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1000,11 +1000,11 @@ extension TabViewController: WKNavigationDelegate {
         
         isShowingFullScreenDaxDialog = true
         scheduleTrackerNetworksAnimation(collapsing: !spec.highlightAddressBar)
-        let currentURL = self.url
+        let daxDialogSourceURL = self.url
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             // https://app.asana.com/0/414709148257752/1201620790053163/f
-            if self?.url != currentURL {
+            if self?.url != daxDialogSourceURL {
                 return
             }
             

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1005,7 +1005,7 @@ extension TabViewController: WKNavigationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             // https://app.asana.com/0/414709148257752/1201620790053163/f
             if self?.url != daxDialogSourceURL {
-                DaxDialogs.shared.overrideShownFlagForSpec(spec: spec, flag: false)
+                DaxDialogs.shared.overrideShownFlagFor(spec, flag: false)
                 self?.isShowingFullScreenDaxDialog = false
                 return
             }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1005,9 +1005,11 @@ extension TabViewController: WKNavigationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             // https://app.asana.com/0/414709148257752/1201620790053163/f
             if self?.url != daxDialogSourceURL {
+                DaxDialogs.shared.overrideShownFlagForSpec(spec: spec, flag: false)
+                self?.isShowingFullScreenDaxDialog = false
                 return
             }
-            
+
             self?.chromeDelegate?.omniBar.resignFirstResponder()
             self?.chromeDelegate?.setBarsHidden(false, animated: true)
             self?.performSegue(withIdentifier: "DaxDialog", sender: spec)

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -80,11 +80,11 @@ class DaxDialogTests: XCTestCase {
         // swiftlint:disable line_length
         let testCases = [
             (urls: [ URLs.google ], expected: DaxDialogs.BrowsingSpec.withOneTracker.format(args: "Google"), line: #line),
-            (urls: [ URLs.google, URLs.amazon ], expected: DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: 0, "Google", "Amazon.com"), line: #line),
-            (urls: [ URLs.amazon, URLs.ownedByFacebook ], expected: DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: 0, "Facebook", "Amazon.com"), line: #line),
-            (urls: [ URLs.facebook, URLs.google ], expected: DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: 0, "Google", "Facebook"), line: #line),
-            (urls: [ URLs.facebook, URLs.google, URLs.amazon ], expected: DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: 1, "Google", "Facebook"), line: #line),
-            (urls: [ URLs.facebook, URLs.google, URLs.amazon, URLs.tracker ], expected: DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: 2, "Google", "Facebook"), line: #line)
+            (urls: [ URLs.google, URLs.amazon ], expected: DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: 0, "Google", "Amazon.com"), line: #line),
+            (urls: [ URLs.amazon, URLs.ownedByFacebook ], expected: DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: 0, "Facebook", "Amazon.com"), line: #line),
+            (urls: [ URLs.facebook, URLs.google ], expected: DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: 0, "Google", "Facebook"), line: #line),
+            (urls: [ URLs.facebook, URLs.google, URLs.amazon ], expected: DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: 1, "Google", "Facebook"), line: #line),
+            (urls: [ URLs.facebook, URLs.google, URLs.amazon, URLs.tracker ], expected: DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: 2, "Google", "Facebook"), line: #line)
         ]
         // swiftlint:enable line_length
 

--- a/DuckDuckGoTests/DaxDialogsBrowsingSpecTests.swift
+++ b/DuckDuckGoTests/DaxDialogsBrowsingSpecTests.swift
@@ -46,7 +46,7 @@ class DaxDialogsBrowsingSpecTests: XCTestCase {
         let majorTracker1 = "TestTracker1"
         let majorTracker2 = "TestTracker2"
         let count = 1
-        let message = DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: count, majorTracker1, majorTracker2).message
+        let message = DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: count, majorTracker1, majorTracker2).message
         XCTAssertTrue(message.contains(majorTracker1))
         XCTAssertTrue(message.contains(majorTracker2))
         XCTAssertTrue(message.contains("\(count)"))
@@ -61,7 +61,7 @@ class DaxDialogsBrowsingSpecTests: XCTestCase {
         let majorTracker1 = "TestTracker1"
         let majorTracker2 = "TestTracker2"
         let count = 6
-        let message = DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: count, majorTracker1, majorTracker2).message
+        let message = DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: count, majorTracker1, majorTracker2).message
         XCTAssertTrue(message.contains(majorTracker1))
         XCTAssertTrue(message.contains(majorTracker2))
         XCTAssertTrue(message.contains("\(count)"))
@@ -72,7 +72,7 @@ class DaxDialogsBrowsingSpecTests: XCTestCase {
     func testWhenTwoTrackersThenMessageContainsBothTrackers() {
         let majorTracker1 = "TestTracker1"
         let majorTracker2 = "TestTracker2"
-        let message = DaxDialogs.BrowsingSpec.withMutipleTrackers.format(args: 0, majorTracker1, majorTracker2).message
+        let message = DaxDialogs.BrowsingSpec.withMultipleTrackers.format(args: 0, majorTracker1, majorTracker2).message
         XCTAssertTrue(message.contains(majorTracker1))
         XCTAssertTrue(message.contains(majorTracker2))
         XCTAssertTrue(message.contains("\n"))


### PR DESCRIPTION
Add a check to make sure the dax dialog is only displayed if the current URL is the same as the one who originated it


Task/Issue URL: https://app.asana.com/0/414709148257752/1201620790053163/f


**Description**:


**Steps to test this PR**:

1. Clean install
2. Perform a search
3. Click a link that's likely got some trackers
4. Time it so that the page has loaded a bit but before the dialog shows
5. Swipe back
6. Dax dialog should not be displayed 

ps. After testing with a clean install, if you want to force the dialogs to be displayed without reinstalling the app I recommend removing the following lines:
https://github.com/duckduckgo/iOS/blob/123a583a08a313e0ef680824e036a1faaef1fc58/DuckDuckGo/DaxDialogs.swift#L205

https://github.com/duckduckgo/iOS/blob/123a583a08a313e0ef680824e036a1faaef1fc58/DuckDuckGo/DaxDialogs.swift#L288

https://github.com/duckduckgo/iOS/blob/123a583a08a313e0ef680824e036a1faaef1fc58/DuckDuckGo/FullscreenDaxDialogViewController.swift#L155
<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


**Device Testing**:

* [x] iPhone 13
* [x] iPad

**OS Testing**:

* [ ] iOS 13
* [x] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
