### PR TITLE
Fix tests and ics QL preview

### DIFF
--- a/DuckDuckGo/DownloadManager.swift
+++ b/DuckDuckGo/DownloadManager.swift
@@ -88,12 +88,7 @@ class DownloadManager {
         if let temporary = temporary {
             temporaryFile = temporary
         } else {
-            switch metaData.mimeType {
-            case .reality, .usdz, .passbook:
-                temporaryFile = true
-            default:
-                temporaryFile = false
-            }
+            temporaryFile = FilePreviewHelper.canAutoPreviewMIMEType(metaData.mimeType)
         }
         
         let session: DownloadSession

--- a/DuckDuckGo/FilePreviewHelper.swift
+++ b/DuckDuckGo/FilePreviewHelper.swift
@@ -30,4 +30,13 @@ struct FilePreviewHelper {
             return QuickLookPreviewHelper(filePath, viewController: viewController)
         }
     }
+    
+    static func canAutoPreviewMIMEType(_ mimeType: MIMEType) -> Bool {
+        switch mimeType {
+        case .reality, .usdz, .passbook, .calendar:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/DuckDuckGo/MimeType.swift
+++ b/DuckDuckGo/MimeType.swift
@@ -26,6 +26,7 @@ enum MIMEType: String {
     case octetStream = "application/octet-stream"
     case xhtml = "application/xhtml+xml"
     case html = "text/html"
+    case calendar = "text/calendar"
     case unknown
     
     var isHTML: Bool {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -933,7 +933,7 @@ class TabViewController: UIViewController {
     }
 
     private func previewDownloadedFileIfNecessary(_ download: Download) {
-        guard shouldAutoPreviewDownloadWithMIMEType(download.mimeType),
+        guard FilePreviewHelper.canAutoPreviewMIMEType(download.mimeType),
               let fileHandler = FilePreviewHelper.fileHandlerForDownload(download, viewController: self),
               let delegate = self.delegate else { return }
         
@@ -943,16 +943,7 @@ class TabViewController: UIViewController {
             Pixel.fire(pixel: .presentPreviewWithoutTab)
         }
     }
-    
-    private func shouldAutoPreviewDownloadWithMIMEType(_ mimeType: MIMEType) -> Bool {
-        switch mimeType {
-        case .passbook, .reality, .usdz:
-            return true
-        default :
-            return false
-        }
-    }
-}   
+}
 
 extension TabViewController: LoginFormDetectionDelegate {
     
@@ -1045,7 +1036,7 @@ extension TabViewController: WKNavigationDelegate {
             }
             
             if let downloadMetadata = downloadManager.downloadMetaData(for: navigationResponse) {
-                if shouldAutoPreviewDownloadWithMIMEType(downloadMetadata.mimeType) {
+                if FilePreviewHelper.canAutoPreviewMIMEType(downloadMetadata.mimeType) {
                     startDownload()
                 } else {
                     let alert = SaveToDownloadsAlert.makeAlert(downloadMetadata: downloadMetadata) {

--- a/DuckDuckGoTests/DownloadManagerTests.swift
+++ b/DuckDuckGoTests/DownloadManagerTests.swift
@@ -24,13 +24,15 @@ import WebKit
 import WidgetKit
 
 class DownloadManagerTests: XCTestCase {
+    private let downloadManagerTestsHelper = DownloadTestsHelper(downloadsDirectory: DownloadManager().downloadsDirectory)
+    
     var mockDependencyProvider: MockDependencyProvider!
     
     override func setUp() {
     }
     
     override func tearDown() {
-        DownloadTestsHelper.deleteAllFiles()
+        downloadManagerTestsHelper.deleteAllFiles()
     }
     
     func testNotificationTemporaryPKPassDownload() {
@@ -44,13 +46,13 @@ class DownloadManagerTests: XCTestCase {
         
         let expectation = expectation(description: "Download finish")
         
-        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { notification in
+        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { [self] notification in
           
-            if DownloadTestsHelper.downloadForNotification(notification) == download {
-                let (tmpPath, finalPath) = DownloadTestsHelper.temporaryAndFinalPathForDownload(download)
+            if downloadManagerTestsHelper.downloadForNotification(notification) == download {
+                let (tmpPath, finalPath) = downloadManagerTestsHelper.temporaryAndFinalPathForDownload(download)
 
-                XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(tmpPath), "File should exist")
-                XCTAssertFalse(DownloadTestsHelper.checkIfFileExists(finalPath), "File should not exist")
+                XCTAssertTrue(downloadManagerTestsHelper.checkIfFileExists(tmpPath), "File should exist")
+                XCTAssertFalse(downloadManagerTestsHelper.checkIfFileExists(finalPath), "File should not exist")
                 expectation.fulfill()
             }
         }
@@ -71,13 +73,13 @@ class DownloadManagerTests: XCTestCase {
         
         let expectation = expectation(description: "Download finish")
         
-        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { notification in
+        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { [self] notification in
            
-            if DownloadTestsHelper.downloadForNotification(notification) == download {
-                let (tmpPath, finalPath) = DownloadTestsHelper.temporaryAndFinalPathForDownload(download)
+            if downloadManagerTestsHelper.downloadForNotification(notification) == download {
+                let (tmpPath, finalPath) = downloadManagerTestsHelper.temporaryAndFinalPathForDownload(download)
 
-                XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(tmpPath), "File should exist")
-                XCTAssertFalse(DownloadTestsHelper.checkIfFileExists(finalPath), "File should not exist")
+                XCTAssertTrue(downloadManagerTestsHelper.checkIfFileExists(tmpPath), "File should exist")
+                XCTAssertFalse(downloadManagerTestsHelper.checkIfFileExists(finalPath), "File should not exist")
                 expectation.fulfill()
             }
         }
@@ -98,13 +100,13 @@ class DownloadManagerTests: XCTestCase {
         
         let expectation = expectation(description: "Download finish")
         
-        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { notification in
+        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { [self] notification in
             
-            if DownloadTestsHelper.downloadForNotification(notification) == download {
-                let (tmpPath, finalPath) = DownloadTestsHelper.temporaryAndFinalPathForDownload(download)
+            if downloadManagerTestsHelper.downloadForNotification(notification) == download {
+                let (tmpPath, finalPath) = downloadManagerTestsHelper.temporaryAndFinalPathForDownload(download)
 
-                XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(tmpPath), "File should exist")
-                XCTAssertFalse(DownloadTestsHelper.checkIfFileExists(finalPath), "File should not exist")
+                XCTAssertTrue(downloadManagerTestsHelper.checkIfFileExists(tmpPath), "File should exist")
+                XCTAssertFalse(downloadManagerTestsHelper.checkIfFileExists(finalPath), "File should not exist")
                 expectation.fulfill()
             }
         }
@@ -124,13 +126,13 @@ class DownloadManagerTests: XCTestCase {
         
         let expectation = expectation(description: "Download finish")
         
-        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { notification in
+        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { [self] notification in
            
-            if DownloadTestsHelper.downloadForNotification(notification) == download {
-                let (tmpPath, finalPath) = DownloadTestsHelper.temporaryAndFinalPathForDownload(download)
+            if downloadManagerTestsHelper.downloadForNotification(notification) == download {
+                let (tmpPath, finalPath) = downloadManagerTestsHelper.temporaryAndFinalPathForDownload(download)
 
-                XCTAssertFalse(DownloadTestsHelper.checkIfFileExists(tmpPath), "File should not exist")
-                XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(finalPath), "File should exist")
+                XCTAssertFalse(downloadManagerTestsHelper.checkIfFileExists(tmpPath), "File should not exist")
+                XCTAssertTrue(downloadManagerTestsHelper.checkIfFileExists(finalPath), "File should exist")
                 expectation.fulfill()
             }
         }
@@ -148,12 +150,12 @@ class DownloadManagerTests: XCTestCase {
         
         let expectation = expectation(description: "Download finish")
 
-        downloadManager.startDownload(download) { error in
-            let (tmpPath, finalPath) = DownloadTestsHelper.temporaryAndFinalPathForDownload(download)
+        downloadManager.startDownload(download) { [self] error in
+            let (tmpPath, finalPath) = downloadManagerTestsHelper.temporaryAndFinalPathForDownload(download)
 
             XCTAssertNil(error)
-            XCTAssertFalse(DownloadTestsHelper.checkIfFileExists(tmpPath), "File should not exist")
-            XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(finalPath), "File should exist")
+            XCTAssertFalse(downloadManagerTestsHelper.checkIfFileExists(tmpPath), "File should not exist")
+            XCTAssertTrue(downloadManagerTestsHelper.checkIfFileExists(finalPath), "File should exist")
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
@@ -167,9 +169,9 @@ class DownloadManagerTests: XCTestCase {
         let download = downloadManager.makeDownload(navigationResponse: sessionSetup.response, downloadSession: sessionSetup.session)!
         let expectation = expectation(description: "Download finish")
         
-        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { notification in
+        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { [self] notification in
            
-            if DownloadTestsHelper.downloadForNotification(notification) == download {
+            if downloadManagerTestsHelper.downloadForNotification(notification) == download {
                 XCTAssertEqual(downloadManager.downloadList.count, 0)
                 expectation.fulfill()
             }
@@ -200,13 +202,13 @@ class DownloadManagerTests: XCTestCase {
         
         let expectation = expectation(description: "Download finish")
         
-        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { notification in
+        notificationCenter.addObserver(forName: .downloadFinished, object: nil, queue: nil) { [self] notification in
            
-            if DownloadTestsHelper.downloadForNotification(notification) == download {
-                let (tmpPath, finalPath) = DownloadTestsHelper.temporaryAndFinalPathForDownload(download)
+            if downloadManagerTestsHelper.downloadForNotification(notification) == download {
+                let (tmpPath, finalPath) = downloadManagerTestsHelper.temporaryAndFinalPathForDownload(download)
                 
-                XCTAssertFalse(DownloadTestsHelper.checkIfFileExists(tmpPath), "File should not exist")
-                XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(finalPath), "File should exist")
+                XCTAssertFalse(downloadManagerTestsHelper.checkIfFileExists(tmpPath), "File should not exist")
+                XCTAssertTrue(downloadManagerTestsHelper.checkIfFileExists(finalPath), "File should exist")
                 XCTAssertEqual(expectedName, download.filename, "Names should be equal")
                 expectation.fulfill()
             }
@@ -238,8 +240,8 @@ class DownloadManagerTests: XCTestCase {
         let fileWithExtension = "duck.txt"
         let fileWithoutExtension = "duck"
         
-        DownloadTestsHelper.createMockFile(on: DownloadTestsHelper.documentsDirectory.appendingPathComponent(fileWithExtension))
-        DownloadTestsHelper.createMockFile(on: DownloadTestsHelper.documentsDirectory.appendingPathComponent(fileWithoutExtension))
+        downloadManagerTestsHelper.createMockFile(on: downloadManagerTestsHelper.downloadsDirectory.appendingPathComponent(fileWithExtension))
+        downloadManagerTestsHelper.createMockFile(on: downloadManagerTestsHelper.downloadsDirectory.appendingPathComponent(fileWithoutExtension))
         
         let numberOfFiles = 3
         var files = [String](repeating: fileWithExtension, count: numberOfFiles)

--- a/DuckDuckGoTests/DownloadMocks.swift
+++ b/DuckDuckGoTests/DownloadMocks.swift
@@ -71,14 +71,16 @@ struct MockSessionSetup {
         response.suggestedFileName = file
         response.mimeType = mimeType
         
-        session = MockDownloadSession(DownloadTestsHelper.mockURL)
+        let downloadTestsHelper = DownloadTestsHelper(downloadsDirectory: downloadManager.downloadsDirectory)
+        
+        session = MockDownloadSession(downloadTestsHelper.mockURL)
         session.delaySeconds = completionDelay
 
-        let tmpPath = DownloadTestsHelper.tmpDirectory.appendingPathComponent(tmpName)
+        let tmpPath = downloadTestsHelper.tmpDirectory.appendingPathComponent(tmpName)
     
         session.temporaryFilePath = tmpPath
         
-        DownloadTestsHelper.createMockFile(on: tmpPath)
+        downloadTestsHelper.createMockFile(on: tmpPath)
     }
 }
 

--- a/DuckDuckGoTests/DownloadTests.swift
+++ b/DuckDuckGoTests/DownloadTests.swift
@@ -21,61 +21,62 @@ import XCTest
 @testable import DuckDuckGo
 
 class DownloadTests: XCTestCase {
-
+    private let downloadManagerTestsHelper = DownloadTestsHelper(downloadsDirectory: DownloadManager().downloadsDirectory)
+    
     override func setUpWithError() throws {
     }
     
     override func tearDownWithError() throws {
-        DownloadTestsHelper.deleteAllFiles()
+        downloadManagerTestsHelper.deleteAllFiles()
     }
-
+    
     func testTemporaryDownload() {
-        let mockSession = MockDownloadSession(DownloadTestsHelper.mockURL)
+        let mockSession = MockDownloadSession(        downloadManagerTestsHelper.mockURL)
         
         let tmpName = "MOCK_\(UUID().uuidString).tmp"
         let filename = "\(UUID().uuidString).zip"
         
-        let path = DownloadTestsHelper.tmpDirectory.appendingPathComponent(tmpName)
-        DownloadTestsHelper.createMockFile(on: path)
+        let path = downloadManagerTestsHelper.tmpDirectory.appendingPathComponent(tmpName)
+        downloadManagerTestsHelper.createMockFile(on: path)
         
-        let finalFilePath = DownloadTestsHelper.tmpDirectory.appendingPathComponent(filename)
+        let finalFilePath = downloadManagerTestsHelper.tmpDirectory.appendingPathComponent(filename)
         
         mockSession.temporaryFilePath = path
         
         let temporaryDownload = Download(filename: filename, mimeType: .passbook, temporary: true, downloadSession: mockSession)
-                
+        
         let expectation = expectation(description: "Download finish")
         temporaryDownload.start()
-
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertTrue(temporaryDownload.temporary, "File should be temporary")
-            XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(finalFilePath), "File should exist")
+            XCTAssertTrue(self.downloadManagerTestsHelper.checkIfFileExists(finalFilePath), "File should exist")
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
     }
     
     func testPermanentDownload() {
-        let mockSession = MockDownloadSession(DownloadTestsHelper.mockURL)
+        let mockSession = MockDownloadSession(downloadManagerTestsHelper.mockURL)
         
         let tmpName = "MOCK_\(UUID().uuidString).tmp"
         let filename = "\(UUID().uuidString).zip"
         
-        let path = DownloadTestsHelper.tmpDirectory.appendingPathComponent(tmpName)
-        DownloadTestsHelper.createMockFile(on: path)
+        let path = downloadManagerTestsHelper.tmpDirectory.appendingPathComponent(tmpName)
+        downloadManagerTestsHelper.createMockFile(on: path)
         
-        let finalFilePath = DownloadTestsHelper.tmpDirectory.appendingPathComponent(filename)
+        let finalFilePath = downloadManagerTestsHelper.tmpDirectory.appendingPathComponent(filename)
         
         mockSession.temporaryFilePath = path
         
         let temporaryDownload = Download(filename: filename, mimeType: .passbook, temporary: false, downloadSession: mockSession)
-
+        
         let expectation = expectation(description: "Download finish")
         temporaryDownload.start()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertFalse(temporaryDownload.temporary, "File should not be temporary")
-            XCTAssertTrue(DownloadTestsHelper.checkIfFileExists(finalFilePath), "File should exist")
+             XCTAssertTrue(self.downloadManagerTestsHelper.checkIfFileExists(finalFilePath), "File should exist")
             expectation.fulfill()
         }
         

--- a/DuckDuckGoTests/DownloadTestsHelper.swift
+++ b/DuckDuckGoTests/DownloadTestsHelper.swift
@@ -21,24 +21,23 @@ import Foundation
 @testable import DuckDuckGo
 
 struct DownloadTestsHelper {
-    static let mockURL = URL(string: "https://duck.com")!
-    static let tmpDirectory = FileManager.default.temporaryDirectory
-    // swiftlint:disable force_try
-    static let documentsDirectory = try! FileManager.default.url(for: .documentDirectory,
-                                                                     in: .userDomainMask,
-                                                                     appropriateFor: nil,
-                                                                     create: false)
-    // swiftlint:enable force_try
-
-    static func createMockFile(on path: URL) {
+    let mockURL = URL(string: "https://duck.com")!
+    let tmpDirectory = FileManager.default.temporaryDirectory
+    let downloadsDirectory: URL
+        
+    internal init(downloadsDirectory: URL) {
+        self.downloadsDirectory = downloadsDirectory
+    }
+    
+    func createMockFile(on path: URL) {
         try? Data("FakeFileData".utf8).write(to: path)
     }
     
-    static func checkIfFileExists(_ filePath: URL) -> Bool {
+    func checkIfFileExists(_ filePath: URL) -> Bool {
         return FileManager.default.fileExists(atPath: filePath.path)
     }
     
-    static func deleteFilesOnPath(_ url: URL) {
+    func deleteFilesOnPath(_ url: URL) {
         do {
             let files = try FileManager.default.contentsOfDirectory(at: url,
                                                                     includingPropertiesForKeys: nil,
@@ -53,21 +52,21 @@ struct DownloadTestsHelper {
         }
     }
     
-    static func deleteAllFiles() {
-        DownloadTestsHelper.deleteFilesOnPath(DownloadTestsHelper.documentsDirectory)
-        DownloadTestsHelper.deleteFilesOnPath(DownloadTestsHelper.tmpDirectory)
+     func deleteAllFiles() {
+        deleteFilesOnPath(downloadsDirectory)
+        deleteFilesOnPath(tmpDirectory)
     }
     
-    static func downloadForNotification(_ notification: Notification) -> Download {
+    func downloadForNotification(_ notification: Notification) -> Download {
         if let download = notification.userInfo?[DownloadManager.UserInfoKeys.download] as? Download {
             return download
         }
         fatalError("Should only be used to test valid downloads")
     }
     
-    static func temporaryAndFinalPathForDownload(_ download: Download) -> (URL, URL) {
-        let tmpPath = DownloadTestsHelper.tmpDirectory.appendingPathComponent(download.filename)
-        let finalPath = DownloadTestsHelper.documentsDirectory.appendingPathComponent(download.filename)
+    func temporaryAndFinalPathForDownload(_ download: Download) -> (URL, URL) {
+        let tmpPath = tmpDirectory.appendingPathComponent(download.filename)
+        let finalPath = downloadsDirectory.appendingPathComponent(download.filename)
 
         return (tmpPath, finalPath)
     }


### PR DESCRIPTION

**Description**:
Fix Tests: DownloadTestsHelper now receives a downloads url path
Add support for previewing .ics file

**Steps to test this PR**:
1. Open https://www.apple.com/apple-events/
2. Tap on "Add to your calendar"
3. See if preview is correctly displayed
------
1. Run tests locally
2. Check if bitrise is passing
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
