### PR TITLE
Fix incorrect m_downloads_sharing_predownloaded_local_file pixel parameter value

### DIFF
--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -325,7 +325,8 @@ extension TabViewController {
         AppDependencyProvider.shared.downloadManager.startDownload(download) { error in
             DispatchQueue.main.async {
                 if error == nil, let downloadLink = download.link {
-                    let isFileSizeGreaterThan10MB = (downloadLink.url.fileSize > 10 * 1000 * 1000)
+                    let fileSize = downloadLink.localFileURL?.fileSize ?? 0
+                    let isFileSizeGreaterThan10MB = (fileSize > 10 * 1000 * 1000)
                     Pixel.fire(pixel: .downloadsSharingPredownloadedLocalFile,
                                withAdditionalParameters: [PixelParameters.fileSizeGreaterThan10MB: isFileSizeGreaterThan10MB ? "1" : "0"])
                     completion(downloadLink)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202061602206523/f
Tech Design URL:
CC:

**Description**:
The pixel m_downloads_sharing_predownloaded_local_file was introduced in version 7.66.0. It is sent with a custom parameter file_size_greater_than_10mb that due to error in logic is reported with an incorrect value.

**Steps to test this PR**:
1. Open a file that can be previewed inside webview larger than 10MB (e.g. PDF document https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6036617.pdf) 
2. Tap share button
3. Check the param of m_downloads_sharing_predownloaded_local_file pixel

**Device Testing**:
* [ ] iPhone

