### PR TITLE
Translation for accessibility labels

### DIFF
--- a/DuckDuckGo/bg.lproj/Autocomplete.strings
+++ b/DuckDuckGo/bg.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Няма предложения";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Предложение за автоматично довършване";
+

--- a/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/DuckDuckGo/bg.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Отмяна";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Предложение за автоматично довършване";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Отметка";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Отваряне на уебсайта";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Търсене в DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Добавяне";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Включено";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Скриване на паролата";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Преглед";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Запазване на паролата?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Показване на паролата";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Актуализиране на данните за вход";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Блокирайте имейл тракерите и скрийте своя адрес";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Отмени";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Забележка: При премахване на защитата на имейла от устройството, вашият Duck адрес няма да бъде изтрит.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Премахване";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Да се премахне ли защитата на имейла?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Възникна грешка при включване в списъка с чакащи. Моля, опитайте отново по-късно.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Първи стъпки";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Имам код за покана";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Получихте покана!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Включване в списък с чакащи за личен адрес";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "В списъка с чакащи сте!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Вашата покана ще се покаже, когато сме готови. Искате ли %1$@, когато пристигне? %2$@ за защитата на имейли.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "да получите известие";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Ще ви изпратим известие, когато вашата защита на имейли е готова. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Научете повече";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Ще ви изпратим известие, когато можете да започнете да използвате защитата на имейла.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Искате ли да Ви изпратим известие, когато дойде Вашият ред?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Присъединихте се към списъка с чакащи и поискахте да ви уведомим, когато дойде вашият ред да изпробвате нашата функция за защита на имейл.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Не, благодаря";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "УВЕДОМЕТЕ МЕ";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Вашата покана за защита на имейл пристигна!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Ние не запазваме вашите имейли. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Поверителност на имейла с две думи.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Блокирайте имейл тракерите и скрийте своя адрес, без да променяте имейл доставчика си. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Все още няма добавени отметки";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "ОК";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Съобщение от %@:";
 

--- a/DuckDuckGo/cs.lproj/Autocomplete.strings
+++ b/DuckDuckGo/cs.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Žádné návrhy";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Použít návrh automatického doplňování";
+

--- a/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/DuckDuckGo/cs.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Vrátit";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Použít návrh automatického doplňování";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Záložka";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Otevřít webovou stránku";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Hledat na DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Přidat";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Aktivní";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Skrýt heslo";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Zobrazit";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Uložit heslo?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Zobrazit heslo";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Aktualizovat přihlašovací údaje";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokování trackerů v e-mailu a skrytí adresy";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Zrušit";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Poznámka: Když odeberete ochranu e-mailů z tohoto zařízení, vaše adresa Duck zůstane zachovaná.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Odstranit";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Odebrat ochranu e-mailů?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Při zařazování do pořadníku došlo k chybě, zkuste to znovu později";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Začínáme";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Mám zvací kód";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Přišla vám pozvánka";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Připojte se k soukromému pořadníku";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Jste v pořadníku";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Vaše pozvánka se tu objeví, až na vás budeme připravení. Chcete %1$@, až dorazí? %2$@ o ochraně e-mailů.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "dostat oznámení";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Pošleme vám oznámení, až pro vás bude ochrana e-mailů připravená. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Více informací";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Pošleme vám oznámení, až budete moct začít používat ochrana e-mailů.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Máme tě upozornit, až budeš na řadě?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Zapsali jste se do pořadníku a požádali nás, abychom vás upozornili, až budete moct vyzkoušet naši ochranu e-mailů.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Ne, děkuji";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "UPOZORNĚTE MĚ";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Vaše pozvánka k ochraně e-mailů je zde!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Vaše e-maily neukládáme. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-mailové soukromí, zjednodušené.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokujte e-mailové trackery a skryjte svou adresu bez nutnosti měnit poskytovatele e-mailu. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Zatím nebyly přidány žádné záložky.";
@@ -1172,7 +1121,7 @@
 "privacy.protection.no.other.third.party.domains.loaded" = "Nebyly načteny žádné požadavky třetích stran";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.adclickattribution" = "Protože nedávno došlo ke kliknutí na reklamu %@ na DuckDuckGo, byly načteny požadavky následujících domén. Tyto požadavky pomáhají vyhodnotit účinnost reklamy. Žádná reklama na DuckDuckGo nevytváří tvůj profil.";
+"privacy.protection.other.domains.adclickattribution" = "Protože nedávno došlo ke kliknutí na reklamu %@ na DuckDuckGo, byly načteny požadavky následujících domén. Tyhle požadavky pomáhají vyhodnocovat účinnost reklam. Žádná reklama na DuckDuckGo nevytváří tvůj profil.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.exceptions" = "Následující požadavky domény byly načteny, aby se zabránilo narušení funkčnosti webové stránky.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "DOBŘE";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Zpráva od %@:";
 

--- a/DuckDuckGo/da.lproj/Autocomplete.strings
+++ b/DuckDuckGo/da.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Ingen forslag";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Autoudfyld forslaget";
+

--- a/DuckDuckGo/da.lproj/Localizable.strings
+++ b/DuckDuckGo/da.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Fortryd";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Autoudfyld forslaget";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Bogmærke";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Åbn websted";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Søg på DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Tilføj";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Til";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Skjul adgangskode";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Se";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Gem adgangskode?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Vis adgangskode";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Opdater login";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Bloker e-mailtrackere, og skjul din adresse";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Annullér";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Bemærk: Fjernelse af e-mailbeskyttelse fra denne enhed sletter ikke din Duck-adresse.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Fjern";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Vil du fjerne e-mailbeskyttelse?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Der opstod en fejl, da du tilmeldte dig til ventelisten. Prøv igen senere";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Kom igang";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Jeg har en invitationskode";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Du er blevet inviteret!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Slut dig til den private venteliste";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Du er på ventelisten!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Din invitation vises her, når vi er klar til dig. Vil du %1$@, når den ankommer? %2$@ om e-mailbeskyttelse.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "have besked";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Vi sender dig en meddelelse, når<br/> e-mailbeskyttelse er klar til dig. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Mere info";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Vi sender dig en meddelelse, når du kan begynde at bruge e-mailbeskyttelse.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Skal vi give dig besked, når det er din tur?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Du har tilmeldt dig ventelisten og bedt os om at underrette dig, når det er din tur til at prøve vores e-mailbeskyttelsesfunktion.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nej tak.";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "UNDERRET MIG";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Din invitation til e-mailbeskyttelse er her!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Vi gemmer ikke dine e-mails. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Fortrolighed af e-mail, forenklet.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokér e-mailtrackere, og skjul din adresse<br/> uden at ændre din e-mailudbyder. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Ingen bogmærker tilføjet endnu";
@@ -1205,7 +1154,7 @@
 "privacy.protection.other.domains.thirdparties.empty" = "Vi har ikke registreret anmodninger fra tredjepartsdomæner.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.third.party.domains.loaded" = "Anmodninger fra tredjeparter indlæst";
+"privacy.protection.other.third.party.domains.loaded" = "Anmodninger fra tredjeparter";
 
 /* No comment provided by engineer. */
 "privacy.protection.platform.limitations.footer.info" = "Bemærk: Platformsbegrænsninger kan begrænse vores evne til at registrere alle anmodninger.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "Okay";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "En besked fra %@:";
 

--- a/DuckDuckGo/de.lproj/Autocomplete.strings
+++ b/DuckDuckGo/de.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Keine Vorschläge";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Vorschläge für die Autovervollständigung";
+

--- a/DuckDuckGo/de.lproj/Localizable.strings
+++ b/DuckDuckGo/de.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Rückgängig machen";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Vorschläge für die Autovervollständigung";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Lesezeichen";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Website öffnen";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Suche bei DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Hinzufügen";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "An";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Passwort ausblenden";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Ansehen";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Passwort speichern?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Passwort anzeigen";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Anmeldedaten aktualisieren";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "E-Mail-Tracker blockieren und deine Adresse verbergen";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Abbrechen";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Hinweis: Beim Entfernen des E-Mail-Schutzes von diesem Gerät wird deine Duck-Adresse nicht gelöscht.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Entfernen";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "E-Mail-Schutz entfernen?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Bei der Aktion „Auf die Warteliste setzen“ ist ein Fehler aufgetreten. Bitte versuche es später noch einmal.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Los geht's!";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Ich habe einen Einladungscode";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Du wurdest eingeladen!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Auf die private Warteliste setzen";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Du stehst auf der Warteliste!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Deine Einladung wird hier angezeigt, wenn es soweit ist. Möchtest du %1$@, wenn sie eintrifft? %2$@ über E-Mail-Schutz.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "Benachrichtigt werden";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Du erhältst eine Benachrichtigung, wenn du die E-Mail-Schutzfunktion testen kannst. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Mehr erfahren";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Wir senden dir eine Benachrichtigung, wenn du den E-Mail-Schutz nutzen kannst.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Möchtest du von uns benachrichtigt werden, wenn du an der Reihe bist?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Du hast dich auf die Warteliste setzen lassen und uns darum gebeten, dich zu benachrichtigen, wenn auch du unseren E-Mail-Schutz testen kannst.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nein, danke";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "ICH MÖCHTE BENACHRICHTIGT WERDEN";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Deine Einladung zum E-Mail-Schutz ist da!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Wir speichern keine E-Mails. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-Mail-Datenschutz, vereinfacht.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "E-Mail-Tracker blockieren und deine Adresse verbergen, ohne dafür den E-Mail-Anbieter wechseln zu müssen. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Noch keine Lesezeichen hinzugefügt";
@@ -1181,7 +1130,7 @@
 "privacy.protection.other.domains.firstparty" = "Die Anforderungen der folgenden Domain wurden geladen, da sie mit %@ verknüpft sind.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info" = "Die Anfragen der folgenden Drittanbieter-Domains wurden geladen. Wenn die Anfragen eines Unternehmens geladen werden, kann dies ihm erlauben, ein Profil von dir zu erstellen, obwohl unsere anderen Schutzmaßnahmen für das Web-Tracking weiterhin gelten.";
+"privacy.protection.other.domains.info" = "Die Anfragen der folgenden Drittanbieter-Domains wurden geladen. Wenn die Anfragen eines Unternehmens geladen werden, kann dies ihnen erlauben, ein Profil von dir zu erstellen, obwohl unsere anderen Schutzmaßnahmen für das Web-Tracking weiterhin gelten.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.info.disabled.protection" = "Das Laden von Anfragen von Drittanbietern wurde nicht blockiert, da der Schutz für diese Website deaktiviert ist. Wenn die Anfragen eines Unternehmens geladen werden, kann ihm dies ermöglichen, ein Profil von dir zu erstellen.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Eine Nachricht von %@:";
 

