### PR TITLE
Add JS Alert block button

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -170,6 +170,9 @@ public enum PixelName: String {
     
     case textSizeSettingsShown = "m_text_size_settings_shown"
     case textSizeSettingsChanged = "m_text_size_settings_changed"
+    
+    case jsAlertShown = "m_js_alert_shown"
+    case jsAlertBlocked = "m_js_alert_blocked"
 
     // MARK: SERP pixels
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1379,8 +1379,8 @@ extension TabViewController: WKUIDelegate {
                   initiatedByFrame frame: WKFrameInfo,
                   completionHandler: @escaping () -> Void) {
         if canDisplayJavaScriptAlert {
-            let alertController = WebJSAlert(message: message, alertType: .alert(handler: { [weak self] suppress in
-                self?.shouldBlockJSAlert = suppress
+            let alertController = WebJSAlert(message: message, alertType: .alert(handler: { [weak self] blockAlerts in
+                self?.shouldBlockJSAlert = blockAlerts
                 completionHandler()
             })).createAlertController()
             
@@ -1397,8 +1397,8 @@ extension TabViewController: WKUIDelegate {
         
         if canDisplayJavaScriptAlert {
             let alertController = WebJSAlert(message: message,
-                                             alertType: .confirm(handler: { [weak self] suppress, confirm in
-                self?.shouldBlockJSAlert = suppress
+                                             alertType: .confirm(handler: { [weak self] blockAlerts, confirm in
+                self?.shouldBlockJSAlert = blockAlerts
                 completionHandler(confirm)
             })).createAlertController()
             
@@ -1415,9 +1415,9 @@ extension TabViewController: WKUIDelegate {
                  completionHandler: @escaping (String?) -> Void) {
         if canDisplayJavaScriptAlert {
             let alertController = WebJSAlert(message: prompt,
-                                             alertType: .text(handler: { [weak self] suppress, text in
+                                             alertType: .text(handler: { [weak self] blockAlerts, text in
                 
-                self?.shouldBlockJSAlert = suppress
+                self?.shouldBlockJSAlert = blockAlerts
                 completionHandler(text)
             }, defaultText: defaultText)).createAlertController()
             

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -425,6 +425,6 @@ public struct UserText {
         let message = NSLocalizedString("textSize.footer", value: "Text Size - %@", comment: "Replacement string is a current percent value e.g. '120%'")
         return message.format(arguments: percentage)
     }
-    public static let webJSAlertDisableAlertsButton = NSLocalizedString("webJSAlert.disable-alerts.button", value: "Disable Alerts", comment: "Disable Alerts button for JavaScript alertss")
+    public static let webJSAlertDisableAlertsButton = NSLocalizedString("webJSAlert.block-alerts.button", value: "Block Alerts", comment: "Block Alerts button for JavaScript alerts")
 
 }

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -425,4 +425,6 @@ public struct UserText {
         let message = NSLocalizedString("textSize.footer", value: "Text Size - %@", comment: "Replacement string is a current percent value e.g. '120%'")
         return message.format(arguments: percentage)
     }
+    public static let webJSAlertDisableAlertsButton = NSLocalizedString("webJSAlert.disable-alerts.button", value: "Disable Alerts", comment: "Disable Alerts button for JavaScript alertss")
+
 }

--- a/DuckDuckGo/WebJSAlert.swift
+++ b/DuckDuckGo/WebJSAlert.swift
@@ -36,7 +36,6 @@ struct WebJSAlert {
     
     func createAlertController() -> UIAlertController {
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        let suppressButtonTitle = "Suppress Dialogs"
         switch alertType {
             
         case .confirm(let handler):
@@ -50,7 +49,7 @@ struct WebJSAlert {
                 handler(false, false)
             }))
             
-            alertController.addAction(UIAlertAction(title: suppressButtonTitle,
+            alertController.addAction(UIAlertAction(title: UserText.webJSAlertDisableAlertsButton,
                                                     style: .destructive, handler: { _ in
                 handler(true, false)
             }))
@@ -61,7 +60,7 @@ struct WebJSAlert {
                                                     style: .default, handler: { _ in
                 handler(false)
             }))
-            alertController.addAction(UIAlertAction(title: suppressButtonTitle,
+            alertController.addAction(UIAlertAction(title: UserText.webJSAlertDisableAlertsButton,
                                                     style: .destructive, handler: { _ in
                 handler(true)
             }))
@@ -83,7 +82,7 @@ struct WebJSAlert {
                 handler(false, nil)
             }))
             
-            alertController.addAction(UIAlertAction(title: suppressButtonTitle,
+            alertController.addAction(UIAlertAction(title: UserText.webJSAlertDisableAlertsButton,
                                                     style: .destructive, handler: { _ in
                 handler(true, nil)
             }))

--- a/DuckDuckGo/WebJSAlert.swift
+++ b/DuckDuckGo/WebJSAlert.swift
@@ -21,9 +21,9 @@ import UIKit
 
 struct WebJSAlert {
     enum JSAlertType {
-        case confirm(handler: (Bool) -> Void)
-        case text(handler: (String?) -> Void, defaultText: String?)
-        case alert(handler: () -> Void)
+        case confirm(handler: (_ suppress: Bool, _ confirm: Bool) -> Void)
+        case text(handler: (_ suppress: Bool, _ text: String?) -> Void, defaultText: String?)
+        case alert(handler: (_ suppress: Bool) -> Void)
     }
     
     private let message: String
@@ -36,25 +36,34 @@ struct WebJSAlert {
     
     func createAlertController() -> UIAlertController {
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        
+        let suppressButtonTitle = "Suppress Dialogs"
         switch alertType {
-        
+            
         case .confirm(let handler):
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertOKButton,
                                                     style: .default, handler: { _ in
-                handler(true)
+                handler(false, true)
             }))
             
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertCancelButton,
-                                                    style: .cancel, handler: { _ in
-                handler(false)
+                                                    style: .default, handler: { _ in
+                handler(false, false)
+            }))
+            
+            alertController.addAction(UIAlertAction(title: suppressButtonTitle,
+                                                    style: .destructive, handler: { _ in
+                handler(true, false)
             }))
             return alertController
             
         case .alert(let handler):
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertOKButton,
                                                     style: .default, handler: { _ in
-                handler()
+                handler(false)
+            }))
+            alertController.addAction(UIAlertAction(title: suppressButtonTitle,
+                                                    style: .destructive, handler: { _ in
+                handler(true)
             }))
             return alertController
             
@@ -65,16 +74,21 @@ struct WebJSAlert {
             
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertOKButton,
                                                     style: .default, handler: { [weak alertController] _ in
-                handler(alertController?.textFields?.first?.text)
-
+                handler(false, alertController?.textFields?.first?.text)
+                
             }))
-
+            
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertCancelButton,
-                                                    style: .cancel, handler: { _ in
-                handler(nil)
+                                                    style: .default, handler: { _ in
+                handler(false, nil)
+            }))
+            
+            alertController.addAction(UIAlertAction(title: suppressButtonTitle,
+                                                    style: .destructive, handler: { _ in
+                handler(true, nil)
             }))
             
             return alertController
         }
-     }
+    }
 }

--- a/DuckDuckGo/WebJSAlert.swift
+++ b/DuckDuckGo/WebJSAlert.swift
@@ -18,12 +18,13 @@
 //
 
 import UIKit
+import Core
 
 struct WebJSAlert {
     enum JSAlertType {
-        case confirm(handler: (_ suppress: Bool, _ confirm: Bool) -> Void)
-        case text(handler: (_ suppress: Bool, _ text: String?) -> Void, defaultText: String?)
-        case alert(handler: (_ suppress: Bool) -> Void)
+        case confirm(handler: (_ blockAlerts: Bool, _ confirm: Bool) -> Void)
+        case text(handler: (_ blockAlerts: Bool, _ text: String?) -> Void, defaultText: String?)
+        case alert(handler: (_ blockAlerts: Bool) -> Void)
     }
     
     private let message: String
@@ -35,6 +36,10 @@ struct WebJSAlert {
     }
     
     func createAlertController() -> UIAlertController {
+        
+        // createAlertController is only called right before its presentation
+        Pixel.fire(pixel: .jsAlertShown)
+        
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         switch alertType {
             
@@ -51,6 +56,7 @@ struct WebJSAlert {
             
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertDisableAlertsButton,
                                                     style: .destructive, handler: { _ in
+                Pixel.fire(pixel: .jsAlertBlocked)
                 handler(true, false)
             }))
             return alertController
@@ -62,6 +68,7 @@ struct WebJSAlert {
             }))
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertDisableAlertsButton,
                                                     style: .destructive, handler: { _ in
+                Pixel.fire(pixel: .jsAlertBlocked)
                 handler(true)
             }))
             return alertController
@@ -84,6 +91,7 @@ struct WebJSAlert {
             
             alertController.addAction(UIAlertAction(title: UserText.webJSAlertDisableAlertsButton,
                                                     style: .destructive, handler: { _ in
+                Pixel.fire(pixel: .jsAlertBlocked)
                 handler(true, nil)
             }))
             

--- a/DuckDuckGo/bg.lproj/InfoPlist.strings
+++ b/DuckDuckGo/bg.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Позволява запазване на изображения на вашето устройство";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Необходимо е за използване на гласово търсене. DuckDuckGo никога не записва какво казвате.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Поставяне от клипборда";
 

--- a/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/DuckDuckGo/bg.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Добавено в любими";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Блокиране на предупрежденията";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Отмени";
 

--- a/DuckDuckGo/cs.lproj/InfoPlist.strings
+++ b/DuckDuckGo/cs.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Umožňuje vám ukládat obrázky do vašeho zařízení";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Je potřeba pro používání hlasového vyhledávání. DuckDuckGo nikdy nenahrává, co říkáš.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Vložit ze schránky";
 

--- a/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/DuckDuckGo/cs.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Oblíbené položky uloženy";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokovat výstrahy";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Zrušit";
 

--- a/DuckDuckGo/da.lproj/InfoPlist.strings
+++ b/DuckDuckGo/da.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Gør det muligt at gemme billeder på din enhed";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Dette er nødvendigt for at bruge stemmesøgning. DuckDuckGo optager aldrig det, du siger.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Indsæt fra udklipsholder";
 

--- a/DuckDuckGo/da.lproj/Localizable.strings
+++ b/DuckDuckGo/da.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favorit tilføjet";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Bloker advarsler";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Annullér";
 

--- a/DuckDuckGo/de.lproj/InfoPlist.strings
+++ b/DuckDuckGo/de.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Speichere Bilder auf deinem Gerät";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Dies ist für die Nutzung der Sprachsuche erforderlich. DuckDuckGo zeichnet nie auf, was du sagst.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Vom Clipboard einfügen";
 

--- a/DuckDuckGo/de.lproj/Localizable.strings
+++ b/DuckDuckGo/de.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favorit wurde hinzugefügt";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Benachrichtigungen blockieren";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Abbrechen";
 

--- a/DuckDuckGo/el.lproj/InfoPlist.strings
+++ b/DuckDuckGo/el.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Σας επιτρέπει να αποθηκεύετε φωτογραφίες στη συσκευή σας";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Αυτό είναι απαραίτητο για τη χρήση φωνητικής αναζήτησης. Το DuckDuckGo δεν καταγράφει ποτέ ό,τι λέτε.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Επικόλληση από το πρόχειρο";
 

--- a/DuckDuckGo/el.lproj/Localizable.strings
+++ b/DuckDuckGo/el.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Προστέθηκε αγαπημένο";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Αποκλεισμός ειδοποιήσεων";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Ακύρωση";
 

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1081,6 +1081,9 @@
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Cancel";
 
+/* Disable Alerts button for JavaScript alertss */
+"webJSAlert.disable-alerts.button" = "Disable Alerts";
+
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
 

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1078,11 +1078,11 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favorite added";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Block Alerts";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Cancel";
-
-/* Disable Alerts button for JavaScript alertss */
-"webJSAlert.disable-alerts.button" = "Disable Alerts";
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";

--- a/DuckDuckGo/es.lproj/InfoPlist.strings
+++ b/DuckDuckGo/es.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Te permite guardar imágenes en tu dispositivo";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Esto es necesario para utilizar la búsqueda por voz. DuckDuckGo nunca graba lo que dices.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Pegar desde el portapapeles";
 

--- a/DuckDuckGo/es.lproj/Localizable.strings
+++ b/DuckDuckGo/es.lproj/Localizable.strings
@@ -557,7 +557,7 @@
 "feedback.positive.header" = "¡Es fantástico oír eso!";
 
 /* No comment provided by engineer. */
-"feedback.positive.noThanks" = "No, gracias. He terminado";
+"feedback.positive.noThanks" = "No, gracias He terminado";
 
 /* Button encouraging uses to share details aboout their feedback */
 "feedback.positive.submit" = "Compartir detalles";
@@ -1077,6 +1077,9 @@
 
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favorito añadido";
+
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Bloquear alertas";
 
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Cancelar";

--- a/DuckDuckGo/et.lproj/InfoPlist.strings
+++ b/DuckDuckGo/et.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Võimaldab salvestada pilte oma seadmesse";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "See on vajalik häälotsingu kasutamiseks. DuckDuckGo ei salvesta kunagi seda, mida te ütlete.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Kleebi lõikelaualt";
 

--- a/DuckDuckGo/et.lproj/Localizable.strings
+++ b/DuckDuckGo/et.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Lemmik lisatud";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokeerige märguanded";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Tühista";
 

--- a/DuckDuckGo/fi.lproj/InfoPlist.strings
+++ b/DuckDuckGo/fi.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Voit tallentaa kuvia laitteellesi";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Tämä vaaditaan puhehaun käyttämiseen. DuckDuckGo ei koskaan tallenna puhettasi.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Liitä leikepöydältä";
 

--- a/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/DuckDuckGo/fi.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Suosikki lisätty";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Estä ilmoitukset";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Peruuta";
 

--- a/DuckDuckGo/fr.lproj/InfoPlist.strings
+++ b/DuckDuckGo/fr.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Vous permet d'enregistrer des images sur votre appareil";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Requis pour utiliser la recherche vocale. DuckDuckGo n'enregistre jamais ce que vous dites.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Coller depuis le presse-papier";
 

--- a/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/DuckDuckGo/fr.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favori ajouté";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Bloquer les alertes";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Annuler";
 

--- a/DuckDuckGo/hr.lproj/InfoPlist.strings
+++ b/DuckDuckGo/hr.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Omogućuje ti spremanje slika na uređaj";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "To je potrebno za korištenje glasovnih funkcija. DuckDuckGo nikad ne snima ono što govorite.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Zalijepi iz međuspremnika";
 

--- a/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/DuckDuckGo/hr.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Dodano u Omiljeno";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokiraj upozorenja";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Otkaži";
 

--- a/DuckDuckGo/hu.lproj/InfoPlist.strings
+++ b/DuckDuckGo/hu.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Lehetővé teszi képek mentését az eszközödre";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Erre a hangalapú keresés használatához van szükség. A DuckDuckGo soha nem készít felvételt arról, amit mondasz.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Beillesztés a vágólapról";
 

--- a/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/DuckDuckGo/hu.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Kedvenc hozzáadva";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Figyelmeztetések blokkolása";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Mégsem";
 

--- a/DuckDuckGo/it.lproj/InfoPlist.strings
+++ b/DuckDuckGo/it.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Consente il salvataggio delle immagini sul tuo dispositivo";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "È necessario per utilizzare la ricerca vocale. DuckDuckGo non registra mai quello che dici.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Incolla dagli appunti";
 

--- a/DuckDuckGo/it.lproj/Localizable.strings
+++ b/DuckDuckGo/it.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Preferito aggiunto";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blocca gli avvisi";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Annulla";
 

--- a/DuckDuckGo/lt.lproj/InfoPlist.strings
+++ b/DuckDuckGo/lt.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Leidžia įrašyti nuotraukas į jūsų įrenginį";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Tai būtina, kai naudojama balsu valdoma paieška. „DuckDuckGo“ niekada neįrašinėja to, ką sakote.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Įklijuoti iš mainų srities";
 

--- a/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/DuckDuckGo/lt.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Mėgstamas pridėtas";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokuoti įspėjimus";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Atšaukti";
 

--- a/DuckDuckGo/lv.lproj/InfoPlist.strings
+++ b/DuckDuckGo/lv.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Ļauj saglabāt attēlus ierīcē";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Nepieciešams, lai izmantotu meklēšanu ar balsi. DuckDuckGo neieraksta tevis teikto.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Ielīmēt no starpliktuves";
 

--- a/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/DuckDuckGo/lv.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Izlases vienums ir pievienots";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Bloķēt brīdinājumus";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Atcelt";
 

--- a/DuckDuckGo/nb.lproj/InfoPlist.strings
+++ b/DuckDuckGo/nb.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Gjør at du kan lagre bilder på enheten din";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Dette kreves for å bruke talesøk. DuckDuckGo tar aldri opp det du sier.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Lim inn fra utklippstavlen";
 

--- a/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/DuckDuckGo/nb.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favoritt lagt til";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokker varsler";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Avbryt";
 

--- a/DuckDuckGo/nl.lproj/InfoPlist.strings
+++ b/DuckDuckGo/nl.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Hiermee kun je afbeeldingen op je apparaat opslaan";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Dit is vereist om spraakzoekopdrachten te gebruiken. DuckDuckGo neemt nooit op wat je zegt.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Plakken vanaf klembord";
 

--- a/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/DuckDuckGo/nl.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favoriet toegevoegd";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Meldingen blokkeren";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Annuleren";
 

--- a/DuckDuckGo/pl.lproj/InfoPlist.strings
+++ b/DuckDuckGo/pl.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Umożliwia zapisywanie obrazów na urządzeniu";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Wymagane do korzystania z wyszukiwania głosowego. DuckDuckGo nigdy nie nagrywa tego, co mówisz.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Wklej ze schowka";
 

--- a/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/DuckDuckGo/pl.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Dodano ulubione";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokuj alerty";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Anuluj";
 

--- a/DuckDuckGo/pt.lproj/InfoPlist.strings
+++ b/DuckDuckGo/pt.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Permite-lhe gravar imagens no seu dispositivo";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Isto é necessário para usar a pesquisa por voz. O DuckDuckGo nunca grava o que diz.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Colar da área de transferência";
 

--- a/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/DuckDuckGo/pt.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favorito adicionado";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Bloquear alertas";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Cancelar";
 

--- a/DuckDuckGo/ro.lproj/InfoPlist.strings
+++ b/DuckDuckGo/ro.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Îți permite să salvezi imagini pe dispozitivul tău";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Este necesar pentru a utiliza căutarea vocală. DuckDuckGo nu înregistrează niciodată ceea ce spui.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Lipește din clipboard";
 

--- a/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/DuckDuckGo/ro.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Preferință adăugată";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blochează notificările";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Renunță";
 

--- a/DuckDuckGo/ru.lproj/InfoPlist.strings
+++ b/DuckDuckGo/ru.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Позволяет сохранять изображения на устройство";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Требуется для голосового поиска. DuckDuckGo ни в коем случае не записывает ваши разговоры.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Вставить из буфера обмена";
 

--- a/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/DuckDuckGo/ru.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Сайт добавлен в избранное";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Блокировать уведомления";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Отменить";
 

--- a/DuckDuckGo/sk.lproj/InfoPlist.strings
+++ b/DuckDuckGo/sk.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Umožňuje vám ukladať obrázky do vášho zariadenia";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Toto sa vyžaduje na použitie hlasového vyhľadávania. DuckDuckGo nikdy nenahráva, čo hovoríte.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Prilepiť zo schránky";
 

--- a/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/DuckDuckGo/sk.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Obľúbená položka bola pridaná";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokovať upozornenia";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Zrušiť";
 

--- a/DuckDuckGo/sl.lproj/InfoPlist.strings
+++ b/DuckDuckGo/sl.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Omogoča shranjevanje slik v napravo";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "To je potrebno za uporabo funkcije glasovnega iskanja. DuckDuckGo nikoli ne snema vašega govora.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Prilepi iz odložišča";
 

--- a/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/DuckDuckGo/sl.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Priljubljeni dodan";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blokiraj opozorila";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Prekliči";
 

--- a/DuckDuckGo/sv.lproj/InfoPlist.strings
+++ b/DuckDuckGo/sv.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Gör att du kan spara bilder på din enhet";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Det här krävs för att använda röstsökning. DuckDuckGo spelar aldrig in det du säger.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Klistra in från urklipp";
 

--- a/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/DuckDuckGo/sv.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favorit har lagts till";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Blockera varningar";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "Avbryt";
 

--- a/DuckDuckGo/tr.lproj/InfoPlist.strings
+++ b/DuckDuckGo/tr.lproj/InfoPlist.strings
@@ -19,6 +19,9 @@
 /* Privacy - Photo Library Additions Usage Description */
 "NSPhotoLibraryAddUsageDescription" = "Görselleri cihazınıza kaydetmenize olanak tanır";
 
+/* Privacy - Speech Recognition Usage Description */
+"NSSpeechRecognitionUsageDescription" = "Sesli aramayı kullanmak için bu gereklidir. DuckDuckGo söylediklerinizi asla kaydetmez.";
+
 /* (No Comment) */
 "Paste from clipboard" = "Panodan yapıştır";
 

--- a/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/DuckDuckGo/tr.lproj/Localizable.strings
@@ -1078,6 +1078,9 @@
 /* Confirmation message */
 "web.url.save.favorite.done" = "Favori eklendi";
 
+/* Block Alerts button for JavaScript alerts */
+"webJSAlert.block-alerts.button" = "Uyarıları Engelle";
+
 /* Cancel button for JavaScript alerts */
 "webJSAlert.cancel.button" = "İptal";
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201481513493461/f

**Description**:
Add block action to JS alerts

**Steps to test this PR**:
1. Go to https://privacy-test-pages.glitch.me/features/js-alerts.html
2. Tap on any alert
3. Select Block Alert option
4. Tap on other alerts. 
5. They should not be displayed again.
6. Open another tab
7. Open https://privacy-test-pages.glitch.me/features/js-alerts.html
8. Tap on any alert
9. They should be displayed

**Device Testing**:

* [x] iPhone 13
* [x] iPad

**OS Testing**:

* [x] iOS 14
* [x] iOS 15
* [x] iPadOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**