### PR TITLE
Add 30-minute timeout to the unit tests GHA workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,7 @@ jobs:
     name: Unit Tests
 
     runs-on: macos-12
+    timeout-minutes: 30
 
     steps:
     - name: Check out the code


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203164850287657/f

**Description**:
Add a timeout to terminate workflows early in case they hang up unexpectedly.

**Steps to test this PR**:
1. Ensure that the unit tests workflow runs without a syntax error and finishes without unexpected errors


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
