### PR TITLE
Add temporary Downloads related pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -185,6 +185,7 @@ public enum PixelName: String {
     case downloadsSharingPredownloadedLocalFile = "m_downloads_sharing_predownloaded_local_file"
     
     case downloadPreparingToStart = "m_download_preparing_to_start"
+    case downloadAttemptToOpenBLOB = "m_download_attempt_to_open_blob"
 
     case jsAlertShown = "m_js_alert_shown"
     case jsAlertBlocked = "m_js_alert_blocked"

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -183,6 +183,8 @@ public enum PixelName: String {
     case downloadsListSharePressed = "m_downloads_list_share_pressed"
     
     case downloadsSharingPredownloadedLocalFile = "m_downloads_sharing_predownloaded_local_file"
+    
+    case downloadPreparingToStart = "m_download_preparing_to_start"
 
     case jsAlertShown = "m_js_alert_shown"
     case jsAlertBlocked = "m_js_alert_blocked"
@@ -302,6 +304,7 @@ public struct PixelParameters {
     public static let canAutoPreviewMIMEType = "can_auto_preview_mime_type"
     public static let mimeType = "mime_type"
     public static let fileSizeGreaterThan10MB = "file_size_greater_than_10mb"
+    public static let statusCode = "status_code"
     
 }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1026,6 +1026,11 @@ extension TabViewController: WKNavigationDelegate {
             url = webView.url
             decisionHandler(.allow)
         } else {
+            if let httpResponse = navigationResponse.response as? HTTPURLResponse {
+                Pixel.fire(pixel: .downloadPreparingToStart,
+                           withAdditionalParameters: [PixelParameters.statusCode: String(httpResponse.statusCode)])
+            }
+                           
             let downloadManager = AppDependencyProvider.shared.downloadManager
             
             let startDownload: () -> Download? = {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1020,6 +1020,10 @@ extension TabViewController: WKNavigationDelegate {
                  decidePolicyFor navigationResponse: WKNavigationResponse,
                  decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
         let mimeType = MIMEType(from: navigationResponse.response.mimeType)
+        
+        if let scheme = navigationResponse.response.url?.scheme, scheme.hasPrefix("blob") {
+            Pixel.fire(pixel: .downloadAttemptToOpenBLOB)
+        }
       
         if navigationResponse.canShowMIMEType && !FilePreviewHelper.canAutoPreviewMIMEType(mimeType) {
             setupOrClearTemporaryDownload(for: navigationResponse)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202093255455669/f
CC: @Bunn 

**Description**:
During https://app.asana.com/0/45878998844068/1201600067271022/f it was discussed to add temporary pixels to validate our assumptions to improvements in navigation logic we plan to introduce.

**Steps to test this PR**:
1. Open a BLOB URL: https://www.w3docs.com/tools/editor/21423 or try downloading a song from https://www.soundtrap.com
2. Try downloading a file

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
