### PR TITLE
Prevent autofill prompt from stopping web events

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2229,7 +2229,11 @@ extension TabViewController: SecureVaultManagerDelegate {
     
     func secureVaultManager(_ vault: SecureVaultManager, promptUserToStoreAutofillData data: AutofillData) {
         if let credentials = data.credentials, isAutofillEnabled {
-            presentSavePasswordModal(with: vault, credentials: credentials)
+            // Add a delay to allow propagation of pointer events to the page
+            // see https://app.asana.com/0/1202427674957632/1202532842924584/f
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.presentSavePasswordModal(with: vault, credentials: credentials)
+            }
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202427674957632/1202532842924584/f
Tech Design URL: NA
CC: @shakyShane @Bunn 

**Description**:
Prevent autofill prompt from stopping web events.

**Steps to test this PR**:
1. Visit any login form, for example https://www.rei.com/YourAccountLoginView?toUrl=/yaRegistration
2. Insert a valid email and whatever password (you don't need to have an account, just use a realistic email)
3. Tap the Sign in button
4. You should be prompted to save the credentials, _and_ the form in the background page has been submitted (if you used random credentials the form will show an error)

**OS Testing**:

* [ ] iOS 14
* [x] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