--- a/DuckDuckGo/el.lproj/Autocomplete.strings
+++ b/DuckDuckGo/el.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Δεν υπάρχουν προτάσεις";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Πρόταση αυτόματης συμπλήρωσης";
+

--- a/DuckDuckGo/el.lproj/Localizable.strings
+++ b/DuckDuckGo/el.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Αναίρεση";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Πρόταση αυτόματης συμπλήρωσης";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Σελιδοδείκτης";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Άνοιγμα ιστότοπου";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Αναζήτηση στο DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Προσθήκη";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Ενεργό";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Απόκρυψη κωδικού πρόσβασης";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Προβολή";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Αποθήκευση κωδικού πρόσβασης;";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Εμφάνιση κωδικού πρόσβασης";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Ενημέρωση σύνδεσης";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Ακύρωση";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Σημείωση: Η αφαίρεση της προστασίας email από τη συσκευή αυτή δεν θα διαγράψει τη Διεύθυνση Duck που διαθέτετε.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Αφαίρεση";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Αφαίρεση προστασίας email;";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Προέκυψε σφάλμα κατά την εγγραφή στη Λίστα αναμονής. Ξαναπροσπαθήστε αργότερα.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Ξεκινήστε";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Διαθέτω Κωδικό πρόσκλησης";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Έχετε προσκληθεί!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Εγγραφείτε στην Ιδιωτική λίστα αναμονής";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Βρίσκεστε στη λίστα αναμονής!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Η πρόσκλησή σας θα εμφανιστεί εδώ όταν θα είναι έτοιμη για εσάς. Θέλετε να %1$@ μόλις φτάσει; %2$@ σχετικά με την Προστασία email.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "λάβετε ειδοποίηση";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Θα σας στείλουμε ειδοποίηση όταν θα είναι έτοιμη για σας η Προστασία<br/>email. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Μάθετε περισσότερα";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Θα σας στείλουμε ειδοποίηση όταν θα μπορείτε να αρχίσετε να χρησιμοποιείτε την Προστασία email.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Θα θέλατε να σας ειδοποιήσουμε όταν θα είναι η σειρά σας;";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Εγγραφήκατε στη λίστα αναμονής και μας ζητήσατε να σας ενημερώσουμε για το πότε θα είναι η σειρά σας να δοκιμάσετε την Προστασία email.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Όχι, ευχαριστώ";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "ΝΑ ΕΙΔΟΠΟΙΗΘΩ";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Η πρόσκλησή σας για προστασία των email είναι εδώ!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Δεν αποθηκεύουμε τα email σας. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Ιδιωτικότητα email, απλοποιημένη.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας,<br/>χωρίς να αλλάξετε πάροχο email. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Δεν προστέθηκαν σελιδοδείκτες ακόμα";
@@ -1031,7 +980,7 @@
 "privacy.protection.about.search.protections.link" = "Σχετικά με τις Προστασίες αναζήτησης και τις διαφημίσεις μας";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.search.protections.link.new" = "How our search ads impact our protections";
+"privacy.protection.about.search.protections.link.new" = "Πώς επηρεάζουν οι διαφημίσεις αναζήτησης τις προστασίες μας";
 
 /* Part of certificate info */
 "privacy.protection.encryption.algorithm" = "Αλγόριθμος";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "Εντάξει";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Μήνυμα από %@:";
 

--- a/DuckDuckGo/es.lproj/Autocomplete.strings
+++ b/DuckDuckGo/es.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "No hay sugerencias";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Autocompletar sugerencia";
+

--- a/DuckDuckGo/es.lproj/Localizable.strings
+++ b/DuckDuckGo/es.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Deshacer";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Autocompletar sugerencia";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Añadir a marcadores";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Abrir sitio web";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Buscar en DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Añadir";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Activado";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Ocultar contraseña";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Ver";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "¿Guardar contraseña?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Mostrar contraseña";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Actualizar inicio de sesión";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Bloquea los rastreadores de correo electrónico y oculta tu dirección";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Cancelar";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Nota: Eliminar la protección de correo electrónico de este dispositivo no eliminará tu dirección Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Eliminar";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "¿Eliminar la protección de correo electrónico?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Se ha producido un error al unirte a la lista de espera, inténtalo de nuevo más tarde";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Empezar";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Tengo un código de invitación";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "¡Te han invitado!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Unirse a la lista de espera privada";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "¡Estás en la lista de espera!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Tu invitación aparecerá aquí cuando estemos listos para ti. ¿Quieres %1$@ cuando llegue? %2$@ sobre la protección de correo electrónico.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "recibir una notificación";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Te enviaremos una notificación cuando la protección de correo electrónico esté lista para ti. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Más información";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Te enviaremos una notificación cuando puedas empezar a usar la protección de correo electrónico.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "¿Quieres que te enviemos una notificación cuando te toque?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Te has unido a la lista de espera y nos has pedido que te avisemos cuando te toque probar nuestra protección de correo electrónico.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "No, gracias";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "NOTIFICARME";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "¡Tu invitación de protección de correo electrónico ya está aquí!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "No guardamos tus correos electrónicos. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Privacidad de correo electrónico, simplificada.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Bloquea los rastreadores de correo electrónico y oculta tu dirección sin cambiar de proveedor de correo electrónico. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Aún no se han añadido marcadores";
@@ -1268,10 +1217,10 @@
 "privacy.protection.trackers.found" = "privacy.protection.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.found.new" = "Solicitudes de rastreo encontradas";
+"privacy.protection.trackers.found.new" = "Solicitudes de seguimiento encontradas";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.not.blocked" = "No se han bloqueado solicitudes de rastreo";
+"privacy.protection.trackers.not.blocked" = "No se han bloqueado solicitudes de seguimiento";
 
 /* No comment provided by engineer. */
 "privacy.protection.trackers.not.found" = "No se han encontrado solicitudes de rastreo";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "De acuerdo";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Un mensaje de %@:";
 

--- a/DuckDuckGo/et.lproj/Autocomplete.strings
+++ b/DuckDuckGo/et.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Ettepanekud puuduvad";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Kasuta ettepaneku automaatteksti";
+

--- a/DuckDuckGo/et.lproj/Localizable.strings
+++ b/DuckDuckGo/et.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Võta tagasi";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Kasuta ettepaneku automaatteksti";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Järjehoidja";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Ava veebisait";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Otsing DuckDuckGo's";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Lisa";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Sees";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Peida parool";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Kuva";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Kas salvestada parool?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Kuva parool";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Värskenda sisselogimisandmeid";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokeeri meilijälgurid ja peida oma aadress";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Tühista";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Märkus. E-posti kaitsete eemaldamine sellest seadmest ei kustuta teie Ducki aadressi.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Eemaldage";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Kas eemaldada e-posti kaitsed?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Ooteloendiga liitumisel tekkis tõrge, proovige hiljem uuesti";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Alustage";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Mul on kutse kood";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Olete kutsutud!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Liituge privaatse ootenimekirjaga";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Te olete ootenimekirjas!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Teie kutse kuvatakse siin, kui oleme teie jaoks valmis. Soovite %1$@, kui see saabub? %2$@ e-posti kaitse kohta.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "telli teavitus";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Saadame teile teate, kui E-posti kaitse on teie jaoks valmis. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Loe edasi";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Saadame teile teatise, kui saate e-posti kaitset kasutama hakata.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Kas soovite, et me saadame teile teavituse, kui on teie kord?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Liitusite ootenimekirjaga ja palusite meid teavitada, kui on teie kord proovida meie e-posti kaitset.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Ei aitäh";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "TEAVITAGE MIND";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Teie e-posti kaitse kutse on siin!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Me ei salvesta teie e-kirju. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-posti privaatsus, lihtsustatud.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokeerige e-posti jälgijad ja peitke oma aadress ilma oma e-posti teenuse pakkujat vahetamata. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Järjehoidjaid pole veel lisatud";
@@ -1172,7 +1121,7 @@
 "privacy.protection.no.other.third.party.domains.loaded" = "Kolmanda poole päringud pole laaditud";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.adclickattribution" = "Järgmise domeeni päringud laaditi, sest hiljuti klõpsati DuckDuckGo's %@ reklaamil. Need päringud aitavad hinnata reklaamide tõhusust. Kõik DuckDuckGo reklaamid on mitteprofileerivad.";
+"privacy.protection.other.domains.adclickattribution" = "Järgmise domeeni päringud laaditi, sest hiljuti klõpsati DuckDuckGo's %@ reklaamil. Need päringud aitavad hinnata reklaamide tõhusust. Kõik DuckDuckGo' reklaamid on mitteprofileerivad.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.exceptions" = "Laaditi järgmise domeeni päringud, et vältida saidi töö häirimist.";
@@ -1253,7 +1202,7 @@
 "privacy.protection.tracker.networks.info.empty" = "Jälgimispäringute laadimist ei blokeeritud, sest selle saidi jaoks on kaitsed välja lülitatud. Kui ettevõtte päringud laaditakse, võib see võimaldada neil sind profileerida.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.empty.no.trackers" = "Me ei tuvastanud ühtegi jälgimispäringut.";
+"privacy.protection.tracker.networks.info.empty.no.trackers" = "Me ei tuvastanud ühtegi jälgimistaotlust.";
 
 /* No comment provided by engineer. */
 "privacy.protection.tracker.networks.info.new" = "Järgmiste kolmanda poole domeenide päringute laadimine blokeeriti, sest need tuvastati jälgimispäringutena. Kui ettevõtte päringud laaditakse, võib see võimaldada neil sind profileerida.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Sõnum saatjalt %@:";
 

--- a/DuckDuckGo/fi.lproj/Autocomplete.strings
+++ b/DuckDuckGo/fi.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Ei ehdotuksia";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Automaattisen täydennyksen ehdotus";
+

--- a/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/DuckDuckGo/fi.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Kumoa";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Automaattisen täydennyksen ehdotus";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Lisää kirjanmerkki";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Avaa verkkosivusto";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Hae DuckDuckGosta";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Lisää";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Päällä";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Piilota salasana";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Näytä";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Tallennetaanko salasana?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Näytä salasana";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Päivitä kirjautumistiedot";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Estä sähköpostiseuraajat ja piilota osoitteesi";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Peruuta";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Huomaa: sähköpostisuojauksen poistaminen tältä laitteelta ei poista Duck-osoitettasi.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Poista";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Poistetaanko sähköpostisuojaus?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Virhe liittyessä odotuslistalle, yritä myöhemmin uudelleen";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Aloita";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Minulla on kutsukoodi";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Sinut on kutsuttu!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Liity yksityiselle odotuslistalle";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Olet odotuslistalla!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Kutsusi näkyy täällä, kun olemme valmiita. Haluatko, että sinulle tulee %1$@, kun kutsusi saapuu? %2$@ sähköpostisuojauksesta.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "ilmoitus";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Lähetämme sinulle ilmoituksen, kun sähköpostisuojaus on valmis käytettäväksi. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Lue lisää";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Lähetämme sinulle ilmoituksen, kun voit aloittaa sähköpostisuojauksen käytön.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Haluatko, että ilmoitamme sinulle, kun on sinun vuorosi?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Liityit odotuslistalle ja pyysit meitä ilmoittamaan sinulle, kun on sinun vuorosi kokeilla sähköpostisuojaustamme.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Ei kiitos";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "HALUAN ILMOITUKSEN";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Kutsusi sähköpostin suojaamiseen on täällä!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Emme tallenna sähköpostejasi. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Sähköpostin tietosuoja, yksinkertaisesti.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Estä sähköpostiseuranta ja piilota osoitteesi vaihtamatta sähköpostintarjoajaa. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Kirjanmerkkejä ei ole vielä lisätty";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Viesti käyttäjältä %@:";
 

