### PR TITLE
Update autofill pixel to align with android, and fix but where autofill keep prompt wouldn't show in some circumstances

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -202,8 +202,6 @@ extension Pixel {
         case jsAlertShown
 
         case featureFlaggingInternalUserAuthenticated
-
-        case autofillLoginsSaveLoginModalOnboardingDisplayed
         
         case autofillLoginsSaveLoginModalDisplayed
         case autofillLoginsSaveLoginModalConfirmed
@@ -551,8 +549,6 @@ extension Pixel.Event {
         case .jsAlertShown: return "m_js_alert_shown"
 
         case .featureFlaggingInternalUserAuthenticated: return "m_internal-user_authenticated"
-
-        case .autofillLoginsSaveLoginModalOnboardingDisplayed: return "m_autofill_logins_save_login_onboarding_inline_displayed"
         
         case .autofillLoginsSaveLoginModalDisplayed: return "m_autofill_logins_save_login_inline_displayed"
         case .autofillLoginsSaveLoginModalConfirmed: return "m_autofill_logins_save_login_inline_confirmed"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -73,6 +73,7 @@ extension Pixel {
         case browsingMenuEnableProtection
         case browsingMenuReportBrokenSite
         case browsingMenuFireproof
+        case browsingMenuAutofill
         
         case tabBarBackPressed
         case tabBarForwardPressed
@@ -206,21 +207,32 @@ extension Pixel {
         
         case autofillLoginsSaveLoginModalDisplayed
         case autofillLoginsSaveLoginModalConfirmed
+        case autofillLoginsSaveLoginModalDismissed
         
         case autofillLoginsSavePasswordModalDisplayed
         case autofillLoginsSavePasswordModalConfirmed
+        case autofillLoginsSavePasswordModalDismissed
         
         case autofillLoginsUpdatePasswordModalDisplayed
         case autofillLoginsUpdatePasswordModalConfirmed
+        case autofillLoginsUpdatePasswordModalDismissed
         
-        case autofillLoginsUpdateUsernameModelDisplayed
-        case autofillLoginsUpdateUsernameModelConfirmed
+        case autofillLoginsUpdateUsernameModalDisplayed
+        case autofillLoginsUpdateUsernameModalConfirmed
+        case autofillLoginsUpdateUsernameModalDismissed
 
-        case autofillLoginsFillLoginInlineDisplayed
-        case autofillLoginsFillLoginInlineConfirmed
+        case autofillLoginsFillLoginInlineManualDisplayed
+        case autofillLoginsFillLoginInlineManualConfirmed
+        case autofillLoginsFillLoginInlineManualDismissed
+        
+        case autofillLoginsFillLoginInlineAutopromptDisplayed
+        case autofillLoginsFillLoginInlineAutopromptConfirmed
+        
+        case autofillLoginsFillLoginInlineAuthenticationDeviceDisplayed
         case autofillLoginsFillLoginInlineAuthenticationDeviceAuthAuthenticated
         case autofillLoginsFillLoginInlineAuthenticationDeviceAuthFailed
         case autofillLoginsFillLoginInlineAuthenticationDeviceAuthUnavailable
+        case autofillLoginsFillLoginInlineAuthenticationDeviceAuthCancelled
         case autofillLoginsAutopromptDismissed
         
         case autofillLoginsFillLoginInlineDisablePromptShown
@@ -410,6 +422,7 @@ extension Pixel.Event {
         case .browsingMenuEnableProtection: return "mb_wlr"
         case .browsingMenuReportBrokenSite: return "mb_rb"
         case .browsingMenuFireproof: return "mb_f"
+        case .browsingMenuAutofill: return "m_nav_autofill_menu_item_pressed"
             
         case .tabBarBackPressed: return "mt_bk"
         case .tabBarForwardPressed: return "mt_fw"
@@ -543,24 +556,37 @@ extension Pixel.Event {
         
         case .autofillLoginsSaveLoginModalDisplayed: return "m_autofill_logins_save_login_inline_displayed"
         case .autofillLoginsSaveLoginModalConfirmed: return "m_autofill_logins_save_login_inline_confirmed"
+        case .autofillLoginsSaveLoginModalDismissed: return "m_autofill_logins_save_login_inline_dismissed"
         
         case .autofillLoginsSavePasswordModalDisplayed: return "m_autofill_logins_save_password_inline_displayed"
         case .autofillLoginsSavePasswordModalConfirmed: return "m_autofill_logins_save_password_inline_confirmed"
+        case .autofillLoginsSavePasswordModalDismissed: return "m_autofill_logins_save_password_inline_dismissed"
         
         case .autofillLoginsUpdatePasswordModalDisplayed: return "m_autofill_logins_update_password_inline_displayed"
         case .autofillLoginsUpdatePasswordModalConfirmed: return "m_autofill_logins_update_password_inline_confirmed"
+        case .autofillLoginsUpdatePasswordModalDismissed: return "m_autofill_logins_update_password_inline_dismissed"
         
-        case .autofillLoginsUpdateUsernameModelDisplayed: return "m_autofill_logins_update_username_inline_displayed"
-        case .autofillLoginsUpdateUsernameModelConfirmed: return "m_autofill_logins_update_username_inline_confirmed"
+        case .autofillLoginsUpdateUsernameModalDisplayed: return "m_autofill_logins_update_username_inline_displayed"
+        case .autofillLoginsUpdateUsernameModalConfirmed: return "m_autofill_logins_update_username_inline_confirmed"
+        case .autofillLoginsUpdateUsernameModalDismissed: return "m_autofill_logins_update_username_inline_dismissed"
 
-        case .autofillLoginsFillLoginInlineDisplayed: return "m_autofill_logins_fill_login_inline_displayed"
-        case .autofillLoginsFillLoginInlineConfirmed: return "m_autofill_logins_fill_login_inline_confirmed"
+        case .autofillLoginsFillLoginInlineManualDisplayed: return "m_autofill_logins_fill_login_inline_manual_displayed"
+        case .autofillLoginsFillLoginInlineManualConfirmed: return "m_autofill_logins_fill_login_inline_manual_confirmed"
+        case .autofillLoginsFillLoginInlineManualDismissed: return "m_autofill_logins_fill_login_inline_manual_dismissed"
+            
+        case .autofillLoginsFillLoginInlineAutopromptDisplayed: return "m_autofill_logins_fill_login_inline_autoprompt_displayed"
+        case .autofillLoginsFillLoginInlineAutopromptConfirmed: return "m_autofill_logins_fill_login_inline_autoprompt_confirmed"
+            
+        case .autofillLoginsFillLoginInlineAuthenticationDeviceDisplayed:
+            return "m_autofill_logins_fill_login_inline_authentication_device-displayed"
         case .autofillLoginsFillLoginInlineAuthenticationDeviceAuthAuthenticated:
             return "m_autofill_logins_fill_login_inline_authentication_device-auth_authenticated"
         case .autofillLoginsFillLoginInlineAuthenticationDeviceAuthFailed:
             return "m_autofill_logins_fill_login_inline_authentication_device-auth_failed"
         case .autofillLoginsFillLoginInlineAuthenticationDeviceAuthUnavailable:
             return "m_autofill_logins_fill_login_inline_authentication_device-auth_unavailable"
+        case .autofillLoginsFillLoginInlineAuthenticationDeviceAuthCancelled:
+            return "m_autofill_logins_fill_login_inline_authentication_device-auth_cancelled"
         case .autofillLoginsAutopromptDismissed:
             return "m_autofill_logins_autoprompt_dismissed"
             

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -114,7 +114,6 @@ final class AutofillLoginSettingsListViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        Pixel.fire(pixel: .autofillSettingsOpened)
         authenticate()
     }
 

--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -113,7 +113,7 @@ struct SaveLoginView: View {
     
     private var closeButton: some View {
         Button {
-            viewModel.cancel()
+            viewModel.cancelButtonPressed()
         } label: {
             Image(systemName: "xmark")
                 .resizable()
@@ -184,7 +184,7 @@ struct SaveLoginView: View {
             }.buttonStyle(PrimaryButtonStyle())
             
             Button {
-                viewModel.cancel()
+                viewModel.cancelButtonPressed()
             } label: {
                 Text(UserText.autofillSaveLoginNotNowCTA)
             }

--- a/DuckDuckGo/SaveLoginViewController.swift
+++ b/DuckDuckGo/SaveLoginViewController.swift
@@ -100,7 +100,7 @@ class SaveLoginViewController: UIViewController {
         
         switch saveViewModel.layoutType {
         case .newUser:
-            Pixel.fire(pixel: .autofillLoginsSaveLoginModalOnboardingDisplayed)
+            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDisplayed)
         case .saveLogin:
             Pixel.fire(pixel: .autofillLoginsSaveLoginModalDisplayed)
         case .savePassword:

--- a/DuckDuckGo/SaveLoginViewController.swift
+++ b/DuckDuckGo/SaveLoginViewController.swift
@@ -26,12 +26,15 @@ protocol SaveLoginViewControllerDelegate: AnyObject {
     func saveLoginViewController(_ viewController: SaveLoginViewController, didSaveCredentials credentials: SecureVaultModels.WebsiteCredentials)
     func saveLoginViewController(_ viewController: SaveLoginViewController, didUpdateCredentials credentials: SecureVaultModels.WebsiteCredentials)
     func saveLoginViewControllerDidCancel(_ viewController: SaveLoginViewController)
+    func saveLoginViewController(_ viewController: SaveLoginViewController,
+                                 didRequestPresentConfirmKeepUsingAlertController alertController: UIAlertController)
 }
 
 class SaveLoginViewController: UIViewController {
     weak var delegate: SaveLoginViewControllerDelegate?
     private let credentialManager: SaveAutofillLoginManager
     private let domainLastShownOn: String?
+    private var viewModel: SaveLoginViewModel?
 
     internal init(credentialManager: SaveAutofillLoginManager, domainLastShownOn: String? = nil) {
         self.credentialManager = credentialManager
@@ -58,10 +61,37 @@ class SaveLoginViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        guard let viewModel = viewModel else { return }
+        
+        if viewModel.didSave {
+            return
+        }
+        switch viewModel.layoutType {
+        case .newUser:
+            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDismissed)
+        case .saveLogin:
+            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDismissed)
+        case .savePassword:
+            Pixel.fire(pixel: .autofillLoginsSavePasswordModalDismissed)
+        case .saveAdditionalLogin:
+            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDismissed)
+        case .updateUsername:
+            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDismissed)
+        case .updatePassword:
+            Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalDismissed)
+        }
+        
+        viewModel.viewControllerDidDisappear()
+    }
 
     private func setupSaveLoginView() {
         let saveViewModel = SaveLoginViewModel(credentialManager: credentialManager, domainLastShownOn: domainLastShownOn)
         saveViewModel.delegate = self
+        self.viewModel = saveViewModel
 
         let saveLoginView = SaveLoginView(viewModel: saveViewModel)
         let controller = UIHostingController(rootView: saveLoginView)
@@ -78,7 +108,7 @@ class SaveLoginViewController: UIViewController {
         case .saveAdditionalLogin:
             Pixel.fire(pixel: .autofillLoginsSaveLoginModalDisplayed)
         case .updateUsername:
-            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModelDisplayed)
+            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDisplayed)
         case .updatePassword:
             Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalDisplayed)
         }
@@ -99,7 +129,7 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
             if viewModel.layoutType == .updatePassword {
                 Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalConfirmed)
             } else {
-                Pixel.fire(pixel: .autofillLoginsUpdateUsernameModelConfirmed)
+                Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalConfirmed)
             }
             delegate?.saveLoginViewController(self, didUpdateCredentials: credentialManager.credentials)
         }
