### PR TITLE
Fix Bookmark editing crash with Swipe-to-delete control

### DIFF
--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -96,7 +96,7 @@ class BookmarksViewController: UITableViewController {
     
     @objc func dataDidChange(notification: Notification) {
         tableView.reloadData()
-        if currentDataSource.isEmpty && tableView.isEditing {
+        if currentDataSource.isEmpty && isEditingBookmarks {
             finishEditing()
         }
         refreshEditButton()
@@ -125,7 +125,7 @@ class BookmarksViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = currentDataSource.item(at: indexPath) else { return }
         
-        if tableView.isEditing {
+        if isEditingBookmarks {
             tableView.deselectRow(at: indexPath, animated: true)
             if let bookmark = item as? Bookmark {
                 performSegue(withIdentifier: "AddOrEditBookmark", sender: bookmark)
@@ -272,7 +272,7 @@ class BookmarksViewController: UITableViewController {
     private func configureToolbarMoreItem() {
         guard #available(iOS 14, *) else { return }
 
-        if tableView.isEditing {
+        if isEditingBookmarks {
             if toolbarItems?.count ?? 0 >= 5 {
                 toolbarItems?.remove(at: 4)
                 toolbarItems?.remove(at: 3)
@@ -288,9 +288,9 @@ class BookmarksViewController: UITableViewController {
     }
 
     private func refreshEditButton() {
-        if (currentDataSource.isEmpty && !tableView.isEditing) || currentDataSource === searchDataSource {
+        if (currentDataSource.isEmpty && !isEditingBookmarks) || currentDataSource === searchDataSource {
             disableEditButton()
-        } else if !tableView.isEditing {
+        } else if !isEditingBookmarks {
             enableEditButton()
         }
     }
@@ -305,7 +305,7 @@ class BookmarksViewController: UITableViewController {
 
     @available(iOS 14.0, *)
     private func refreshMoreButton() {
-        if tableView.isEditing || currentDataSource === searchDataSource  || dataSource.folder != nil {
+        if isEditingBookmarks || currentDataSource === searchDataSource  || dataSource.folder != nil {
             disableMoreButton()
         } else {
             enableMoreButton()
@@ -329,7 +329,7 @@ class BookmarksViewController: UITableViewController {
     }
     
     @IBAction func onEditPressed(_ sender: UIBarButtonItem) {
-        if tableView.isEditing {
+        if isEditingBookmarks {
             finishEditing()
         } else {
             startEditing()
@@ -451,15 +451,16 @@ class BookmarksViewController: UITableViewController {
         }
     }
 
+    // when swipe-to-delete control is shown tableView.isEditing is true
+    private var isEditingBookmarks: Bool = false
     private func startEditing() {
-        guard !tableView.isEditing else {
-            return
-        }
+        assert(!isEditingBookmarks)
 
         // necessary in case a cell is swiped (which would mean isEditing is already true, and setting it again wouldn't do anything)
         tableView.isEditing = false
         
         tableView.isEditing = true
+        self.isEditingBookmarks = true
         changeEditButtonToDone()
         if #available(iOS 14, *) {
             configureToolbarMoreItem()
@@ -473,6 +474,7 @@ class BookmarksViewController: UITableViewController {
         }
 
         tableView.isEditing = false
+        self.isEditingBookmarks = false
         refreshEditButton()
         enableDoneButton()
         if #available(iOS 14, *) {

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -270,18 +270,20 @@ class BookmarksViewController: UITableViewController {
     }
 
     private func configureToolbarMoreItem() {
-        if #available(iOS 14, *) {
-            if tableView.isEditing {
-                if toolbarItems?.count ?? 0 >= 5 {
-                    toolbarItems?.remove(at: 4)
-                    toolbarItems?.remove(at: 3)
-                }
-            } else {
+        guard #available(iOS 14, *) else { return }
+
+        if tableView.isEditing {
+            if toolbarItems?.count ?? 0 >= 5 {
+                toolbarItems?.remove(at: 4)
+                toolbarItems?.remove(at: 3)
+            }
+        } else {
+            if toolbarItems?.contains(moreBarButtonItem) == false {
                 let flexibleSpace = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: self, action: nil)
                 toolbarItems?.insert(flexibleSpace, at: 3)
                 toolbarItems?.insert(moreBarButtonItem, at: 4)
-                refreshMoreButton()
             }
+            refreshMoreButton()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: 
- https://app.asana.com/0/414709148257752/1202232885673989/f
- https://app.asana.com/0/414709148257752/1202232885673991/f

GH Issue URL: 
- https://github.com/duckduckgo/iOS/issues/1195 
- https://github.com/duckduckgo/iOS/issues/1194

Tech Design URL:
CC: @miasma13 

**Description**:
Fix crash happening after Swipe to Delete after Edit Bookmarks mode
Allow entering Edit mode while swipe-to-delete control is displayed

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Swipe to delete on a bookmark (but don't delete)
2. Press edit
Should enter editing mode and not crash

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
