### PR TITLE
Explicitly hide suggestions tray if we do not show tray for favorites

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -764,23 +764,27 @@ class MainViewController: UIViewController {
         omniBar.enterPhoneState()
     }
 
-    func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {
-        
-        if suggestionTrayController?.willShow(for: type) ?? false {
-            applyWidthToTrayController()
-
-            if !AppWidthObserver.shared.isLargeWidth {
-                if !DaxDialogs.shared.shouldShowFireButtonPulse {
-                    ViewHighlighter.hideAll()
-                }
-                if type.hideOmnibarSeparator() {
-                    omniBar.hideSeparator()
-                }
-            }
-            
-            suggestionTrayContainer.isHidden = false
+    @discardableResult
+    func tryToShowSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) -> Bool {
+        let canShow = suggestionTrayController?.canShow(for: type) ?? false
+        if canShow {
+            showSuggestionTray(type)
         }
-        
+        return canShow
+    }
+    
+    private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {
+        suggestionTrayController?.show(for: type)
+        applyWidthToTrayController()
+        if !AppWidthObserver.shared.isLargeWidth {
+            if !DaxDialogs.shared.shouldShowFireButtonPulse {
+                ViewHighlighter.hideAll()
+            }
+            if type.hideOmnibarSeparator() {
+                omniBar.hideSeparator()
+            }
+        }
+        suggestionTrayContainer.isHidden = false
     }
     
     func hideSuggestionTray() {
@@ -1085,11 +1089,14 @@ extension MainViewController: OmniBarDelegate {
             if homeController != nil {
                 hideSuggestionTray()
             } else {
-                showSuggestionTray(.favorites)
+                let didShow = tryToShowSuggestionTray(.favorites)
+                if !didShow {
+                    hideSuggestionTray()
+                }
             }
         } else {
             let bookmarksSearch = bookmarksCachingSearch ?? BookmarksCachingSearch()
-            showSuggestionTray(.autocomplete(query: updatedQuery, bookmarksCachingSearch: bookmarksSearch))
+            tryToShowSuggestionTray(.autocomplete(query: updatedQuery, bookmarksCachingSearch: bookmarksSearch))
         }
         
     }
@@ -1173,9 +1180,9 @@ extension MainViewController: OmniBarDelegate {
         
         if !skipSERPFlow, isSERPPresented, let query = omniBar.textField.text {
             let bookmarksSearch = bookmarksCachingSearch ?? BookmarksCachingSearch()
-            showSuggestionTray(.autocomplete(query: query, bookmarksCachingSearch: bookmarksSearch))
+            tryToShowSuggestionTray(.autocomplete(query: query, bookmarksCachingSearch: bookmarksSearch))
         } else {
-            showSuggestionTray(.favorites)
+            tryToShowSuggestionTray(.favorites)
         }
     }
 

--- a/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/DuckDuckGo/SuggestionTrayViewController.swift
@@ -80,16 +80,27 @@ class SuggestionTrayViewController: UIViewController {
     
     override var canBecomeFirstResponder: Bool { return true }
     
-    func willShow(for type: SuggestionType) -> Bool {
+    func canShow(for type: SuggestionType) -> Bool {
+        var canShow = false
+        switch type {
+        case .autocomplete(let query, _):
+            canShow = canDisplayAutocompleteSuggestions(forQuery: query)
+        case.favorites:
+            canShow = canDisplayFavorites
+        }
+        return canShow
+    }
+    
+    func show(for type: SuggestionType) {
         switch type {
         case .autocomplete(let query, let bookmarksCachingSearch):
-            return displayAutocompleteSuggestions(forQuery: query, bookmarksCachingSearch: bookmarksCachingSearch)
-        case.favorites:
+            displayAutocompleteSuggestions(forQuery: query, bookmarksCachingSearch: bookmarksCachingSearch)
+        case .favorites:
             if isPad {
                 removeAutocomplete()
-                return displayFavorites()
+                displayFavoritesIfNeeded()
             } else {
-                return displayFavorites { [weak self] in
+                displayFavoritesIfNeeded { [weak self] in
                     self?.removeAutocomplete()
                 }
             }
@@ -177,35 +188,48 @@ class SuggestionTrayViewController: UIViewController {
         containerView.addGestureRecognizer(foregroundTap)
     }
     
-    private func displayFavorites(onInstall: @escaping () -> Void = {}) -> Bool {
-        guard bookmarkManager.favoritesCount != 0 else { return false }
-
-        if favoritesOverlay == nil {
-            let controller = FavoritesOverlay()
-            controller.delegate = favoritesOverlayDelegate
-            install(controller: controller, completion: onInstall)
-            favoritesOverlay = controller
-        }
-        
-        return true
+    private var canDisplayFavorites: Bool {
+        bookmarkManager.favoritesCount != 0
     }
     
-    private func displayAutocompleteSuggestions(forQuery query: String, bookmarksCachingSearch: BookmarksCachingSearch) -> Bool {
-        guard appSettings.autocomplete && !query.isEmpty else {
+    private func displayFavoritesIfNeeded(onInstall: @escaping () -> Void = {}) {
+        if favoritesOverlay == nil {
+            installFavoritesOverlay(onInstall: onInstall)
+        }
+    }
+    
+    private func installFavoritesOverlay(onInstall: @escaping () -> Void = {}) {
+        let controller = FavoritesOverlay()
+        controller.delegate = favoritesOverlayDelegate
+        install(controller: controller, completion: onInstall)
+        favoritesOverlay = controller
+    }
+    
+    private func canDisplayAutocompleteSuggestions(forQuery query: String) -> Bool {
+        let canDisplay = appSettings.autocomplete && !query.isEmpty
+        if !canDisplay {
             removeAutocomplete()
-            return false
         }
-        
-        if autocompleteController == nil {
-            let controller = AutocompleteViewController.loadFromStoryboard(bookmarksCachingSearch: bookmarksCachingSearch)
-            install(controller: controller)
-            controller.delegate = autocompleteDelegate
-            controller.presentationDelegate = self
-            autocompleteController = controller
-        }
-        
+        return canDisplay
+    }
+    
+    private func displayAutocompleteSuggestions(forQuery query: String, bookmarksCachingSearch: BookmarksCachingSearch) {
+        installAutocompleteSuggestionsIfNeeded(with: bookmarksCachingSearch)
         autocompleteController?.updateQuery(query: query)
-        return true
+    }
+    
+    private func installAutocompleteSuggestionsIfNeeded(with bookmarksCachingSearch: BookmarksCachingSearch) {
+        if autocompleteController == nil {
+            installAutocompleteSuggestions(with: bookmarksCachingSearch)
+        }
+    }
+    
+    private func installAutocompleteSuggestions(with bookmarksCachingSearch: BookmarksCachingSearch) {
+        let controller = AutocompleteViewController.loadFromStoryboard(bookmarksCachingSearch: bookmarksCachingSearch)
+        install(controller: controller)
+        controller.delegate = autocompleteDelegate
+        controller.presentationDelegate = self
+        autocompleteController = controller
     }
 
     private func removeAutocomplete() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1201707820832685/f

**Description**:
Once user types something in search and then removes it the suggestions tray doesn't hide and show suggestions for the last letter.

**Steps to test this PR**:
1. Make sure you don't have any favorites.
2. Tap on search bar and start searching for something.
3. The suggestions tray should appear.
4. Start removing characters one by one.
5. When the search bar is empty the tray should disappear.
6. Repeat the scenario 2-4 for the case when you have favorites.
7. The tray should show your favorites.

**Device Testing**:

* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
