### PR TITLE
Pixel for downloads triggered by by not being able to handle unknown MIME type

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -172,6 +172,7 @@ public enum PixelName: String {
     case widgetEducationDismissed = "m_widget_education_dismissed"
     
     case downloadStarted = "m_download_started"
+    case downloadStartedDueToUnhandledMIMEType = "m_download_started_due_to_unhandled_mime_type"
     case downloadTriedToPresentPreviewWithoutTab = "m_download_tried_to_present_preview_without_tab"
     case downloadsListOpened = "m_downloads_list_opened"
 
@@ -299,6 +300,7 @@ public struct PixelParameters {
     public static let textSizeUpdated = "text_size_updated"
     
     public static let canAutoPreviewMIMEType = "can_auto_preview_mime_type"
+    public static let mimeType = "mime_type"
     public static let fileSizeGreaterThan10MB = "file_size_greater_than_10mb"
     
 }

--- a/DuckDuckGo/DownloadMetadata.swift
+++ b/DuckDuckGo/DownloadMetadata.swift
@@ -30,7 +30,6 @@ struct DownloadMetadata {
         guard let mimeType = response.mimeType,
               let url = response.url else {
                   return nil
-                  #warning("Do we want a pixel here?")
               }
         
         if let name = filename {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1051,6 +1051,12 @@ extension TabViewController: WKNavigationDelegate {
                         startDownload()
                         Pixel.fire(pixel: .downloadStarted,
                                    withAdditionalParameters: [PixelParameters.canAutoPreviewMIMEType: "0"])
+                        
+                        if downloadMetadata.mimeType != .octetStream {
+                            let mimeType = downloadMetadata.mimeTypeSource
+                            Pixel.fire(pixel: .downloadStartedDueToUnhandledMIMEType,
+                                       withAdditionalParameters: [PixelParameters.mimeType: mimeType])
+                        }
                     }
                     DispatchQueue.main.async {
                         self.present(alert, animated: true, completion: nil)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/69071770703008/1201993703641353/f
Tech Design URL:
CC:

**Description**:
Pixel for downloads triggered by by not being able to handle unknown MIME type

**Steps to test this PR**:
1. Open a link to a file not renderable by the browser (e.g. PDF documents, images etc.) and not served as a download (with application/octet-stream MIME type).
2. It will trigger the file download flow and pixel will be sent.

**Device Testing**:

* [ ] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
