### PR TITLE
Normalize exception domain names for Content Blocking

### DIFF
--- a/Core/StringExtension.swift
+++ b/Core/StringExtension.swift
@@ -18,7 +18,6 @@
 //
 
 import Foundation
-import Punycode
 import BrowserServicesKit
 
 extension String {

--- a/Core/StringExtension.swift
+++ b/Core/StringExtension.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import Punycode
+import BrowserServicesKit
 
 extension String {
 
@@ -99,13 +100,6 @@ extension String {
         let hostPathSeparator = !encodedPath.isEmpty || hasSuffix("/") ? "/" : ""
         let url = originalScheme + host + hostPathSeparator + encodedPath + query
         return URL(string: url)
-    }
-    
-    public var punycodeEncodedHostname: String {
-        return self.split(separator: ".")
-            .map { String($0) }
-            .map { $0.idnaEncoded ?? $0 }
-            .joined(separator: ".")
     }
 
     public func sha256() -> String {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6901,8 +6901,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				branch = "bartek/normalize-exception-domains";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.2.8;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -626,7 +626,6 @@
 		F46FEC5727987A5F0061D9DF /* KeychainItemsDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46FEC5627987A5F0061D9DF /* KeychainItemsDebugViewController.swift */; };
 		F47E53D9250A97330037C686 /* OnboardingDefaultBroswerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47E53D8250A97330037C686 /* OnboardingDefaultBroswerViewController.swift */; };
 		F47E53DB250A9A1C0037C686 /* Onboarding.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F47E53DA250A9A1C0037C686 /* Onboarding.xcassets */; };
-		F486D306250697AF002D07D7 /* Punnycode in Frameworks */ = {isa = PBXBuildFile; productRef = F486D305250697AF002D07D7 /* Punnycode */; };
 		F486D31D2506980E002D07D7 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = F486D31C2506980E002D07D7 /* Swifter */; };
 		F486D33425069BBB002D07D7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = F486D33325069BBB002D07D7 /* Kingfisher */; };
 		F486D3362506A037002D07D7 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = F486D3352506A037002D07D7 /* OHHTTPStubs */; };
@@ -2108,7 +2107,6 @@
 				4B82E98025B634B800656FE7 /* TrackerRadarKit in Frameworks */,
 				F486D33425069BBB002D07D7 /* Kingfisher in Frameworks */,
 				4BE86C5D2633DBD8001C0E77 /* BrowserServicesKit in Frameworks */,
-				F486D306250697AF002D07D7 /* Punnycode in Frameworks */,
 				C14882ED27F211A000D59F0C /* SwiftSoup in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4270,7 +4268,6 @@
 			);
 			name = Core;
 			packageProductDependencies = (
-				F486D305250697AF002D07D7 /* Punnycode */,
 				F486D33325069BBB002D07D7 /* Kingfisher */,
 				4B82E97F25B634B800656FE7 /* TrackerRadarKit */,
 				4BE86C5C2633DBD8001C0E77 /* BrowserServicesKit */,
@@ -4386,7 +4383,6 @@
 			mainGroup = 84E341891E2F7EFB00BDBA6F;
 			packageReferences = (
 				F486D2EF25069482002D07D7 /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				F486D2FA25069613002D07D7 /* XCRemoteSwiftPackageReference "PunycodeSwift" */,
 				F486D2FD25069744002D07D7 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
 				F486D3022506975E002D07D7 /* XCRemoteSwiftPackageReference "swifter" */,
 				F4D1BFA22587EA0600469046 /* XCRemoteSwiftPackageReference "lottie-ios" */,
@@ -6925,14 +6921,6 @@
 				minimumVersion = 7.1.0;
 			};
 		};
-		F486D2FA25069613002D07D7 /* XCRemoteSwiftPackageReference "PunycodeSwift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/gumob/PunycodeSwift.git";
-			requirement = {
-				kind = exactVersion;
-				version = 2.1.0;
-			};
-		};
 		F486D2FD25069744002D07D7 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs.git";
@@ -6974,11 +6962,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */;
 			productName = SwiftSoup;
