### PR TITLE
Autofill modal navigation changes

### DIFF
--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -20,6 +20,7 @@
 import UIKit
 import Combine
 import Core
+import BrowserServicesKit
 
 @available(iOS 14.0, *)
 protocol AutofillLoginSettingsListViewControllerDelegate: AnyObject {
@@ -91,6 +92,12 @@ final class AutofillLoginSettingsListViewController: UIViewController {
         super.setEditing(editing, animated: animated)
 
         tableView.setEditing(editing, animated: animated)
+    }
+    
+    func showAccountDetails(_ account: SecureVaultModels.WebsiteAccount, animated: Bool = true) {
+        let detailsController = AutofillLoginDetailsViewController(account: account, authenticator: viewModel.authenticator)
+        detailsController.delegate = self
+        navigationController?.pushViewController(detailsController, animated: animated)
     }
     
     private func setupCancellables() {
@@ -256,10 +263,7 @@ extension AutofillLoginSettingsListViewController: UITableViewDelegate {
         switch viewModel.sections[indexPath.section] {
         case .credentials(_, let items):
             let item = items[indexPath.row]
-            let detailsController = AutofillLoginDetailsViewController(account: item.account, authenticator: viewModel.authenticator)
-            detailsController.delegate = self
-            navigationController?.pushViewController(detailsController, animated: true)
-            
+            showAccountDetails(item.account)
         default:
             break
         }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -816,7 +816,15 @@ class MainViewController: UIViewController {
         let autofillSettingsViewController = AutofillLoginSettingsListViewController(appSettings: appSettings)
         autofillSettingsViewController.delegate = self
         let navigationController = UINavigationController(rootViewController: autofillSettingsViewController)
+        autofillSettingsViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(title: UserText.autofillNavigationButtonItemTitleClose,
+                                                                                          style: .plain,
+                                                                                          target: self,
+                                                                                          action: #selector(closeAutofillModal))
         self.present(navigationController, animated: true, completion: nil)
+    }
+    
+    @objc private func closeAutofillModal() {
+        dismiss(animated: true)
     }
     
     fileprivate func launchSettings() {

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -230,11 +230,20 @@ class SettingsViewController: UITableViewController {
         debugCell.isHidden = !shouldShowDebugCell
     }
         
-    private func showAutofill() {
+    private func showAutofill(animated: Bool = true) {
         if #available(iOS 14.0, *) {
             let autofillController = AutofillLoginSettingsListViewController(appSettings: appSettings)
             autofillController.delegate = self
-            navigationController?.pushViewController(autofillController, animated: true)
+            navigationController?.pushViewController(autofillController, animated: animated)
+        }
+    }
+    
+    func showAutofillAccountDetails(_ account: SecureVaultModels.WebsiteAccount, animated: Bool = true) {
+        if #available(iOS 14.0, *) {
+            let autofillController = AutofillLoginSettingsListViewController(appSettings: appSettings)
+            autofillController.delegate = self
+            navigationController?.pushViewController(autofillController, animated: animated)
+            autofillController.showAccountDetails(account, animated: animated)
         }
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1596,10 +1596,13 @@ extension TabViewController: WKNavigationDelegate {
     
     @available(iOS 14.0, *)
     private func showLoginDetails(with account: SecureVaultModels.WebsiteAccount) {
-        let autofill = AutofillLoginDetailsViewController(account: account, authenticator: AutofillLoginListAuthenticator())
-        let navigationController = UINavigationController(rootViewController: autofill)
-        autofill.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissLoginDetails))
-        self.present(navigationController, animated: true)
+        if let navController = SettingsViewController.loadFromStoryboard() as? UINavigationController,
+           let settingsController = navController.topViewController as? SettingsViewController {
+            settingsController.loadViewIfNeeded()
+            
+            settingsController.showAutofillAccountDetails(account, animated: false)
+            self.present(navController, animated: true)
+        }
     }
     
     @objc private func dismissLoginDetails() {

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -643,5 +643,5 @@ public struct UserText {
     public static let autofillLoginListAuthenticationReason = "Unlock To Use Saved Login" // Reason for auth when opening login list
     public static let autofillLoginDetailsDefaultTitle = "Login" // Title for autofill login details
     public static let autofillLoginDetailsEditTitle = "Edit Login" // Title when editing autofill login details
-
+    public static let autofillNavigationButtonItemTitleClose = "Close" // Title for close navigation button
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1202473712458857/f

**Description**:
Changes how the modal navigation works on Autofill, more specifically in:
* Add a close button on the autofill list if opened from the overflow menu
* When opening the credentials details from the toast confirmation view, the stack is now automatically pushed from Settings -> Autofill List -> Autofill details
 

**Steps to test this PR**:
Important, this is an Autofill PR, if you're testing on release mode, make sure to log-in with Duo first

1. Open autofill from the overflow menu, check if there is a close button on the top left
2. Tap the close button, check if it works correctly

--------
1. Save a new login (or update an existing one) using a website like [this](https://news.ycombinator.com/login?goto=news)
2. Tap on "View" on the notification toast
3. Check if the correct credential is presented
4. Check if the navigation stack respects Settings -> Autofill list -> Autofill details


**Device Testing**:

* [x] iPhone X

**OS Testing**:

* [x] iOS 14
* [x] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
