### PR TITLE
Add escape to FindInPage

### DIFF
--- a/DuckDuckGo/FindInPage.swift
+++ b/DuckDuckGo/FindInPage.swift
@@ -57,7 +57,12 @@ class FindInPage: NSObject {
     func search(forText text: String) -> Bool {
         guard text != searchTerm else { return false }
         searchTerm = text
-        webView.evaluateJavaScript("window.__firefox__.find('\(text)')")
+        
+        let escaped =
+        text.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\'", with: "\\\'")
+        
+        webView.evaluateJavaScript("window.__firefox__.find('\(escaped)')")
         
         return true
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1202221570562481/f
Tech Design URL:
CC:

**Description**:
The following characters could not be searched by "Find in Page", so I fixed them.

- `\`
- `'`

**Steps to test this PR**:
1. Open "Find in Page".
2. Search one character, `\` or `'`. 

Thanks.