### PR TITLE
Autofill reduced authentication friction for multi login processes

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -518,6 +518,8 @@
 		C1B7B53028944E390098FD6A /* RemoteMessagingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B52F28944E390098FD6A /* RemoteMessagingStoreTests.swift */; };
 		C1B7B53428944EFA0098FD6A /* CoreDataTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B53328944EFA0098FD6A /* CoreDataTestUtilities.swift */; };
 		C1CCCBA7283E101500CF3791 /* FaviconsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CCCBA6283E101500CF3791 /* FaviconsHelper.swift */; };
+		C1D21E2D293A5965006E5A05 /* AutofillLoginSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D21E2C293A5965006E5A05 /* AutofillLoginSession.swift */; };
+		C1D21E2F293A599C006E5A05 /* AutofillLoginSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D21E2E293A599C006E5A05 /* AutofillLoginSessionTests.swift */; };
 		CB2A7EEF283D185100885F67 /* RulesCompilationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2A7EEE283D185100885F67 /* RulesCompilationMonitor.swift */; };
 		CB2A7EF128410DF700885F67 /* PixelEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2A7EF028410DF700885F67 /* PixelEvent.swift */; };
 		CB2A7EF4285383B300885F67 /* AppLastCompiledRulesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2A7EF3285383B300885F67 /* AppLastCompiledRulesStore.swift */; };
@@ -1883,6 +1885,8 @@
 		C1B7B52F28944E390098FD6A /* RemoteMessagingStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteMessagingStoreTests.swift; sourceTree = "<group>"; };
 		C1B7B53328944EFA0098FD6A /* CoreDataTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataTestUtilities.swift; sourceTree = "<group>"; };
 		C1CCCBA6283E101500CF3791 /* FaviconsHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaviconsHelper.swift; sourceTree = "<group>"; };
+		C1D21E2C293A5965006E5A05 /* AutofillLoginSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillLoginSession.swift; sourceTree = "<group>"; };
+		C1D21E2E293A599C006E5A05 /* AutofillLoginSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillLoginSessionTests.swift; sourceTree = "<group>"; };
 		CB1AEFB02799AA940031AE3D /* SwiftUICollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUICollectionViewCell.swift; sourceTree = "<group>"; };
 		CB2A7EEE283D185100885F67 /* RulesCompilationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesCompilationMonitor.swift; sourceTree = "<group>"; };
 		CB2A7EF028410DF700885F67 /* PixelEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelEvent.swift; sourceTree = "<group>"; };
@@ -4011,6 +4015,7 @@
 			isa = PBXGroup;
 			children = (
 				F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */,
+				C1D21E2E293A599C006E5A05 /* AutofillLoginSessionTests.swift */,
 			);
 			name = Autofill;
 			sourceTree = "<group>";
