### PR TITLE
Fix omnibar subscribing to notifications multiple times

### DIFF
--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -80,6 +80,10 @@ class OmniBar: UIView {
         super.awakeFromNib()
         configureMenuButton()
         configureTextField()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(textDidChange),
+                                               name: UITextField.textDidChangeNotification,
+                                               object: textField)
         configureSeparator()
         configureEditingMenu()
         refreshState(state)
@@ -120,11 +124,6 @@ class OmniBar: UIView {
         textField.attributedPlaceholder = NSAttributedString(string: UserText.searchDuckDuckGo,
                                                              attributes: [.foregroundColor: theme.searchBarTextPlaceholderColor])
         textField.delegate = self
-        
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(textDidChange),
-                                               name: UITextField.textDidChangeNotification,
-                                               object: textField)
         
         textField.textDragInteraction?.isEnabled = false
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1201807279816077/f
Tech Design URL:
CC: @jaceklyp 

**Description**:
Simple fix to stop the omnibar subscribing to notifications multiple times

**Steps to test this PR**:
1. Use breakpoints/printing to check how many times the textDidChange notification is called
2. Check this hasn't disrupted anything that responds to that notification (e.g. displaying search suggestions)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
