### PR TITLE
Change the logic for tab preparation for data clearing

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1638,13 +1638,15 @@ extension MainViewController: AutoClearWorker {
         let spid = Instruments.shared.startTimedEvent(.clearingData)
         Pixel.fire(pixel: .forgetAllExecuted)
         
+        tabManager.prepareAllTabsExceptCurrentForDataClearing()
+        
         fireButtonAnimator?.animate {
-            self.tabManager.prepareTabsForDataClearing {
-                self.stopAllOngoingDownloads()
-                self.forgetData()
-                DaxDialogs.shared.resumeRegularFlow()
-                self.forgetTabs()
-            }
+            self.tabManager.prepareCurrentTabForDataClearing()
+            
+            self.stopAllOngoingDownloads()
+            self.forgetData()
+            DaxDialogs.shared.resumeRegularFlow()
+            self.forgetTabs()
         } onTransitionCompleted: {
             ActionMessageView.present(message: UserText.actionForgetAllDone)
             transitionCompletion?()

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -227,19 +227,13 @@ class TabManager {
         model.save()
     }
     
-    func prepareTabsForDataClearing(completion: @escaping () -> Void) {
-
-        let totalCount = tabControllerCache.count
-        
-        var prepared = 0
-        tabControllerCache.forEach { $0.prepareForDataClearing {
-            prepared += 1
-            if prepared >= totalCount {
-                completion()
-            }
-        } }
+    func prepareAllTabsExceptCurrentForDataClearing() {
+        tabControllerCache.filter { $0 != current }.forEach { $0.prepareForDataClearing() }
     }
-
+    
+    func prepareCurrentTabForDataClearing() {
+        current?.prepareForDataClearing()
+    }
 }
 
 extension TabManager: Themable {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -188,8 +188,6 @@ class TabViewController: UIViewController {
         return !shouldBlockJSAlert && presentedViewController == nil && delegate?.tabCheckIfItsBeingCurrentlyPresented(self) ?? false
     }
     
-    private var onWebsiteLoaded: (() -> Void)?
-
     static func loadFromStoryboard(model: Tab) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "TabViewController") as? TabViewController else {
@@ -425,10 +423,13 @@ class TabViewController: UIViewController {
         }
     }
     
-    func prepareForDataClearing(completion: @escaping () -> Void) {
+    func prepareForDataClearing() {
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        delegate = nil
+        
         webView.stopLoading()
-        webView.load(URLRequest(url: URL(string: "about:blank")!))
-        onWebsiteLoaded = completion
+        webView.loadHTMLString("", baseURL: nil)
     }
     
     private func load(urlRequest: URLRequest) {
@@ -1128,11 +1129,6 @@ extension TabViewController: WKNavigationDelegate {
     
     private func onWebpageDidFinishLoading() {
         os_log("webpageLoading finished", log: generalLog, type: .debug)
-        
-        if let callback = onWebsiteLoaded {
-            callback()
-            onWebsiteLoaded = nil
-        }
         
         siteRating?.finishedLoading = true
         updateSiteRating()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202026066957933/f
Tech Design URL:
CC:

**Description**:
During last two weeks we observed increased reports of `Snapshots not cleared error` that started rising since around March 13. Upon investigation it turned out that the increased errors are caused by recent change in data clearing logic. Additionally that change introduced two additional issues: memory leak on data clearing and fire animation stutter. 

**Steps to test this PR**:
_Snapshots not cleared error_
1. Open multiple tabs
2. Tap the Fire button but as the animation starts minimise the app
3. Reopen the app - the `assertTabPreviewCount()` will make a check and trigger the error if snapshot check condition is met

_TabViewController leak_
1. Open multiple tabs
2. Tap the Fire button
3. Check memory graph for TabViewController instances count (should be equal to number of tabs after clearing - 1)

_Fire animation not smooth_
1. Open multiple tabs (e.g. check for 5/10/15/20)
2. Tap the Fire button
3. The fire animation should always be smooth and and without any initial delay

_Check local storage clearing_
Open local storage test page http://privacy-test-pages.glitch.me/features/local-storage.html and run it. The value is stored in browsers local storage and is retrieved on future test page visits. Fire button should clear the local storage so when visiting the test page the initial result is `undefined`. Please check those variants:
1. Open test page and run the test. Tap fire button.
2. Open test page and run the test. Tap start test multiple times. Tap fire button.
3. Open test page and run the test. Tap start test multiple times. Open multiple other tabs. Tap fire button.
4. Open test page and run the test. Tap start test multiple times. Open multiple other tabs including other tabs with test page. Tap fire button.
In all above variants upon the next visit to the test page the initial result should be `undefined`.