--- a/DuckDuckGo/fr.lproj/Autocomplete.strings
+++ b/DuckDuckGo/fr.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Aucune suggestion";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Saisie semi-automatique de la suggestion";
+

--- a/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/DuckDuckGo/fr.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Annuler";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Saisie semi-automatique de la suggestion";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Ajouter aux signets";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Ouvrir le site Web";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Rechercher sur DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Ajouter";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Activé";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Masquer le mot de passe";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Voir";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Enregistrer le mot de passe ?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Afficher le mot de passe";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Modifier l'identifiant";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Bloquez les traqueurs d'e-mails et masquez votre adresse";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Annuler";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Remarque : la suppression de la protection des e-mails sur cet appareil ne supprimera pas votre adresse Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Supprimer";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Supprimer la protection des e-mails ?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Une erreur s'est produite lors de l'inscription sur la liste d'attente. Veuillez réessayer plus tard.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Commencer";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "J'ai un code d'invitation";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Vous avez été invité(e) !";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Rejoindre la liste d'attente privée";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Vous êtes sur liste d'attente !";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Votre invitation s'affichera ici lorsque vous aurez accès à la fonctionnalité. Vous souhaitez %1$@ de son lancement ? %2$@ sur la protection des e-mails.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "être prévenu(e)";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Nous vous contacterons lorsque la protection des e-mails sera disponible pour vous. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "En savoir plus";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Nous vous enverrons une notification dès que vous pourrez commencer à utiliser la protection des e-mails.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Souhaitez-vous être prévenu(e) lorsque ce sera votre tour ?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Vous vous êtes inscrit(e) sur la liste d'attente et nous avez demandé de vous informer lorsque vous pourrez tester notre fonctionnalité de protection des e-mails.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Non merci";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "ME PRÉVENIR";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Vous avez reçu votre invitation pour tester la protection des e-mails !";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Nous n'enregistrons pas vos adresses e-mail. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "La confidentialité des e-mails, simplifiée.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Bloquez les traqueurs d'e-mails et masquez votre adresse, sans changer de fournisseur de messagerie. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Aucun signet ajouté pour le moment";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Message de %@ :";
 

--- a/DuckDuckGo/hr.lproj/Autocomplete.strings
+++ b/DuckDuckGo/hr.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Nema prijedloga";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Prijedlog za automatsko ispunjavanje";
+

--- a/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/DuckDuckGo/hr.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Poništi";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Prijedlog za automatsko ispunjavanje";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Knjižna oznaka";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Otvori web lokaciju";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Pretraži na DuckDuckGou";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Dodaj";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Uključeno";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Sakrij lozinku";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Pregled";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Želiš li spremiti lozinku?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Pokaži lozinku";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Ažuriraj prijavu";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokiraj programe za praćenje e-pošte i sakrij svoju adresu";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Otkaži";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Napomena: uklanjanjem zaštite e-pošte s ovog uređaja neće se izbrisati vaša Duck adresa.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Ukloni";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Ukloniti zaštitu e-pošte?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Došlo je do pogreške prilikom pridruživanja listi čekanja; pokušajte ponovo kasnije";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Započnite";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Imam pozivnu šifru";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Pozvani ste!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Pridružite se privatnoj listi čekanja";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Na listi ste čekanja!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Vaša pozivnica pojavit će se ovdje kad budemo spremni za vas. Želite li %1$@ kad stigne? %2$@ o zaštiti e-pošte.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "primite obavijest";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Poslat ćemo vam obavijest kad zaštita e-pošte bude spremna za vas. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Saznajte više";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Poslat ćemo vam obavijest kad možete početi koristiti zaštitu e-pošte.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Želite li da vas obavijestimo kada dođete na red?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Pridružili ste se listi čekanja i zatražili da vas obavijestimo kada dođete na red za isprobavanje naše značajke zaštite e-pošte.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Ne, hvala";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "OBAVIJESTI ME";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Vaša pozivnica za zaštitu e-pošte je stigla!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Ne čuvamo vašu e-poštu. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Zaštita privatnosti e-pošte, na jednostavan način.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokirajte programe za praćenje e-pošte i sakrijte svoju adresu bez promjene pružatelja usluga e-pošte. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Još nema dodanih knjižnih oznaka";
@@ -1025,10 +974,10 @@
 "preserveLogins.remove.all.ok" = "U redu";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.protections.link" = "O našoj zaštiti od web-praćenja";
+"privacy.protection.about.protections.link" = "O našoj zaštiti od praćenja na webu";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.search.protections.link" = "O našoj zaštiti pretraživanja i oglasima";
+"privacy.protection.about.search.protections.link" = "O našoj zaštiti pretraživanja i oglasa";
 
 /* No comment provided by engineer. */
 "privacy.protection.about.search.protections.link.new" = "Kako naši pretraživački oglasi utječu na našu zaštitu";
@@ -1157,7 +1106,7 @@
 "privacy.protection.major.trackers.found" = "privacy.protection.major.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.major.trackers.found.new" = "Pronađene su veće mreže za praćenje";
+"privacy.protection.major.trackers.found.new" = "Pronađene glavne mreže za praćenje";
 
 /* No comment provided by engineer. */
 "privacy.protection.major.trackers.not.found" = "Nije pronađena nijedna veća mreža za praćenje";
@@ -1175,16 +1124,16 @@
 "privacy.protection.other.domains.adclickattribution" = "Sljedeći zahtjevi domene učitani su jer je nedavno kliknut oglas %@ na DuckDuckGou. Ovi zahtjevi pomažu u procjeni učinkovitosti oglasa. Svi oglasi na DuckDuckGou su neprofilirajući.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.exceptions" = "Sljedeći zahtjevi domene učitani su kako bi se spriječili problemi s web-lokacijom.";
+"privacy.protection.other.domains.exceptions" = "Sljedeći zahtjevi domene učitani su kako bi se spriječio pad web stranice.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.firstparty" = "Sljedeći zahtjevi domene učitani su jer su povezani s %@.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info" = "Učitani su sljedeći zahtjevi domena trećih strana. Ako su zahtjevi tvrtke učitani, to im može omogućiti da te profiliraju, iako se i dalje primjenjuju naše druge zaštite web praćenja.";
+"privacy.protection.other.domains.info" = "Učitani su sljedeći zahtjevi domena trećih strana. Ako su zahtjevi tvrtke učitani, to im može omogućiti da vas profiliraju, iako se i dalje primjenjuju naše druge zaštite web praćenja.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info.disabled.protection" = "Učitavanje zahtjeva trećih strana nije blokirano jer su zaštite isključene za ovu web-lokaciju. Ako su zahtjevi tvrtke učitani, to im može omogućiti da te profiliraju.";
+"privacy.protection.other.domains.info.disabled.protection" = "Učitavanje zahtjeva trećih strana nije blokirano jer su zaštite isključene za ovo web-mjesto. Ako su zahtjevi tvrtke učitani, to im može omogućiti da te profiliraju.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.info.header.disabled.protection" = "Učitani su zahtjevi za praćenje sljedećih domena.";
@@ -1208,7 +1157,7 @@
 "privacy.protection.other.third.party.domains.loaded" = "Učitani su zahtjevi trećih strana";
 
 /* No comment provided by engineer. */
-"privacy.protection.platform.limitations.footer.info" = "Imaj na umu: ograničenja platforme mogu ograničiti našu sposobnost otkrivanja svih zahtjeva.";
+"privacy.protection.platform.limitations.footer.info" = "Imajte na umu: ograničenja platforme mogu ograničiti našu sposobnost otkrivanja svih zahtjeva.";
 
 /* No comment provided by engineer. */
 "privacy.protection.platform.tracker.category.non.profiling" = "Neprofiliranje";
@@ -1250,25 +1199,25 @@
 "privacy.protection.tracker.networks.info" = "Alati za praćenje pomažu tvrtkama da te profiliraju. Blokirali smo ove alate za praćenje učitavanja i praćenja tvojih aktivnosti na ovoj stranici.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.empty" = "Učitavanje zahtjeva za praćenje nije blokirano jer su zaštite isključene za ovu stranicu. Ako su zahtjevi tvrtke učitani, to im može omogućiti da te profiliraju.";
+"privacy.protection.tracker.networks.info.empty" = "Učitavanje zahtjeva za praćenje nije blokirano jer su zaštite isključene za ovo web-mjesto. Ako su zahtjevi tvrtke učitani, to im može omogućiti da te profiliraju.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.empty.no.trackers" = "Nismo otkrili nijedan zahtjev za praćenje.";
+"privacy.protection.tracker.networks.info.empty.no.trackers" = "Nismo otkrili nikakve zahtjeve za praćenje.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.new" = "Sljedećim zahtjevima domena trećih strana blokirano je učitavanje jer su identificirani kao zahtjevi za praćenje. Ako su zahtjevi tvrtke učitani, to im može omogućiti da vas profiliraju.";
+"privacy.protection.tracker.networks.info.new" = "Sljedećim zahtjevima domena trećih strana blokirano je učitavanje jer su identificirani kao zahtjevi za praćenje. Ako su zahtjevi tvrtke učitani, to im može omogućiti da te profiliraju.";
 
 /* Do not translate - stringsdict entry */
 "privacy.protection.trackers.blocked" = "privacy.protection.trackers.blocked";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.blocked.new" = "Zahtjevi su blokirani za učitavanje";
+"privacy.protection.trackers.blocked.new" = "Zahtjevi blokirani od učitavanja";
 
 /* Do not translate - stringsdict entry */
 "privacy.protection.trackers.found" = "privacy.protection.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.found.new" = "Pronađeni su zahtjevi za praćenjem";
+"privacy.protection.trackers.found.new" = "Pronađeni zahtjevi za praćenje";
 
 /* No comment provided by engineer. */
 "privacy.protection.trackers.not.blocked" = "Nema blokiranih zahtjeva za praćenje";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "U redu";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Poruka od %@:";
 

