### PR TITLE
Include request status code in Missing ETag error pixel

### DIFF
--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -84,7 +84,7 @@ public class ContentBlockerLoader {
                              with contentBlockerRequest: ContentBlockerRemoteDataSource,
                              _ semaphore: DispatchSemaphore,
                              _ progress: ContentBlockerLoaderProgress? = nil) {
-        contentBlockerRequest.request(configuration) { response in
+        contentBlockerRequest.request(configuration, validatePresenceOfEtag: true) { response in
             defer {
                 progress?(configuration)
             }

--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -94,11 +94,6 @@ public class ContentBlockerLoader {
                 return
             }
             
-            if etag == nil {
-                let params = [PixelParameters.configuration: configuration.rawValue]
-                Pixel.fire(pixel: .configDownloadMissingETag, withAdditionalParameters: params)
-            }
-            
             let isCached = etag != nil && self.etagStorage.etag(for: configuration) == etag
             self.etags[configuration] = etag
             

--- a/Core/ContentBlockerRequest.swift
+++ b/Core/ContentBlockerRequest.swift
@@ -23,7 +23,12 @@ protocol ContentBlockerRemoteDataSource {
     
     var requestCount: Int { get }
     
-    func request(_ configuration: ContentBlockerRequest.Configuration, completion:@escaping (ContentBlockerRequest.Response) -> Void)
+    func request(_ configuration: ContentBlockerRequest.Configuration,
+                 completion:@escaping (ContentBlockerRequest.Response) -> Void)
+    
+    func request(_ configuration: ContentBlockerRequest.Configuration,
+                 validatePresenceOfEtag: Bool,
+                 completion:@escaping (ContentBlockerRequest.Response) -> Void)
 }
 
 public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
@@ -50,6 +55,10 @@ public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
     }
     
     func request(_ configuration: Configuration, completion: @escaping (Response) -> Void) {
+        request(configuration, validatePresenceOfEtag: false, completion: completion)
+    }
+    
+    func request(_ configuration: Configuration, validatePresenceOfEtag: Bool, completion: @escaping (Response) -> Void) {
         requestCount += 1
         
         let spid = Instruments.shared.startTimedEvent(.fetchingContentBlockerData, info: configuration.rawValue)
@@ -67,6 +76,20 @@ public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
             }
 
             Instruments.shared.endTimedEvent(for: spid, result: "success")
+            
+            if validatePresenceOfEtag && response.etag == nil {
+                let httpResponse = response.urlResponse as? HTTPURLResponse
+                let statusCode: String
+                if let code = httpResponse?.statusCode {
+                    statusCode = String(code)
+                } else {
+                    statusCode = "nil"
+                }
+                let params = [PixelParameters.configuration: configuration.rawValue,
+                              PixelParameters.responseCode: statusCode]
+                Pixel.fire(pixel: .configDownloadMissingETag, withAdditionalParameters: params)
+            }
+            
             completion(.success(etag: response.etag, data: data))
         }
     }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -235,7 +235,7 @@ public enum PixelName: String {
     case contentBlockingErrorReportingIssue = "m_content_blocking_error_reporting_issue"
     case contentBlockingCompilationTime = "m_content_blocking_compilation_time"
     
-    case configDownloadMissingETag = "m_d_config_download_missing_etag"
+    case configDownloadMissingETag = "m_d_config_download_missing_etag2"
 
     case ampBlockingRulesCompilationFailed = "m_debug_amp_rules_compilation_failed"
 

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -297,6 +297,7 @@ public struct PixelParameters {
     public static let etag = "et"
     
     public static let configuration = "configuration"
+    public static let responseCode = "responseCode"
 
     public static let emailCohort = "cohort"
     public static let emailLastUsed = "duck_address_last_used"

--- a/DuckDuckGoTests/ContentBlockerLoaderTests.swift
+++ b/DuckDuckGoTests/ContentBlockerLoaderTests.swift
@@ -169,6 +169,10 @@ class MockContentBlockingRequest: ContentBlockerRemoteDataSource {
         
         completion(response)
     }
+    
+    func request(_ configuration: ContentBlockerRequest.Configuration, validatePresenceOfEtag: Bool, completion: @escaping (ContentBlockerRequest.Response) -> Void) {
+        
+    }
 }
 
 class MockStorageCache: StorageCacheUpdating {

--- a/DuckDuckGoTests/ContentBlockerLoaderTests.swift
+++ b/DuckDuckGoTests/ContentBlockerLoaderTests.swift
@@ -162,16 +162,16 @@ class MockContentBlockingRequest: ContentBlockerRemoteDataSource {
     var mockResponse: ContentBlockerRequest.Response?
     
     func request(_ configuration: ContentBlockerRequest.Configuration, completion: @escaping (ContentBlockerRequest.Response) -> Void) {
+        request(configuration, validatePresenceOfEtag: false, completion: completion)
+    }
+    
+    func request(_ configuration: ContentBlockerRequest.Configuration, validatePresenceOfEtag: Bool, completion: @escaping (ContentBlockerRequest.Response) -> Void) {
         guard let response = mockResponse else {
             fatalError("No mock response set")
         }
         requestCount += 1
         
         completion(response)
-    }
-    
-    func request(_ configuration: ContentBlockerRequest.Configuration, validatePresenceOfEtag: Bool, completion: @escaping (ContentBlockerRequest.Response) -> Void) {
-        
     }
 }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1202241705934500
Tech Design URL:
CC:

**Description**:

Include request status code in Missing ETag error pixel, so we know if there is a pattern.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Comment out etag check in ContentBlockerRequest:80 to check if pixel is fired.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone 
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
