### PR TITLE
Autofill In Browser layout improvements for landscape / iPad

### DIFF
--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -203,8 +203,7 @@ struct SaveLoginView: View {
             .frame(maxWidth: .infinity)
             .multilineTextAlignment(.center)
             .padding(.horizontal, 10)
-            .padding(.top, 56)
-            .padding(.bottom, 56)
+            .padding(.horizontal, isSmallFrame ? Const.Size.paddingSmallDevice : Const.Size.paddingDefault)
     }
     
     private var additionalLoginContentView: some View {
@@ -213,8 +212,7 @@ struct SaveLoginView: View {
             .secondaryTextStyle()
             .frame(maxWidth: .infinity)
             .multilineTextAlignment(.center)
-            .padding(.top, 56)
-            .padding(.bottom, 56)
+            .padding(.horizontal, isSmallFrame ? Const.Size.paddingSmallDevice : Const.Size.paddingDefault)
     }
     
     // We have specific layouts for the smaller iPhones

--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -88,16 +88,22 @@ struct SaveLoginView: View {
                 titleHeaderView
                 if isIPad {
                     Spacer()
-                } else {
+                } else if layoutType == .newUser || layoutType == .saveLogin {
                     Spacer()
                         .frame(maxHeight: isSmallFrame ? 8 : 24)
+                } else {
+                    Spacer()
+                        .frame(maxHeight: isSmallFrame ? 24 : 56)
                 }
                 contentView
                 if isIPad {
                     Spacer()
-                } else {
+                } else if layoutType == .newUser || layoutType == .saveLogin {
                     Spacer()
                         .frame(maxHeight: isSmallFrame ? 24 : 40)
+                } else {
+                    Spacer()
+                        .frame(maxHeight: isSmallFrame ? 24 : 56)
                 }
                 ctaView
                 if isIPhonePortrait {
@@ -202,7 +208,6 @@ struct SaveLoginView: View {
             .lineLimit(1)
             .frame(maxWidth: .infinity)
             .multilineTextAlignment(.center)
-            .padding(.horizontal, 10)
             .padding(.horizontal, isSmallFrame ? Const.Size.paddingSmallDevice : Const.Size.paddingDefault)
     }
     

--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -32,6 +32,9 @@ struct SaveLoginView: View {
     }
     @State var frame: CGSize = .zero
     @ObservedObject var viewModel: SaveLoginViewModel
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+
     var layoutType: LayoutType {
         viewModel.layoutType
     }
@@ -68,6 +71,8 @@ struct SaveLoginView: View {
         GeometryReader { geometry in
             makeBodyView(geometry)
         }
+        .padding([.horizontal], isIPhonePortrait ? 16 : 48)
+        .ignoresSafeArea()
     }
     
     private func makeBodyView(_ geometry: GeometryProxy) -> some View {
@@ -81,12 +86,26 @@ struct SaveLoginView: View {
             
             VStack(spacing: 0) {
                 titleHeaderView
+                if isIPad {
+                    Spacer()
+                } else {
+                    Spacer()
+                        .frame(maxHeight: isSmallFrame ? 8 : 24)
+                }
                 contentView
+                if isIPad {
+                    Spacer()
+                } else {
+                    Spacer()
+                        .frame(maxHeight: isSmallFrame ? 24 : 40)
+                }
                 ctaView
-                Spacer()
+                if isIPhonePortrait {
+                    Spacer()
+                } else {
+                    Spacer(minLength: isIPad ? 64 : 32)
+                }
             }
-            .frame(width: Const.Size.contentWidth)
-            .padding(.top, isSmallFrame ? 19 : 43)
         }
     }
     
@@ -116,7 +135,7 @@ struct SaveLoginView: View {
     }
     
     var titleHeaderView: some View {
-        VStack {
+        VStack(spacing: 0) {
             HStack {
                 FaviconView(viewModel: FaviconViewModel(domain: viewModel.accountDomain))
                     .scaledToFit()
@@ -124,21 +143,21 @@ struct SaveLoginView: View {
                 Text(viewModel.accountDomain)
                     .secondaryTextStyle()
                     .font(Const.Fonts.titleCaption)
-                    
             }
-            
-            VStack {
-                Text(title)
-                    .font(Const.Fonts.title)
-                    .frame(maxWidth: .infinity)
-                    .multilineTextAlignment(.center)
-            }
-            .padding(.top, isSmallFrame ? 15 : 25)
+
+            Text(title)
+                .font(Const.Fonts.title)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, isSmallFrame ? 2 : (isIPhonePortrait ? 25 : 29))
         }
+        .frame(width: isIPhone ? Const.Size.contentWidth : frame.width)
+        .padding(.top, isSmallFrame ? 20 : (isIPhonePortrait ? 40 : 54))
     }
     
     var ctaView: some View {
-        VStack {
+        VStack(spacing: 8) {
             Button {
                 viewModel.save()
             } label: {
@@ -152,6 +171,7 @@ struct SaveLoginView: View {
             }
             .buttonStyle(SecondaryButtonStyle())
         }
+        .frame(width: isIPhonePortrait ? Const.Size.contentWidth : frame.width)
     }
     
     @ViewBuilder
@@ -170,11 +190,10 @@ struct SaveLoginView: View {
         Text(UserText.autofillSaveLoginMessageNewUser)
             .font(Const.Fonts.subtitle)
             .secondaryTextStyle()
-            .frame(maxWidth: .infinity)
             .multilineTextAlignment(.center)
-            .padding(.horizontal, isSmallFrame ? 28 : 30)
-            .padding(.top, isSmallFrame ? 10 : 24)
-            .padding(.bottom, isSmallFrame ? 15 : 40)
+            .padding(.horizontal, isSmallFrame ? Const.Size.paddingSmallDevice : Const.Size.paddingDefault)
+            .frame(width: isIPhonePortrait ? Const.Size.contentWidth : frame.width)
+            .fixedSize(horizontal: false, vertical: true)
     }
     
     private var updateContentView: some View {
@@ -201,6 +220,18 @@ struct SaveLoginView: View {
     // We have specific layouts for the smaller iPhones
     private var isSmallFrame: Bool {
         frame.width <= Const.Size.smallDevice || frame.height <= Const.Size.smallDevice
+    }
+
+    private var isIPhonePortrait: Bool {
+        verticalSizeClass == .regular && horizontalSizeClass == .compact
+    }
+
+    private var isIPhone: Bool {
+        verticalSizeClass == .compact || horizontalSizeClass == .compact
+    }
+
+    private var isIPad: Bool {
+        verticalSizeClass == .regular && horizontalSizeClass == .regular
     }
 }
 
@@ -256,11 +287,11 @@ struct SaveLoginView_Previews: PreviewProvider {
 
 private enum Const {
     enum Fonts {
-        static let title = Font.system(size: 20).weight(.bold)
-        static let subtitle = Font.system(size: 13.0)
-        static let updatedInfo = Font.system(size: 16)
-        static let titleCaption = Font.system(size: 13)
-        static let userInfo = Font.system(size: 13).weight(.bold)
+        static let title = Font.system(.title3).weight(.bold)
+        static let subtitle = Font.system(.footnote)
+        static let updatedInfo = Font.system(.callout)
+        static let titleCaption = Font.system(.footnote)
+        static let userInfo = Font.system(.footnote).weight(.bold)
     }
 
     enum Margin {
@@ -278,5 +309,7 @@ private enum Const {
         static var closeButtonOffset: CGFloat {
             closeButtonTappableArea - closeButtonSize
         }
+        static let paddingSmallDevice: CGFloat = 28
+        static let paddingDefault: CGFloat = 30
     }
 }

--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -34,6 +34,7 @@ struct SaveLoginView: View {
     @ObservedObject var viewModel: SaveLoginViewModel
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.verticalSizeClass) var verticalSizeClass
+    @State private var orientation = UIDevice.current.orientation
 
     var layoutType: LayoutType {
         viewModel.layoutType
@@ -71,8 +72,11 @@ struct SaveLoginView: View {
         GeometryReader { geometry in
             makeBodyView(geometry)
         }
-        .padding([.horizontal], isIPhonePortrait ? 16 : 48)
-        .ignoresSafeArea()
+        .padding(.horizontal, isIPhonePortrait ? 16 : 48)
+        .ignoresSafeArea(edges: [.top, .bottom])
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            orientation = UIDevice.current.orientation
+        }
     }
     
     private func makeBodyView(_ geometry: GeometryProxy) -> some View {
@@ -83,34 +87,15 @@ struct SaveLoginView: View {
         
         return ZStack {
             closeButtonHeader
-            
+                .offset(x: isIPhonePortrait ? 16 : 48)
+
             VStack(spacing: 0) {
                 titleHeaderView
-                if isIPad {
-                    Spacer()
-                } else if layoutType == .newUser || layoutType == .saveLogin {
-                    Spacer()
-                        .frame(maxHeight: isSmallFrame ? 8 : 24)
-                } else {
-                    Spacer()
-                        .frame(maxHeight: isSmallFrame ? 24 : 56)
-                }
+                contentViewTopSpacer
                 contentView
-                if isIPad {
-                    Spacer()
-                } else if layoutType == .newUser || layoutType == .saveLogin {
-                    Spacer()
-                        .frame(maxHeight: isSmallFrame ? 24 : 40)
-                } else {
-                    Spacer()
-                        .frame(maxHeight: isSmallFrame ? 24 : 56)
-                }
+                contentViewBottomSpacer
                 ctaView
-                if isIPhonePortrait {
-                    Spacer()
-                } else {
-                    Spacer(minLength: isIPad ? 64 : 32)
-                }
+                bottomSpacer
             }
         }
     }
@@ -161,7 +146,35 @@ struct SaveLoginView: View {
         .frame(width: isIPhone ? Const.Size.contentWidth : frame.width)
         .padding(.top, isSmallFrame ? 20 : (isIPhonePortrait ? 40 : 54))
     }
-    
+
+    var contentViewTopSpacer: some View {
+        VStack {
+            if isIPad {
+                Spacer()
+            } else if layoutType == .newUser || layoutType == .saveLogin {
+                Spacer()
+                    .frame(maxHeight: isSmallFrame ? 8 : 24)
+            } else {
+                Spacer()
+                    .frame(maxHeight: isSmallFrame ? 24 : 56)
+            }
+        }
+    }
+
+    var contentViewBottomSpacer: some View {
+        VStack {
+            if isIPad {
+                Spacer()
+            } else if layoutType == .newUser || layoutType == .saveLogin {
+                Spacer()
+                    .frame(maxHeight: isSmallFrame ? 24 : 40)
+            } else {
+                Spacer()
+                    .frame(maxHeight: isSmallFrame ? 24 : 56)
+            }
+        }
+    }
+
     var ctaView: some View {
         VStack(spacing: 8) {
             Button {
@@ -178,6 +191,20 @@ struct SaveLoginView: View {
             .buttonStyle(SecondaryButtonStyle())
         }
         .frame(width: isIPhonePortrait ? Const.Size.contentWidth : frame.width)
+    }
+
+    var bottomSpacer: some View {
+        VStack {
+            if isIPhonePortrait {
+                Spacer()
+            } else if isIPad {
+                Spacer()
+                    .frame(height: orientation == .portrait ? 24 : 64)
+            } else {
+                Spacer()
+                    .frame(height: 44)
+            }
+        }
     }
     
     @ViewBuilder


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1202809065048067/f
Tech Design URL:
CC:

**Description**:
Landscape and iPad layout handling for all prompts including:
- Save login
- Save username / password
- Save additional login
- Update username / password
- Choose from saved login (single)
- Choose from saved login (multiple)

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run through the different view states confirming the layouts match designs for iPhone landscape and iPad portrait & landscape
2. Confirm iPhone portrait layouts are still correct

Note:
- iOS 14 has not been throughly tested (will do a full iOS 14 review of all Autofill screens separately)
- Custom detents not implemented for iOS 16 (will tackle in an iOS 16 improvements PR)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