--- a/DuckDuckGo/hu.lproj/Autocomplete.strings
+++ b/DuckDuckGo/hu.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Nincs javaslat";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Automatikus kiegészítési javaslat";
+

--- a/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/DuckDuckGo/hu.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Visszavonás";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Automatikus kiegészítési javaslat";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Könyvjelző";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Webhely megnyitása";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Keresés a DuckDuckGón";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Hozzáadás";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Be";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Jelszó elrejtése";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Megtekintés";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Mented a jelszót?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Jelszó megjelenítése";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Bejelentkezés frissítése";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "E-mail nyomkövetők letiltása, és a cím elrejtése";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Mégsem";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Megjegyzés: az e-mail-védelem eltávolítása erről az eszközről nem törli a Duck-címedet.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Eltávolítás";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Eltávolítod az e-mail-védelmet?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Hiba történt a várólistához való csatlakozás közben. Kérjük, próbálkozz újra később.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Első lépések";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Van meghívókódom";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Meghívót kaptál!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Csatlakozz a privát várólistához";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Felkerültél a várólistára!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "A meghívód itt fog megjelenni, amikor készen állunk. Szeretnél %1$@, amikor megérkezik? %2$@ az e-mail-védelemről.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "értesítést kapni";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Értesítést küldünk, amikor az e-mail-védelem készen áll számodra. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "További tudnivalók";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Értesítést küldünk, amikor megkezdheted az e-mail-védelem használatát.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Szeretnéd, hogy értesítsünk, amikor rád kerül a sor?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Feliratkoztál a várólistára, és arra kértél minket, hogy értesítsünk, amikor rád kerül a sor, hogy kipróbálhasd az e-mail-védelmet.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nem, köszönöm";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "ÉRTESÍTSETEK";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Megérkezett az e-mail védelmi meghívód!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Nem mentjük el az e-mailjeidet. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-mail adatvédelem, egyszerűsítve.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Tiltsd le az e-mail nyomkövetőket, és rejtsd el a címedet anélkül, hogy e-mail szolgáltatót váltanál. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Még nincsenek könyvjelzők hozzáadva";
@@ -1025,7 +974,7 @@
 "preserveLogins.remove.all.ok" = "OK";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.protections.link" = "A webes követés elleni védelemről";
+"privacy.protection.about.protections.link" = "A webes követés elleni védelmünkről";
 
 /* No comment provided by engineer. */
 "privacy.protection.about.search.protections.link" = "A keresés védelméről és a hirdetésekről";
@@ -1169,25 +1118,25 @@
 "privacy.protection.network.leaderboard.gathering" = "Folyamatosan gyűjtjük az adatokat, hogy bemutathassuk, hány\nnyomkövetőt tiltottunk le.";
 
 /* No comment provided by engineer. */
-"privacy.protection.no.other.third.party.domains.loaded" = "Harmadik féltől származó kérések nincsenek betöltve";
+"privacy.protection.no.other.third.party.domains.loaded" = "Nincsenek harmadik féltől származó kérések betöltve";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.adclickattribution" = "A következő tartomány kérései azért lettek betöltve, mert a DuckDuckGón nemrég rákattintottak a(z) %@ hirdetésére. Ezek a kérések segítenek értékelni a hirdetések hatékonyságát. A DuckDuckGo egyik hirdetése sem profilozó.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.exceptions" = "A következő domain kérései a webhely megszakadásának megelőzése érdekében lettek betöltve.";
+"privacy.protection.other.domains.exceptions" = "A következő tartomány kérései a webhely megszakadásának megelőzése érdekében lettek betöltve.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.firstparty" = "A következő tartomány kérései azért lettek betöltve, mert a következőhöz vannak társítva: %@.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info" = "A következő harmadik fél tartományok kérései be lettek töltve. Ha egy cég kérései betöltődnek, ez lehetővé teheti számukra, hogy profilokat készítsenek a felhasználóról, bár a többi webes nyomkövetési védelmünk továbbra is érvényben van.";
+"privacy.protection.other.domains.info" = "A következő harmadik fél tartományok kérései be lettek töltve. Ha egy cég kérései betöltődnek, ez lehetővé teheti számukra, hogy profilokat készítsenek rólad, bár a többi webes nyomkövetési védelmünk továbbra is működik.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info.disabled.protection" = "A harmadik féltől származó kérések betöltése nincs blokkolva, mert a végelem ki van kapcsolva ehhez a webhelyhez. Ha egy cég kérései betöltődnek, az lehetővé teheti számukra, hogy profilokat készítsenek a felhasználóról.";
+"privacy.protection.other.domains.info.disabled.protection" = "A harmadik féltől származó kérések betöltése nincs blokkolva, mert a védelem ki van kapcsolva ehhez a webhelyhez. Ha egy cég kérései betöltődnek, az lehetővé teheti számukra, hogy profilokat készítsenek rólad.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info.header.disabled.protection" = "A következő tartományok követési kérelmei lettek betöltve.";
+"privacy.protection.other.domains.info.header.disabled.protection" = "A következő tartományok követési kérései lettek betöltve.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.info.header.disabled.protection.also.new" = "A következő tartomány kérései is be lettek töltve.";
@@ -1205,7 +1154,7 @@
 "privacy.protection.other.domains.thirdparties.empty" = "Nem észleltünk harmadik fél tartományából származó kéréseket.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.third.party.domains.loaded" = "A harmadik féltől származó kérések be lettek töltve";
+"privacy.protection.other.third.party.domains.loaded" = "A harmadik fél kérései be lettek töltve";
 
 /* No comment provided by engineer. */
 "privacy.protection.platform.limitations.footer.info" = "Fontos tudni: a platformkorlátozások korlátozhatják az összes kérés észlelését.";
@@ -1247,16 +1196,16 @@
 "privacy.protection.tos.unknown" = "Ismeretlen adatvédelmi gyakorlatok";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info" = "A nyomkövetők segítségével a cégek profilt alkothatnak rólad. Megakadályoztuk, hogy ezek a nyomkövetők betöltsék és nyomon kövessék a tevékenységedet ezen az oldalon.";
+"privacy.protection.tracker.networks.info" = "A nyomkövetők segítségével a cégek profilt alkothatnak rólad. Megakadályoztuk, hogy ezek a nyomkövetők betöltődjenek, és nyomon kövessék a tevékenységedet ezen az oldalon.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.empty" = "A nyomkövető kérések betöltése nincs blokkolva, mert a végelem ki van kapcsolva ehhez a webhelyhez. Ha egy cég kérései betöltődnek, az lehetővé teheti számukra, hogy profilokat készítsenek a felhasználóról.";
+"privacy.protection.tracker.networks.info.empty" = "A nyomkövető kérések betöltése nincs blokkolva, mert a védelem ki van kapcsolva ehhez a webhelyhez. Ha egy cég kérései betöltődnek, az lehetővé teheti számukra, hogy profilokat készítsenek rólad.";
 
 /* No comment provided by engineer. */
 "privacy.protection.tracker.networks.info.empty.no.trackers" = "Nem észleltünk nyomkövetési kérést.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.new" = "A következő harmadik fél tartományok kéréseinek betöltése blokkolva van, mivel nyomkövető kérésként lettek beazonosítva. Ha egy cég kérései betöltődnek, az lehetővé teheti számukra, hogy profilokat készítsenek a felhasználóról.";
+"privacy.protection.tracker.networks.info.new" = "A következő harmadik fél tartományok kéréseinek betöltése blokkolva van, mivel nyomkövető kérésként lettek beazonosítva. Ha egy cég kérései betöltődnek, az lehetővé teheti számukra, hogy profilokat készítsenek rólad.";
 
 /* Do not translate - stringsdict entry */
 "privacy.protection.trackers.blocked" = "privacy.protection.trackers.blocked";
@@ -1271,7 +1220,7 @@
 "privacy.protection.trackers.found.new" = "Nyomkövető kérések találhatók";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.not.blocked" = "Nyomkövető kérések nincsenek blokkolva";
+"privacy.protection.trackers.not.blocked" = "Nincsenek nyomkövetési kérések blokkolva";
 
 /* No comment provided by engineer. */
 "privacy.protection.trackers.not.found" = "Nem találhatók nyomkövetési kérések";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "%@ üzenete:";
 

--- a/DuckDuckGo/it.lproj/Autocomplete.strings
+++ b/DuckDuckGo/it.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Nessun suggerimento";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Mostra suggerimenti di completamento automatico";
+

--- a/DuckDuckGo/it.lproj/Localizable.strings
+++ b/DuckDuckGo/it.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Annulla";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Mostra suggerimenti di completamento automatico";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Segnalibro";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Apri il sito web";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Cerca su DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Aggiungi";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "On";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Nascondi password";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Visualizza";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Salvare password?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Mostra password";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Aggiorna dati di accesso";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blocca i sistemi di tracciamento delle email e nascondi il tuo indirizzo";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Annulla";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Nota: la rimozione di Protezione e-mail da questo dispositivo non eliminerà il tuo indirizzo Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Rimuovi";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Rimuovere Protezione e-mail?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Si è verificato un errore durante l'iscrizione alla lista d'attesa, riprova più tardi";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Iniziamo";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Ho un codice invito";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Hai ricevuto un invito.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Iscriviti alla lista d'attesa privata";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Sei sulla lista d'attesa.";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Vedrai il tuo invito qui quando saremo pronti per te. Vuoi %1$@ quando arriva? %2$@ su Protezione e-mail.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "ricevere una notifica";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Ti invieremo una notifica quando la funzione Protezione e-mail sarà pronta per te. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Ulteriori informazioni";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Ti invieremo una notifica non appena potrai iniziare a utilizzare Protezione e-mail.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Vuoi che ti avvisiamo quando sarà il tuo turno?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Hai effettuato l'iscrizione alla lista d'attesa e ci hai chiesto di avvisarti quando sarà il tuo turno di provare la nostra Protezione e-mail.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "No, grazie";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "INVIAMI UNA NOTIFICA";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Il tuo invito alla protezione e-mail è arrivato.";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Non salviamo le tue e-mail. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Tutelare la privacy delle e-mail, ora è semplice.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blocca i sistemi di tracciamento delle e-mail e nascondi il tuo indirizzo, senza cambiare il provider di posta elettronica. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Non è ancora stato aggiunto nessun segnalibro";
@@ -1157,7 +1106,7 @@
 "privacy.protection.major.trackers.found" = "privacy.protection.major.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.major.trackers.found.new" = "Rete di sistemi di tracciamento principale rilevata";
+"privacy.protection.major.trackers.found.new" = "Principali reti del sistema di tracciamento trovate";
 
 /* No comment provided by engineer. */
 "privacy.protection.major.trackers.not.found" = "Nessuna rete del sistema di tracciamento principale rilevata";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Un messaggio da parte di %@:";
 

