### PR TITLE
Change new autofill login page to be modal

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -271,7 +271,7 @@ class AutofillLoginDetailsViewController: UIViewController {
     
     @objc private func cancel() {
         if viewModel.viewMode == .new {
-            navigationController?.popViewController(animated: true)
+            dismiss(animated: true)
         } else {
             toggleEditMode()
         }

--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -24,7 +24,7 @@ import Common
 import Combine
 
 protocol AutofillLoginDetailsViewControllerDelegate: AnyObject {
-    func autofillLoginDetailsViewControllerDidSave(_ controller: AutofillLoginDetailsViewController)
+    func autofillLoginDetailsViewControllerDidSave(_ controller: AutofillLoginDetailsViewController, account: SecureVaultModels.WebsiteAccount?)
     func autofillLoginDetailsViewControllerDelete(account: SecureVaultModels.WebsiteAccount)
 }
 
@@ -266,7 +266,6 @@ class AutofillLoginDetailsViewController: UIViewController {
     
     @objc private func save() {
         viewModel.save()
-        delegate?.autofillLoginDetailsViewControllerDidSave(self)
     }
     
     @objc private func cancel() {
@@ -280,7 +279,14 @@ class AutofillLoginDetailsViewController: UIViewController {
 
 extension AutofillLoginDetailsViewController: AutofillLoginDetailsViewModelDelegate {
     func autofillLoginDetailsViewModelDidSave() {
-        
+        if viewModel.viewMode == .new {
+            dismiss(animated: true) { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.autofillLoginDetailsViewControllerDidSave(self, account: self.viewModel.account)
+            }
+        } else {
+            delegate?.autofillLoginDetailsViewControllerDidSave(self, account: nil)
+        }
     }
     
     func autofillLoginDetailsViewModelDidAttemptToSaveDuplicateLogin() {

--- a/DuckDuckGo/AutofillLoginDetailsViewModel.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewModel.swift
@@ -228,7 +228,6 @@ final class AutofillLoginDetailsViewModel: ObservableObject {
                     self.updateData(with: newCredential.account)
                 }
                 
-                viewMode = .view
             } catch let error {
                 if case SecureVaultError.duplicateRecord = error {
                     Pixel.fire(pixel: .autofillLoginsSettingsAddNewLoginErrorAttemptedToCreateDuplicate)

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -540,9 +540,13 @@ extension AutofillLoginSettingsListViewController: UITableViewDataSource {
 // MARK: AutofillLoginDetailsViewControllerDelegate
 
 extension AutofillLoginSettingsListViewController: AutofillLoginDetailsViewControllerDelegate {
-    func autofillLoginDetailsViewControllerDidSave(_ controller: AutofillLoginDetailsViewController) {
+    func autofillLoginDetailsViewControllerDidSave(_ controller: AutofillLoginDetailsViewController, account: SecureVaultModels.WebsiteAccount?) {
         viewModel.updateData()
         tableView.reloadData()
+
+        if let account = account {
+            showAccountDetails(account)
+        }
     }
 
     func autofillLoginDetailsViewControllerDelete(account: SecureVaultModels.WebsiteAccount) {

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -152,7 +152,8 @@ final class AutofillLoginSettingsListViewController: UIViewController {
                                                                    tld: tld,
                                                                    authenticationNotRequired: viewModel.authenticationNotRequired)
         detailsController.delegate = self
-        navigationController?.pushViewController(detailsController, animated: true)
+        let detailsNavigationController = UINavigationController(rootViewController: detailsController)
+        navigationController?.present(detailsNavigationController, animated: true)
     }
     
     func showAccountDetails(_ account: SecureVaultModels.WebsiteAccount, animated: Bool = true) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1203473309989293/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Changes the new login page to be modal, and modifies the save behaviour so that once the login has been saved dismiss the screen and then segue to the newly created account. There is no change to the existing view / edit states 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. From the browsing menu open the Autofill logins screen. Tap to add a new login and confirm it is presented modally. 
2. Confirm cancel button dismisses the screen correctly
3. Save a new login. Confirm the screen is dismissed and that you are segued to the new account + can view / edit as normal
4. Go back to main logins list screen and tap to add another login
5. Try to create a duplicate login and confirm the duplicate login alert shows as before and that the screen is not dismissed if there is an error
6. Repeat above steps accessing the Autofill logins screen from the Settings screen

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
