### PR TITLE
Revert "Move secure vault to group + pixels (#1217)"

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -510,11 +510,6 @@ extension Pixel.Event {
             
         case .secureVaultInitFailedError: return "m_secure-vault_error_init-failed"
         case .secureVaultFailedToOpenDatabaseError: return "m_secure-vault_error_failed-to-open-database"
-        
-        // The pixels are for debugging a specific problem and should be removed when resolved
-        // https://app.asana.com/0/0/1202498365125439/f
-        case .secureVaultIsEnabledCheckedWhenEnabled: return "m_secure-vault_is-enabled-checked_when-enabled"
-        case .secureVaultIsEnabledCheckedWhenDisabled: return "m_secure-vault_is-enabled-checked_when-disabled"
             
         // MARK: SERP pixels
             

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -230,11 +230,6 @@ extension Pixel {
         case secureVaultInitFailedError
         case secureVaultFailedToOpenDatabaseError
         
-        // The pixels are for debugging a specific problem and should be removed when resolved
-        // https://app.asana.com/0/0/1202498365125439/f
-        case secureVaultIsEnabledCheckedWhenEnabled
-        case secureVaultIsEnabledCheckedWhenDisabled
-        
         // MARK: SERP pixels
         
         case serpRequerySame

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7114,8 +7114,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				branch = "revert-113-elle/move-secure-vault-to-group";
-				kind = branch;
+				kind = exactVersion;
+				version = 18.0.0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7114,8 +7114,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit.git";
 			requirement = {
-				kind = exactVersion;
-				version = 17.0.2;
+				branch = "revert-113-elle/move-secure-vault-to-group";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo/DuckDuckGo.entitlements
+++ b/DuckDuckGo/DuckDuckGo.entitlements
@@ -8,9 +8,8 @@
 	<array>
 		<string>$(GROUP_ID_PREFIX).bookmarks</string>
 		<string>$(GROUP_ID_PREFIX).contentblocker</string>
-		<string>$(GROUP_ID_PREFIX).database</string>
 		<string>$(GROUP_ID_PREFIX).statistics</string>
-		<string>group.com.duckduckgo.vault</string>
+		<string>$(GROUP_ID_PREFIX).database</string>
 	</array>
 </dict>
 </plist>

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -29,13 +29,11 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
 #if DEBUG
         guard !ProcessInfo().arguments.contains("testing") else { return }
 #endif
-        let isBackgrounded = UIApplication.shared.applicationState == .background
-        let pixelParams = [PixelParameters.isBackgrounded: isBackgrounded ? "true" : "false"]
         switch error {
         case .initFailed(let error):
-            Pixel.fire(pixel: .secureVaultInitFailedError, error: error, withAdditionalParameters: pixelParams)
+            Pixel.fire(pixel: .secureVaultInitFailedError, error: error)
         case .failedToOpenDatabase(let error):
-            Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error, withAdditionalParameters: pixelParams)
+            Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error)
         default:
             Pixel.fire(pixel: .secureVaultError, includedParameters: [])
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2010,18 +2010,6 @@ extension TabViewController: SecureVaultManagerDelegate {
         SecureVaultErrorReporter.shared.secureVaultInitFailed(error)
     }
     
-    func secureVaultManagerIsEnabledStatus(_: SecureVaultManager) -> Bool {
-        let isEnabled = featureFlagger.isFeatureOn(.autofill)
-        let isBackgrounded = UIApplication.shared.applicationState == .background
-        let pixelParams = [PixelParameters.isBackgrounded: isBackgrounded ? "true" : "false"]
-        if isEnabled {
-            Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenEnabled, withAdditionalParameters: pixelParams)
-        } else {
-            Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenDisabled, withAdditionalParameters: pixelParams)
-        }
-        return isEnabled
-    }
-    
     func secureVaultManager(_ vault: SecureVaultManager, promptUserToStoreAutofillData data: AutofillData) {
         if let credentials = data.credentials, isAutofillEnabled {
             presentSavePasswordModal(with: vault, credentials: credentials)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1202546257736894/f

**Description**:
This reverts commit 90607594d16770ac870f540430e802bbc5ef98c1 (PR https://github.com/duckduckgo/iOS/pull/1217)
which introduced a crash when the app moved to the background.


**Steps to test this PR**:
1. Open App
2. Move it to the background
3. Wait around ~8 seconds
4. App should not crash

-------
1. Make sure autofill still works (testing steps here: https://github.com/duckduckgo/iOS/pull/1184)
-------

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
