### PR TITLE
Fix a crash when searching bookmarks

### DIFF
--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -450,6 +450,10 @@ class BookmarksViewController: UITableViewController {
     }
 
     private func startEditing() {
+        guard !tableView.isEditing else {
+            return
+        }
+
         // necessary in case a cell is swiped (which would mean isEditing is already true, and setting it again wouldn't do anything)
         tableView.isEditing = false
         
@@ -462,6 +466,10 @@ class BookmarksViewController: UITableViewController {
     }
 
     private func finishEditing() {
+        guard tableView.isEditing else {
+            return
+        }
+
         tableView.isEditing = false
         refreshEditButton()
         enableDoneButton()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1151605488805945/f
Tech Design URL:
CC:

**Description**:

This PR adds checks to the start/finish editing functions to prevent duplicate calls from crashing the app.

**Steps to test this PR**:
1. Open the bookmarks screen and test that searching for bookmarks works
2. Try entering and exiting editing states and verifying that those work correctly

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
