### PR TITLE
refresh the widgets when favicons are stored

### DIFF
--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -21,6 +21,7 @@ import Kingfisher
 import UIKit
 import os
 import LinkPresentation
+import WidgetKit
 
 // swiftlint:disable type_body_length file_length
 public class Favicons {
@@ -274,6 +275,7 @@ public class Favicons {
             case .success(let image):
                 if let image = image.image {
                     Constants.caches[toCache]?.store(image, forKey: resource.cacheKey, options: .init(options))
+                    WidgetCenter.shared.reloadAllTimelines()
                 }
                 completion?(image.image)
 
@@ -313,6 +315,7 @@ public class Favicons {
                 if let image = image {
                     let image = self.scaleDownIfNeeded(image: image, toFit: Constants.maxFaviconSize)
                     targetCache.store(image, forKey: resource.cacheKey, options: .init(options))
+                    WidgetCenter.shared.reloadAllTimelines()
                 }
                 completion?(image)
             }

--- a/DuckDuckGo/ImageCacheDebugViewController.swift
+++ b/DuckDuckGo/ImageCacheDebugViewController.swift
@@ -19,6 +19,7 @@
 
 import UIKit
 import Core
+import WidgetKit
 
 class ImageCacheDebugViewController: UITableViewController {
 
@@ -140,6 +141,7 @@ class ImageCacheDebugViewController: UITableViewController {
 
         alert.addAction(UIAlertAction(title: "Clear", style: .destructive, handler: { _ in
             self.clearCacheAndReload()
+            WidgetCenter.shared.reloadAllTimelines()
         }))
 
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1203041498281218/f
Tech Design URL: 
CC:

**Description**:

Updates Widgets when the favicons are stored in the cache.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.  Add a few favorites
3. Add the favorites widget to the home screen - should show the favicons
4. Use the debug menu to clear the image cache
1. Check the widget - favicons should be gone (might take a second)
1. Use the firebutton  
1. Visit the websites, check the widget, should be updated with favicon

**Device Testing**:

* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
