### PR TITLE
Handle share sheet with local file path

### DIFF
--- a/Core/Link.swift
+++ b/Core/Link.swift
@@ -35,7 +35,7 @@ public class Link: NSObject, NSCoding {
 
     public let title: String?
     public let url: URL
-    public let localPath: URL?
+    public let localFileURL: URL?
     
     public var displayTitle: String? {
         let host = url.host?.dropPrefix(prefix: "www.") ?? url.absoluteString
@@ -53,7 +53,7 @@ public class Link: NSObject, NSCoding {
     public required init(title: String?, url: URL, localPath: URL? = nil) {
         self.title = title
         self.url = url
-        self.localPath = localPath
+        self.localFileURL = localPath
     }
 
     public convenience required init?(coder decoder: NSCoder) {
@@ -66,12 +66,12 @@ public class Link: NSObject, NSCoding {
     public func encode(with coder: NSCoder) {
         coder.encode(title, forKey: NSCodingKeys.title)
         coder.encode(url, forKey: NSCodingKeys.url)
-        coder.encode(localPath, forKey: NSCodingKeys.localPath)
+        coder.encode(localFileURL, forKey: NSCodingKeys.localPath)
     }
 
     public override func isEqual(_ other: Any?) -> Bool {
         guard let other = other as? Link else { return false }
-        return title == other.title && url == other.url && localPath == other.localPath
+        return title == other.title && url == other.url && localFileURL == other.localFileURL
     }
 
     /**

--- a/Core/Link.swift
+++ b/Core/Link.swift
@@ -28,12 +28,14 @@ public class Link: NSObject, NSCoding {
     private struct NSCodingKeys {
         static let title = "title"
         static let url = "url"
+        static let localPath = "localPath"
     }
     
     static let appUrls = AppUrls()
 
     public let title: String?
     public let url: URL
+    public let localPath: URL?
     
     public var displayTitle: String? {
         let host = url.host?.dropPrefix(prefix: "www.") ?? url.absoluteString
@@ -48,25 +50,28 @@ public class Link: NSObject, NSCoding {
         return displayTitle
     }
 
-    public required init(title: String?, url: URL) {
+    public required init(title: String?, url: URL, localPath: URL? = nil) {
         self.title = title
         self.url = url
+        self.localPath = localPath
     }
 
     public convenience required init?(coder decoder: NSCoder) {
         guard let url = decoder.decodeObject(forKey: NSCodingKeys.url) as? URL else { return nil }
         let title = decoder.decodeObject(forKey: NSCodingKeys.title) as? String
-        self.init(title: title, url: url)
+        let localPath = decoder.decodeObject(forKey: NSCodingKeys.localPath) as? URL
+        self.init(title: title, url: url, localPath: localPath)
     }
 
     public func encode(with coder: NSCoder) {
         coder.encode(title, forKey: NSCodingKeys.title)
         coder.encode(url, forKey: NSCodingKeys.url)
+        coder.encode(localPath, forKey: NSCodingKeys.localPath)
     }
 
     public override func isEqual(_ other: Any?) -> Bool {
         guard let other = other as? Link else { return false }
-        return title == other.title && url == other.url
+        return title == other.title && url == other.url && localPath == other.localPath
     }
 
     /**

--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -127,6 +127,9 @@ extension Core.BookmarkManagedObject: UIActivityItemSource {
 extension Core.Link: UIActivityItemSource {
 
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        if let localFileURL = localFileURL {
+            return localFileURL
+        }
         return AppUrls().removeInternalSearchParameters(fromUrl: url)
     }
 
@@ -134,11 +137,11 @@ extension Core.Link: UIActivityItemSource {
                                        itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
         
         // We don't want to save localPath to favorites or bookmarks
-        if let localPath = localPath,
+        if let localFileURL = localFileURL,
            activityType != .saveBookmarkInDuckDuckGo,
            activityType != .saveFavoriteInDuckDuckGo {
         
-            return localPath
+            return localFileURL
         }
         return AppUrls().removeInternalSearchParameters(fromUrl: url)
     }

--- a/Core/UIViewControllerExtension.swift
+++ b/Core/UIViewControllerExtension.swift
@@ -132,6 +132,14 @@ extension Core.Link: UIActivityItemSource {
 
     public func activityViewController(_ activityViewController: UIActivityViewController,
                                        itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        
+        // We don't want to save localPath to favorites or bookmarks
+        if let localPath = localPath,
+           activityType != .saveBookmarkInDuckDuckGo,
+           activityType != .saveFavoriteInDuckDuckGo {
+        
+            return localPath
+        }
         return AppUrls().removeInternalSearchParameters(fromUrl: url)
     }
 

--- a/DuckDuckGo/Download.swift
+++ b/DuckDuckGo/Download.swift
@@ -40,10 +40,11 @@ class Download: NSObject, Identifiable, ObservableObject {
 
     var link: Link? {
         guard let location = location,
+              let remoteURL = session.task?.currentRequest?.url,
               FileManager.default.fileExists(atPath: location.path) else {
             return nil
         }
-        return Link(title: filename, url: location)
+        return Link(title: filename, url: remoteURL, localPath: location)
     }
     
     @Published private(set) var state: URLSessionTask.State = .suspended

--- a/DuckDuckGo/DownloadMetadata.swift
+++ b/DuckDuckGo/DownloadMetadata.swift
@@ -30,6 +30,7 @@ struct DownloadMetadata {
         guard let mimeType = response.mimeType,
               let url = response.url else {
                   return nil
+                  #warning("Do we want a pixel here?")
               }
         
         if let name = filename {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1201843271276831/f

**Description**:
Prevent the bookmark/favorite share sheet action to save local file paths

**Steps to test this PR**:
1. Open a PDF on the browser
2. Tap share
3. Tap Add Bookmark
4. Check if the bookmark is pointing to the remote URL instead of a local filepath

---- 

1. Open a PDF on the browser
2. Tap share
3. Tap Add Favorite
4. Check if the favorite is pointing to the remote URL instead of a local filepath

**OS Testing**:

* [x] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