@@ -109,7 +139,10 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
         delegate?.saveLoginViewControllerDidCancel(self)
     }
 
-    func saveLoginViewModelConfirmKeepUsing(_ viewModel: SaveLoginViewModel) {
+    func saveLoginViewModelConfirmKeepUsing(_ viewModel: SaveLoginViewModel, isAlreadyDismissed: Bool) {
+        
+        let isSelfPresentingAlert = !isAlreadyDismissed
+        
         let alertController = UIAlertController(title: UserText.autofillKeepEnabledAlertTitle,
                                                 message: UserText.autofillKeepEnabledAlertMessage,
                                                 preferredStyle: .alert)
@@ -117,13 +150,17 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
 
         let disableAction = UIAlertAction(title: UserText.autofillKeepEnabledAlertDisableAction, style: .cancel) { _ in
             Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptAutofillDisabled)
-            self.delegate?.saveLoginViewControllerDidCancel(self)
+            if isSelfPresentingAlert {
+                self.delegate?.saveLoginViewControllerDidCancel(self)
+            }
             AppDependencyProvider.shared.appSettings.autofillCredentialsEnabled = false
         }
 
         let keepUsingAction = UIAlertAction(title: UserText.autofillKeepEnabledAlertKeepUsingAction, style: .default) { _ in
             Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptAutofillKept)
-            self.delegate?.saveLoginViewControllerDidCancel(self)
+            if isSelfPresentingAlert {
+                self.delegate?.saveLoginViewControllerDidCancel(self)
+            }
         }
 
         alertController.addAction(disableAction)
