### PR TITLE
Do not refresh page on Storage Cache update

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -851,9 +851,12 @@ class TabViewController: UIViewController {
         adClickAttributionLogic.onRulesChanged(latestRules: ContentBlocking.contentBlockingManager.currentRules)
     }
 
-    @objc func onStorageCacheChange() {
-        DispatchQueue.main.async {
-            self.reload(scripts: true)
+    @objc func onStorageCacheChange(notification: Notification) {
+        
+        if let cacheProvider = notification.object as? StorageCacheProvider {
+            DispatchQueue.main.async {
+                self.storageCache = cacheProvider.current
+            }
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1201931895486656
Tech Design URL:
CC:

**Description**:

We don't need to refresh the pate on storage cache update, as it doesn't contain anything that would justify that (e.g. privacy protections). Content Blocking stack handles refreshes on its own.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

1. Create conditions where storage cache is updated e.g. when TDS changes. 
2. Restart the app and see that page is not refreshed during initial loading.  

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


**Device Testing**:

* [ ] iPhone
* [ ] iPad


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
