### PR TITLE
Start downloads only when response has 2xx status code

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -187,7 +187,6 @@ public enum PixelName: String {
     
     case downloadsSharingPredownloadedLocalFile = "m_downloads_sharing_predownloaded_local_file"
     
-    case downloadPreparingToStart = "m_download_preparing_to_start"
     case downloadAttemptToOpenBLOB = "m_download_attempt_to_open_blob"
 
     case jsAlertShown = "m_js_alert_shown"
@@ -317,7 +316,6 @@ public struct PixelParameters {
     public static let canAutoPreviewMIMEType = "can_auto_preview_mime_type"
     public static let mimeType = "mime_type"
     public static let fileSizeGreaterThan10MB = "file_size_greater_than_10mb"
-    public static let statusCode = "status_code"
     
     public static let bookmarkCount = "bco"
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1071,7 +1071,7 @@ extension TabViewController: WKNavigationDelegate {
         
             decisionHandler(.cancel)
         } else {
-            // MIME should trigger download but no 2xx status code
+            // MIME type should trigger download but response has no 2xx status code
             decisionHandler(.allow)
         }
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1033,11 +1033,6 @@ extension TabViewController: WKNavigationDelegate {
             url = webView.url
             decisionHandler(.allow)
         } else if isSuccessfulResponse {
-            if let httpResponse = navigationResponse.response as? HTTPURLResponse {
-                Pixel.fire(pixel: .downloadPreparingToStart,
-                           withAdditionalParameters: [PixelParameters.statusCode: String(httpResponse.statusCode)])
-            }
-                           
             let downloadManager = AppDependencyProvider.shared.downloadManager
             
             let startDownload: () -> Download? = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202179200624745/f

**Description**:
Some of the download responses are not from the 2xx HTTP status code ranges. For those downloads the experience for the users will be confusing - most probably it will result in not saving of the requested file but instead a HTML error page often under unknown file name.
