### PR TITLE
Cleanup related to fix for widget not showing favorites when favicons are too large

### DIFF
--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -158,13 +158,10 @@ public class Favicons {
                 return
             }
 
-            let group = DispatchGroup()
             files.forEach { file in
-                group.enter()
                 guard let data = (try? Data(contentsOf: file)),
                       let image = UIImage(data: data),
                       !self.isValidImage(image, forMaxSize: size) else {
-                    group.leave()
                     return
                 }
 
@@ -172,9 +169,7 @@ public class Favicons {
                 if let data = resizedImage.pngData() {
                     try? data.write(to: file)
                 }
-                group.leave()
             }
-            group.wait()
 
             Constants.bookmarksCache.clearMemoryCache()
             self.sizeNeedsMigration = false


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1202381793018418
Tech Design URL:
CC: @jaceklyp 

**Description**:
After discussion with @jaceklyp this PR is a small cleanup to remove DispatchGroup code from favicons migration resize.

I wavered on whether DispatchGroup should be included in my 1st PR for this issue and decided to include for safety in case it prevented any other app issues (race conditions) I might not be aware of as another Favicon migration call included this.   After discussion with @jaceklyp I'm removing + agree conceptually it is not needed. I've added a smoke test to steps 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Install the app on device from last release and add twitter.com as a favorite. Add widget to your home screen and confirm the favicons are not loading in the widget. Also confirm in Debug > Image Cache that the bookmark cache image for twitter.com is 1024x1024
2. Install the app on the same device from this branch / PR 
3. Confirm that the widget now displays favicons
4. Confirm in Debug > Image Cache that the bookmark cache image for twitter.com is now 192x192
5. Visit si.com (which has a 512x512 favicon) in browser and add to favorites. 
6. Confirm in Debug > Image Cache that its favicon size in both bookmarks and tabs caches is 192x192
7. Perform general smoke test to ensure no app functionality is impacted especially regarding app launch time, the loading of webpages and saving favorites + bookmarks

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
