### PR TITLE
Fix for menu button state when opening new tab

### DIFF
--- a/DuckDuckGo/BrowsingMenu/BrowsingMenuAnimator.swift
+++ b/DuckDuckGo/BrowsingMenu/BrowsingMenuAnimator.swift
@@ -99,7 +99,12 @@ final class BrowsingMenuAnimator: NSObject, UIViewControllerAnimatedTransitionin
 
         fromViewController.view.isHidden = true
 
-        toViewController.presentedMenuButton.setState(.menuImage, animated: true)
+        if toViewController.homeController != nil {
+            toViewController.presentedMenuButton.setState(.bookmarksImage, animated: true)
+        } else {
+            toViewController.presentedMenuButton.setState(.menuImage, animated: true)
+        }
+
         UIView.animate(withDuration: Constants.dismissAnimationDuration, animations: {
             snapshot?.alpha = 0
             snapshot?.frame = Self.menuOriginFrameForAnimation(for: fromViewController)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1202891647826308/f
Tech Design URL:
CC:

**Description**:
When opening a new tab via the browsing menu, the far right toolbar button is the '...' button instead of the bookmarks button. As a result when tapped the browsing menu is displayed incorrectly (there is a screen recording of the issue in the Asana task)
<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open a new tab via the '...' toolbar button, by tapping the '+' button at the top of the browsing menu
2. Confirm the new tab that opens has the bookmarks button in the toolbar, not the '...' button
3. Confirm the bookmarks button works as expected
4. Load a webpage in the tab and confirm the button updates to the correct state i.e. '...'
5. Tap on the '...' button confirming the browsing menu displays correctly and that the toolbar buttons updates to 'x'
6. Dismiss the browsing menu and confirm button state returns to '...'
7. Generally open / close a few tabs, also via the tab switcher, open some bookmarks etc and navigate around web a little to confirm button state is always correct


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
