### PR TITLE
Fix for fullscreen video playback and viewing control center bug

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -417,10 +417,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if overlayWindow == nil {
             tryToObtainOverlayWindow()
         }
-        
-        overlayWindow?.isHidden = true
-        overlayWindow = nil
-        window?.makeKeyAndVisible()
+
+        if let overlay = overlayWindow {
+            overlay.isHidden = true
+            overlayWindow = nil
+            window?.makeKeyAndVisible()
+        }
     }
 
     private func handleShortCutItem(_ shortcutItem: UIApplicationShortcutItem) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1203112075539983/f
Tech Design URL:
CC:

**Description**:
When app becomes active again after control center was accessed, there is a call to `window?.makeKeyAndVisible()` after removing overlayView, regardless of whether or not there was actually an overlay view, which affects fullscreen video playback.  This PR restricts this call to only happen when an overlayView was actually present 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open YouTube in a new tab and play video in fullscreen
2. Pull down control center for a few seconds and then close it. Confirm video is still playing and is still in full screen mode
3. Enable Application Lock in Settings and lightly smoke test to confirm this all still works as before

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
