### PR TITLE
Widget crash fix

### DIFF
--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -424,6 +424,9 @@ extension BookmarksCoreDataStorage {
     
     public func favoritesUncachedForWidget(completion: @escaping ([BookmarkManagedObject]) -> Void) {
         guard BookmarksCoreDataStorageMigration.migratedFromUserDefaults else {
+            // Users with a pre-folders install who have then installed a build with folders and have not yet migrated it will
+            // not be able to read folders from Core Data. This will be resolved the first time they launch the app, so an empty
+            // set of favorites is returned here to avoid the widget crashing.
             completion([])
             return
         }

--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -717,7 +717,7 @@ extension BookmarksCoreDataStorage {
 public class BookmarksCoreDataStorageMigration {
     
     @UserDefaultsWrapper(key: .bookmarksMigratedFromUserDefaultsToCD, defaultValue: false)
-    fileprivate static var migratedFromUserDefaults: Bool
+    private static var migratedFromUserDefaults: Bool
     
     public static func migrate(fromBookmarkStore bookmarkStore: BookmarkStore, context: NSManagedObjectContext) {
         if migratedFromUserDefaults {

--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -719,7 +719,7 @@ public class BookmarksCoreDataStorageMigration {
     @UserDefaultsWrapper(key: .bookmarksMigratedFromUserDefaultsToCD, defaultValue: false)
     private static var migratedFromUserDefaults: Bool
     
-    public static func migrate(fromBookmarkStore bookmarkStore: BookmarkStore, context: NSManagedObjectContext) {
+    public static func migrate(fromBookmarkStore bookmarkStore: BookmarkStore, context: NSManagedObjectContext, completion: () -> Void) {
         if migratedFromUserDefaults {
             return
         }
@@ -773,6 +773,7 @@ public class BookmarksCoreDataStorageMigration {
         }
 
         migratedFromUserDefaults = true
+        completion()
     }
 }
 

--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -423,8 +423,13 @@ extension BookmarksCoreDataStorage {
     }
     
     public func favoritesUncachedForWidget(completion: @escaping ([BookmarkManagedObject]) -> Void) {
+        guard BookmarksCoreDataStorageMigration.migratedFromUserDefaults else {
+            completion([])
+            return
+        }
+        
         getTopLevelFolder(isFavorite: true, onContext: viewContext) { folder in
-            
+
             let children = folder.children?.array as? [BookmarkItemManagedObject] ?? []
             let favorites: [BookmarkManagedObject] = children.map {
                 if let fav = $0 as? BookmarkManagedObject {
@@ -701,7 +706,7 @@ extension BookmarksCoreDataStorage {
 public class BookmarksCoreDataStorageMigration {
     
     @UserDefaultsWrapper(key: .bookmarksMigratedFromUserDefaultsToCD, defaultValue: false)
-    private static var migratedFromUserDefaults: Bool
+    fileprivate static var migratedFromUserDefaults: Bool
     
     public static func migrate(fromBookmarkStore bookmarkStore: BookmarkStore, context: NSManagedObjectContext) {
         if migratedFromUserDefaults {

--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -719,9 +719,12 @@ public class BookmarksCoreDataStorageMigration {
     @UserDefaultsWrapper(key: .bookmarksMigratedFromUserDefaultsToCD, defaultValue: false)
     private static var migratedFromUserDefaults: Bool
     
-    public static func migrate(fromBookmarkStore bookmarkStore: BookmarkStore, context: NSManagedObjectContext, completion: () -> Void) {
+    /// Migrates bookmark data to Core Data.
+    ///
+    /// - Returns: A boolean representing whether the migration took place. If the migration has already happened and this function is called, it returns `false`.
+    public static func migrate(fromBookmarkStore bookmarkStore: BookmarkStore, context: NSManagedObjectContext) -> Bool {
         if migratedFromUserDefaults {
-            return
+            return false
         }
         
         context.performAndWait {
@@ -773,7 +776,7 @@ public class BookmarksCoreDataStorageMigration {
         }
 
         migratedFromUserDefaults = true
-        completion()
+        return true
     }
 }
 

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8512EA4C24ED30D20073EE19"
+               BuildableName = "WidgetsExtension.appex"
+               BlueprintName = "WidgetsExtension"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+               BuildableName = "DuckDuckGo.app"
+               BlueprintName = "DuckDuckGo"
+               ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8512EA4C24ED30D20073EE19"
+            BuildableName = "WidgetsExtension.appex"
+            BlueprintName = "WidgetsExtension"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = "FavoritesWidget"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "snapshot"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "medium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84E341911E2F7EFB00BDBA6F"
+            BuildableName = "DuckDuckGo.app"
+            BlueprintName = "DuckDuckGo"
+            ReferencedContainer = "container:DuckDuckGo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -91,8 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         BookmarksCoreDataStorage.shared.loadStoreAndCaches { context in
-            BookmarksCoreDataStorageMigration.migrate(fromBookmarkStore: self.bookmarkStore, context: context) {
-                
+            if BookmarksCoreDataStorageMigration.migrate(fromBookmarkStore: self.bookmarkStore, context: context) {
                 if #available(iOS 14, *) {
                     WidgetCenter.shared.reloadAllTimelines()
                 }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -90,7 +90,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         BookmarksCoreDataStorage.shared.loadStoreAndCaches { context in
-            BookmarksCoreDataStorageMigration.migrate(fromBookmarkStore: self.bookmarkStore, context: context)
+            BookmarksCoreDataStorageMigration.migrate(fromBookmarkStore: self.bookmarkStore, context: context) {
+                
+                if #available(iOS 14, *) {
+                    WidgetCenter.shared.reloadAllTimelines()
+                }
+            }
         }
         
         HTTPSUpgrade.shared.loadDataAsync()

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -52,6 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: lifecycle
 
+    // swiftlint:disable function_body_length
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         #if targetEnvironment(simulator)
         if ProcessInfo.processInfo.environment["UITESTING"] == "true" {
@@ -127,6 +128,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         appIsLaunching = true
         return true
     }
+    // swiftlint:enable function_body_length
 
     private func clearTmp() {
         let tmp = FileManager.default.temporaryDirectory

--- a/DuckDuckGo/BookmarksCachingSearch.swift
+++ b/DuckDuckGo/BookmarksCachingSearch.swift
@@ -1,5 +1,5 @@
 //
-//  BookmarksSearch.swift
+//  BookmarksCachingSearch.swift
 //  DuckDuckGo
 //
 //  Copyright © 2020 DuckDuckGo. All rights reserved.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201654842382336/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:

This PR fixes a crash in the widget extension, where users who update to a version of the app that supports bookmarks folders but don't yet launch it will have their widget crash repeatedly without realizing.

This workaround is just to stop the crash, it doesn't restore favourites in the widget - users need to launch the app so that they can be migrated before favourites will appear again.

**Steps to test this PR**:
1. Install a pre-folders build of the app to the simulator, i.e. `git checkout 7.65.2`
2. Run the app, add some favorites
3. Add a widget to the Home Screen, verify that favourites appear
4. Kill the app and swap over to this branch with `git checkout sam/widget-crash-fix`
5. Run the new `WidgetsExtension` scheme that was added in this branch. This will launch the widget with the debugger attached but will **not** run the app, so the migration won't take place (which is what we want)
6. Verify that there are no favourites on the widget, and also that nothing has crashed. Add a breakpoint in `hasTopLevelFolder()` to make sure the debugger is actually attached, I had some issues with reliability here – keep trying if you can't hit a breakpoint in this function. Make sure the breakpoint is hit, and that no exceptions pop up after you resume.
7. Launch the app, verify that your favourites show up in the Bookmarks screen
8. Go back to the Home Screen, verify that favourites now show up in the widget

Also, test this on the on a physical device over top of the latest release if you can, just to make sure nothing's broken.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
