### PR TITLE
Persist Auto Clear settings when they change

### DIFF
--- a/DuckDuckGo/AutoClearSettingsViewController.swift
+++ b/DuckDuckGo/AutoClearSettingsViewController.swift
@@ -55,7 +55,10 @@ class AutoClearSettingsViewController: UITableViewController {
     
     override func willMove(toParent parent: UIViewController?) {
         guard parent == nil else { return }
-        
+        storeSettingsIfChanged()
+    }
+    
+    private func storeSettingsIfChanged() {
         let oldSettings = loadClearDataSettings()
         if oldSettings != clearDataSettings {
             store()
@@ -102,6 +105,8 @@ class AutoClearSettingsViewController: UITableViewController {
         } else if indexPath.section == Sections.timing.rawValue {
             clearDataSettings?.timing = AutoClearSettingsModel.Timing(rawValue: indexPath.row) ?? .termination
         }
+        
+        storeSettingsIfChanged()
         tableView.reloadData()
     }
     

--- a/DuckDuckGo/AutoClearSettingsViewController.swift
+++ b/DuckDuckGo/AutoClearSettingsViewController.swift
@@ -149,6 +149,8 @@ class AutoClearSettingsViewController: UITableViewController {
             clearDataSettings = nil
             tableView.deleteSections(.init(integersIn: Sections.action.rawValue...Sections.timing.rawValue), with: .fade)
         }
+        
+        storeSettingsIfChanged()
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1201825607538046/f
Tech Design URL:
CC:

**Description**:

This PR updates the Auto Clear Settings view controller to persist settings when they change, instead of when the view controller is dismissed. The reason for this is that the previous approach was not persisting settings when swiping the modal to dismiss.

Closes #1054.

**Steps to test this PR**:
1.  Open the Auto Clear settings view controller and make some changes
2. Navigate out of the view controller with the Back button
3. Verify that the changes were reflected in the settings row, and open Auto Clear settings again to verify that they are correct there as well
4. Make some more Auto Clear settings changes
5. Swipe the view controller modal down to dismiss it
6. Open settings again, and verify that the changes were remembered

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
