### PR TITLE
Autofill settings list grouping and ordering

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -644,6 +644,7 @@
 		F1F5337C1F26A9EF00D80D4F /* UserText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F5337B1F26A9EF00D80D4F /* UserText.swift */; };
 		F1F533841F26ABAC00D80D4F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F1F533861F26ABAC00D80D4F /* Localizable.strings */; };
 		F1FCF3B31F3550BD00C23128 /* APIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FCF3B11F354F7200C23128 /* APIRequestTests.swift */; };
+		F40F843728C939760081AE75 /* AutofillLoginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */; };
 		F4118EC52761725800CA91CA /* BookmarkSectionDataSources.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4118EC42761725800CA91CA /* BookmarkSectionDataSources.swift */; };
 		F4147354283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4147353283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift */; };
 		F41C2DA326C1925700F9A760 /* BookmarksAndFolders.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F41C2DA126C1925600F9A760 /* BookmarksAndFolders.xcdatamodeld */; };
@@ -2070,6 +2071,7 @@
 		F1EEAC4C1EAFC708006128D9 /* readme.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = readme.txt; sourceTree = "<group>"; };
 		F1F5337B1F26A9EF00D80D4F /* UserText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserText.swift; sourceTree = "<group>"; };
 		F1FCF3B11F354F7200C23128 /* APIRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIRequestTests.swift; sourceTree = "<group>"; };
+		F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillLoginListViewModelTests.swift; sourceTree = "<group>"; };
 		F4118EC42761725800CA91CA /* BookmarkSectionDataSources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSectionDataSources.swift; sourceTree = "<group>"; };
 		F4147353283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillContentScopeFeatureToggles.swift; sourceTree = "<group>"; };
 		F41C2DA226C1925700F9A760 /* BookmarksAndFolders.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = BookmarksAndFolders.xcdatamodel; sourceTree = "<group>"; };
@@ -3509,6 +3511,7 @@
 				F17669A21E411D63003D3222 /* Application */,
 				981FED7222045FFA008488D7 /* AutoClear */,
 				85E5602D26541D0900F4DC44 /* AutoComplete */,
+				F40F843228C92B1C0081AE75 /* Autofill */,
 				98559FD0267099F400A83094 /* ContentBlocker */,
 				83134D7F20E2E013006CE65D /* Feedback */,
 				8588026724E4249800C24AB6 /* iPad */,
@@ -4153,6 +4156,14 @@
 				31669B9928020A460071CC18 /* SaveLoginViewModel.swift */,
 			);
 			name = SaveLogin;
