### PR TITLE
Add download user notification dot

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -73,6 +73,8 @@ public struct UserDefaultsWrapper<T> {
         case voiceSearchPrivacyAlertWasConfirmed = "com.duckduckgo.app.voiceSearchPrivacyAlertWasConfirmed"
         case bookmarksMigratedFromUserDefaultsToCD = "com.duckduckgo.app.bookmarksMigratedFromUserDefaultsToCoreData"
         case textSize = "com.duckduckgo.ios.textSize"
+        case downloadUserNotificationAvailable = "com.duckduckgo.app.downloadUserNotificationAvailable"
+
     }
 
     private let key: Key

--- a/DuckDuckGo/BrowsingMenu/BrowsingMenuEntryViewCell.swift
+++ b/DuckDuckGo/BrowsingMenu/BrowsingMenuEntryViewCell.swift
@@ -24,8 +24,9 @@ class BrowsingMenuEntryViewCell: UITableViewCell {
     
     @IBOutlet weak var entryImage: UIImageView!
     @IBOutlet weak var entryLabel: UILabel!
+    @IBOutlet weak var notificationDot: UIView!
     
-    func configure(image: UIImage, label: String, accessibilityLabel: String?, theme: Theme) {
+    func configure(image: UIImage, label: String, accessibilityLabel: String?, theme: Theme, showNotificationDot: Bool = false) {
         entryImage.image = image
         entryLabel.setAttributedTextString(label)
         entryLabel.accessibilityLabel = accessibilityLabel
@@ -34,6 +35,9 @@ class BrowsingMenuEntryViewCell: UITableViewCell {
         entryLabel.textColor = theme.browsingMenuTextColor
         backgroundColor = theme.browsingMenuBackgroundColor
         setHighlightedStateBackgroundColor(theme.browsingMenuHighlightColor)
+        
+        notificationDot.isHidden = !showNotificationDot
+        notificationDot.layer.cornerRadius = 4
     }
     
     static func preferredWidth(for text: String) -> CGFloat {

--- a/DuckDuckGo/BrowsingMenu/BrowsingMenuEntryViewCell.xib
+++ b/DuckDuckGo/BrowsingMenu/BrowsingMenuEntryViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qWj-8a-8jk">
-                        <rect key="frame" x="57" y="8" width="251" height="22"/>
+                        <rect key="frame" x="57" y="8" width="41" height="22"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="2iM-nN-FLn"/>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="a9h-KJ-eDP"/>
@@ -41,12 +41,23 @@
                         </attributedString>
                         <nil key="highlightedColor"/>
                     </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2CU-K3-y7b">
+                        <rect key="frame" x="104" y="17" width="8" height="8"/>
+                        <color key="backgroundColor" red="0.40392156862745099" green="0.5607843137254902" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="8" id="dNQ-eb-G4Q"/>
+                            <constraint firstAttribute="width" constant="8" id="jys-jP-D4z"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="2CU-K3-y7b" firstAttribute="centerY" secondItem="ixL-08-GlI" secondAttribute="centerY" id="5KY-pf-zRc"/>
                     <constraint firstItem="ixL-08-GlI" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="CN5-Qf-X8E"/>
                     <constraint firstAttribute="bottom" secondItem="qWj-8a-8jk" secondAttribute="bottom" constant="10" id="UZs-M1-4Ux"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2CU-K3-y7b" secondAttribute="trailing" constant="12" id="UlI-Dg-87r"/>
+                    <constraint firstItem="2CU-K3-y7b" firstAttribute="leading" secondItem="qWj-8a-8jk" secondAttribute="trailing" constant="6" id="Ydy-J5-vIB"/>
                     <constraint firstItem="ixL-08-GlI" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="13" id="chn-gh-o3S"/>
-                    <constraint firstAttribute="trailing" secondItem="qWj-8a-8jk" secondAttribute="trailing" constant="12" id="cpo-HZ-Wr4"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qWj-8a-8jk" secondAttribute="trailing" constant="12" id="cpo-HZ-Wr4"/>
                     <constraint firstItem="qWj-8a-8jk" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="jrv-Y0-BbN"/>
                     <constraint firstItem="qWj-8a-8jk" firstAttribute="leading" secondItem="ixL-08-GlI" secondAttribute="trailing" constant="17" id="xQM-6N-B1C"/>
                 </constraints>
@@ -55,8 +66,9 @@
             <connections>
                 <outlet property="entryImage" destination="ixL-08-GlI" id="Ojf-bi-gFQ"/>
                 <outlet property="entryLabel" destination="qWj-8a-8jk" id="cTn-bv-R1r"/>
+                <outlet property="notificationDot" destination="2CU-K3-y7b" id="h4X-4s-K3a"/>
             </connections>
-            <point key="canvasLocation" x="30" y="76"/>
+            <point key="canvasLocation" x="28.985507246376812" y="75.669642857142847"/>
         </tableViewCell>
     </objects>
 </document>

--- a/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
+++ b/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
@@ -26,7 +26,7 @@ protocol BrowsingMenu {
 
 enum BrowsingMenuEntry {
     
-    case regular(name: String, accessibilityLabel: String? = nil, image: UIImage, action: () -> Void)
+    case regular(name: String, accessibilityLabel: String? = nil, image: UIImage, showNotificationDot: Bool = false, action: () -> Void)
     case separator
 }
 
@@ -240,7 +240,7 @@ class BrowsingMenuViewController: UIViewController, BrowsingMenu {
         }
         
         for (entry, view) in zip(entries, headerButtons) {
-            guard case .regular(let name, let accessibilityLabel, let image, let action) = entry else {
+            guard case .regular(let name, let accessibilityLabel, let image, _ , let action) = entry else {
                 fatalError("Regular entry not found")
             }
             
@@ -260,7 +260,7 @@ class BrowsingMenuViewController: UIViewController, BrowsingMenu {
     private func recalculatePreferredWidthConstraint() {
         
         let longestEntry = menuEntries.reduce("") { (result, entry) -> String in
-            guard case BrowsingMenuEntry.regular(let name, _, _, _) = entry else { return result }
+            guard case BrowsingMenuEntry.regular(let name, _, _, _, _) = entry else { return result }
             if result.length() < name.length() {
                 return name
             }
@@ -284,7 +284,7 @@ extension BrowsingMenuViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
         switch menuEntries[indexPath.row] {
-        case .regular(_, _, _, let action):
+        case .regular(_, _, _, _, let action):
             dismiss?()
             action()
         case .separator:
@@ -305,12 +305,12 @@ extension BrowsingMenuViewController: UITableViewDataSource {
         let theme = ThemeManager.shared.currentTheme
         
         switch menuEntries[indexPath.row] {
-        case .regular(let name, let accessibilityLabel, let image, _):
+        case .regular(let name, let accessibilityLabel, let image, let showNotificationDot, _):
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "BrowsingMenuEntryViewCell", for: indexPath) as? BrowsingMenuEntryViewCell else {
                 fatalError()
             }
             
-            cell.configure(image: image, label: name, accessibilityLabel: accessibilityLabel, theme: theme)
+            cell.configure(image: image, label: name, accessibilityLabel: accessibilityLabel, theme: theme, showNotificationDot: showNotificationDot)
             return cell
         case .separator:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "BrowsingMenuSeparatorViewCell", for: indexPath) as? BrowsingMenuSeparatorViewCell else {

--- a/DuckDuckGo/DownloadsManager.swift
+++ b/DuckDuckGo/DownloadsManager.swift
@@ -37,6 +37,9 @@ class DownloadsManager {
     private let notificationCenter: NotificationCenter
     private var downloadsDirectoryMonitor: DirectoryMonitor?
     
+    @UserDefaultsWrapper(key: .downloadUserNotificationAvailable, defaultValue: false)
+    private(set) var userNotificationAvailable: Bool
+    
     var downloadsDirectory: URL {
         do {
             let documentsDirectory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -79,6 +79,7 @@ extension TabViewController {
             
             entries.append(BrowsingMenuEntry.regular(name: UserText.actionDownloads,
                                                      image: UIImage(named: "MenuDownloads")!,
+                                                     showNotificationDot: AppDependencyProvider.shared.downloadsManager.userNotificationAvailable,
                                                      action: { [weak self] in
                 self?.onOpenDownloadsAction()
             }))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1201850613737473/f

**Description**:
Display user notification dot on the downloads menu section

**Steps to test this PR**:
1. Run the app, see if there's no notification dot available anywhere on the menu
2. Add `userNotificationAvailable = true` to `DownloadsManager` initialization
3. Open the menu and notice that *only* the Downloads menu item has the notification dot


**OS Testing**:
* [x] iOS 15

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
