### PR TITLE
Process config data only when valid etag is present

### DIFF
--- a/Core/ContentBlockerLoader.swift
+++ b/Core/ContentBlockerLoader.swift
@@ -152,13 +152,14 @@ public class ContentBlockerLoader {
             defer {
                 progress?(.httpsExcludedDomains)
             }
-
-            guard case ContentBlockerRequest.Response.success(let etag, let data) = response else {
+            
+            guard case ContentBlockerRequest.Response.success(let etag, let data) = response,
+                  let etag = etag else {
                 semaphore.signal()
                 return
             }
             
-            let isCached = etag != nil && self.etagStorage.etag(for: .httpsExcludedDomains) == etag
+            let isCached = self.etagStorage.etag(for: .httpsExcludedDomains) == etag
             
             if !isCached, let excludedDomains = try? HTTPSUpgradeParser.convertExcludedDomainsData(data) {
                 self.newData[.httpsExcludedDomains] = excludedDomains

--- a/Core/ContentBlockerRequest.swift
+++ b/Core/ContentBlockerRequest.swift
@@ -25,10 +25,6 @@ protocol ContentBlockerRemoteDataSource {
     
     func request(_ configuration: ContentBlockerRequest.Configuration,
                  completion:@escaping (ContentBlockerRequest.Response) -> Void)
-    
-    func request(_ configuration: ContentBlockerRequest.Configuration,
-                 validatePresenceOfEtag: Bool,
-                 completion:@escaping (ContentBlockerRequest.Response) -> Void)
 }
 
 public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
@@ -55,10 +51,6 @@ public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
     }
     
     func request(_ configuration: Configuration, completion: @escaping (Response) -> Void) {
-        request(configuration, validatePresenceOfEtag: false, completion: completion)
-    }
-    
-    func request(_ configuration: Configuration, validatePresenceOfEtag: Bool, completion: @escaping (Response) -> Void) {
         requestCount += 1
         
         let spid = Instruments.shared.startTimedEvent(.fetchingContentBlockerData, info: configuration.rawValue)
@@ -76,20 +68,6 @@ public class ContentBlockerRequest: ContentBlockerRemoteDataSource {
             }
 
             Instruments.shared.endTimedEvent(for: spid, result: "success")
-            
-            if validatePresenceOfEtag && response.etag == nil {
-                let httpResponse = response.urlResponse as? HTTPURLResponse
-                let statusCode: String
-                if let code = httpResponse?.statusCode {
-                    statusCode = String(code)
-                } else {
-                    statusCode = "nil"
-                }
-                let params = [PixelParameters.configuration: configuration.rawValue,
-                              PixelParameters.responseCode: statusCode]
-                Pixel.fire(pixel: .configDownloadMissingETag, withAdditionalParameters: params)
-            }
-            
             completion(.success(etag: response.etag, data: data))
         }
     }

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -234,8 +234,6 @@ public enum PixelName: String {
     
     case contentBlockingErrorReportingIssue = "m_content_blocking_error_reporting_issue"
     case contentBlockingCompilationTime = "m_content_blocking_compilation_time"
-    
-    case configDownloadMissingETag = "m_d_config_download_missing_etag2"
 
     case ampBlockingRulesCompilationFailed = "m_debug_amp_rules_compilation_failed"
 
@@ -295,9 +293,6 @@ public struct PixelParameters {
     public static let tabPreviewCountDelta = "cd"
     
     public static let etag = "et"
-    
-    public static let configuration = "configuration"
-    public static let responseCode = "responseCode"
 
     public static let emailCohort = "cohort"
     public static let emailLastUsed = "duck_address_last_used"

--- a/DuckDuckGoTests/ContentBlockerLoaderTests.swift
+++ b/DuckDuckGoTests/ContentBlockerLoaderTests.swift
@@ -162,10 +162,6 @@ class MockContentBlockingRequest: ContentBlockerRemoteDataSource {
     var mockResponse: ContentBlockerRequest.Response?
     
     func request(_ configuration: ContentBlockerRequest.Configuration, completion: @escaping (ContentBlockerRequest.Response) -> Void) {
-        request(configuration, validatePresenceOfEtag: false, completion: completion)
-    }
-    
-    func request(_ configuration: ContentBlockerRequest.Configuration, validatePresenceOfEtag: Bool, completion: @escaping (ContentBlockerRequest.Response) -> Void) {
         guard let response = mockResponse else {
             fatalError("No mock response set")
         }

--- a/DuckDuckGoTests/ContentBlockerLoaderTests.swift
+++ b/DuckDuckGoTests/ContentBlockerLoaderTests.swift
@@ -78,21 +78,13 @@ class ContentBlockerLoaderTests: XCTestCase {
         XCTAssertNotNil(mockStorageCache.processedUpdates[.privacyConfiguration])
     }
 
-    func testWhenEtagIsMissingThenResponseIsStored() {
+    func testWhenEtagIsMissingThenResponseIsNotStored() {
         
         mockRequest.mockResponse = .success(etag: nil, data: Data())
         mockEtagStorage.set(etag: "test", for: .surrogates)
         
         let loader = ContentBlockerLoader(etagStorage: mockEtagStorage)
-        XCTAssertTrue(loader.checkForUpdates(dataSource: mockRequest))
-        
-        XCTAssertEqual(mockEtagStorage.etags[.surrogates], "test")
-        
-        loader.applyUpdate(to: mockStorageCache)
-        
-        XCTAssertEqual(mockEtagStorage.etags[.surrogates], "test")
-        
-        XCTAssertNotNil(mockStorageCache.processedUpdates[.surrogates])
+        XCTAssertFalse(loader.checkForUpdates(dataSource: mockRequest))
     }
     
     func testWhenStoringFailsThenEtagIsNotStored() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1202366066612128
Tech Design URL:
CC:

**Description**:

Make sure response returned correct etag before processing data.
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Smoke tests of configuration downloading.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
