### PR TITLE
Enable back button when app is active and user requested to open URL

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -292,6 +292,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             mainViewController?.loadQueryInNewTab(query, reuseExisting: true)
         } else if AppDeepLinks.isAddFavorite(url: url) {
             mainViewController?.startAddFavoriteFlow()
+        } else if app.applicationState == .active,
+                  let currentTab = mainViewController?.currentTab {
+            // If app is in active state, treat this navigation as something initiated form the context of the current tab.
+            mainViewController?.tab(currentTab,
+                                    didRequestNewTabForUrl: url,
+                                    openedByPage: true,
+                                    inheritingAttribution: nil)
         } else {
             Pixel.fire(pixel: .defaultBrowserLaunch)
             mainViewController?.loadUrlInNewTab(url, reuseExisting: true, inheritedAttribution: nil)


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1202933198359780
Tech Design URL:
CC:

**Description**:

Enable back button if new tab is opened through external call, but when app is in the active state (indicating request came from user action while app has been in the foreground).

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Select text, choose 'lookup'
2. Search term in Default browser.

Expected: new tab is opened with back button that can be used to close the tab.1
<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
