### PR TITLE
Add Pixel for possible error when downloading configuration

### DIFF
--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -94,6 +94,11 @@ public class ContentBlockerLoader {
                 return
             }
             
+            if etag == nil {
+                let params = [PixelParameters.configuration: configuration.rawValue]
+                Pixel.fire(pixel: .configDownloadMissingETag, withAdditionalParameters: params)
+            }
+            
             let isCached = etag != nil && self.etagStorage.etag(for: configuration) == etag
             self.etags[configuration] = etag
             

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -234,6 +234,8 @@ public enum PixelName: String {
     
     case contentBlockingErrorReportingIssue = "m_content_blocking_error_reporting_issue"
     case contentBlockingCompilationTime = "m_content_blocking_compilation_time"
+    
+    case configDownloadMissingETag = "m_d_config_download_missing_etag"
 
     case ampBlockingRulesCompilationFailed = "m_debug_amp_rules_compilation_failed"
 
@@ -293,6 +295,8 @@ public struct PixelParameters {
     public static let tabPreviewCountDelta = "cd"
     
     public static let etag = "et"
+    
+    public static let configuration = "configuration"
 
     public static let emailCohort = "cohort"
     public static let emailLastUsed = "duck_address_last_used"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1202241705934500
Tech Design URL:
CC:

**Description**:

Detect if we are not getting correct etag when updating app configuration.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Modify response code to return nil instead of etag -> see pixel being reported.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


**Device Testing**:

* [ ] iPhone 
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
