### PR TITLE
Fix how we setup temporary download for sharing a file

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1022,7 +1022,7 @@ extension TabViewController: WKNavigationDelegate {
 
         if navigationResponse.canShowMIMEType && !FilePreviewHelper.canAutoPreviewMIMEType(mimeType) {
             url = webView.url
-            if let decision = setupOrClearTemporaryDownload(for: navigationResponse.response) {
+            if navigationResponse.isForMainFrame, let decision = setupOrClearTemporaryDownload(for: navigationResponse.response) {
                 decisionHandler(decision)
             } else {
                 if navigationResponse.isForMainFrame && isSuccessfulResponse {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203216489723509/f

**Description**:
For some sites the assets may be loaded dynamically within non-main frames. Since we lacked that check we could have setup in rare cases the temporary download for one of such assets where none should be present (e.g. we were navigating to a standard HTML page). As a result share action resulted in sharing that asset instead of a page's URL.

**Steps to test this PR**:
1. Navigate to https://www.rockymountaineer.com 
2. Tap share
3. (should share website's url not an image or any other asset from the file)
4. Browse through the website and verify for subpages
5. Smoketest opening non-HTML URLs and sharing

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
