### PR TITLE
Fix for repeated FaceID request when getting back to the app

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -295,6 +295,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         os_log("App launched with url %s", log: lifecycleLog, type: .debug, url.absoluteString)
+        NotificationCenter.default.post(name: AutofillLoginListAuthenticator.Notifications.invalidateContext, object: nil)
         mainViewController?.clearNavigationStack()
         autoClear?.applicationWillMoveToForeground()
         showKeyboardIfSettingOn = false

--- a/DuckDuckGo/AutofillLoginListAuthenticator.swift
+++ b/DuckDuckGo/AutofillLoginListAuthenticator.swift
@@ -31,6 +31,10 @@ final class AutofillLoginListAuthenticator {
     enum AuthenticationState {
         case loggedIn, loggedOut
     }
+
+    public struct Notifications {
+        public static let invalidateContext = Notification.Name("com.duckduckgo.app.AutofillLoginListAuthenticator.invalidateContext")
+    }
     
     private var context = LAContext()
     @Published private(set) var state = AuthenticationState.loggedOut
@@ -69,5 +73,9 @@ final class AutofillLoginListAuthenticator {
         } else {
             completion?(.noAuthAvailable)
         }
+    }
+
+    func invalidateContext() {
+        context.invalidate()
     }
 }

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -127,6 +127,10 @@ final class AutofillLoginListViewModel: ObservableObject {
         authenticator.authenticate(completion: completion)
     }
 
+    func authenticateInvalidateContext() {
+        authenticator.invalidateContext()
+    }
+
     func rowsInSection(_ section: Int) -> Int {
         switch self.sections[section] {
         case .enableAutofill:

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -179,6 +179,10 @@ final class AutofillLoginSettingsListViewController: UIViewController {
         notificationCenter.addObserver(self,
                                        selector: #selector(appWillMoveToBackgroundCallback),
                                        name: UIApplication.willResignActiveNotification, object: nil)
+
+        notificationCenter.addObserver(self,
+                                       selector: #selector(authenticatorInvalidateContext),
+                                       name: AutofillLoginListAuthenticator.Notifications.invalidateContext, object: nil)
     }
     
     @objc private func appWillMoveToForegroundCallback() {
@@ -187,6 +191,10 @@ final class AutofillLoginSettingsListViewController: UIViewController {
     
     @objc private func appWillMoveToBackgroundCallback() {
         viewModel.lockUI()
+    }
+
+    @objc private func authenticatorInvalidateContext() {
+        viewModel.authenticateInvalidateContext()
     }
     
     private func authenticate() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/1202427674957632/1203164782223326/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Fix for repeated Face ID requests when launching the app via a link. If the last screen the user was on was an Autofill Logins screen, there is a race condition where AutofillLoginSettingsListViewController.appWillMoveToForegroundCallback is called before AppDelegate.application(_:open:options:), triggering an authenticate call to happen before the Autofill Logins screen is dismissed. This fix cancels any authentication calls when the app is launched via link, so that there is no Face ID prompt while the Autofill Logins screen is being dismissed

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Tap overflow->settings->autofill logins
2. Verify using Face ID to access logins
3. Background the app
4. Re-launch the app using a link (e.g., tapping on a favourite in a widget, clicking a link in another app when we're the default browser etc...)
5. Confirm Face ID does not prompt, that the autofill logins screen is dismissed and that the link loads
6. Access autofill logins screen again
7. Minimise app
8. Re-open and confirm you are still on the autofill logins screen, that the lock screen is displayed and that you are prompted for Face ID again before being able to view saved logins 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
