### PR TITLE
Fix for proper toolbar hiding when leaving Unprotected Sites view

### DIFF
--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -56,10 +56,15 @@ class UnprotectedSitesViewController: UITableViewController {
     
     override func willMove(toParent parent: UIViewController?) {
         super.willMove(toParent: parent)
-
+        
         if parent == nil {
-            navigationController?.setToolbarHidden(true, animated: false)
+            navigationController?.setToolbarHidden(true, animated: true)
         }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setToolbarHidden(false, animated: true)
     }
     
     private func refreshToolbarItems(animated: Bool) {

--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -54,10 +54,12 @@ class UnprotectedSitesViewController: UITableViewController {
         infoText.attributedText = text
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        
-        navigationController?.setToolbarHidden(true, animated: false)
+    override func willMove(toParent parent: UIViewController?) {
+        super.willMove(toParent: parent)
+
+        if parent == nil {
+            navigationController?.setToolbarHidden(true, animated: false)
+        }
     }
     
     private func refreshToolbarItems(animated: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1201988294830333/f
Tech Design URL:
CC:

**Description**:
When navigating to the "Unprotected Sites" settings screen and back the bottom toolbar is still visible, but shouldn't.

**Steps to test this PR**:
1. Open Settings view
2. Open "Unprotected Sites"
3. Tap back button to go back to Settings

| Before | After |
| --- | --- |
| ![lingering-toolbar](https://user-images.githubusercontent.com/2386389/159919857-65837661-d024-410c-b4e9-83256a9e66b7.gif) | ![lingering-toolbar-fixed](https://user-images.githubusercontent.com/2386389/159919872-716007a6-59b0-4eba-a7ef-88b73c3f53c4.gif) |

**Device Testing**:

* [ ] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
