### PR TITLE
Only reset lastUpgradedURL flag if loading new URL comes from the user action

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -371,7 +371,14 @@ class TabViewController: UIViewController {
     }
     
     public func load(url: URL) {
-        lastUpgradedURL = nil
+        load(url: url, didUpgradeUrl: false)
+    }
+    
+    private func load(url: URL, didUpgradeUrl: Bool) {
+        if !didUpgradeUrl {
+            lastUpgradedURL = nil
+        }
+        
         if !url.isBookmarklet() {
             self.url = url
         }
@@ -1314,7 +1321,7 @@ extension TabViewController: WKNavigationDelegate {
             if isUpgradable, let upgradedUrl = self?.upgradeUrl(url, navigationAction: navigationAction) {
                 NetworkLeaderboard.shared.incrementHttpsUpgrades()
                 self?.lastUpgradedURL = upgradedUrl
-                self?.load(url: upgradedUrl)
+                self?.load(url: upgradedUrl, didUpgradeUrl: true)
                 completion(.cancel)
                 return
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1201744487271704/f
CC: @brindy 

**Description**:
We use lastUpgradedURL flag to prevent us from infinite loop when upgrading certain sites from http to https. The change in https://github.com/duckduckgo/iOS/commit/421e979a916c081531f97e63b264784e72b49685 broke that behavior. Now, we will differentiate whether the page loads due to upgrading to https or due to user action and act accordingly.

**Steps to test this PR**:
1. Make sure to comment out / override privacy config - the page is now on exception list https://github.com/duckduckgo/privacy-configuration/pull/121
2. Search for "blizzard 96 blankets cnn" and open the first link.
3. The page should load with http scheme.
4. Check if the scenario described under https://app.asana.com/0/0/1200360875209797/1200372135556550/f still works.

**OS Testing**:
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
