### PR TITLE
Fix bookmarks edit button when data source empty

### DIFF
--- a/DuckDuckGo/BookmarkSectionDataSources.swift
+++ b/DuckDuckGo/BookmarkSectionDataSources.swift
@@ -215,7 +215,9 @@ class BookmarksSectionDataSource: BookmarkItemsSectionDataSource {
             cell.separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
             return cell
         } else {
-            return (self as BookmarkItemsSectionDataSource).createEmptyCell(tableView, forIndex: index)
+            let cell = (self as BookmarkItemsSectionDataSource).createEmptyCell(tableView, forIndex: index)
+            cell.label.text =  UserText.emptyBookmarks
+            return cell
         }
     }
 }

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -58,6 +58,9 @@ class BookmarksViewController: UITableViewController {
     
     @objc func dataDidChange(notification: Notification) {
         tableView.reloadData()
+        if currentDataSource.isEmpty && tableView.isEditing {
+            finishEditing()
+        }
         refreshEditButton()
     }
     
@@ -209,7 +212,7 @@ class BookmarksViewController: UITableViewController {
     }
 
     private func refreshEditButton() {
-        if currentDataSource.isEmpty || currentDataSource === searchDataSource {
+        if (currentDataSource.isEmpty && !tableView.isEditing) || currentDataSource === searchDataSource {
             disableEditButton()
         } else if !tableView.isEditing {
             enableEditButton()
@@ -229,7 +232,7 @@ class BookmarksViewController: UITableViewController {
     }
     
     @IBAction func onEditPressed(_ sender: UIBarButtonItem) {
-        if tableView.isEditing && !currentDataSource.isEmpty {
+        if tableView.isEditing {
             finishEditing()
         } else {
             startEditing()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1201734092442531/f
Tech Design URL:
CC:

**Description**:
Fixes two issues: sometimes the empty bookmark cell has the wrong text, and sometimes it's impossible to leave the edit bookmarks state. Now when there are no items, it should leave the editing state automatically  

**Steps to test this PR**:
1. Add a folder
1. Switch to edit state
1. Delete the folder → Done button for the edit state should disappear, and the top right done button should reappear
------
Also test the above within a subfolder

------
1. Add two folders
2. Delete one of the folders
3. Check that the done button at the bottom (to end the editing state) is there and works
------
1. Create a bookmark or bookmark folder
1. Delete all bookmark items, check the empty bookmark cell reads "No bookmarks added yet", and not "No Favorites added yet"

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
