### PR TITLE
fix: use `nearlyBlackLight` for initial background of webview

### DIFF
--- a/DuckDuckGo/DarkTheme.swift
+++ b/DuckDuckGo/DarkTheme.swift
@@ -125,4 +125,5 @@ struct DarkTheme: Theme {
     var autofillEmptySearchViewTextColor = UIColor.gray20
     var autofillLockedViewTextColor = UIColor.lightMercury
 
+    var privacyDashboardWebviewBackgroundColor = UIColor.nearlyBlackLight
 }

--- a/DuckDuckGo/LightTheme.swift
+++ b/DuckDuckGo/LightTheme.swift
@@ -126,4 +126,5 @@ struct LightTheme: Theme {
     var autofillEmptySearchViewTextColor = UIColor.gray50
     var autofillLockedViewTextColor = UIColor.nearlyBlack
 
+    var privacyDashboardWebviewBackgroundColor = UIColor.white
 }

--- a/DuckDuckGo/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/PrivacyDashboardViewController.swift
@@ -105,7 +105,7 @@ private extension PrivacyDashboardViewController {
 extension PrivacyDashboardViewController: Themable {
     
     func decorate(with theme: Theme) {
-        view.backgroundColor = theme.backgroundColor
+        view.backgroundColor = theme.privacyDashboardWebviewBackgroundColor
         privacyDashboardController.theme = privacyDashboardTheme(from: theme)
     }
     

--- a/DuckDuckGo/Theme.swift
+++ b/DuckDuckGo/Theme.swift
@@ -132,4 +132,6 @@ protocol Theme {
     var autofillEmptySearchViewTextColor: UIColor { get }
     var autofillLockedViewTextColor: UIColor { get }
 
+    var privacyDashboardWebviewBackgroundColor: UIColor { get }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/0/1203418581768782/f
Tech Design URL: n/a
CC: @miasma13 @bwaresiak 

**Description**:

This PR prevents the flicker of different background colors when the dashboard is loading into the webview.

**Steps to test this PR**:
1. Review the video or the build - ensure the background color of the webview doesn't alter (in both light/dark mode)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
