### PR TITLE
Fix incorrect m_download_tried_to_present_preview_without_tab pixel reporting

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -939,11 +939,13 @@ class TabViewController: UIViewController {
     }
 
     private func previewDownloadedFileIfNecessary(_ download: Download) {
-        guard FilePreviewHelper.canAutoPreviewMIMEType(download.mimeType),
-              let fileHandler = FilePreviewHelper.fileHandlerForDownload(download, viewController: self),
-              let delegate = self.delegate else { return }
+        guard let delegate = self.delegate,
+              delegate.tabCheckIfItsBeingCurrentlyPresented(self),
+              FilePreviewHelper.canAutoPreviewMIMEType(download.mimeType),
+              let fileHandler = FilePreviewHelper.fileHandlerForDownload(download, viewController: self)
+        else { return }
         
-        if delegate.tabCheckIfItsBeingCurrentlyPresented(self) {
+        if mostRecentAutoPreviewDownloadID == download.id {
             fileHandler.preview()
         } else {
             Pixel.fire(pixel: .downloadTriedToPresentPreviewWithoutTab)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202054242256338/f
Tech Design URL:
CC:

**Description**:
The pixel m_download_tried_to_present_preview_without_tab was introduced in version 7.66.0. Due to error in logic it is reported in a wrong way, resulting in many false positives.

**Steps to test this PR**:
1. Open multiple tabs
2. Open link to a file that is handled for preview ( Wallet pass or AR file)
3. Check the `previewDownloadedFileIfNecessary` calls. 
