### PR TITLE
Rework autodisable autofill logic to be less aggressive

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -76,8 +76,9 @@ public struct UserDefaultsWrapper<T> {
         
         case lastCompiledRules = "com.duckduckgo.app.lastCompiledRules"
 
-        case autofill = "com.duckduckgo.ios.autofill"
+        case autofillCredentialsEnabled = "com.duckduckgo.ios.autofillCredentialsEnabled"
         case autofillSaveModalRejectionCount = "com.duckduckgo.ios.autofillSaveModalRejectionCount"
+        case autofillSaveModalDisablePromptShown = "com.duckduckgo.ios.autofillSaveModalDisablePromptShown"
         case autofillFirstTimeUser = "com.duckduckgo.ios.autofillFirstTimeUser"
         
         case featureFlaggingDidVerifyInternalUser = "com.duckduckgo.app.featureFlaggingDidVerifyInternalUser"

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -34,7 +34,7 @@ protocol AppSettings: AnyObject {
     
     var textSize: Int { get set }
     
-    var autofill: Bool { get set }
+    var autofillCredentialsEnabled: Bool { get set }
 
     var voiceSearchEnabled: Bool { get set }
 

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -169,8 +169,8 @@ public class AppUserDefaults: AppSettings {
     @UserDefaultsWrapper(key: .textSize, defaultValue: 100)
     var textSize: Int
     
-    @UserDefaultsWrapper(key: .autofill, defaultValue: true)
-    var autofill: Bool
+    @UserDefaultsWrapper(key: .autofillCredentialsEnabled, defaultValue: true)
+    var autofillCredentialsEnabled: Bool
     
     @UserDefaultsWrapper(key: .voiceSearchEnabled, defaultValue: false)
     var voiceSearchEnabled: Bool

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -30,7 +30,7 @@ extension ContentScopeFeatureToggles {
         let context = LAContext()
         var error: NSError?
         let canAuthenticate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
-        return featureFlagger.isFeatureOn(.autofill) && appSettings.autofill && canAuthenticate
+        return featureFlagger.isFeatureOn(.autofill) && appSettings.autofillCredentialsEnabled && canAuthenticate
     }
     
     static var supportedFeaturesOniOS: ContentScopeFeatureToggles {

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -70,9 +70,9 @@ final class AutofillLoginListViewModel: ObservableObject {
     }
     
     var isAutofillEnabled: Bool {
-        get { appSettings.autofill }
+        get { appSettings.autofillCredentialsEnabled }
         set {
-            appSettings.autofill = newValue
+            appSettings.autofillCredentialsEnabled = newValue
             NotificationCenter.default.post(name: AppUserDefaults.Notifications.autofillEnabledChange, object: self)
         }
     }

--- a/DuckDuckGo/SaveLoginViewController.swift
+++ b/DuckDuckGo/SaveLoginViewController.swift
@@ -31,9 +31,11 @@ protocol SaveLoginViewControllerDelegate: AnyObject {
 class SaveLoginViewController: UIViewController {
     weak var delegate: SaveLoginViewControllerDelegate?
     private let credentialManager: SaveAutofillLoginManager
+    private let domainLastShownOn: String?
 
-    internal init(credentialManager: SaveAutofillLoginManager) {
+    internal init(credentialManager: SaveAutofillLoginManager, domainLastShownOn: String? = nil) {
         self.credentialManager = credentialManager
+        self.domainLastShownOn = domainLastShownOn
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -58,7 +60,7 @@ class SaveLoginViewController: UIViewController {
     }
 
     private func setupSaveLoginView() {
-        let saveViewModel = SaveLoginViewModel(credentialManager: credentialManager)
+        let saveViewModel = SaveLoginViewModel(credentialManager: credentialManager, domainLastShownOn: domainLastShownOn)
         saveViewModel.delegate = self
 
         let saveLoginView = SaveLoginView(viewModel: saveViewModel)
@@ -115,7 +117,7 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
 
         let disableAction = UIAlertAction(title: UserText.autofillKeepEnabledAlertDisableAction, style: .cancel) { _ in
             self.delegate?.saveLoginViewControllerDidCancel(self)
-            AppDependencyProvider.shared.appSettings.autofill = false
+            AppDependencyProvider.shared.appSettings.autofillCredentialsEnabled = false
         }
 
         let keepUsingAction = UIAlertAction(title: UserText.autofillKeepEnabledAlertKeepUsingAction, style: .default) { _ in


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1202951461895525/f
Tech Design URL:
CC:

**Description**:
Changes the autofill disable prompt logic to take into account if it's been shown before, and if it's been shown on the same site before. See code comments or asana task for full details of the logic

Also forces the autofill setting to be reenabled for everyone on iOS, given the previously over eager auto disabling logic (by changing it's name, since it defaults to true)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Testing this is quite complicated and will require a lot of fresh installs 😅 
1. Fresh install. Go to a site with a login (e.g. katesclothing.co.uk), login. Reject the prompt to save. Do this 3 more times. Make sure you're not prompted to disable autofill (or that it's disabled automatically)
----
1. Do as above, but kill the app between each login. After the third, you should be prompted to disable autofill.
1. Login _again_ on a new site and don't save. You shouldn't see the disable prompt again
----
1. Fresh install again. Login twice on one site and dismiss the prompt again. Do the same twice on a different site. Shouldn't see the dismiss prompt. Try on a third site, should see it.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
