### PR TITLE
Fix empty voice search on iOS 16

### DIFF
--- a/DuckDuckGo/SpeechRecognizer.swift
+++ b/DuckDuckGo/SpeechRecognizer.swift
@@ -144,6 +144,10 @@ final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
             try audioEngine.start()
             
             self.recognitionTask = self.speechRecognizer?.recognitionTask(with: recognitionRequest) { [weak self] (result, error) in
+                guard let recognitionTask = self?.recognitionTask, !recognitionTask.isCancelled else {
+                    return
+                }
+                
                 var isFinal = false
                 var transcription: String?
                 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202599139452865/f
Tech Design URL:
CC:

**Description**:
Due to changes introduced in on-device speech recognition framework the result handler for `SFSpeechRecognitionTask` appears to be called even after it is cancelled. Those extraneous calls are with empty string result and thus override the query triggering loading of empty SERP. 
To avoid this scenario we should check if `SpeechRecognizer`'s internal state is coherent: that the speech recognition task is not cancelled and still assigned to a property before proceeding with processing the result. Otherwise the results are after reported after cancelling the task.

**Steps to test this PR**:
1. Make sure local voice search is enabled on your device (Settings -> Accessibility -> Voice Control -> Language and download appropriate language)
2. Tap voice search mic icon in the address bar
3. Speak the search phrase
4. SERP should load for the spoken query 

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
