### PR TITLE
Fix import bookmarks button text not wrapping for longer translation strings

### DIFF
--- a/DuckDuckGo/Base.lproj/Bookmarks.storyboard
+++ b/DuckDuckGo/Base.lproj/Bookmarks.storyboard
@@ -54,7 +54,7 @@
                             <rect key="frame" x="0.0" y="234.5" width="375" height="82"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pyc-rk-XMJ">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="pyc-rk-XMJ">
                                     <rect key="frame" x="19" y="30" width="337" height="31"/>
                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="14"/>
                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -88,13 +88,13 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="744" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lqe-Wh-Evj">
-                                                    <rect key="frame" x="32" y="0.0" width="264.5" height="24"/>
+                                                    <rect key="frame" x="32" y="0.0" width="263.5" height="24"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Semibold" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vil-gw-sgh" userLabel="NumberOfChildren">
-                                                    <rect key="frame" x="304.5" y="0.0" width="38.5" height="24"/>
+                                                    <rect key="frame" x="303.5" y="0.0" width="39.5" height="24"/>
                                                     <fontDescription key="fontDescription" name="ProximaNova-Regular" family="Proxima Nova" pointSize="16"/>
                                                     <color key="textColor" name="TableCellAccessoryTextColor"/>
                                                     <nil key="highlightedColor"/>

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -203,6 +203,7 @@ class BookmarksViewController: UITableViewController {
         if #available(iOS 14, *) {
             importFooterButton.setTitle(UserText.importBookmarksFooterButton, for: .normal)
             importFooterButton.setTitleColor(UIColor.cornflowerBlue, for: .normal)
+            importFooterButton.titleLabel?.textAlignment = .center
 
             importFooterButton.addAction(UIAction { [weak self] _ in
                 self?.presentDocumentPicker()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1202154480850238/f
Tech Design URL:
CC:

**Description**:
When a user doesn't have any bookmarks saved, a button is displayed prompting the user to import bookmarks. This button title was set incorrectly set to truncate instead of word wrap

**Steps to test this PR**:
1. Delete any existing bookmarks / favorites (if any)
2. Change your device language to French 
3. Go to the Bookmarks screen 
4. Confirm the button text in the center of the screen word wraps instead of truncating 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