--- a/DuckDuckGo/lt.lproj/Autocomplete.strings
+++ b/DuckDuckGo/lt.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Pasiūlymų nėra";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Automatinio užbaigimo pasiūlymas";
+

--- a/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/DuckDuckGo/lt.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Anuliuoti";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Automatinio užbaigimo pasiūlymas";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Žymė";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Atidaryti svetainę";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Ieškoti „DuckDuckGo“";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Papildyti";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Įjungti";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Paslėpti slaptažodį";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Peržiūrėti";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Išsaugoti slaptažodį?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Rodyti slaptažodį";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Atnaujinti prisijungimą";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokuokite el. laiškų sekimo priemones ir paslėpkite savo adresą";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Atšaukti";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Pastaba: jei iš šio įrenginio pašalinsite el. pašto adreso apsaugos priemonę, jūsų „Duck“ adresas nebus ištrintas.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Pašalinti";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Pašalinti el. pašto adreso apsaugos priemonę?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Jungiantis prie laukimo sąrašo atsirado klaida; vėliau pabandykite dar kartą";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Pradėti";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Turiu kvietimo kodą";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Buvote pakviesti!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Prisijungti prie privataus laukimo sąrašo";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Esate laukimo sąraše!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Kai jums viską paruošime, pakvietimą matysite čia. Ar nori %1$@, kai gausi pakvietimą? %2$@ apie el. pašto adreso apsaugos priemonę.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "gauti pranešimą";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Kai el. pašto adreso apsaugos priemonė jums bus paruošta, atsiųsime pranešimą. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Sužinokite daugiau";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Kai galėsite pradėti naudoti el. pašto adreso apsaugos priemonę, atsiųsime pranešimą.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Ar norite, kad praneštume, kai ateis jūsų eilė?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Prisijungėte prie laukimo sąrašo ir paprašėte mus informuoti, kai ateis jūsų eilė išbandyti mūsų parengtą el. pašto adreso apsaugos priemonę.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Ne, dėkoju";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "INFORMUOTI";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Jūsų el. pašto apsaugos kvietimas jau čia!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Jūsų el. laiškų neišsaugome. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Supaprastintas el. pašto privatumas.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Užbluokuokite el. pašto adresų stebėjimo priemones ir paslėpkite savo adresus nekeisdami el. pašto paslaugų teikėjo. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Žymių dar nepridėta";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "GERAI";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Pranešimas iš %@:";
 

--- a/DuckDuckGo/lv.lproj/Autocomplete.strings
+++ b/DuckDuckGo/lv.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Nav ieteikumu";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Automātiski pabeigt ieteikumu";
+

--- a/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/DuckDuckGo/lv.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Atsaukt";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Automātiski pabeigt ieteikumu";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Pievienot grāmatzīmi";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Atvērt tīmekļa vietni";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Meklēt vietnē DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Pievienot";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Ieslēgts";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Paslēpt paroli";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Skatīt";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Saglabāt paroli?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Rādīt paroli";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Atjaunināt pieteikšanās datus";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Bloķē e-pasta izsekotājus un paslēp savu adresi";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Atcelt";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Piezīme: noņemot e-pasta aizsardzību no šīs ierīces, tava Duck adrese netiks dzēsta.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Noņemt";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Vai noņemt e-pasta aizsardzību?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Radusies kļūda, pievienojoties gaidīšanas sarakstam, lūdzu, mēģini vēlāk";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Sākt darbu";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Man ir uzaicinājuma kods";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Tu saņēmi uzaicinājumu!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Pievienojies privātajam nogaides sarakstam";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Tu esi gaidīšanas sarakstā!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Tavs uzaicinājums parādīsies šeit, kad būsim gatavi uzņemt tevi. Vai vēlies %1$@, kad tas atnāks? %2$@ par e-pasta aizsardzību.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "saņemt paziņojumu";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Mēs nosūtīsim tev paziņojumu, ka e-pasta aizsardzība būs sagatavota. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Uzzināt vairāk";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Mēs nosūtīsim tev paziņojumu, kad varēsi sākt lietot e-pasta aizsardzību.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Vai vēlies, lai tev paziņojam, kad būs pienākusi tava kārta?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Tu pievienojies nogaides sarakstam un lūdzi mūs informēt, kad būs pienākusi tava kārta izmēģināt mūsu e-pasta aizsardzību.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nē, paldies";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "INFORMĒT MANI";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Tavs uzaicinājums izmantot e-pasta aizsardzības funkciju ir šeit!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Mēs nesaglabājam tavas e-pasta vēstules. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-pasta konfidencialitāte, vienkāršota.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Bloķē e-pasta izsekotājus un paslēp savu adresi, nemainot e-pasta pakalpojumu sniedzēju. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Vēl nav pievienota neviena grāmatzīme";
@@ -1025,7 +974,7 @@
 "preserveLogins.remove.all.ok" = "Labi";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.protections.link" = "Par mūsu tīmekļa izsekošanas aizsardzību";
+"privacy.protection.about.protections.link" = "Par mūsu Tīmekļa izsekošanas aizsardzību";
 
 /* No comment provided by engineer. */
 "privacy.protection.about.search.protections.link" = "Par mūsu meklēšanas aizsardzību un reklāmām";
@@ -1157,7 +1106,7 @@
 "privacy.protection.major.trackers.found" = "privacy.protection.major.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.major.trackers.found.new" = "Atrasti lielāko izsekotāju tīkli";
+"privacy.protection.major.trackers.found.new" = "Atrastie lielie izsekotāju tīkli";
 
 /* No comment provided by engineer. */
 "privacy.protection.major.trackers.not.found" = "Nav atrasts neviens lielāko izsekotāju tīkls";
@@ -1181,10 +1130,10 @@
 "privacy.protection.other.domains.firstparty" = "Šī domēna pieprasījumi tika ielādēti, jo tie ir saistīti ar %@.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info" = "Tika ielādēti šādu trešo pušu domēnu pieprasījumi. Ja tiek ielādēti uzņēmuma pieprasījumi, tas var ļaut tiem veidot tavu profilu, lai gan joprojām ir spēkā mūsu pārējās tīmekļa izsekošanas aizsardzības prasības.";
+"privacy.protection.other.domains.info" = "Tika ielādēti šādi trešo pušu domēnu pieprasījumi. Ja tiek ielādēti uzņēmuma pieprasījumi, tas var ļaut uzņēmumam tevi profilēt, lai gan joprojām ir spēkā citi mūsu tīmekļa izsekošanas aizsardzības līdzekļi.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info.disabled.protection" = "Netika bloķēta trešo pušu pieprasījumu ielāde, jo šai vietnei ir izslēgta aizsardzība. Ja uzņēmuma pieprasījumi tiek ielādēti, tas var ļaut tiem izveidot tavu profilu.";
+"privacy.protection.other.domains.info.disabled.protection" = "Netika bloķēta nekādu trešo pušu pieprasījumu ielāde, jo šai vietnei ir izslēgta aizsardzība. Ja uzņēmuma pieprasījumi tiek ielādēti, tas var ļaut uzņēmumam veidot tavu profilu.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.info.header.disabled.protection" = "Tika ielādēti šādu domēnu izsekošanas pieprasījumi.";
@@ -1202,10 +1151,10 @@
 "privacy.protection.other.domains.thirdparties" = "Tika ielādēti šāda domēna pieprasījumi.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.thirdparties.empty" = "Mēs neatradām pieprasījumus no neviena trešās puses domēna.";
+"privacy.protection.other.domains.thirdparties.empty" = "Mēs neatklājām nevienu pieprasījumu no trešo pušu domēniem.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.third.party.domains.loaded" = "Ielādēti trešo pušu pieprasījumi";
+"privacy.protection.other.third.party.domains.loaded" = "Ielādētie trešo pušu pieprasījumi";
 
 /* No comment provided by engineer. */
 "privacy.protection.platform.limitations.footer.info" = "Lūdzu, ņemiet vērā: platformas ierobežojumi var ierobežot mūsu spēju noteikt visus pieprasījumus.";
@@ -1250,28 +1199,28 @@
 "privacy.protection.tracker.networks.info" = "Izsekotāji palīdz uzņēmumiem veidot tavu profilu. Mēs bloķējām šo izsekotāju ielādēšanu un tavu darbību novērošanu šajā lapā.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.empty" = "Neviens izsekošanas pieprasījums netika bloķēts, jo šai vietnei ir izslēgta aizsardzība. Ja uzņēmuma pieprasījumi tiek ielādēti, tas var ļaut tiem izveidot tavu profilu.";
+"privacy.protection.tracker.networks.info.empty" = "Netika bloķēta neviena izsekošanas pieprasījuma ielāde, jo šai vietnei ir izslēgta aizsardzība. Ja uzņēmuma pieprasījumi tiek ielādēti, tas var ļaut uzņēmumam veidot tavu profilu.";
 
 /* No comment provided by engineer. */
 "privacy.protection.tracker.networks.info.empty.no.trackers" = "Mēs neatradām nevienu izsekošanas pieprasījumu.";
 
 /* No comment provided by engineer. */
-"privacy.protection.tracker.networks.info.new" = "Turpmāk norādīto trešo pušu domēnu pieprasījumu ielāde tika bloķēta, jo tie tika identificēti kā izsekošanas pieprasījumi. Ja uzņēmuma pieprasījumi tiek ielādēti, tas var ļaut tiem izveidot tavu profilu.";
+"privacy.protection.tracker.networks.info.new" = "Turpmāk norādīto trešo pušu domēnu pieprasījumu ielāde tika bloķēta, jo tie tika identificēti kā izsekošanas pieprasījumi. Ja uzņēmuma pieprasījumi tiek ielādēti, tas var ļaut uzņēmumam veidot tavu profilu.";
 
 /* Do not translate - stringsdict entry */
 "privacy.protection.trackers.blocked" = "privacy.protection.trackers.blocked";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.blocked.new" = "Pieprasījumu ielādēšana bloķēta";
+"privacy.protection.trackers.blocked.new" = "Pieprasījumi, kuru ielādēšana ir bloķēta";
 
 /* Do not translate - stringsdict entry */
 "privacy.protection.trackers.found" = "privacy.protection.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.found.new" = "Atrasti izsekošanas pieprasījumi";
+"privacy.protection.trackers.found.new" = "Atrastie izsekošanas pieprasījumi";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.not.blocked" = "Neviens izsekošanas pieprasījums nav bloķēts";
+"privacy.protection.trackers.not.blocked" = "Nav bloķēts neviens izsekošanas pieprasījums";
 
 /* No comment provided by engineer. */
 "privacy.protection.trackers.not.found" = "Nav atrasts neviens izsekošanas pieprasījums";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "Labi";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Ziņojums no %@:";
 

