### PR TITLE
Revert setting HomeCollectionView backgroundColor

### DIFF
--- a/DuckDuckGo/HomeCollectionView.swift
+++ b/DuckDuckGo/HomeCollectionView.swift
@@ -159,7 +159,6 @@ class HomeCollectionView: UICollectionView {
 extension HomeCollectionView: Themable {
 
     func decorate(with theme: Theme) {
-        backgroundColor = theme.backgroundColor
         renderers.decorate(with: theme)
         reloadData()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1201852545282569/f
Tech Design URL:
CC:

**Description**:
Due to previous fix for https://app.asana.com/0/414235014887631/1201019331404849 done in 048971ac it turned out that Dax logo is displayed from a VC beneath the current one hence the requirement for clear background.

**Steps to test this PR**:
Reproduced when no favourites are present.
1. Open new tab 
2. There should be a Dax logo visible in the middle

Before             |  After 
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/2386389/155490934-8211dddf-4af3-405a-a3a8-2de84673a8e8.png" width="300">  |  <img src="https://user-images.githubusercontent.com/2386389/155490936-29b521e0-f53d-4ac0-92ce-71b42d127cff.png" width="300" >





**Orientation Testing**:
* [ ] Portrait
* [ ] Landscape

**Device Testing**:
* [ ] iPhone
* [ ] iPad

**OS Testing**:
* [ ] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
