### PR TITLE
Reduce voice-search icon touchable area

### DIFF
--- a/DuckDuckGo/Base.lproj/OmniBar.xib
+++ b/DuckDuckGo/Base.lproj/OmniBar.xib
@@ -88,7 +88,7 @@
                                     </constraints>
                                 </imageView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sek-4Y-GoT" customClass="SearchFieldContainerView" customModule="DuckDuckGo" customModuleProvider="target">
-                                    <rect key="frame" x="30" y="0.0" width="335" height="40"/>
+                                    <rect key="frame" x="30" y="0.0" width="345" height="40"/>
                                     <subviews>
                                         <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="4JV-px-Ypi" customClass="SiteRatingContainerView" customModule="DuckDuckGo" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="120" height="40"/>
@@ -153,7 +153,7 @@
                                             </connections>
                                         </view>
                                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fqM-N4-jNd" customClass="TextFieldWithInsets" customModule="DuckDuckGo" customModuleProvider="target">
-                                            <rect key="frame" x="30" y="0.0" width="305" height="40"/>
+                                            <rect key="frame" x="30" y="0.0" width="315" height="40"/>
                                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                             <accessibility key="accessibilityConfiguration" identifier="searchEntry">
                                                 <accessibilityTraits key="traits" searchField="YES"/>
@@ -194,11 +194,11 @@
                                     </connections>
                                 </view>
                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ita-iD-8ad" userLabel="Voice Button">
-                                    <rect key="frame" x="365" y="0.0" width="40" height="40"/>
+                                    <rect key="frame" x="375" y="5" width="30" height="30"/>
                                     <accessibility key="accessibilityConfiguration" label="Voice Search"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" priority="900" constant="40" id="80Y-p8-kj7"/>
-                                        <constraint firstAttribute="height" constant="40" id="HBn-w2-Tbm"/>
+                                        <constraint firstAttribute="width" priority="900" constant="30" id="80Y-p8-kj7"/>
+                                        <constraint firstAttribute="height" constant="30" id="HBn-w2-Tbm"/>
                                     </constraints>
                                     <state key="normal" image="MicrophoneSolid"/>
                                     <connections>

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -257,7 +257,7 @@ class OmniBar: UIView {
         rightButtonsSpacingConstraint.constant = state.hasLargeWidth ? 24 : 14
 
         if state.showVoiceSearch && state.showClear {
-            searchStackContainer.setCustomSpacing(8, after: voiceSearchButton)
+            searchStackContainer.setCustomSpacing(13, after: voiceSearchButton)
         }
         
         updateOmniBarPadding()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202735976093580/f

**Description**:
Reduce voice-search icon touchable area but keep padding

**Steps to test this PR**:
1. Check if voice-search button is working (Don't forget to enable it on settings)
2. You'll need to check a before and after. The spacing between the voice-search icon and the cancel button should not be different from the version on develop (I suggest taking a screenshot before testing this PR and another when running the PR)
3. The mic button size should now be 30 instead of 40

**Device Testing**:

* [x] iPhone
* [x] iPad


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
