### PR TITLE
Update BSK to fix autofill on macOS Catalina

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6837,8 +6837,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				branch = "ema/fix-autofill-on-catalina";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.2.6;
 			};
 		};
 		F486D2EF25069482002D07D7 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6837,8 +6837,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.2.1;
+				branch = "ema/fix-autofill-on-catalina";
+				kind = branch;
 			};
 		};
 		F486D2EF25069482002D07D7 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/duckduckgo/BrowserServicesKit.git",
         "state": {
-          "branch": "ema/fix-autofill-on-catalina",
-          "revision": "b462685c3549f360d520f3ada2cde85919aaa68b",
-          "version": null
+          "branch": null,
+          "revision": "114c739843e4a12fe2a2c512dbad637be8b4bfb4",
+          "version": "12.2.6"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/duckduckgo/BrowserServicesKit.git",
         "state": {
-          "branch": null,
-          "revision": "e65500ba7a34e3044fd434c597750906393a72b1",
-          "version": "12.2.1"
+          "branch": "ema/fix-autofill-on-catalina",
+          "revision": "b462685c3549f360d520f3ada2cde85919aaa68b",
+          "version": null
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1202127639259814/f
Tech Design URL: NA

**Description**:
Fixes autofill tooltip in Catalina by disabling top autofill (uses the old in-page tooltip).

**Steps to test this PR**:
1. Nothing should have changed for iOS. Try using autofill.

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
