### PR TITLE
Fix edit mode animations

### DIFF
--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -49,6 +49,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
         navigationItem.setHidesBackButton(true, animated: true)
         navigationItem.setRightBarButton(doneButton, animated: true)
 
+        // Fix glitch happening when there's cell that is already in the editing state (swiped to reveal delete button) and user presses 'Edit'.
         tableView.setEditing(false, animated: true)
         tableView.setEditing(true, animated: true)
         

--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -175,6 +175,7 @@ class UnprotectedSitesViewController: UITableViewController {
         hiddenNavBarItems = navigationItem.rightBarButtonItems
         navigationItem.setRightBarButtonItems(nil, animated: true)
         
+        // Fix glitch happening when there's cell that is already in the editing state (swiped to reveal delete button) and user presses 'Edit'.
         tableView.setEditing(false, animated: true)
         tableView.setEditing(true, animated: true)
         

--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -134,9 +134,11 @@ class UnprotectedSitesViewController: UITableViewController {
             } else {
                 refreshToolbarItems(animated: true)
             }
+            
+            tableView.reloadData()
+        } else {
+            tableView.deleteRows(at: [indexPath], with: .automatic)
         }
-
-        tableView.reloadData()
     }
 
     // MARK: actions
@@ -169,23 +171,25 @@ class UnprotectedSitesViewController: UITableViewController {
     }
     
     @IBAction func startEditing() {
-        // Fix glitch happening when there's cell that is already in the editing state (swiped to reveal delete button) and user presses 'Edit'.
-        tableView.isEditing = false
-        tableView.isEditing = true
-        tableView.reloadData()
-        refreshToolbarItems(animated: true)
-        
+        navigationItem.setHidesBackButton(true, animated: true)
         hiddenNavBarItems = navigationItem.rightBarButtonItems
         navigationItem.setRightBarButtonItems(nil, animated: true)
+        
+        tableView.setEditing(false, animated: true)
+        tableView.setEditing(true, animated: true)
+        
+        refreshToolbarItems(animated: true)
     }
     
     @IBAction func endEditing() {
-        tableView.isEditing = false
-        tableView.reloadData()
+        navigationItem.setHidesBackButton(false, animated: true)
+        if let hiddenNavBarItems = hiddenNavBarItems {
+            navigationItem.setRightBarButtonItems(hiddenNavBarItems, animated: true)
+        }
+        
+        tableView.setEditing(false, animated: true)
         
         refreshToolbarItems(animated: true)
-        
-        navigationItem.setRightBarButtonItems(hiddenNavBarItems, animated: true)
     }
 
     // MARK: private


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202018305067278/f

**Description**:
During development of Downloads the toggling of table view edit mode comes animated by default. Aiming at providing consistency and polish it was proposed to introduce edit mode animations on other lists: _fireproof sites_ and _unprotected sites_.

**Steps to test this PR**:
_Fireproof Sites_
* toggling edit mode should be animated (min. 1 item on the list required)
* on edit mode toggle the (dis)appearance of "Remove All Fireproof Sites" button should animate
* removing item by a wide swipe from right-to-left should have a fluid animation 
* removing item by a revealing and tapping the "Delete" button should have a fluid animation
* when cell has a "Delete" button revealed tapping "Edit" should have a fluid transition into the edit mode
* manipulating the list items (removing, removing last, removing all etc.) should not crash

_Unprotected sites_
* toggling edit mode should be animated (min. 1 item on the list required)
* removing item by a wide swipe from right-to-left should have a fluid animation 
* removing item by a revealing and tapping the "Delete" button should have a fluid animation
* when cell has a "Delete" button revealed tapping "Edit" should have a fluid transition into the edit mode
* manipulating the list items (adding, removing, removing last, removing all etc.) should not crash


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
