### PR TITLE
Prevent repeated completions. Respect feature flags

### DIFF
--- a/Core/AMPCanonicalExtractor.swift
+++ b/Core/AMPCanonicalExtractor.swift
@@ -32,8 +32,12 @@ public class AMPCanonicalExtractor: NSObject {
         }
 
         func completeWithURL(_ url: URL?) {
-            completion?(url)
+            // Make a copy of completion and set it to nil
+            // This will prevent other callers before the completion has completed completing
+            let compBlock = completion
             completion = nil
+            compBlock?(url)
+            
         }
 
     }
@@ -104,6 +108,7 @@ public class AMPCanonicalExtractor: NSObject {
     public func urlContainsAmpKeyword(_ url: URL?,
                                       config: PrivacyConfiguration = PrivacyConfigurationManager.shared.privacyConfig) -> Bool {
         linkCleaner.lastAmpUrl = nil
+        guard config.isEnabled(featureKey: .ampLinks) else { return false }
         guard let url = url, !linkCleaner.isURLExcluded(url: url, config: config) else { return false }
         let urlStr = url.absoluteString
         
@@ -143,6 +148,10 @@ public class AMPCanonicalExtractor: NSObject {
                                 config: PrivacyConfiguration = PrivacyConfigurationManager.shared.privacyConfig,
                                 completion: @escaping ((URL?) -> Void)) {
         cancelOngoingExtraction()
+        guard config.isEnabled(featureKey: .ampLinks) else {
+            completion(nil)
+            return
+        }
         guard let url = url, !linkCleaner.isURLExcluded(url: url, config: config) else {
             completion(nil)
             return

--- a/Core/LinkCleaner.swift
+++ b/Core/LinkCleaner.swift
@@ -54,6 +54,7 @@ public class LinkCleaner {
     public func extractCanonicalFromAmpLink(initiator: URL?, destination url: URL?,
                                             config: PrivacyConfiguration = PrivacyConfigurationManager.shared.privacyConfig) -> URL? {
         lastAmpUrl = nil
+        guard config.isEnabled(featureKey: .ampLinks) else { return nil }
         guard let url = url, !isURLExcluded(url: url, config: config) else { return nil }
         if let initiator = initiator, isURLExcluded(url: initiator, config: config) {
             return nil


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201680299225249
Tech Design URL:
CC: @brindy @kdzwinel 

**Description**:
This PR adds protection in the AMP canonical extractor to prevent the completion block being called twice. Additionally this adds checks to make sure the feature is enabled in the privacy config before attempting any AMP checks.

**Steps to test this PR**:
1. Comment out lines 86-88 of `PrivacyConfigurationManager.swift` such that they return the embedded config
2. In `ios-config.json` change the `state` of `ampLinks` to `disabled`
2. Launch the app and Visit basecamp.com
2. Click "Give basecamp a try"
3. App should not crash
4. Use breakpoints to ensure that config is being respected

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [x] iPad

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
