### PR TITLE
Move secure vault to group + pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -228,6 +228,11 @@ public enum PixelName: String {
     
     case secureVaultInitFailedError = "m_secure-vault_error_init-failed"
     case secureVaultFailedToOpenDatabaseError = "m_secure-vault_error_failed-to-open-database"
+    
+    // The pixels are for debugging a specific problem and should be removed when resolved
+    // https://app.asana.com/0/0/1202498365125439/f
+    case secureVaultIsEnabledCheckedWhenEnabled = "m_secure-vault_is-enabled-checked_when-enabled"
+    case secureVaultIsEnabledCheckedWhenDisabled = "m_secure-vault_is-enabled-checked_when-disabled"
 
     // MARK: SERP pixels
     
@@ -356,6 +361,8 @@ public struct PixelParameters {
     public static let fileSizeGreaterThan10MB = "file_size_greater_than_10mb"
     
     public static let bookmarkCount = "bco"
+    
+    public static let isBackgrounded = "is_backgrounded"
 }
 
 public struct PixelValues {

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -363,6 +363,8 @@ public struct PixelParameters {
     public static let bookmarkCount = "bco"
     
     public static let isBackgrounded = "is_backgrounded"
+    
+    public static let isInternalUser = "is_internal_user"
 }
 
 public struct PixelValues {
@@ -376,6 +378,10 @@ public class Pixel {
     private struct Constants {
         static let tablet = "tablet"
         static let phone = "phone"
+    }
+    
+    private static var isInternalUser: Bool {
+        DefaultFeatureFlagger().isInternalUser
     }
 
     public enum QueryParameters {
@@ -399,6 +405,9 @@ public class Pixel {
         }
         if isDebugBuild {
             newParams[PixelParameters.test] = PixelValues.test
+        }
+        if isInternalUser {
+            newParams[PixelParameters.isInternalUser] = "true"
         }
         
         let url: URL
@@ -438,6 +447,10 @@ extension Pixel {
             newParams[PixelParameters.underlyingErrorCode] = "\(sqlErrorCode.intValue)"
             newParams[PixelParameters.underlyingErrorDomain] = "NSSQLiteErrorDomain"
         }
+        if isInternalUser {
+            newParams[PixelParameters.isInternalUser] = "true"
+        }
+        
         fire(pixel: pixel, withAdditionalParameters: newParams, includedParameters: [], onComplete: onComplete)
     }
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7098,8 +7098,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				kind = exactVersion;
-				version = 16.0.0;
+				kind = revision;
+				revision = 457169c31ab9002112d0500a6f754442bca557b6;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7098,8 +7098,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				kind = revision;
-				revision = 457169c31ab9002112d0500a6f754442bca557b6;
+				branch = "feature/elle/move-secure-vault-to-group";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7098,8 +7098,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				branch = "feature/elle/move-secure-vault-to-group";
-				kind = branch;
+				kind = exactVersion;
+				version = 17.0.0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo/DuckDuckGo.entitlements
+++ b/DuckDuckGo/DuckDuckGo.entitlements
@@ -8,8 +8,9 @@
 	<array>
 		<string>$(GROUP_ID_PREFIX).bookmarks</string>
 		<string>$(GROUP_ID_PREFIX).contentblocker</string>
-		<string>$(GROUP_ID_PREFIX).statistics</string>
 		<string>$(GROUP_ID_PREFIX).database</string>
+		<string>$(GROUP_ID_PREFIX).statistics</string>
+		<string>group.com.duckduckgo.vault</string>
 	</array>
 </dict>
 </plist>

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -29,11 +29,13 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
 #if DEBUG
         guard !ProcessInfo().arguments.contains("testing") else { return }
 #endif
+        let isBackgrounded = UIApplication.shared.applicationState == .background
+        let pixelParams = [PixelParameters.isBackgrounded: isBackgrounded ? "true" : "false"]
         switch error {
         case .initFailed(let error):
-            Pixel.fire(pixel: .secureVaultInitFailedError, error: error)
+            Pixel.fire(pixel: .secureVaultInitFailedError, error: error, withAdditionalParameters: pixelParams)
         case .failedToOpenDatabase(let error):
-            Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error)
+            Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error, withAdditionalParameters: pixelParams)
         default:
             Pixel.fire(pixel: .secureVaultError, includedParameters: [])
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1976,6 +1976,18 @@ extension TabViewController: SecureVaultManagerDelegate {
         SecureVaultErrorReporter.shared.secureVaultInitFailed(error)
     }
     
+    func secureVaultManagerIsEnabledStatus(_: SecureVaultManager) -> Bool {
+        let isEnabled = featureFlagger.isFeatureOn(.autofill)
+        let isBackgrounded = UIApplication.shared.applicationState == .background
+        let pixelParams = [PixelParameters.isBackgrounded: isBackgrounded ? "true" : "false"]
+        if isEnabled {
+            Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenEnabled, withAdditionalParameters: pixelParams)
+        } else {
+            Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenDisabled, withAdditionalParameters: pixelParams)
+        }
+        return isEnabled
+    }
+    
     func secureVaultManager(_ vault: SecureVaultManager, promptUserToStoreAutofillData data: AutofillData) {
         if let credentials = data.credentials, isAutofillEnabled {
             presentSavePasswordModal(with: vault, credentials: credentials)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
**Important note. This PR introduces a new group, which affects certs and stuff**

See BSK PR for what that does
This also:
- Adds two additional pixels to see if the check for secure vault being available is being spammed
- Adds param to see if the app is backgrounded, this will help us get more certainty on the secure vault errors
- Adds a param if the user is internal, so in future if an error pixel is only firing for internal users we can calm down

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. The most important thing to test is that autofill still works with the app group/write ahead logging. See here for autofill testing steps: https://github.com/duckduckgo/iOS/pull/1184
2. Check that all pixels have the is internal user flag. 
3. In FeatureFlagger, hard code internal user to false, pixels should not have the param at all (not even set to false)4. 
4. When you load a page check that "m_secure-vault_is-enabled-checked_when-enabled" and "m_secure-vault_is-enabled-checked_when-disabled" are being sent appropriately (hard code it off in FeatureFlagger to check the latter). Check they also have the isBackgrounded flag5. 
5. See https://github.com/duckduckgo/iOS/pull/1212 to test secure vault error pixels, check they have the isBackgrounded param6. 
<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 13
* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
