### PR TITLE
fix error reporting of snapshot preview deletions

### DIFF
--- a/DuckDuckGo/TabPreviewsSource.swift
+++ b/DuckDuckGo/TabPreviewsSource.swift
@@ -76,9 +76,11 @@ class TabPreviewsSource {
         guard let url = previewLocation(for: tab) else { return }
         
         cache[tab.uid] = nil
-        
+
         do {
-            try FileManager.default.removeItem(at: url)
+            if FileManager.default.fileExists(atPath: url.filePath) {
+                try FileManager.default.removeItem(at: url)
+            }
         } catch {
             Pixel.fire(pixel: .cachedTabPreviewRemovalError, error: error)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1200123805767782/f
Tech Design URL:
CC:

**Description**:

The original snapshot error has probably been fixed, but we still report when the removal fails.  The removal can fail because the file doesn't exist, which is the case if you are in horizontal cell mode in the tab view when opening new tabs and visiting pages.

**Steps to test this PR**:
Might be easier to check by using a break point and stepping over.

1. Open a few tabs on different pages.
2. Go the tab switcher and in preview mode close a tab.
3. Check the related file is deleted
4. Change to horizontal tabs mode and close a tab 
5. Check the associated file is deleted (will have been created because the tab view was in preview mode)
7. Close all tabs 
8. With the tab switcher still in horizontal tabs mode open a few pages 
9. Close a few tabs
10. Note that the pixel is NOT fired and that there is not attempt to delete the file because it doesn't exist

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone X
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
