### PR TITLE
Add extra pixels to debug core data crash

### DIFF
--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -775,10 +775,18 @@ extension BookmarksCoreDataStorage {
             
             let results = try? viewContext.fetch(fetchRequest)
             guard (results?.count ?? 0) <= 1 else {
+              
+                let count = results?.count ?? 0
+                let pixelParam = [PixelParameters.bookmarkFolderCount: "\(count)"]
+                
+                Pixel.fire(pixel: .debugBookmarkOrphanFolder, withAdditionalParameters: pixelParam)
+                Thread.sleep(forTimeInterval: 1)
                 fatalError("There shouldn't be an orphaned folder")
             }
             
             guard let folder = results?.first else {
+                Pixel.fire(pixel: .debugBookmarkTopLevelMissing)
+                Thread.sleep(forTimeInterval: 1)
                 fatalError("Top level folder missing")
             }
             
@@ -795,10 +803,17 @@ extension BookmarksCoreDataStorage {
             
             let results = try? viewContext.fetch(fetchRequest)
             guard (results?.count ?? 0) <= 1 else {
+                let count = results?.count ?? 0
+                let pixelParam = [PixelParameters.bookmarkFolderCount: "\(count)"]
+
+                Pixel.fire(pixel: .debugFavoriteOrphanFolder, withAdditionalParameters: pixelParam)
+                Thread.sleep(forTimeInterval: 1)
                 fatalError("There shouldn't be an orphaned folder")
             }
             
             guard let folder = results?.first else {
+                Pixel.fire(pixel: .debugFavoriteTopLevelMissing)
+                Thread.sleep(forTimeInterval: 1)
                 fatalError("Top level folder missing")
             }
             

--- a/Core/BookmarksCoreDataStorage.swift
+++ b/Core/BookmarksCoreDataStorage.swift
@@ -777,7 +777,7 @@ extension BookmarksCoreDataStorage {
             guard (results?.count ?? 0) <= 1 else {
               
                 let count = results?.count ?? 0
-                let pixelParam = [PixelParameters.bookmarkFolderCount: "\(count)"]
+                let pixelParam = [PixelParameters.bookmarkErrorOrphanedFolderCount: "\(count)"]
                 
                 Pixel.fire(pixel: .debugBookmarkOrphanFolder, withAdditionalParameters: pixelParam)
                 Thread.sleep(forTimeInterval: 1)
@@ -804,7 +804,7 @@ extension BookmarksCoreDataStorage {
             let results = try? viewContext.fetch(fetchRequest)
             guard (results?.count ?? 0) <= 1 else {
                 let count = results?.count ?? 0
-                let pixelParam = [PixelParameters.bookmarkFolderCount: "\(count)"]
+                let pixelParam = [PixelParameters.bookmarkErrorOrphanedFolderCount: "\(count)"]
 
                 Pixel.fire(pixel: .debugFavoriteOrphanFolder, withAdditionalParameters: pixelParam)
                 Thread.sleep(forTimeInterval: 1)

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -95,8 +95,7 @@ public struct PixelParameters {
     public static let emailKeychainError = "error"
     public static let emailKeychainKeychainStatus = "keychain_status"
     
-    //
-    public static let bookmarkFolderCount = "folder_count"
+    public static let bookmarkErrorOrphanedFolderCount = "bookmark_error_orphaned_count"
 }
 
 public struct PixelValues {

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -94,6 +94,9 @@ public struct PixelParameters {
     public static let emailKeychainAccessType = "access_type"
     public static let emailKeychainError = "error"
     public static let emailKeychainKeychainStatus = "keychain_status"
+    
+    //
+    public static let bookmarkFolderCount = "folder_count"
 }
 
 public struct PixelValues {

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -320,6 +320,10 @@ extension Pixel {
         case adAttributionLogicWrongVendorOnSuccessfulCompilation
         case adAttributionLogicWrongVendorOnFailedCompilation
         
+        case debugBookmarkOrphanFolder
+        case debugBookmarkTopLevelMissing
+        case debugFavoriteOrphanFolder
+        case debugFavoriteTopLevelMissing
     }
     
 }
@@ -613,6 +617,12 @@ extension Pixel.Event {
             return "m_compilation_result_\(result)_time_\(waitTime)_state_\(appState)"
             
         case .emailAutofillKeychainError: return "m_email_autofill_keychain_error"
+        
+        case .debugBookmarkOrphanFolder: return "m_d_bookmark_orphan_folder"
+        case .debugBookmarkTopLevelMissing: return "m_d_bookmark_top_level_missing"
+        
+        case .debugFavoriteOrphanFolder: return "m_d_favorite_orphan_folder"
+        case .debugFavoriteTopLevelMissing: return "m_d_bookmark_top_level_missing"
         
         // MARK: Ad Attribution
             


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1202790972018040/f 

**Description**:
New pixels added to help to identify where the crash is happening 

**Steps to test this PR**:
1. Manually change the conditions on the guard statements for them to fail
2. Check if the pixels are being correctly triggered


**Device Testing**:

* [x] iPhone

**OS Testing**:

* [x] iOS 15



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
