### PR TITLE
Cleanup `BookmarkCell.willTransition`

### DIFF
--- a/DuckDuckGo/BookmarkCell.swift
+++ b/DuckDuckGo/BookmarkCell.swift
@@ -79,12 +79,8 @@ class BookmarkCell: UITableViewCell {
     var currentState: UITableViewCell.StateMask = []
     
     override func willTransition(to state: UITableViewCell.StateMask) {
-        currentState = state
         super.willTransition(to: state)
         currentState = state
-        if state == .showingEditControl {
-            
-        }
     }
 
     override func setEditing(_ editing: Bool, animated: Bool) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1202579604827022/f
Tech Design URL:
CC:

**Description**:
Cleanup `BookmarkCell.willTransition`.

- Remove empty `if` statement.
- Remove duplicate `currentState = state`.

Thanks.

**Device Testing**:

* [x] iPhone 8

**OS Testing**:

* [x] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
