### PR TITLE
Fix debug pixel name

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -622,7 +622,7 @@ extension Pixel.Event {
         case .debugBookmarkTopLevelMissing: return "m_d_bookmark_top_level_missing"
         
         case .debugFavoriteOrphanFolder: return "m_d_favorite_orphan_folder"
-        case .debugFavoriteTopLevelMissing: return "m_d_bookmark_top_level_missing"
+        case .debugFavoriteTopLevelMissing: return "m_d_favorite_top_level_missing"
         
         // MARK: Ad Attribution
             


### PR DESCRIPTION
**Description**:
This is a simple pixel rename. Both `debugBookmarkTopLevelMissing` and `debugFavoriteTopLevelMissing` are triggering the `m_d_bookmark_top_level_missing` pixel, which is wrong.
`debugFavoriteTopLevelMissing` should trigger `m_d_favorite_top_level_missing` instead.