### PR TITLE
Update GHA to not treat compilation failures as successful runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Build and test
       run: |
-        xcodebuild test \
+        set -o pipefail && xcodebuild test \
           -scheme "DuckDuckGo" \
           -destination "platform=iOS Simulator,name=iPhone 8" \
           | xcpretty -r junit -o unittests.xml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,6 @@ jobs:
 
     - name: Publish unit tests report
       uses: mikepenz/action-junit-report@v3
-      if: always() # always run even if the previous step fails
       with:
         report_paths: unittests.xml
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -129,7 +129,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ThemeManager.shared.updateUserInterfaceStyle(window: window)
 
         appIsLaunching = true
-        
         return true
     }
     // swiftlint:enable function_body_length

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -130,8 +130,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         appIsLaunching = true
         
-        invalidFunctionCall()
-        
         return true
     }
     // swiftlint:enable function_body_length

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -129,6 +129,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ThemeManager.shared.updateUserInterfaceStyle(window: window)
 
         appIsLaunching = true
+        
+        invalidFunctionCall()
+        
         return true
     }
     // swiftlint:enable function_body_length


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1202540647556934/f
Tech Design URL:
CC:

**Description**:

This PR updates our GitHub Actions workflow to fail when xcodebuild fails. The issue was that xcodebuild itself was failing, but it was piping output through to xcpretty which wasn't. The fix was to set `pipefail`.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Push a deliberate compilation failure to this branch and check that GitHub Actions fails
2. Remove the compilation failure and verify that GitHub Actions succeeds

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
