### PR TITLE
Fix inconsistent favs suggestion tray behaviour for empty omnibar state

### DIFF
--- a/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/DuckDuckGo/SuggestionTrayViewController.swift
@@ -40,6 +40,7 @@ class SuggestionTrayViewController: UIViewController {
 
     private var autocompleteController: AutocompleteViewController?
     private var favoritesOverlay: FavoritesOverlay?
+    private var willRemoveAutocomplete = false
 
     var selectedSuggestion: Suggestion? {
         autocompleteController?.selectedSuggestion
@@ -100,8 +101,10 @@ class SuggestionTrayViewController: UIViewController {
                 removeAutocomplete()
                 displayFavoritesIfNeeded()
             } else {
+                willRemoveAutocomplete = true
                 displayFavoritesIfNeeded { [weak self] in
                     self?.removeAutocomplete()
+                    self?.willRemoveAutocomplete = false
                 }
             }
         }
@@ -268,7 +271,7 @@ class SuggestionTrayViewController: UIViewController {
 extension SuggestionTrayViewController: AutocompleteViewControllerPresentationDelegate {
     
     func autocompleteDidChangeContentHeight(height: CGFloat) {
-        if autocompleteController != nil {
+        if autocompleteController != nil && !willRemoveAutocomplete {
             removeFavorites()
         }
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1201885711979652/f
Tech Design URL:
CC:

**Description**:
When deleting characters in the omnibar wether or not favourites would show was inconsistent. This fixes it.
https://user-images.githubusercontent.com/1093508/155007869-a7d7c65c-1ba4-47cb-8663-62e37ffb11f9.mp4

See asana task for more details

**Steps to test this PR**:
1. Go to some web page
1. Try deleting chars in the URL bar until it's empty and check that favourites is displayed3. 
1. Type and delete repeatedly at a variety of speeds. The original issue occurred when deleting quickly (race condition...)2. 
1. Test nothing else in the omnibar/suggestions tray is effected (shows at the right time, hides at the right time, contains bookmark suggestions etc)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