--- a/DuckDuckGo/nb.lproj/Autocomplete.strings
+++ b/DuckDuckGo/nb.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Ingen forslag";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Forslag fra autofullfør";
+

--- a/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/DuckDuckGo/nb.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Angre";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Forslag fra autofullfør";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Legg til";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Åpne nettsted";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Søk med DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Legg til";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "På";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Skjul passord";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Vis";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Vil du lagre passordet?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Vis passord";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Oppdater påloggingen";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokker e-postsporere og skjul adressen din";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Avbryt";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Merk: Duck-adressen din slettes ikke ved at du fjerner e-postbeskyttelse fra denne enheten.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Fjern";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Vil du fjerne e-postbeskyttelse?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Det oppstod en feil under registrering for ventelisten. Prøv igjen senere.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Kom i gang";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Jeg har en invitasjonskode";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Du er invitert!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Sett deg på den private ventelisten";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Du er på ventelisten!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Invitasjonen vises her når vi er klare for deg. Vil du %1$@ når den kommer? %2$@ om e-postbeskyttelse.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "få et varsel";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Vi sender deg et varsel når e-postbeskyttelse er klar for deg. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Finn ut mer";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Vi sender deg et varsel når du kan begynne å bruke e-postbeskyttelse.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Vil du at vi skal varsle deg når det er din tur?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Du har satt deg på ventelisten og bedt oss om å varsle deg når det er din tur til å prøve funksjonen for e-postbeskyttelse.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nei takk";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "VARSLE MEG";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Invitasjonen til e-postbeskyttelse er her!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Vi lagrer ikke e-postene dine. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Personvern for e-post gjort enkelt.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokker e-postsporere og skjul adressen din, uten å bytte e-postleverandør. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Ingen bokmerker lagt til ennå";
@@ -1028,7 +977,7 @@
 "privacy.protection.about.protections.link" = "Om nettsporingsbeskyttelsen vår";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.search.protections.link" = "Om søkebeskyttelsen og annonsene våre";
+"privacy.protection.about.search.protections.link" = "Om søkebeskyttelsene og annonsene våre";
 
 /* No comment provided by engineer. */
 "privacy.protection.about.search.protections.link.new" = "Hvordan søkeannonsene våre påvirker beskyttelsen vår";
@@ -1157,7 +1106,7 @@
 "privacy.protection.major.trackers.found" = "privacy.protection.major.trackers.found";
 
 /* No comment provided by engineer. */
-"privacy.protection.major.trackers.found.new" = "Store sporingsnettverk er oppdaget";
+"privacy.protection.major.trackers.found.new" = "Store sporingsnettverk oppdaget";
 
 /* No comment provided by engineer. */
 "privacy.protection.major.trackers.not.found" = "Ingen større sporingsnettverk ble oppdaget";
@@ -1169,13 +1118,13 @@
 "privacy.protection.network.leaderboard.gathering" = "Vi samler fortsatt inn data for å vise deg\nhvor mange sporinger vi har blokkert.";
 
 /* No comment provided by engineer. */
-"privacy.protection.no.other.third.party.domains.loaded" = "Ingen tredjepartsforespørsler er lastet";
+"privacy.protection.no.other.third.party.domains.loaded" = "Ingen tredjepartsforespørsler lastet";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.adclickattribution" = "Forespørslene fra følgende domene ble lastet fordi en %@-annonse på DuckDuckGo nylig ble klikket på. Disse forespørslene bidrar til å evaluere annonseeffektiviteten. Alle annonser på DuckDuckGo er ikke-profilerende.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.exceptions" = "Forespørslene fra følgende domene ble lastet for å forhindre brudd på nettstedet.";
+"privacy.protection.other.domains.exceptions" = "Forespørslene fra følgende domene ble lastet for å forhindre feil på nettstedet.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.firstparty" = "Forespørslene fra følgende domene ble lastet fordi de er tilknyttet %@.";
@@ -1205,7 +1154,7 @@
 "privacy.protection.other.domains.thirdparties.empty" = "Vi oppdaget ingen forespørsler fra tredjepartsdomener.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.third.party.domains.loaded" = "Tredjepartsforespørsler er lastet";
+"privacy.protection.other.third.party.domains.loaded" = "Tredjepartsforespørsler lastet";
 
 /* No comment provided by engineer. */
 "privacy.protection.platform.limitations.footer.info" = "Merk: Plattformbegrensninger kan begrense kapasiteten vår til å oppdage alle forespørsler.";
@@ -1271,10 +1220,10 @@
 "privacy.protection.trackers.found.new" = "Sporingsforespørsler funnet";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.not.blocked" = "Ingen sporingsforespørsler er blokkert";
+"privacy.protection.trackers.not.blocked" = "Ingen sporingsforespørsler blokkert";
 
 /* No comment provided by engineer. */
-"privacy.protection.trackers.not.found" = "Ingen sporingsforespørsler er funnet";
+"privacy.protection.trackers.not.found" = "Ingen sporingsforespørsler funnet";
 
 /* Deny action */
 "prompt.custom.url.scheme.dontopen" = "Avbryt";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "En melding fra %@:";
 

--- a/DuckDuckGo/nl.lproj/Autocomplete.strings
+++ b/DuckDuckGo/nl.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Geen suggesties";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Suggestie automatisch aanvullen";
+

--- a/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/DuckDuckGo/nl.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Ongedaan maken";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Suggestie automatisch aanvullen";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Toevoegen als bladwijzer";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Website openen";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Zoeken op DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Toevoegen";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Aan";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Wachtwoord verbergen";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Weergeven";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Wachtwoord opslaan?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Wachtwoord weergeven";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Login bijwerken";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokkeer e-mailtrackers en verberg je adres";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Annuleren";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Let op: als je E-mailbescherming van dit apparaat verwijdert, wordt je Duck-adres niet verwijderd.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Verwijderen";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "E-mailbescherming verwijderen?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Er is een fout opgetreden bij het inschrijven op de wachtlijst. Probeer het later opnieuw.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Aan de slag";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Ik heb een uitnodigingscode";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Je bent uitgenodigd!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Schrijf je in voor de privéwachtlijst";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Je staat op de wachtlijst!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Je uitnodiging wordt hier weergegeven als je aan de beurt bent. Wil je %1$@ wanneer het toekomt? %2$@ over E-mailbescherming.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "krijg een melding";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "We sturen je een melding wanneer<br/> E-mailbescherming voor je klaar staat. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Meer informatie";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "We sturen je een melding wanneer je E-mailbescherming kunt gaan gebruiken.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Wil je dat we je een melding sturen als je aan de beurt bent?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Je hebt je ingeschreven voor de wachtlijst en ons gevraagd je te laten weten wanneer je aan de beurt bent om onze E-mailbescherming te proberen.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nee, bedankt";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "MELDING STUREN";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Je hebt een uitnodiging voor E-mailbescherming ontvangen!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "We bewaren je e-mails niet. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-mailprivacy, vereenvoudigd.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokkeer e-mailtrackers en verberg je adres, zonder van e-mailprovider te wisselen. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Nog geen bladwijzers toegevoegd";
@@ -1025,13 +974,13 @@
 "preserveLogins.remove.all.ok" = "OK";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.protections.link" = "Over onze webtrackingbeveiliging";
+"privacy.protection.about.protections.link" = "Over onze bescherming tegen webtracking";
 
 /* No comment provided by engineer. */
 "privacy.protection.about.search.protections.link" = "Over onze zoekbescherming en advertenties";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.search.protections.link.new" = "How our search ads impact our protections";
+"privacy.protection.about.search.protections.link.new" = "Hoe onze zoekadvertenties onze bescherming beïnvloeden";
 
 /* Part of certificate info */
 "privacy.protection.encryption.algorithm" = "Algoritme";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Een bericht van %@:";
 

--- a/DuckDuckGo/pl.lproj/Autocomplete.strings
+++ b/DuckDuckGo/pl.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Brak sugestii";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Propozycja autouzupełniania";
+

--- a/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/DuckDuckGo/pl.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Cofnij";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Propozycja autouzupełniania";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Zakładka";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Otwórz witrynę internetową";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Szukaj w DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Dodaj";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Włączone";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Ukryj hasło";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Wyświetl";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Zapisać hasło?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Pokaż hasło";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Aktualizuj logowanie";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Zablokuj skrypty śledzące pocztę e-mail i ukryj swój adres";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Anuluj";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Uwaga: usunięcie ochrony poczty e-mail z tego urządzenia nie spowoduje usunięcia Twojego adresu Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Usuń";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Usunąć ochronę poczty e-mail?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Wystąpił błąd podczas dołączania do listy oczekujących, spróbuj ponownie później";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Rozpocznij";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Mam kod zaproszenia";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Masz zaproszenie!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Dołącz do prywatnej listy oczekujących";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Jesteś na liście oczekujących!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Twoje zaproszenie pojawi się tutaj, gdy będzie gotowe. Chcesz %1$@, gdy będzie gotowe? %2$@ o ochronie poczty e-mail.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "otrzymaj powiadomienie";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Wyślemy Ci powiadomienie, gdy ochrona poczty e-mail będzie gotowa. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Dowiedz się więcej";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Wyślemy Ci powiadomienie, gdy będzie można zacząć korzystać z ochrony poczty e-mail.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Czy chcesz otrzymać powiadomienie, gdy nadejdzie Twoja kolej?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Jesteś już na liście oczekujących i powiadomimy Cię, gdy nadejdzie Twoja kolej na wypróbowanie ochrony poczty e-mail.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nie, dziękuję";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "POWIADOM MNIE";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Twoje zaproszenie do ochrony poczty e-mail jest gotowe!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Nie zapisujemy Twoich wiadomości e-mail. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Uproszczona prywatność poczty e-mail.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Zablokuj skrypty śledzące pocztę e-mail i ukryj swój adres<br/>bez zmiany dostawcy poczty e-mail. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Nie dodano jeszcze żadnych zakładek";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Wiadomość od %@:";
 

--- a/DuckDuckGo/pt.lproj/Autocomplete.strings
+++ b/DuckDuckGo/pt.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Sem sugestões";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Sugestão de preenchimento automático";
+