+			sourceTree = "<group>";
+		};
+		F40F843228C92B1C0081AE75 /* Autofill */ = {
+			isa = PBXGroup;
+			children = (
+				F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */,
+			);
+			name = Autofill;
 			sourceTree = "<group>";
 		};
 		F4118EC32761721D00CA91CA /* BookmarkDataSources */ = {
@@ -5279,6 +5290,7 @@
 				4BC21A2F27238B7500229F0E /* RunLoopExtensionTests.swift in Sources */,
 				851B1283221FE65E004781BC /* ImproveOnboardingExperiment1Tests.swift in Sources */,
 				F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */,
+				F40F843728C939760081AE75 /* AutofillLoginListViewModelTests.swift in Sources */,
 				C14882E827F20DAB00D59F0C /* TestDataLoader.swift in Sources */,
 				C14882EA27F20DD000D59F0C /* MockBookmarksCoreDataStorage.swift in Sources */,
 				981FED7422046017008488D7 /* AutoClearTests.swift in Sources */,

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -31,10 +31,18 @@ internal enum AutofillLoginListSectionType: Comparable {
     static func < (lhs: AutofillLoginListSectionType, rhs: AutofillLoginListSectionType) -> Bool {
         if case .credentials(let leftTitle, _) = lhs,
            case .credentials(let rightTitle, _) = rhs {
+            if leftTitle == miscSectionHeading {
+                return false
+            } else if rightTitle == miscSectionHeading {
+                return true
+            }
+            
             return leftTitle.localizedCaseInsensitiveCompare(rightTitle) == .orderedAscending
         }
         return true
     }
+    
+    static let miscSectionHeading = "#"
 }
 
 final class AutofillLoginListViewModel: ObservableObject {
@@ -225,7 +233,7 @@ internal extension Array where Element == SecureVaultModels.WebsiteAccount {
                 
                 key = String(deDistinctionedChar)
             } else {
-                key = "#"
+                key = AutofillLoginListSectionType.miscSectionHeading
             }
             
             return result[key, default: []].append(AutofillLoginListItemViewModel(account: account))

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -214,12 +214,21 @@ internal extension Array where Element == SecureVaultModels.WebsiteAccount {
     
     func autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter() -> [String: [AutofillLoginListItemViewModel]] {
         reduce(into: [String: [AutofillLoginListItemViewModel]]()) { result, account in
-            let firstChar = String(account.name.first ?? Character(""))
+            
             // Unfortunetly, folding doesn't produce perfect results despite respecting the system locale
             // E.g. Romainian should treat letters with diacritics as seperate letters, but folding doesn't
             // Apple's own apps (e.g. contacts) seem to suffer from the same problem
-            let deDistinctionedString = firstChar.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
-            return result[deDistinctionedString, default: []].append(AutofillLoginListItemViewModel(account: account))
+            let key: String
+            if let firstChar = account.name.first,
+               let deDistinctionedChar = String(firstChar).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil).first,
+               deDistinctionedChar.isLetter {
+                
+                key = String(deDistinctionedChar)
+            } else {
+                key = "#"
+            }
+            
+            return result[key, default: []].append(AutofillLoginListItemViewModel(account: account))
         }
     }
 }

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -345,6 +345,29 @@ extension AutofillLoginSettingsListViewController: UITableViewDataSource {
         viewModel.viewState == .showItems ? UILocalizedIndexedCollation.current().sectionIndexTitles : []
     }
     
+    func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
+        var closestSoFar = 0
+        var exactMatchIndex: Int?
+        for (index, section) in viewModel.sections.enumerated() {
+            if case .credentials(let sectionTitle, _) = section {
+                
+                if let first = title.first, !first.isLetter {
+                    return viewModel.sections.count - 1
+                }
+                
+                let result = sectionTitle.localizedCaseInsensitiveCompare(title)
+                if result == .orderedSame {
+                    exactMatchIndex = index
+                    break
+                } else if result == .orderedDescending {
+                    break
+                }
+            }
+            closestSoFar = index
+        }
+        return exactMatchIndex ?? closestSoFar
+    }
+    
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         switch viewModel.sections[indexPath.section] {
         case .credentials:

--- a/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -27,13 +27,25 @@ import XCTest
 class AutofillLoginListSectionTypeTests: XCTestCase {
     
     func testWhenComparedThenSortedCorrectly() {
-        let testData = [AutofillLoginListSectionType.credentials(title: "elephant", items: []),
-                        AutofillLoginListSectionType.credentials(title: "èlephant", items: []),
-                        AutofillLoginListSectionType.credentials(title: "Elephants", items: []),
-                        AutofillLoginListSectionType.credentials(title: "felephants", items: [])]
+        let testData = [AutofillLoginListSectionType.credentials(title: "e", items: []),
+                        AutofillLoginListSectionType.credentials(title: "E", items: []),
+                        AutofillLoginListSectionType.credentials(title: "è", items: []),
+                        AutofillLoginListSectionType.credentials(title: "f", items: [])]
         
         let result = testData.sorted()
         XCTAssertEqual(testData, result)
+    }
+    
+    func testWhenComparedThenSymbolsAreAtTheEnd() {
+        func testWhenComparedThenSortedCorrectly() {
+            let testData = [AutofillLoginListSectionType.credentials(title: "e", items: []),
+                            AutofillLoginListSectionType.credentials(title: "è", items: []),
+                            AutofillLoginListSectionType.credentials(title: "#", items: []),
+                            AutofillLoginListSectionType.credentials(title: "f", items: [])]
+            
+            let result = testData.sorted()
+            XCTAssertEqual(testData, result)
+        }
     }
 }
 
@@ -49,7 +61,7 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
     
-    func testWhenCreatingViewModelsThenNumbersAndSymbolsGroupCorrectly() {
+    func testWhenCreatingViewModelsThenNumbersAndSymbolsGroupedCorrectly() {
         let domain = "whateverNotImportantForThisTest"
         let testData = [SecureVaultModels.WebsiteAccount(title: nil, username: "1", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "0", domain: domain),
@@ -63,5 +75,26 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
         let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
         // All non letters should be grouped together
         XCTAssertEqual(result.count, 1)
+    }
+    
+    func testWhenCreatingSectionsThenTitlesWithinASectionAreSortedCorrectly() {
+        let domain = "whateverNotImportantForThisTest"
+        let testData = ["e": [
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephant", username: "1", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephants", username: "2", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "Elephant", username: "3", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "èlephant", username: "4", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "è", username: "5", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: nil, username: "ezy", domain: domain))]]
+        let result = testData.autofillLoginListSectionsForViewModelsSortedByTitle()
+        if case .credentials(_, let viewModels) = result[0] {
+            XCTAssertEqual(viewModels[0].title, "è")
+            XCTAssertEqual(viewModels[1].title, "elephant")
+            XCTAssertEqual(viewModels[2].title, "Elephant")
+            XCTAssertEqual(viewModels[3].title, "èlephant")
+            XCTAssertEqual(viewModels[4].title, "elephants")
+        } else {
+            XCTFail("Expected section did not exist")
+        }
     }
 }

