### PR TITLE
Fix reload triggering process kill on User Scripts Installed

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -318,6 +318,7 @@ extension Pixel {
         
         case webKitDidTerminate
         case webKitDidBecomeUnresponsive
+        case expectedNavigationForcedWebViewRecreation
         case webKitTerminationDidReloadCurrentTab
         
         case backgroundTaskSubmissionFailed
@@ -670,6 +671,7 @@ extension Pixel.Event {
             
         case .webKitDidTerminate: return "m_d_wkt"
         case .webKitDidBecomeUnresponsive: return "m_d_wkunresponsive"
+        case .expectedNavigationForcedWebViewRecreation: return "m_d_wkforceterminate"
         case .webKitTerminationDidReloadCurrentTab: return "m_d_wktct"
             
         case .backgroundTaskSubmissionFailed: return "m_bt_rf"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -318,7 +318,6 @@ extension Pixel {
         
         case webKitDidTerminate
         case webKitDidBecomeUnresponsive
-        case expectedNavigationForcedWebViewRecreation
         case webKitTerminationDidReloadCurrentTab
         
         case backgroundTaskSubmissionFailed
@@ -671,7 +670,6 @@ extension Pixel.Event {
             
         case .webKitDidTerminate: return "m_d_wkt"
         case .webKitDidBecomeUnresponsive: return "m_d_wkunresponsive"
-        case .expectedNavigationForcedWebViewRecreation: return "m_d_wkforceterminate"
         case .webKitTerminationDidReloadCurrentTab: return "m_d_wktct"
             
         case .backgroundTaskSubmissionFailed: return "m_bt_rf"

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -284,7 +284,7 @@ class TabViewController: UIViewController {
         }
         if let timer = navigationExpectationTimer,
            timePassed(sinceScheduling: timer) > Constants.forceExpectedNavigationThreshold {
-
+            Pixel.fire(pixel: .expectedNavigationForcedWebViewRecreation)
             timer.fire()
             return true
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1203338569768096/f
CC: @brindy @samsymons 

**Description**:
- Resets navigation expectation timer on UserScripts Installed delegate call
- Adds threshold before triggering force process kill

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Validate the following scenario doesn‘t trigger process killing:

- Open in new tab
- Load request
- Scheduler timer
- Content scripts get set up
- Webview reloaded
- Schedule timer
 - Timer already exists
 - Fire timer prematurely 
