### PR TITLE
Do not populate bookmarks cache with favicons for all visited sites

### DIFF
--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -365,7 +365,15 @@ class BookmarksViewController: UITableViewController {
             case .success:
                 dataSource.bookmarksManager.reloadWidgets()
 
-                let bookmarkCountAfterImport = await dataSource.bookmarksManager.allBookmarksAndFavoritesFlat().count
+                let bookmarks = await dataSource.bookmarksManager.allBookmarksAndFavoritesFlat()
+                for bookmark in bookmarks {
+                    if let domain = bookmark.url?.host {
+                        await Favicons.shared.loadFavicon(forDomain: domain, intoCache: .bookmarks, fromCache: .tabs)
+                    }
+                }
+                tableView.reloadData()
+
+                let bookmarkCountAfterImport = bookmarks.count
                 let bookmarksImported = bookmarkCountAfterImport - bookmarkCountBeforeImport
                 Pixel.fire(pixel: .bookmarkImportSuccess,
                            withAdditionalParameters: [PixelParameters.bookmarkCount: "\(bookmarksImported)"])

--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -143,7 +143,6 @@ public class Favicons {
             let resource = defaultResource(forDomain: domain),
             (Constants.bookmarksCache.isCached(forKey: resource.cacheKey) || bookmarksStore.contains(domain: domain)),
             let options = kfOptions(forDomain: domain, usingCache: .bookmarks) else {
-                loadFavicon(forDomain: domain, intoCache: .bookmarks, fromCache: .tabs)
                 return
             }
 
@@ -264,6 +263,23 @@ public class Favicons {
 
         }
 
+    }
+    
+    @discardableResult
+    public func loadFavicon(forDomain domain: String?,
+                            fromURL url: URL? = nil,
+                            intoCache targetCacheType: CacheType,
+                            fromCache: CacheType? = nil,
+                            queue: DispatchQueue? = OperationQueue.current?.underlyingQueue) async -> UIImage? {
+        await withCheckedContinuation { continuation in
+            loadFavicon(forDomain: domain,
+                        fromURL: url,
+                        intoCache: targetCacheType,
+                        fromCache: fromCache,
+                        queue: queue) { image in
+                continuation.resume(returning: image)
+            }
+        }
     }
 
     private func loadImageFromNetwork(_ imageUrl: URL?,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202223699061973/f
CC: @miasma13

**Description**:
When we import bookmarks from HTML file we want to download favicons for them not before by messing with caches.

**Steps to test this PR**:
1. Export bookmarks to HTML file.
2. Remove all bookmarks.
3. Import bookmark from HTML file.
4. Make sure that imported websites get the favicon.