@@ -131,7 +168,11 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
 
         alertController.preferredAction = keepUsingAction
 
-        Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown)
-        present(alertController, animated: true)
+        if isAlreadyDismissed {
+            delegate?.saveLoginViewController(self, didRequestPresentConfirmKeepUsingAlertController: alertController)
+        } else {
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown)
+            present(alertController, animated: true)
+        }
     }
 }

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -222,6 +222,7 @@ class SettingsViewController: UITableViewController {
     private func showAutofill(animated: Bool = true) {
         let autofillController = AutofillLoginSettingsListViewController(appSettings: appSettings)
         autofillController.delegate = self
+        Pixel.fire(pixel: .autofillSettingsOpened)
         navigationController?.pushViewController(autofillController, animated: animated)
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2689,6 +2689,12 @@ extension TabViewController: SaveLoginViewControllerDelegate {
     func saveLoginViewControllerDidCancel(_ viewController: SaveLoginViewController) {
         viewController.dismiss(animated: true)
     }
+    
+    func saveLoginViewController(_ viewController: SaveLoginViewController,
+                                 didRequestPresentConfirmKeepUsingAlertController alertController: UIAlertController) {
+        Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown)
+        present(alertController, animated: true)
+    }
 }
 
 extension WKWebView {

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -361,6 +361,7 @@ extension TabViewController {
     }
     
     private func onOpenAutofillLoginsAction() {
+        Pixel.fire(pixel: .browsingMenuAutofill)
         delegate?.tabDidRequestAutofillLogins(tab: self)
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203161281124771/f
Tech Design URL:
CC:

**Description**:
Renames and adds new pixels to align with android. Anything that isn't green on this spreadsheet should be covered by this PR: https://duckduckgo-my.sharepoint.com/:x:/p/nlittlejohns/EX2JGpC23ARIhp36_aEc8owBZHonuMXoSjHsPDV51yJ04Q?e=KYbjhh

In doing this, I also discovered an issue with the alert view that asks if users want to disable autofill. If the save prompt was dismissed by a way other than the buttons (e.g. swiping down, tapping above it), the necessary functions wouldn't be called, so the count of how many times it had been dismissed wasn't incremented, and it wouldn't show the prompt if required. So this also fixes that.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Test each pixel in the spreadsheet fires correctly
2. Pay special attention to the dismiss ones for different possible dismiss actions (cross button, cancel button, swiping down, tapping above the modal)3. 
3. Test that the disable prompt appears as expected, both when using the dismiss buttons, but now also when swiping down or tapping above the model too.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