--- a/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -39,13 +39,29 @@ class AutofillLoginListSectionTypeTests: XCTestCase {
 
 class AutofillLoginListItemViewModelTests: XCTestCase {
     
-    func testWhenCreatingViewModelsThenGroupedCorrectly() {
+    func testWhenCreatingViewModelsThenDiacriticsGroupedCorrectly() {
         let domain = "whateverNotImportantForThisTest"
         let testData = [SecureVaultModels.WebsiteAccount(title: nil, username: "c", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "ç", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "C", domain: domain)]
         let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
         // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
+        XCTAssertEqual(result.count, 1)
+    }
+    
+    func testWhenCreatingViewModelsThenNumbersAndSymbolsGroupCorrectly() {
+        let domain = "whateverNotImportantForThisTest"
+        let testData = [SecureVaultModels.WebsiteAccount(title: nil, username: "1", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "0", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "#", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "9", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "3asdasfd", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "~", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "?????", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "&%$£$%", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "99999", domain: domain)]
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
+        // All non letters should be grouped together
         XCTAssertEqual(result.count, 1)
     }
 }

--- a/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -1,0 +1,51 @@
+//
+//  AutofillLoginListViewModelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+import XCTest
+@testable import DuckDuckGo
+@testable import Core
+@testable import BrowserServicesKit
+
+class AutofillLoginListSectionTypeTests: XCTestCase {
+    
+    func testWhenComparedThenSortedCorrectly() {
+        let testData = [AutofillLoginListSectionType.credentials(title: "elephant", items: []),
+                        AutofillLoginListSectionType.credentials(title: "èlephant", items: []),
+                        AutofillLoginListSectionType.credentials(title: "Elephants", items: []),
+                        AutofillLoginListSectionType.credentials(title: "felephants", items: [])]
+        
+        let result = testData.sorted()
+        XCTAssertEqual(testData, result)
+    }
+}
+
+class AutofillLoginListItemViewModelTests: XCTestCase {
+    
+    func testWhenCreatingViewModelsThenGroupedCorrectly() {
+        let domain = "whateverNotImportantForThisTest"
+        let testData = [SecureVaultModels.WebsiteAccount(title: nil, username: "c", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "ç", domain: domain),
+                        SecureVaultModels.WebsiteAccount(title: nil, username: "C", domain: domain)]
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
+        // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
+        XCTAssertEqual(result.count, 1)
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202808746542215/f
Tech Design URL:
CC:

**Description**:
Fixes settings logins list grouping and ordering to follow the rules here: https://app.asana.com/0/0/1202719748114893/f (with the exception that # is at the bottom, as the iOS powers at be demand)
This means all non letters (numbers and symbols) should now be in a single group. Generally speaking diacritics should be  in the same group as the root letter.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Add a bunch of test data, including diacritics, symbols and numbers, and check that it groups correctly (see screenshots). Also check that they are sorted correctly, e.g. èlephant should be before elephants
1. Also check the section index works as expected

![Simulator Screen Shot - iPhone 13 - 2022-09-08 at 17 27 45](https://user-images.githubusercontent.com/1093508/189175810-07c8ac41-cc94-4715-9668-df5bccd359a4.png)
![Simulator Screen Shot - iPhone 13 - 2022-09-08 at 17 27 42](https://user-images.githubusercontent.com/1093508/189175821-384d9639-b99a-4a54-a250-95915d9fa840.png)


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
