### PR TITLE
Add assert and pixel for catching fail scenario when downloaded file is not found

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -292,6 +292,8 @@ extension Pixel {
         case cachedTabPreviewsExceedsTabCount
         case cachedTabPreviewRemovalError
         
+        case missingDownloadedFile
+        
         case compilationResult(result: CompileRulesResult, waitTime: CompileRulesWaitTime, appState: AppState)
         
     }
@@ -572,6 +574,8 @@ extension Pixel.Event {
             
         case .cachedTabPreviewsExceedsTabCount: return "m_d_tpetc"
         case .cachedTabPreviewRemovalError: return "m_d_tpre"
+            
+        case .missingDownloadedFile: return "m_missing_downloaded_file"
             
         case .compilationResult(result: let result, waitTime: let waitTime, appState: let appState):
             return "m_compilation_result_\(result)_time_\(waitTime)_state_\(appState)"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -575,7 +575,7 @@ extension Pixel.Event {
         case .cachedTabPreviewsExceedsTabCount: return "m_d_tpetc"
         case .cachedTabPreviewRemovalError: return "m_d_tpre"
             
-        case .missingDownloadedFile: return "m_missing_downloaded_file"
+        case .missingDownloadedFile: return "m_d_missing_downloaded_file"
             
         case .compilationResult(result: let result, waitTime: let waitTime, appState: let appState):
             return "m_compilation_result_\(result)_time_\(waitTime)_state_\(appState)"

--- a/DuckDuckGo/URLDownloadSession.swift
+++ b/DuckDuckGo/URLDownloadSession.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import Core
 import Foundation
 import WebKit
 
@@ -68,6 +69,8 @@ extension URLDownloadSession: URLSessionTaskDelegate, URLSessionDownloadDelegate
             try FileManager.default.moveItem(at: location, to: tmpURL)
             self.location = tmpURL
         } catch {
+            Pixel.fire(pixel: .missingDownloadedFile, error: error)
+            assertionFailure("Failed to rename file in temp dir - downloaded file is missing")
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202675417049719/f
Tech Design URL:
CC:

**Description**:
Add assert and pixel for catching fail scenario when downloaded file is not found