--- a/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/DuckDuckGo/pt.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Anular";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Sugestão de preenchimento automático";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Marcador";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Abrir website";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Pesquisar no DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Adicionar";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Ligado";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Ocultar palavra-passe";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Visualizar";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Guardar palavra-passe?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Mostrar palavra-passe";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Atualizar início de sessão";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Bloqueie rastreadores de e-mail e oculte o seu endereço.";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Cancelar";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Nota: Ao remover a proteção de e-mail deste dispositivo não excluirá o seu endereço Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Remover";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Remover a proteção de e-mail?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Ocorreu um erro ao entrar na Lista de Espera, tente novamente mais tarde";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Comece";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Tenho um Código de Convite";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Você foi convidado!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Adira à Lista de Espera Privada";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Você está na lista de espera!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "O seu convite aparecerá aqui quando estivermos prontos para si. Quer %1$@ quando chegar? %2$@ sobre a proteção de e-mail.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "receba uma notificação";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Enviaremos uma notificação quando a proteção de e-mail estiver pronta para si. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Saiba mais";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Enviaremos uma notificação quando começar a usar a proteção de e-mail.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Gostaria que o notificássemos quando for a sua vez?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Você entrou na lista de espera e pediu-nos para o notificar quando for a sua vez de experimentar a nossa proteção de e-mail.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Não, obrigado";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "NOTIFICAR-ME";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "O seu convite para Proteção de E-mail está aqui!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Não guardamos os seus e-mails. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "A privacidade dos e-mails, simplificada.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Bloqueie os rastreadores de e-mail e oculte o seu endereço, sem alterar o seu provedor de e-mail. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Ainda não foram adicionados marcadores";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Uma mensagem de %@:";
 

--- a/DuckDuckGo/ro.lproj/Autocomplete.strings
+++ b/DuckDuckGo/ro.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Fără sugestii";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Sugestie de completare automată";
+

--- a/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/DuckDuckGo/ro.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Anulați";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Sugestie de completare automată";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Marcat";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Deschide site-ul";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Caută pe DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Adăugați";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Activat";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Ascunde parola";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Vezi";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Salvezi parola?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Arată parola";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Actualizează autentificarea";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blochează tehnologiile de urmărire prin e-mail și ascunde-ți adresa";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Renunță";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Notă: eliminarea protecției comunicațiilor prin e-mail de pe acest dispozitiv nu va șterge adresa ta Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Elimină";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Elimină protecția comunicațiilor prin e-mail?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "S-a produs o eroare la aderarea la lista de așteptare, încearcă din nou mai târziu";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Să începem";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Am un cod de invitație";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Ai primit o invitație!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Alătură-te listei de așteptare private";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Ești pe lista de așteptare!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Invitația ta va apărea aici, când vom fi pregătiți pentru tine. Dorești să %1$@ în momentul în care sosește? %2$@ despre protecția comunicațiilor prin e-mail.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "primește o notificare";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Îți vom trimite o notificare când<br/> protecția comunicațiilor prin e-mail este pregătită pentru tine. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Află mai multe";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Îți vom trimite o notificare în momentul în care poți începe să folosești protecția comunicațiilor prin e-mail.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Vrei să te înștiințăm când îți vine rândul?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Te-ai alăturat listei de așteptare și ne-ai solicitat să te anunțăm când este rândul tău să încerci protecția comunicațiilor prin e-mail.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nu, mulțumesc";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "DORESC SĂ PRIMESC NOTIFICĂRI";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Invitația ta de protecție a comunicațiilor prin e-mail este aici!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Nu îți salvăm e-mailurile. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Confidențialitatea e-mailurilor, simplificată.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa, <br/> fără a schimba furnizorul de e-mail. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Nu s-a adăugat niciun semn de carte";
@@ -1172,7 +1121,7 @@
 "privacy.protection.no.other.third.party.domains.loaded" = "Nu au fost încărcate solicitări terță parte";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.adclickattribution" = "Solicitările următorului domeniu au fost încărcate deoarece s-a făcut clic recent pe o reclamă %@ pe DuckDuckGo. Aceste solicitări ajută la evaluarea eficienței anunțurilor. Nicio reclamă de pe DuckDuckGo nu creează profiluri.";
+"privacy.protection.other.domains.adclickattribution" = "Solicitările următorului domeniu au fost încărcate deoarece s-a făcut recent clic pe o reclamă %@ de pe DuckDuckGo. Aceste solicitări ajută la evaluarea eficienței anunțurilor. Nicio reclamă de pe DuckDuckGo nu creează profiluri.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.exceptions" = "Solicitările următoarelor domenii au fost încărcate pentru a preveni întreruperea site-ului.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Un mesaj de la %@:";
 

--- a/DuckDuckGo/ru.lproj/Autocomplete.strings
+++ b/DuckDuckGo/ru.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Нет предложений";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Предложение для автозаполнения";
+

--- a/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/DuckDuckGo/ru.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Отменить";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Предложение для автозаполнения";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Добавить в закладки";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Открыть сайт";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Поиск в DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Добавить";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Включено";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Скрыть пароль";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Просмотр";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Сохранить пароль?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Показать пароль";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Обновить логин";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Блокировка почтовых трекеров и скрытие адреса";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Отменить";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Внимание: снятие почтовой защиты на этом устройстве не ведет к удалению вашего адреса на Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Удалить";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Удалить защиту почты?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "При постановке в очередь произошла ошибка. Пожалуйста, повторите попытку позже";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Приступим!";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "У меня есть пригласительный код";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Вас пригласили!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Приглашаем встать в очередь";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Вас добавили в список ожидания!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Когда настанет время, ваше приглашение появится здесь. Хотите %1$@, когда оно придет? %2$@ о защите почты.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "получить уведомление";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Мы отправим вам уведомление, когда защита почты станет вам доступна. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Узнать больше";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Мы отправим вам уведомление, когда вы сможете начать пользоваться защитой почты.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Оповестить, когда подойдет ваша очередь?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Ранее вы встали в очередь и попросили нас оповестить вас о возможности применить защиту почты.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Нет, спасибо";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "ОПОВЕСТИТЬ";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Ваше приглашение воспользоваться защитой почты";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Мы не храним вашу электронную почту. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Надежная защита почты и ничего лишнего.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Оказывается, чтобы избавиться от трекеров и скрыть свой адрес,<br/>вовсе не нужно менять почтовый сервис. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Закладок пока нет";
@@ -1031,7 +980,7 @@
 "privacy.protection.about.search.protections.link" = "О рекламе и защите в поисковых системах";
 
 /* No comment provided by engineer. */
-"privacy.protection.about.search.protections.link.new" = "How our search ads impact our protections";
+"privacy.protection.about.search.protections.link.new" = "Как реклама при поиске влияет на защиту";
 
 /* Part of certificate info */
 "privacy.protection.encryption.algorithm" = "Алгоритм";
@@ -1181,7 +1130,7 @@
 "privacy.protection.other.domains.firstparty" = "Запросы этого домена были загружены, так как они связаны с %@.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info" = "Ниже приведен список загруженных запросов сторонних доменов. Благодаря этим запросам компании могут вас профилировать, однако мы по-прежнему защищаем вас от отслеживания в Сети другими способами.";
+"privacy.protection.other.domains.info" = "Ниже приведен список загруженных запросов сторонних доменов. Благодаря этим запросам компании могут вас профилировать, однако мы по-прежнему защищаем вас от отслеживания в сети другими способами.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.info.disabled.protection" = "Мы не заблокировали ни одной загрузки сторонних запросов, так как защита на этом сайте отключена. Загруженные запросы позволяют компаниям вас профилировать.";
@@ -1193,13 +1142,13 @@
 "privacy.protection.other.domains.info.header.disabled.protection.also.new" = "Также загружены запросы следующего домена.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info.header.disabled.protection.new" = "The following domains’ requests were loaded.";
+"privacy.protection.other.domains.info.header.disabled.protection.new" = "Загружены запросы следующих доменов.";
 
 /* Do not translate - stringsdict entry */
 "privacy.protection.other.domains.loaded" = "privacy.protection.other.domains.loaded";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.thirdparties" = "The following domain’s requests were loaded.";
+"privacy.protection.other.domains.thirdparties" = "Загружены запросы следующего домена.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.thirdparties.empty" = "Запросов от сторонних доменов не обнаружено.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "Хорошо";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Сообщение от %@:";
 

--- a/DuckDuckGo/sk.lproj/Autocomplete.strings
+++ b/DuckDuckGo/sk.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Žiadne návrhy";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Zobraziť návrhy automatického dopĺňania";
+

--- a/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/DuckDuckGo/sk.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Vrátenie späť";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Zobraziť návrhy automatického dopĺňania";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Záložka";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Otvoriť webovú lokalitu";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Vyhľadávať na DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Pridať";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Zapnuté";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Skryť heslo";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Zobraziť";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Uložiť heslo?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Zobraziť heslo";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Aktualizovať prihlasovacie údaje";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Zablokujte nástroje na sledovanie e‑mailov a skryte vašu adresu";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Zrušiť";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Upozornenie: Odstránením e-mailovej ochrany z tohto zariadenia sa neodstráni vaša adresa Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Odstrániť";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Odstrániť e-mailovú ochranu?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Pri pridávaní na zoznam čakateľov sa vyskytla chyba. Prosím, skúste to neskôr znova.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Začnite";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Mám pozývací kód";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Boli ste pozvaný/á!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Pridajte sa do súkromného zoznamu čakateľov";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Ste na zozname čakateľov!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Vaša pozvánka sa zobrazí tu, keď pre vás budeme pripravení. Prajete si, aby sme vám poslali %1$@, keď budete mať pozvánku? %2$@ o e-mailovej ochrane.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "dostať upozornenie";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Pošleme vám upozornenie, keď bude pre vás pripravená e-mailová ochrana. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Zistite viac";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Pošleme vám upozornenie, keď budete môcť začať používať e-mailovú ochranu.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Chcete, aby sme vám poslali upozornenie, keď budete na rade?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Pridali ste sa na zoznam čakateľov a požiadali ste nás, aby sme vás upozornili, keď na vás príde rad a keď budete si môcť vyskúšať našu e-mailovú ochranu.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nie, ďakujem";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "UPOZORNITE MA";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Vaše pozvánka na ochranu e‑mailu je tu!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Vaše e-maily neukladáme. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Zjednodušená ochrana súkromia v e‑mailoch.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Zablokujte e-mailové trackery a skryte svoju adresu bez toho, aby ste museli prepínať svojich poskytovateľov e-mailu. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Zatiaľ neboli pridané žiadne záložky";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Správa od %@:";
 

--- a/DuckDuckGo/sl.lproj/Autocomplete.strings
+++ b/DuckDuckGo/sl.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Ni predlogov";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Pokaži predlog za samodokončanje";
+

