### PR TITLE
Add specific rules for NSExtensionActivationRule

### DIFF
--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -27,18 +27,14 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<string>
-            SUBQUERY (
-            extensionItems,
-            $extensionItem,
-                SUBQUERY (
-                    $extensionItem.attachments,
-                    $attachment,
-                    ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url" ||
-                    ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
-                    ).@count &lt;= 2
-            ).@count == 1
-            </string>
+			<dict>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+			</dict>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1201843271276832/f

**Description**:
Add specific rules for our Share Extension NSExtensionActivationRule to prevent it from being displayed on non-ideal scenarios.

**Steps to test this PR**: 
(Best to be tested on real devices instead of simulators)

1. See Asana Task to check how to reproduce the bug
2. Open any file that can share binary files
3. Tap share and see if our app is displayed as a share extension (it shouldn't)
-----
1. Open a different browser, like FF
2. Tap on Share a webpage
3. See if our app is displayed as a share extension (it should)
4. Select our app and see if it opens the webpage correctly

-----
1. Open a different app that has text, like Mail
2. Select a string and tap share on the contextual menu
3. See if our app is displayed as a share extension (it should)
4. 4. Select our app and see if it opens the search query correctly

**OS Testing**:

* [x] iOS 13
* [x] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
