### PR TITLE
Fix text size setting on page load

### DIFF
--- a/Core/TextSizeUserScript.swift
+++ b/Core/TextSizeUserScript.swift
@@ -32,6 +32,10 @@ public class TextSizeUserScript: NSObject, UserScript {
     public var injectionTime: WKUserScriptInjectionTime = .atDocumentStart
     public var forMainFrameOnly: Bool = false
     public var messageNames: [String] = []
+    
+    public init(textSizeAdjustmentInPercents: Int) {
+        self.textSizeAdjustmentInPercents = textSizeAdjustmentInPercents
+    }
 
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) { }
     

--- a/DuckDuckGo/UserScripts.swift
+++ b/DuckDuckGo/UserScripts.swift
@@ -37,7 +37,7 @@ final class UserScripts: UserScriptsProvider {
     private(set) var findInPageScript = FindInPageUserScript()
     private(set) var fullScreenVideoScript = FullScreenVideoUserScript()
     private(set) var printingUserScript = PrintingUserScript()
-    private(set) var textSizeUserScript = TextSizeUserScript()
+    private(set) var textSizeUserScript = TextSizeUserScript(textSizeAdjustmentInPercents: AppDependencyProvider.shared.appSettings.textSize)
     private(set) var debugScript = DebugUserScript()
 
     init(with sourceProvider: ScriptSourceProviding) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1203360000128186/f

**Description**:
The text size setting stopped being applied on page load due to recent changes how user scripts are initiated and delayed passing of the stored text size setting value. As a solution the current text size setting value should be passed at TextSizeUserScript initialization.

**Steps to test this PR**:
1. Open Settings -> Text Size
2. Adjust the value with slider
3. Reload or open new page
4. The text size should be adjusted to specified value on page load

**Device Testing**:

* [ ] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