--- a/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/DuckDuckGo/sl.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Prekliči spremembe";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Pokaži predlog za samodokončanje";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Zaznamek";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Odpri spletno mesto";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Iskanje v DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Dodaj";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Vključeno";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Skrij geslo";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Oglejte si";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Želite shraniti geslo?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Prikaži geslo";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Posodobitev prijave";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blokirajte sledilnike e-pošte in skrijte svoj naslov";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Prekliči";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Opomba: če odstranite zaščito e-pošte iz te naprave, s tem ne boste izbrisali svojega naslova Duck.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Odstrani";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Želite odstraniti zaščito e-pošte?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Pri dodajanju na čakalni seznam je prišlo do napake, poskusite znova pozneje";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Začni";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Imam kodo povabila";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Prejeli ste povabilo!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Pridruži se zasebnemu čakalnemu seznamu";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Ste na čakalnem seznamu!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Vaše povabilo se bo prikazalo tukaj, ko bomo pripravljeni. Želite %1$@, ko prispe? %2$@ o zaščiti e-pošte.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "prejeti obvestilo";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Obvestili vas bomo, ko bo zaščita e-pošte pripravljena za vas. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Več informacij";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Ko bo mogoče začeti uporabljati zaščito e-pošte, vam bomo poslali obvestilo.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Želite, da vas obvestimo, ko boste na vrsti?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Pridružili ste se čakalnemu seznamu in prosili, da vas obvestimo, ko boste na vrsti, da preizkusite našo zaščite e-pošte.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Ne, hvala";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "OBVESTI ME";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Vabilo za zaščito e-pošte je tu!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Vaše e-pošte ne shranjujemo. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Poenostavljena zasebnost e-pošte.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blokirajte sledilnike e-pošte in skrijte svoj naslov, ne da bi vam bilo treba zamenjati ponudnika e-pošte. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Zaznamki še niso dodani";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "V REDU";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Sporočilo od %@:";
 

--- a/DuckDuckGo/sv.lproj/Autocomplete.strings
+++ b/DuckDuckGo/sv.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Inga förslag";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Komplettera automatiskt-förslag";
+

--- a/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/DuckDuckGo/sv.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Återställ";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Komplettera automatiskt-förslag";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Spara bokmärke";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Öppna webbplatsen";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "Sök på DuckDuckGo";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Lägg till";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "På";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Dölj lösenord";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Visa";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Spara lösenord?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Visa lösenord";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Uppdatera inloggning";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "Blockera e-postspårare och dölj din adress";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "Avbryt";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "Obs! Att ta bort e-postskydd från den här enheten innebär inte att din Duck-adress raderas.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Ta bort";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "Ta bort e-postskydd";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Det inträffade ett fel när du gick med i väntelistan. Försök igen senare.";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Kom igång";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Jag har en inbjudningskod";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Du är inbjuden!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Ställ dig i den privata väntelistan";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Du står på väntelistan!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Din inbjudan visas här när vi är redo att ta emot dig. Vill du %1$@ när den kommer? %2$@ om e-postskydd.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "få ett meddelande";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "Vi skickar dig ett meddelande när e-postskydd är redo för dig. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Läs mer";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "Vi skickar dig ett meddelande när du kan börja använda e-postskydd.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Vill du att vi meddelar dig när det är din tur?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Du satte upp dig på väntelistan och bad oss att meddela dig när det är din tur att prova e-postskydd.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Nej tack";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "MEDDELA MIG";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "Din inbjudan till e-postskydd har kommit!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "Vi sparar inte dina e-postmeddelanden. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "Enklare E-postintegritet.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "Blockera e-postspårare och dölj din adress<br/>utan att byta e-postleverantör. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Inga bokmärken har lagts till ännu";
@@ -1181,7 +1130,7 @@
 "privacy.protection.other.domains.firstparty" = "Följande domäns förfrågningar lästes in eftersom de är kopplade till %@.";
 
 /* No comment provided by engineer. */
-"privacy.protection.other.domains.info" = "Följande tredjepartsdomäners förfrågningar lästes in. Om ett företags förfrågningar läses in kan det göra det möjligt för företaget att profilera dig, även om våra övriga webbspårningsskydd fortfarande gäller.";
+"privacy.protection.other.domains.info" = "Följande tredjepartsdomäners förfrågningar lästes in. Om ett företags förfrågningar läses in kan det göra det möjligt för företaget att profilera dig, även om våra övriga webbspårningsskydd fortfarande är aktiva.";
 
 /* No comment provided by engineer. */
 "privacy.protection.other.domains.info.disabled.protection" = "Inga förfrågningar från tredje part blockerades från att läsas in eftersom skyddet är avstängt för den här webbplatsen. Om ett företags förfrågningar läses in kan det göra det möjligt för företaget att profilera dig.";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "OK";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "Ett meddelande från %@:";
 

--- a/DuckDuckGo/tr.lproj/Autocomplete.strings
+++ b/DuckDuckGo/tr.lproj/Autocomplete.strings
@@ -4,3 +4,6 @@
 /* Class = "UILabel"; text = "No Suggestions"; ObjectID = "gPe-Cv-14j"; */
 "gPe-Cv-14j.text" = "Öneri yok";
 
+/* Class = "UIButton"; accessibilityLabel = "Autocomplete suggestion"; ObjectID = "N97-eI-Lps"; */
+"N97-eI-Lps.accessibilityLabel" = "Otomatik tamamlama önerisi";
+

--- a/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/DuckDuckGo/tr.lproj/Localizable.strings
@@ -10,6 +10,18 @@
 /* Button label for Undo action */
 "action.generic.undo" = "Geri al";
 
+/* Autocomplete selected suggestion into the Address Bar button accessibility label */
+"action.suggestion.autocomplete" = "Otomatik tamamlama önerisi";
+
+/* Open suggested bookmark action accessibility title */
+"action.suggestion.open.bookmark" = "Yer imi ekle";
+
+/* Open suggested website action accessibility title */
+"action.suggestion.open.website" = "Web sitesini aç";
+
+/* Search for suggestion action accessibility title */
+"action.suggestion.search" = "DuckDuckGo'da ara";
+
 /* Add action - button shown in alert */
 "action.title.add" = "Ekle";
 
@@ -160,6 +172,9 @@
 /* No comment provided by engineer. */
 "autoclear.on" = "Açık";
 
+/* Accessibility title for a Hide Password button replacing displayed password with ***** */
+"autofill.hide-password" = "Parolayı gizle";
+
 /* Button displayed after saving/updating an autofill login that takes the user to the saved login */
 "autofill.login-save-action-button.toast" = "Görüntüle";
 
@@ -192,6 +207,9 @@
 
 /* Title displayed on modal asking for the user to save the password */
 "autofill.save-password.title" = "Şifre Kaydedilsin mi?";
+
+/* Accessibility title for a Show Password button displaying actial password instead of ***** */
+"autofill.show-password" = "Parolayı göster";
 
 /* Confirm CTA displayed on modal asking for the user to update the login */
 "autofill.update-login.save.CTA" = "Girişi Güncelle";
@@ -492,75 +510,6 @@
 
 /* Subtitle for the email settings cell */
 "email.settings.subtitle" = "E-posta izleyicileri engelleyin ve adresinizi gizleyin";
-
-/* Cancel option for the email sign out alert */
-"email.signOutAlert.cancel" = "İptal";
-
-/* Description for the email sign out alert */
-"email.signOutAlert.description" = "E-posta Korumasının bu cihazdan kaldırılması Duck Adresinizin silinmesine yol açmaz.";
-
-/* Remove option for the email sign out alert */
-"email.signOutAlert.remove" = "Kaldır";
-
-/* Title for the email sign out alert */
-"email.signOutAlert.title" = "E-posta Koruması Kaldırılsın mı?";
-
-/* Error text when failing to join the waitlist */
-"email.waitlist.error-joining" = "Bekleme listesine katılırken bir hata oluştu, lütfen daha sonra tekrar deneyin";
-
-/* Action button text for the email waitlist */
-"email.waitlist.get-started" = "Başlayın";
-
-/* Invite code button text for the email waitlist */
-"email.waitlist.have-invite-code" = "Davet Kodum var";
-
-/* Header text for the email waitlist */
-"email.waitlist.invited" = "Davet edildiniz!";
-
-/* Action button text for the email waitlist */
-"email.waitlist.join" = "Özel Bekleme Listesine Katılın";
-
-/* Header text for the email waitlist */
-"email.waitlist.joined" = "Bekleme listesindesiniz!";
-
-/* First parameter is 'get a notification', second is 'Learn more'. */
-"email.waitlist.joined.no-notification" = "Özellik hazır olduğunda davetiyeniz burada gösterilecek. Hazır olduğunda %1$@ ister misiniz? E-posta Koruması hakkında %2$@.";
-
-/* Notification text for the email waitlist */
-"email.waitlist.joined.no-notification.get-notification" = "bildirim almak";
-
-/* Description text for the email waitlist. Parameter is 'Learn more.' */
-"email.waitlist.joined.notification" = "E-posta Koruması hazır olduğunda size bildirim gönderilecektir. %@.";
-
-/* Footer text for the email waitlist */
-"email.waitlist.learn-more" = "Daha fazla bilgi";
-
-/* Body text for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.body" = "E-posta Koruması'nı kullanmaya başlayabileceğiniz zaman size bir bildirim göndereceğiz.";
-
-/* Title for the permission notification for the email waitlist */
-"email.waitlist.notification-permission.title" = "Sıra size geldiğinde haber vermemizi ister misiniz?";
-
-/* Body text for the email waitlist notification */
-"email.waitlist.notification.body" = "Bekleme listesine katılarak E-posta Koruması'nı deneme sırası size geldiğinde sizi bilgilendirmemizi istediniz.";
-
-/* Decline option for the permission notification for the email waitlist */
-"email.waitlist.notification.no-thanks" = "Hayır Teşekkürler";
-
-/* Accept option for the permission notification for the email waitlist */
-"email.waitlist.notification.notify-me" = "BANA BİLDİR";
-
-/* Title for the email waitlist notification */
-"email.waitlist.notification.title" = "E-posta Koruması için Davetlisiniz!";
-
-/* Footer text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.privacy-guarantee" = "E-postalarınızı kaydetmiyoruz. %@.";
-
-/* Header text for the email waitlist */
-"email.waitlist.privacy-simplified" = "E-posta gizliliğinin basitleştirilmiş hâli.";
-
-/* Description text for the email waitlist. Parameter is 'Learn more'. */
-"email.waitlist.summary" = "E-posta sağlayıcınızı değiştirmeden e-posta izleyicileri engelleyin ve adresinizi gizleyin. %@.";
 
 /* Empty list state placholder */
 "empty.bookmarks" = "Henüz yer imi eklenmedi";
@@ -1404,4 +1353,7 @@
 
 /* OK button for JavaScript alerts */
 "webJSAlert.OK.button" = "Tamam";
+
+/* Alert title explaining the message is shown by a website */
+"webJSAlert.website-message.format" = "%@ size bir mesaj gönderdi:";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1202854620659929/f
Tech Design URL:
CC: @mallexxx 

**Description:**
Add missing translation to localization strings

**Steps to test this PR:**

Just checking the strings file should be good, but if you're feeling inspired you can:

1. Change your device to a non-english but supported language
2. Turn on voice over on accessibility
3. Check Auto fill show/hide button
4. Check the auto-complete suggestion accessibility labels

**Device Testing**:

* [ ] iPhone 



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
