### PR TITLE
Only dismiss find-in-page on navigation start

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1400,11 +1400,6 @@ extension MainViewController: TabDelegate {
         closeTab(tab.tabModel)
     }
 
-    func tabDidStartLoading(_ tab: TabViewController) {
-        self.findInPageView.done()
-        self.tabLoadingStateDidChange(tab: tab)
-    }
-
     func tabLoadingStateDidChange(tab: TabViewController) {
         if currentTab == tab {
             refreshControls()
@@ -1498,6 +1493,15 @@ extension MainViewController: TabDelegate {
     func tabDidRequestFindInPage(tab: TabViewController) {
         updateFindInPage()
         _ = findInPageView?.becomeFirstResponder()
+    }
+
+    func closeFindInPage(tab: TabViewController) {
+        if tab === currentTab {
+            findInPageView.done()
+        } else {
+            tab.findInPage?.done()
+            tab.findInPage = nil
+        }
     }
     
     func tabDidRequestForgetAll(tab: TabViewController) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1400,9 +1400,12 @@ extension MainViewController: TabDelegate {
         closeTab(tab.tabModel)
     }
 
+    func tabDidStartLoading(_ tab: TabViewController) {
+        self.findInPageView.done()
+        self.tabLoadingStateDidChange(tab: tab)
+    }
+
     func tabLoadingStateDidChange(tab: TabViewController) {
-        findInPageView.done()
-        
         if currentTab == tab {
             refreshControls()
         }

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -42,7 +42,8 @@ protocol TabDelegate: AnyObject {
     func tab(_ tab: TabViewController,
              didRequestNewBackgroundTabForUrl url: URL,
              inheritingAttribution: AdClickAttributionLogic.State?)
-    
+
+    func tabDidStartLoading(_ tab: TabViewController)
     func tabLoadingStateDidChange(tab: TabViewController)
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage)
 

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -43,7 +43,6 @@ protocol TabDelegate: AnyObject {
              didRequestNewBackgroundTabForUrl url: URL,
              inheritingAttribution: AdClickAttributionLogic.State?)
 
-    func tabDidStartLoading(_ tab: TabViewController)
     func tabLoadingStateDidChange(tab: TabViewController)
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage)
 
@@ -62,6 +61,7 @@ protocol TabDelegate: AnyObject {
     func tabDidRequestSettings(tab: TabViewController)
     
     func tabDidRequestFindInPage(tab: TabViewController)
+    func closeFindInPage(tab: TabViewController)
 
     func tabContentProcessDidTerminate(tab: TabViewController)
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -125,11 +125,15 @@ class TabViewController: UIViewController {
     let userAgentManager: UserAgentManager = DefaultUserAgentManager.shared
 
     public var url: URL? {
+        willSet {
+            if newValue != url {
+                delegate?.closeFindInPage(tab: self)
+            }
+        }
         didSet {
             updateTabModel()
             delegate?.tabLoadingStateDidChange(tab: self)
             checkLoginDetectionAfterNavigation()
-            delegate?.closeFindInPage(tab: self)
         }
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1122,7 +1122,7 @@ extension TabViewController: WKNavigationDelegate {
         resetSiteRating()
         
         tabModel.link = link
-        delegate?.tabLoadingStateDidChange(tab: self)
+        delegate?.tabDidStartLoading(self)
 
         trackerNetworksDetectedOnPage.removeAll()
         pageHasTrackers = false
@@ -1504,8 +1504,6 @@ extension TabViewController: WKNavigationDelegate {
                 if let isDdg = self?.appUrls.isDuckDuckGoSearch(url: url), isDdg {
                     StatisticsLoader.shared.refreshSearchRetentionAtb()
                 }
-                
-                self?.findInPage?.done()
             }
             decisionHandler(decision)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1202735559936001
Tech Design URL:
CC: @miasma13 @brindy 

**Description**:
Changes Find In Page behaviour to only close on navigation start event instead of everly "loading state changed" event which may have leaded to unexpected Find In Page disappearing

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate Find In Page disappears when expected (on navigation events including non-reloading navigations like Asana) and does not disappear when unexpected (like on frame loading events or loading did finish events)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
