### PR TITLE
Fix incorrect fire button prompt about ongoing downloads after opening non-HTML file in a tab

### DIFF
--- a/DuckDuckGo/ForgetDataAlert.swift
+++ b/DuckDuckGo/ForgetDataAlert.swift
@@ -42,6 +42,8 @@ class ForgetDataAlert {
     }
     
     static private func ongoingDownloadsInProgress() -> Bool {
-        !AppDependencyProvider.shared.downloadManager.downloadList.isEmpty
+        let allDownloads = AppDependencyProvider.shared.downloadManager.downloadList
+        let ongoingDownloads = allDownloads.filter { $0.state == .running && !$0.temporary }
+        return !ongoingDownloads.isEmpty
     }
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1112,6 +1112,7 @@ extension TabViewController: WKNavigationDelegate {
                                                                              cookieStore: cookieStore,
                                                                              temporary: true)
         } else {
+            temporaryDownloadForPreviewedFile?.cancel()
             temporaryDownloadForPreviewedFile = nil
         }
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -903,6 +903,7 @@ class TabViewController: UIViewController {
     }
     
     deinit {
+        temporaryDownloadForPreviewedFile?.cancel()
         removeMessageHandlers()
         removeObservers()
     }


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/0/414709148257752/1202245567032288/f
Tech Design URL:
CC:

**Description**:
- when tapping fire button while there are ongoing downloads the fire button has additional description that the ongoing downloads will also be cancelled ("This will also cancel downloads in progress")
- the condition checks if the Download Manager's queue has any download object
- to enable sharing the files opened in a tab (e.g. PDFs) we create a temporary download object for this file. The download object is not fired, it contains the metadata, and the download is started when tapping share button
- due to faulty logic the "not started" download object is recognised as unfinished download triggering the wrong fire button description
- closing the tab or navigating to other tab is not removing this temporary download object from the download manager either (it is cleaned from the tab)

**Scenarios to test this PR**:
Scenario 1: 
1. Open a PDF, e.g. any from the list https://filesamples.com/formats/pdf
2. Wait for the document to fully load.
3. Tap the fire button 
Result: Alert should not display Downloads related prompt

Scenario 2: 
1. Open a PDF, e.g. any from the list https://filesamples.com/formats/pdf
2. Wait for the document to fully load.
3. Navigate to any other webpage (normal HTML page, not document)
4. Tap the fire button (Alert should not display Downloads related prompt)
Result: Alert should not display Downloads related prompt

Scenario 3: 
1. Open a PDF, e.g. any from the list https://filesamples.com/formats/pdf
2. Wait for the document to fully load.
3. Close the tab
4. Tap the fire button
Result: Alert should not display Downloads related prompt

Scenario 4: 
1. Trigger file download (most preferably large) e.g. from https://www.thinkbroadband.com/download
2. Before the download completes tap the fire button
Result: Alert should display Downloads related prompt


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
