### PR TITLE
Open Shortcuts app URLs with a confirmation dialog

### DIFF
--- a/Core/SchemeHandler.swift
+++ b/Core/SchemeHandler.swift
@@ -47,6 +47,7 @@ public class SchemeHandler {
         case itmsApps = "itms-apps"
         case itmsAppss = "itms-appss"
         case itunes
+        case shortcuts
     }
     
     private enum BlockedScheme: String {
@@ -68,7 +69,7 @@ public class SchemeHandler {
         }
 
         switch PlatformScheme(rawValue: schemeString) {
-        case .sms, .mailto, .itms, .itmss, .itunes, .itmsApps, .itmsAppss:
+        case .sms, .mailto, .itms, .itmss, .itunes, .itmsApps, .itmsAppss, .shortcuts:
             return .external(.askForConfirmation)
         case .none:
             return .unknown

--- a/Core/SchemeHandler.swift
+++ b/Core/SchemeHandler.swift
@@ -48,6 +48,8 @@ public class SchemeHandler {
         case itmsAppss = "itms-appss"
         case itunes
         case shortcuts
+        case shortcutsProduction = "shortcuts-production"
+        case workflow
     }
     
     private enum BlockedScheme: String {
@@ -69,7 +71,7 @@ public class SchemeHandler {
         }
 
         switch PlatformScheme(rawValue: schemeString) {
-        case .sms, .mailto, .itms, .itmss, .itunes, .itmsApps, .itmsAppss, .shortcuts:
+        case .sms, .mailto, .itms, .itmss, .itunes, .itmsApps, .itmsAppss, .shortcuts, .shortcutsProduction, .workflow:
             return .external(.askForConfirmation)
         case .none:
             return .unknown


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203051209824446/f
Tech Design URL:
CC:

**Description**:
We define platform schemes that prompt user for confirmation as opening those URLs redirects user to another app. iOS provides a `shortcuts` scheme for launching the Shortcuts app which should be handled in the same way.

**Steps to test this PR**:
1. Create on a simulator or device a shortcut with a predefined name (e.g. "Test shortcut")
2. On a static webpage or jsfiddle.net create a following link (provide the right name as the `name` parameter): 
`<a href="shortcuts://run-shortcut?name=Test%20shortcut">LINK</a>`
3. Tap the link to run the shortcut 4. 

**Device Testing**:
* [ ] iPhone
* [ ] iPad

**OS Testing**:
* [ ] iOS 14
* [x] iOS 15
* [x] iOS 16
