### PR TITLE
Fix for decision handler in decidePolicyForNavigationResponse not being always called

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -293,6 +293,7 @@ extension Pixel {
         case cachedTabPreviewRemovalError
         
         case missingDownloadedFile
+        case unhandledDownload
         
         case compilationResult(result: CompileRulesResult, waitTime: CompileRulesWaitTime, appState: AppState)
         
@@ -576,6 +577,7 @@ extension Pixel.Event {
         case .cachedTabPreviewRemovalError: return "m_d_tpre"
             
         case .missingDownloadedFile: return "m_d_missing_downloaded_file"
+        case .unhandledDownload: return "m_d_unhandled_download"
             
         case .compilationResult(result: let result, waitTime: let waitTime, appState: let appState):
             return "m_compilation_result_\(result)_time_\(waitTime)_state_\(appState)"

--- a/DuckDuckGo/DownloadMetadata.swift
+++ b/DuckDuckGo/DownloadMetadata.swift
@@ -26,21 +26,13 @@ struct DownloadMetadata {
     let mimeType: MIMEType
     let url: URL
     
-    init?(_ response: URLResponse, filename: String? = nil) {
-        guard let mimeType = response.mimeType,
-              let url = response.url else {
-                  return nil
-              }
-        
-        if let name = filename {
-            self.filename = name
-        } else {
-            self.filename = response.suggestedFilename ?? "unknown"
-        }
-        
+    init?(_ response: URLResponse, filename: String) {
+        guard let url = response.url else { return nil }
+
+        self.filename = filename
         self.expectedContentLength = response.expectedContentLength
-        self.mimeTypeSource = mimeType
-        self.mimeType = MIMEType(rawValue: mimeType) ?? .unknown
+        self.mimeTypeSource = response.mimeType ?? ""
+        self.mimeType = MIMEType(from: response.mimeType)
         self.url = url
     }
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1069,6 +1069,9 @@ extension TabViewController: WKNavigationDelegate {
                 } cancelHandler: {
                     decisionHandler(.cancel)
                 }
+            } else {
+                Pixel.fire(pixel: .unhandledDownload)
+                decisionHandler(.cancel)
             }
 
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202688062019256/f
Tech Design URL:
CC:

**Description**:
With release of 7.68.6 a crash was introduced related to download related refactoring. The reason for the crash is decision handler from the webView:decidePolicyForNavigationResponse:decisionHandler: method not being called in all logic flows which is mandated by WebKit.

