### PR TITLE
Revert PR#1214 to fix ActionMessageView crash when adding constraint

### DIFF
--- a/DuckDuckGo/ActionMessageView.swift
+++ b/DuckDuckGo/ActionMessageView.swift
@@ -32,8 +32,7 @@ class ActionMessageView: UIView {
         
         static var animationDuration: TimeInterval = 0.2
         static var duration: TimeInterval = 3.0
-
-        static let paddingFromNavBar: CGFloat = 30
+        
         static var windowBottomPadding: CGFloat {
             if UIDevice.current.userInterfaceIdiom == .phone && !isPortrait {
                 return 40
@@ -91,19 +90,7 @@ class ActionMessageView: UIView {
         }
         
         window.addSubview(messageView)
-        if window.rootViewController?.presentedViewController == nil,
-           let viewController = window.rootViewController?.children.first(where: { $0 is TabViewController }) {
-            window.addConstraint(NSLayoutConstraint(item: viewController.view!,
-                                                    attribute: .bottom,
-                                                    relatedBy: .equal,
-                                                    toItem: messageView,
-                                                    attribute: .bottom,
-                                                    multiplier: 1,
-                                                    constant: Constants.paddingFromNavBar))
-        } else {
-            window.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: messageView.bottomAnchor,
-                                                               constant: Constants.windowBottomPadding).isActive = true
-        }
+        window.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: messageView.bottomAnchor, constant: Constants.windowBottomPadding).isActive = true
         
         let messageViewWidth = window.frame.width <= Constants.maxWidth ? window.frame.width - Constants.minimumHorizontalPadding : Constants.maxWidth
         messageView.widthAnchor.constraint(equalToConstant: messageViewWidth).isActive = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202783782685842/f
Tech Design URL:
CC:

**Description**:
Earlier change introduced a timing issue prone to causing crash during adding constraint to a view controller's view that was being removed from the hierarchy. 