@@ -4028,6 +4033,7 @@
 			isa = PBXGroup;
 			children = (
 				F4147353283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift */,
+				C1D21E2C293A5965006E5A05 /* AutofillLoginSession.swift */,
 				319A370F28299A850079FBCE /* PasswordHider.swift */,
 				31C70B5428045E3500FB6AD1 /* SecureVaultErrorReporter.swift */,
 				31951E94282310FF00CAF535 /* WebsiteAccountExtension.swift */,
@@ -4837,6 +4843,7 @@
 				85F200002215C17B006BB258 /* FindInPage.swift in Sources */,
 				F1386BA41E6846C40062FC3C /* TabDelegate.swift in Sources */,
 				3132FA2A27A0788F00DD7A12 /* QuickLookPreviewHelper.swift in Sources */,
+				C1D21E2D293A5965006E5A05 /* AutofillLoginSession.swift in Sources */,
 				4B53648A26718D0E001AA041 /* EmailWaitlist.swift in Sources */,
 				8524CC98246D66E100E59D45 /* String+Markdown.swift in Sources */,
 				C1B7B529289420830098FD6A /* RemoteMessaging.xcdatamodeld in Sources */,
@@ -5130,6 +5137,7 @@
 				851CD674244D7E6000331B98 /* UserDefaultsExtension.swift in Sources */,
 				850559D223CF710C0055C0D5 /* WebCacheManagerTests.swift in Sources */,
 				8341D807212D5E8D000514C2 /* HashExtensionTest.swift in Sources */,
+				C1D21E2F293A599C006E5A05 /* AutofillLoginSessionTests.swift in Sources */,
 				85D2187924BF6B8B004373D2 /* FaviconSourcesProviderTests.swift in Sources */,
 				1E8146AD28C8ABF000D1AF63 /* TrackerAnimationLogicTests.swift in Sources */,
 				F143C2CC1E4A4B9100CFDE3A /* AppVersionTests.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -290,6 +290,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         displayBlankSnapshotWindow()
         autoClear?.applicationDidEnterBackground()
         lastBackgroundDate = Date()
+        AppDependencyProvider.shared.autofillLoginSession.endSession()
     }
 
     func application(_ application: UIApplication,

--- a/DuckDuckGo/AppDependencyProvider.swift
+++ b/DuckDuckGo/AppDependencyProvider.swift
@@ -31,6 +31,7 @@ protocol DependencyProvider {
     var storageCache: StorageCacheProvider { get }
     var voiceSearchHelper: VoiceSearchHelperProtocol { get }
     var downloadManager: DownloadManager { get }
+    var autofillLoginSession: AutofillLoginSession { get }
 }
 
 /// Provides dependencies for objects that are not directly instantiated
@@ -55,4 +56,5 @@ class AppDependencyProvider: DependencyProvider {
     let storageCache = StorageCacheProvider()
     let voiceSearchHelper: VoiceSearchHelperProtocol = VoiceSearchHelper()
     let downloadManager = DownloadManager()
+    let autofillLoginSession = AutofillLoginSession()
 }

--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -100,6 +100,11 @@ class AutofillLoginDetailsViewController: UIViewController {
         }
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        AppDependencyProvider.shared.autofillLoginSession.lastAccessedAccount = nil
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/DuckDuckGo/AutofillLoginDetailsViewModel.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewModel.swift
@@ -107,6 +107,7 @@ final class AutofillLoginDetailsViewModel: ObservableObject {
         self.headerViewModel = AutofillLoginDetailsHeaderViewModel()
         if let account = account {
             self.updateData(with: account)
+            AppDependencyProvider.shared.autofillLoginSession.lastAccessedAccount = account
         } else {
             viewMode = .new
         }

--- a/DuckDuckGo/AutofillLoginSession.swift
+++ b/DuckDuckGo/AutofillLoginSession.swift
@@ -22,11 +22,15 @@ import BrowserServicesKit
 
 class AutofillLoginSession {
 
+    private enum Constants {
+        static let timeout: TimeInterval = 15
+    }
+
     private var sessionCreationDate: Date?
     private var sessionAccount: SecureVaultModels.WebsiteAccount?
     private let sessionTimeout: TimeInterval
 
-    init(sessionTimeout: TimeInterval = 15) {
+    init(sessionTimeout: TimeInterval = Constants.timeout) {
         self.sessionTimeout = sessionTimeout
     }
 

--- a/DuckDuckGo/AutofillLoginSession.swift
+++ b/DuckDuckGo/AutofillLoginSession.swift
@@ -1,0 +1,55 @@
+//
+//  AutofillLoginSession.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+
+class AutofillLoginSession {
+
+    private var sessionCreationDate: Date?
+    private var sessionAccount: SecureVaultModels.WebsiteAccount?
+    private let sessionTimeout: TimeInterval
+
+    init(sessionTimeout: TimeInterval = 15) {
+        self.sessionTimeout = sessionTimeout
+    }
+
+    var isValidSession: Bool {
+        guard let sessionCreationDate = sessionCreationDate else { return false }
+        return Date().timeIntervalSince(sessionCreationDate) < sessionTimeout
+    }
+
+    var lastAccessedAccount: SecureVaultModels.WebsiteAccount? {
+        get {
+            return isValidSession ? sessionAccount : nil
+        }
+        set {
+            sessionAccount = newValue
+        }
+    }
+
+    func startSession() {
+        sessionCreationDate = Date()
+    }
+
+    func endSession() {
+        sessionCreationDate = nil
+        lastAccessedAccount = nil
+    }
+}

--- a/DuckDuckGo/AutofillLoginSession.swift
+++ b/DuckDuckGo/AutofillLoginSession.swift
@@ -36,7 +36,9 @@ class AutofillLoginSession {
 
     var isValidSession: Bool {
         guard let sessionCreationDate = sessionCreationDate else { return false }
-        return Date().timeIntervalSince(sessionCreationDate) < sessionTimeout
+        let timeInterval = Date().timeIntervalSince(sessionCreationDate)
+        // Check that timeInterval is > 0 to prevent a user circumventing by changing their device clock time
+        return timeInterval > 0 && timeInterval < sessionTimeout
     }
 
     var lastAccessedAccount: SecureVaultModels.WebsiteAccount? {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -848,6 +848,10 @@ class MainViewController: UIViewController {
                                                                                           target: self,
                                                                                           action: #selector(closeAutofillModal))
         self.present(navigationController, animated: true, completion: nil)
+
+        if let account = AppDependencyProvider.shared.autofillLoginSession.lastAccessedAccount {
+            autofillSettingsViewController.showAccountDetails(account, animated: true)
+        }
     }
     
     @objc private func closeAutofillModal() {

--- a/DuckDuckGoTests/AutofillLoginSessionTests.swift
+++ b/DuckDuckGoTests/AutofillLoginSessionTests.swift
@@ -1,0 +1,66 @@
+//
+//  AutofillLoginSessionTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import DuckDuckGo
+@testable import BrowserServicesKit
+
+final class AutofillLoginSessionTests: XCTestCase {
+
+    private var autofillSession = AutofillLoginSession(sessionTimeout: 2)
+
+    func testWhenThereIsNoSessionCreationDateThenAutofillSessionIsFalse() {
+        XCTAssertFalse(autofillSession.isValidSession)
+    }
+
+    func testWhenSessionStartedThenAutofillSessionIsValid() {
+        autofillSession.startSession()
+        XCTAssertTrue(autofillSession.isValidSession)
+    }
+
+    func testWhenSessionEndedThenAutofillSessionIsInvalid() {
+        autofillSession.startSession()
+        autofillSession.endSession()
+        XCTAssertFalse(autofillSession.isValidSession)
+    }
+
+    func testWhenSessionExpiredThenAutofillSessionIsInvalid() {
+        autofillSession.startSession()
+
+        let sessionExpired = expectation(description: "testWhenSessionExpiredThenAutofillSessionIsInvalid")
+        _ = XCTWaiter.wait(for: [sessionExpired], timeout: 2.2)
+        XCTAssertFalse(autofillSession.isValidSession)
+    }
+
+    func testWhenSessionIsValidAndAccountIsSetThenAccountIsReturned() {
+        autofillSession.startSession()
+        let account = SecureVaultModels.WebsiteAccount(title: nil, username: "username", domain: "test")
+        autofillSession.lastAccessedAccount = account
+        XCTAssertNotNil(autofillSession.lastAccessedAccount)
+    }
+
+    func testWhenSessionIsInvalidAndAccountIsSetThenNoAccountIsReturned() {
+        autofillSession.startSession()
+        let account = SecureVaultModels.WebsiteAccount(title: nil, username: "username", domain: "test")
+        autofillSession.lastAccessedAccount = account
+        autofillSession.endSession()
+        XCTAssertNil(autofillSession.lastAccessedAccount)
+    }
+}

--- a/DuckDuckGoTests/MockDependencyProvider.swift
+++ b/DuckDuckGoTests/MockDependencyProvider.swift
@@ -32,6 +32,7 @@ class MockDependencyProvider: DependencyProvider {
     var storageCache: StorageCacheProvider
     var voiceSearchHelper: VoiceSearchHelperProtocol
     var downloadManager: DownloadManager
+    var autofillLoginSession: AutofillLoginSession
 
     init() {
         let defaultProvider = AppDependencyProvider()
@@ -44,5 +45,6 @@ class MockDependencyProvider: DependencyProvider {
         storageCache = defaultProvider.storageCache
         voiceSearchHelper = defaultProvider.voiceSearchHelper
         downloadManager = defaultProvider.downloadManager
+        autofillLoginSession = defaultProvider.autofillLoginSession
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1203313768964242/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Reduction of autofill authentication friction as per rules defined here: https://app.asana.com/0/0/1203091315317194/f

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

**Fill Login**
1. Go to a site with a 2 step auth flow e.g. amazon.com that you have a saved login for
2. Use Autofill to populate the email address. You should have to authenticate
3. Use Autofill to populate the password. You should have not need to authenticate
4. Logout and wait 15 seconds from your last authentication
5. Repeat steps 2 and 3, but this time wait 15 seconds before trying to populate the password. This time you should have to authenticate at both stages
6. Logout and wait 15 seconds from your last authentication
7. Use Autofill to populate the email address. You should have to authenticate
8. Minimise the app. When you re-open, try to autofill the password; you should have to authenticate

**Autofill screens**
1. Wait 15 secs from last authentication, then open the Autofill logins screen from the browsing menu and authenticate.
2. Exit out of the screen and then go back in. You should not need to authenticate
3. Exit out of the screen, wait 15 seconds and the go back in. You should have to authenticate
4. Tap through into a saved login. Drag down to dismiss the Autofill screens (but don't background the app)
5. From the browsing menu, access Autofill logins and you should be taken straight to the last saved login that you accessed, and not prompted to authenticate
6. From the Settings screen, access Autofill logins and you should be only taken to the main logins list screen, not the saved login

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
