### PR TITLE
Fix visual glitch on new tab where previous tab is rendered in background

### DIFF
--- a/DuckDuckGo/HomeCollectionView.swift
+++ b/DuckDuckGo/HomeCollectionView.swift
@@ -161,6 +161,7 @@ class HomeCollectionView: UICollectionView {
 extension HomeCollectionView: Themable {
 
     func decorate(with theme: Theme) {
+        backgroundColor = theme.backgroundColor
         renderers.decorate(with: theme)
         reloadData()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1201019331404849/f
Tech Design URL: -
CC: 

**Description**:
In rare cases visual glitch may be observed while opening a new tab. In those situation last tab's content is rendered in the background of the home view's favourites collection view.
To ensure proper rendering we want to replace current `clearColor` and apply a proper (according to theme) `backgroundColor` on the Home view's `HomeCollectionView`.

**Steps to test this PR**:
Since the visual glitch is related to some race condition and hard to reproduce it can be simulated by commenting the line: 
https://github.com/duckduckgo/iOS/blob/cd8e64b80f99d52e671dff7dd2762dece9608dd7/DuckDuckGo/MainViewController.swift#L888
1. Load a website
2. Open a new tab
3. Home screen should be visible without the previous website in the background
4. Verify for empty home screen and when favourites are present 


**Orientation Testing**:
* [x] Portrait
* [x] Landscape

**Device Testing**:
* [x] iPhone
* [x] iPad

**OS Testing**:
* [x] iOS 15

**Theme Testing**:
* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
