### PR TITLE
Make secure vault errors more specific

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -224,8 +224,10 @@ public enum PixelName: String {
 
     case autofillSettingsOpened = "m_autofill_settings_opened"
 
-    case secureVaultInitError = "m_secure_vault_init_error"
-    case secureVaultError = "m_secure_vault_error"
+    case secureVaultError = "m_secure-vault_error-unspecified"
+    
+    case secureVaultInitFailedError = "m_secure-vault_error_init-failed"
+    case secureVaultFailedToOpenDatabaseError = "m_secure-vault_error_failed-to-open-database"
 
     // MARK: SERP pixels
     

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -35,7 +35,7 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
         case .failedToOpenDatabase(let error):
             Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error)
         default:
-            Pixel.fire(pixel: .secureVaultError)
+            Pixel.fire(pixel: .secureVaultError, includedParameters: [])
 
         }
     }

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -30,8 +30,10 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
         guard !ProcessInfo().arguments.contains("testing") else { return }
 #endif
         switch error {
-        case .initFailed, .failedToOpenDatabase:
-            Pixel.fire(pixel: .secureVaultInitError)
+        case .initFailed(let error):
+            Pixel.fire(pixel: .secureVaultInitFailedError, error: error)
+        case .failedToOpenDatabase(let error):
+            Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error)
         default:
             Pixel.fire(pixel: .secureVaultError)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1202489927113794/f
Tech Design URL:
CC:

**Description**:
We have errors coming in, hard to know why, might just be brindy fucking about :D
But would like to know for sure, so this adds more info

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
This is hard to test since I can't force the errors, and ended up just making sure nothing is wrong with the pixels like this:
![Screenshot 2022-06-22 at 18 22 40](https://user-images.githubusercontent.com/1093508/175099905-33d3209d-ca09-42f5-a22d-4efacc7c6545.png)
Here's some code you can copy and paste:
```
let error = NSError(domain: "domain", code:200, userInfo:nil)
SecureVaultErrorReporter.shared.secureVaultInitFailed(SecureVaultError.failedToOpenDatabase(cause: error))
SecureVaultErrorReporter.shared.secureVaultInitFailed(SecureVaultError.initFailed(cause: error))
SecureVaultErrorReporter.shared.secureVaultInitFailed(SecureVaultError.generalCryptoError)
```
Use something like Charles proxy to check the pixels fire with the error code and domain in there as params

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
