### PR TITLE
Lazy load fire button animation and decouple preloading from the app startup

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -103,7 +103,7 @@ class MainViewController: UIViewController {
     
     let gestureBookmarksButton = GestureToolbarButton()
     
-    private var fireButtonAnimator: FireButtonAnimator?
+    private lazy var fireButtonAnimator: FireButtonAnimator =  = FireButtonAnimator(appSettings: appSettings)
     
     private lazy var bookmarksCachingSearch: BookmarksCachingSearch = CoreDependencyProvider.shared.bookmarksCachingSearch
 
@@ -140,7 +140,6 @@ class MainViewController: UIViewController {
         loadInitialView()
         previewsSource.prepare()
         addLaunchTabNotificationObserver()
-        fireButtonAnimator = FireButtonAnimator(appSettings: appSettings)
 
         findInPageView.delegate = self
         findInPageBottomLayoutConstraint.constant = 0
@@ -1636,7 +1635,7 @@ extension MainViewController: AutoClearWorker {
         
         tabManager.prepareAllTabsExceptCurrentForDataClearing()
         
-        fireButtonAnimator?.animate {
+        fireButtonAnimator.animate {
             self.tabManager.prepareCurrentTabForDataClearing()
             
             self.stopAllOngoingDownloads()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -103,7 +103,7 @@ class MainViewController: UIViewController {
     
     let gestureBookmarksButton = GestureToolbarButton()
     
-    private lazy var fireButtonAnimator: FireButtonAnimator =  = FireButtonAnimator(appSettings: appSettings)
+    private lazy var fireButtonAnimator: FireButtonAnimator = FireButtonAnimator(appSettings: appSettings)
     
     private lazy var bookmarksCachingSearch: BookmarksCachingSearch = CoreDependencyProvider.shared.bookmarksCachingSearch
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -507,6 +507,8 @@ class MainViewController: UIViewController {
     @IBAction func onFirePressed() {
         Pixel.fire(pixel: .forgetAllPressedBrowsing)
         
+        wakeLazyFireButtonAnimator()
+        
         if let spec = DaxDialogs.shared.fireButtonEducationMessage() {
             performSegue(withIdentifier: "ActionSheetDaxDialog", sender: spec)
         } else {
@@ -518,10 +520,18 @@ class MainViewController: UIViewController {
     }
     
     func onQuickFirePressed() {
+        wakeLazyFireButtonAnimator()
+        
         self.forgetAllWithAnimation {}
         self.dismiss(animated: true)
         if KeyboardSettings().onAppLaunch {
             self.enterSearch()
+        }
+    }
+    
+    private func wakeLazyFireButtonAnimator() {
+        DispatchQueue.main.async {
+            _ = self.fireButtonAnimator
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202389859384867/f

**Description**:
The fire button animation is preloaded by FireButtonAnimator and it is triggered from the MainViewController's viewDidLoad method. Due to the Lottie version change (its implementation changed from Obj-C to Swift) it impacted the processing time for loading the animation from the JSON file. This combined impacted the app's launch time.

Proposal
- Make the FireButtonAnimator lazy loaded
- Wake it on FireButton press so it is preloaded on first use (it will not impact UX as we first show action sheet and then fire the animation upon confirmation)

**Steps to test this PR**:
- After fresh app start try as quickly as possible try triggering the fire animation
- It should play without delay and there should not be any lag while it is preloaded for the first time when showing the action sheet
- There should be no lag and the animation should run when triggering the fire button from the keyboard on first use after restart

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone
* [ ] iPad


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