-		};
-		F486D305250697AF002D07D7 /* Punnycode */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F486D2FA25069613002D07D7 /* XCRemoteSwiftPackageReference "PunycodeSwift" */;
-			productName = Punnycode;
 		};
 		F486D31C2506980E002D07D7 /* Swifter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -6905,8 +6905,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.2.7;
+				branch = "bartek/normalize-exception-domains";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
@@ -6929,8 +6929,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gumob/PunycodeSwift.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = exactVersion;
+				version = 2.1.0;
 			};
 		};
 		F486D2FD25069744002D07D7 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/duckduckgo/BrowserServicesKit.git",
         "state": {
-          "branch": "brad/config-v2",
-          "revision": "5f392cd034a7ab32b07f5be89cd1f73f89340d4c",
+          "branch": "bartek/normalize-exception-domains",
+          "revision": "f7237eb79e6202cbc9f6e4ca7725b34ed7e450fa",
           "version": null
         }
       },
@@ -50,9 +50,9 @@
         "package": "Punycode",
         "repositoryURL": "https://github.com/gumob/PunycodeSwift.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "4356ec54e073741449640d3d50a1fd24fd1e1b8b",
-          "version": null
+          "version": "2.1.0"
         }
       },
       {
@@ -80,15 +80,6 @@
           "branch": null,
           "revision": "13ba661fd1146967270fca92ce8195b223631436",
           "version": "2.3.8"
-        }
-      },
-      {
-        "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
-        "state": {
-          "branch": null,
-          "revision": "5f4caf35b8418700a48c64c7c61eb43308c8dacc",
-          "version": "1.0.3"
         }
       }
     ]

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/duckduckgo/BrowserServicesKit.git",
         "state": {
-          "branch": "bartek/normalize-exception-domains",
-          "revision": "f7237eb79e6202cbc9f6e4ca7725b34ed7e450fa",
-          "version": null
+          "branch": null,
+          "revision": "e05c62161b3fcabf42e93ad9cffc26c19b803ba9",
+          "version": "12.2.8"
         }
       },
       {
@@ -80,6 +80,15 @@
           "branch": null,
           "revision": "13ba661fd1146967270fca92ce8195b223631436",
           "version": "2.3.8"
+        }
+      },
+      {
+        "package": "TrackerRadarKit",
+        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
+        "state": {
+          "branch": null,
+          "revision": "5f4caf35b8418700a48c64c7c61eb43308c8dacc",
+          "version": "1.0.3"
         }
       }
     ]

--- a/DuckDuckGo/UnprotectedSitesViewController.swift
+++ b/DuckDuckGo/UnprotectedSitesViewController.swift
@@ -33,7 +33,7 @@ class UnprotectedSitesViewController: UITableViewController {
     private var hiddenNavBarItem: UIBarButtonItem?
     private var hiddenNavBarItems: [UIBarButtonItem]?
     
-    private let protectionStore: DomainsProtectionStore = DomainsProtectionUserDefaultsStore()
+    private let privacyConfig: PrivacyConfiguration = ContentBlocking.privacyConfigurationManager.privacyConfig
     
     var showBackButton = false
     var enforceLightTheme = false
@@ -74,7 +74,7 @@ class UnprotectedSitesViewController: UITableViewController {
             setToolbarItems([flexibleSpace, editButton], animated: animated)
         }
         
-        editButton.isEnabled = protectionStore.unprotectedDomains.count > 0
+        editButton.isEnabled = privacyConfig.userUnprotectedDomains.count > 0
     }
     
     private func configureBackButton() {
@@ -99,7 +99,7 @@ class UnprotectedSitesViewController: UITableViewController {
     // MARK: UITableView data source
 
     private var unprotectedDomains: [String] {
-        return protectionStore.unprotectedDomains.sorted()
+        return privacyConfig.userUnprotectedDomains.sorted()
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -123,7 +123,7 @@ class UnprotectedSitesViewController: UITableViewController {
         guard editingStyle == .delete else { return }
 
         let domain = unprotectedDomains[indexPath.row]
-        protectionStore.enableProtection(forDomain: domain)
+        privacyConfig.userEnabledProtection(forDomain: domain)
 
         if unprotectedDomains.count == 0 {
             if tableView.isEditing {
@@ -193,7 +193,7 @@ class UnprotectedSitesViewController: UITableViewController {
     private func addSite(from controller: UIAlertController) {
         guard let field = controller.textFields?[0] else { return }
         guard let domain = domain(from: field) else { return }
-        protectionStore.disableProtection(forDomain: domain)
+        privacyConfig.userDisabledProtection(forDomain: domain)
         tableView.reloadData()
         refreshToolbarItems(animated: true)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1202191081651325

**Description**:
Normalize exception domain names for Content Blocking when adding these from Unprotected Sites screen.

**Steps to test this PR**:

Test disabling protections on websites with non-ascii characters in address (punycoded).

Test unprotected sites on Privacy Test pages.

Unprotected sites list:
 - Tweak `AppPrivacyConfiguration:userDisabledProtection(_:)` to disable normalization when adding new domains.
 - Go to unprotected sites list in Settings.
 - Add 'Example.com'
 - Navigate to example.com - check protection status.
 - Re-enable protection from Privacy Dashboard.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->
**Device Testing**:

* [ ] iPhone 
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
