### PR TITLE
Fix AR previews not working on iOS 15.4

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */; };
 		310D091B2799F54900DC0060 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D091A2799F54900DC0060 /* DownloadManager.swift */; };
 		310D091D2799F57200DC0060 /* Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D091C2799F57200DC0060 /* Download.swift */; };
-		310D09212799FD1A00DC0060 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D09202799FD1A00DC0060 /* MimeType.swift */; };
+		310D09212799FD1A00DC0060 /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D09202799FD1A00DC0060 /* MIMEType.swift */; };
 		3132FA2627A0784600DD7A12 /* FilePreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132FA2527A0784600DD7A12 /* FilePreviewHelper.swift */; };
 		3132FA2827A0788400DD7A12 /* PassKitPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132FA2727A0788400DD7A12 /* PassKitPreviewHelper.swift */; };
 		3132FA2A27A0788F00DD7A12 /* QuickLookPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3132FA2927A0788F00DD7A12 /* QuickLookPreviewHelper.swift */; };
@@ -782,7 +782,7 @@
 		22CB1ED7203DDD2C00D2C724 /* AppDeepLinksTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeepLinksTests.swift; sourceTree = "<group>"; };
 		310D091A2799F54900DC0060 /* DownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManager.swift; sourceTree = "<group>"; };
 		310D091C2799F57200DC0060 /* Download.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Download.swift; sourceTree = "<group>"; };
-		310D09202799FD1A00DC0060 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
+		310D09202799FD1A00DC0060 /* MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
 		3132FA2527A0784600DD7A12 /* FilePreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewHelper.swift; sourceTree = "<group>"; };
 		3132FA2727A0788400DD7A12 /* PassKitPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassKitPreviewHelper.swift; sourceTree = "<group>"; };
 		3132FA2927A0788F00DD7A12 /* QuickLookPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewHelper.swift; sourceTree = "<group>"; };
@@ -2188,7 +2188,7 @@
 				1E8AD1C827BFAD1500ABA377 /* DirectoryMonitor.swift */,
 				310D091C2799F57200DC0060 /* Download.swift */,
 				31C138A727A3E9C900FFD4B2 /* DownloadSession.swift */,
-				310D09202799FD1A00DC0060 /* MimeType.swift */,
+				310D09202799FD1A00DC0060 /* MIMEType.swift */,
 				3161D13127AC161B00285CF6 /* DownloadMetadata.swift */,
 			);
 			name = Downloads;
@@ -4713,7 +4713,7 @@
 				8505836E219F424500ED4EDB /* RoundedRectangleView.swift in Sources */,
 				F4B0B796252CB35700830156 /* OnboardingWidgetsDetailsViewController.swift in Sources */,
 				85058370219F424500ED4EDB /* SearchBarExtension.swift in Sources */,
-				310D09212799FD1A00DC0060 /* MimeType.swift in Sources */,
+				310D09212799FD1A00DC0060 /* MIMEType.swift in Sources */,
 				986DA94A24884B18004A7E39 /* WebViewTransition.swift in Sources */,
 				31B524572715BB23002225AB /* WebJSAlert.swift in Sources */,
 				F114C55B1E66EB020018F95F /* NibLoading.swift in Sources */,

--- a/DuckDuckGo/MIMEType.swift
+++ b/DuckDuckGo/MIMEType.swift
@@ -1,5 +1,5 @@
 //
-//  MimeType.swift
+//  MIMEType.swift
 //  DuckDuckGo
 //
 //  Copyright © 2022 DuckDuckGo. All rights reserved.

--- a/DuckDuckGo/MimeType.swift
+++ b/DuckDuckGo/MimeType.swift
@@ -29,6 +29,10 @@ enum MIMEType: String {
     case calendar = "text/calendar"
     case unknown
     
+    init(from string: String?) {
+        self = MIMEType(rawValue: string ?? "") ?? .unknown
+    }
+    
     var isHTML: Bool {
         switch self {
         case .html, .xhtml:

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1041,13 +1041,12 @@ extension TabViewController: WKNavigationDelegate {
                 }
             }
             
-            if let downloadMetadata = downloadManager.downloadMetaData(for: navigationResponse) {
-                
-                if FilePreviewHelper.canAutoPreviewMIMEType(downloadMetadata.mimeType) {
-                    startDownload()
-                    Pixel.fire(pixel: .downloadStarted,
-                               withAdditionalParameters: [PixelParameters.canAutoPreviewMIMEType: "1"])
-                } else {
+            if FilePreviewHelper.canAutoPreviewMIMEType(mimeType) {
+                startDownload()
+                Pixel.fire(pixel: .downloadStarted,
+                           withAdditionalParameters: [PixelParameters.canAutoPreviewMIMEType: "1"])
+            } else {
+                if let downloadMetadata = downloadManager.downloadMetaData(for: navigationResponse) {
                     let alert = SaveToDownloadsAlert.makeAlert(downloadMetadata: downloadMetadata) {
                         startDownload()
                         Pixel.fire(pixel: .downloadStarted,
@@ -1064,7 +1063,7 @@ extension TabViewController: WKNavigationDelegate {
                     }
                 }
             }
-            
+        
             decisionHandler(.cancel)
         }
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1025,8 +1025,9 @@ extension TabViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationResponse: WKNavigationResponse,
                  decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        let mimeType = MIMEType(from: navigationResponse.response.mimeType)
       
-        if navigationResponse.canShowMIMEType {
+        if navigationResponse.canShowMIMEType && !FilePreviewHelper.canAutoPreviewMIMEType(mimeType) {
             setupOrClearTemporaryDownload(for: navigationResponse)
             url = webView.url
             decisionHandler(.allow)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202054242256340/f
Tech Design URL:
CC:

**Description**:
Downloads related feature released in 7.66.0 allowed for previewing AR files. When running DDG browser on iOS 15.4 those previews no longer work – after tapping the link raw data is rendered inside tab. The same link on the same app version but when run on iOS 15.3.1 successfully previews the file.
Upon investigation the issue is caused by undocumented internal change in WebKit that was shipped with iOS 15.4

**Steps to test this PR**:
1. Open https://www.dell.com/en-us/work/shop/dell-32-4k-usb-c-hub-monitor-p3222qe/apd/210-bbcq/monitors-monitor-accessories (tap on "View in AR" button)
2. Open https://www.neversummer.com/shop/snowboards/mens-2022-protosynthesis-snowboard/ (Click View in AR)

**Device Testing**:
* [ ] iPhone
* [ ] iPad

**OS Testing**:
* [ ] iOS 15.3.1
* [ ] iOS 15.4

