### PR TITLE
Arthur/improve concurrency gcd

### DIFF
--- a/Core/CoreDependencyProvider.swift
+++ b/Core/CoreDependencyProvider.swift
@@ -26,7 +26,7 @@ public protocol CoreDependencyProvided {
 /// Provides dependencies for objects that are not directly instantiated
 /// through `init` call
 public class CoreDependencyProvider: CoreDependencyProvided {
-    public static var shared: CoreDependencyProvided = CoreDependencyProvider()
+    public static let shared: CoreDependencyProvided = CoreDependencyProvider()
 
     public let bookmarksCachingSearch = BookmarksCachingSearch()
 }


### PR DESCRIPTION
Issues 

For consumeCookies function:
1. For loop will finish task one by one, there is no concurrency
2. “httpCookieStore.setCookie()” doesn’t have a escaping closure, so after this function returned the closure has finished, no escaping of anything, 
3. No need for DispatchGroup, cause the “group.wait()” function only runs after for loop has done all work, always return success.

For removeCookies function:
1. forEach() function will iterate the element one by one, only return after it finishes all task, also no concurrency here.
2. “cookieStore.delete()” function has no escaping closure, all work has been done when this function returns, no escaping of anything.
3. Still no need for the dispatch group here, cause the “group.wait()”function only runs after the forEach has finished iterating all elements, always return success.

For clear function:
1. For loop finish task one by one, no concurrency here.
2. “cookieStore.delete()” has no escaping closure, completion is finished after return, no need for DispatchGroup
3. “group.wait()” always starts after the for loop finish all things, will always return success, no need for group.wait().

For CoreDependencyProvider shared variable:
"var" can not guarantee the same singleton instance for all usages, must use "let" to fix that.

Solutions

For all the issues in these three functions: 
1. I put the delete cookies operation into concurrently work with Dispatch concurrent queue,
2.  delete the misuse of DispatchGroup
3. Remove some code that will never get called
