### PR TITLE
Fix for autofill key still appearing when passcode is disabled

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -284,6 +284,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         beginAuthentication()
         autoClear?.applicationWillMoveToForeground()
         showKeyboardIfSettingOn = true
+        AppDependencyProvider.shared.autofillLoginSession.checkDevicePasscodeStatus()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -30,6 +30,7 @@ extension ContentScopeFeatureToggles {
         let context = LAContext()
         var error: NSError?
         let canAuthenticate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
+        AppDependencyProvider.shared.autofillLoginSession.devicePasscodeEnabled = canAuthenticate
         return featureFlagger.isFeatureOn(.autofill) && appSettings.autofillCredentialsEnabled && canAuthenticate
     }
     

--- a/DuckDuckGo/AutofillLoginSession.swift
+++ b/DuckDuckGo/AutofillLoginSession.swift
@@ -26,6 +26,10 @@ class AutofillLoginSession {
         static let timeout: TimeInterval = 15
     }
 
+    public struct Notifications {
+        public static let devicePasscodeStatusChanged = Notification.Name("com.duckduckgo.app.AutofillLoginSession.devicePasscodeStatusChanged")
+    }
+
     private var sessionCreationDate: Date?
     private var sessionAccount: SecureVaultModels.WebsiteAccount?
     private let sessionTimeout: TimeInterval
@@ -50,6 +54,8 @@ class AutofillLoginSession {
         }
     }
 
+    var devicePasscodeEnabled: Bool?
+
     func startSession() {
         sessionCreationDate = Date()
     }
@@ -57,5 +63,11 @@ class AutofillLoginSession {
     func endSession() {
         sessionCreationDate = nil
         lastAccessedAccount = nil
+    }
+
+    func checkDevicePasscodeStatus() {
+        if let passcodeEnabled = devicePasscodeEnabled, passcodeEnabled != ContentScopeFeatureToggles.supportedFeaturesOniOS.credentialsAutofill {
+            NotificationCenter.default.post(name: Notifications.devicePasscodeStatusChanged, object: nil)
+        }
     }
 }

--- a/DuckDuckGo/ContentBlockingUpdating.swift
+++ b/DuckDuckGo/ContentBlockingUpdating.swift
@@ -83,6 +83,7 @@ public final class ContentBlockingUpdating {
             .combineLatest(onNotificationWithInitial(PreserveLogins.Notifications.loginDetectionStateChanged), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.doNotSellStatusChange), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.autofillEnabledChange), combine)
+            .combineLatest(onNotificationWithInitial(AutofillLoginSession.Notifications.devicePasscodeStatusChanged), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.textSizeChange), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.didVerifyInternalUser), combine)
             .combineLatest(onNotificationWithInitial(StorageCacheProvider.didUpdateStorageCacheNotification)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1966,7 +1966,8 @@ extension TabViewController: UserContentControllerDelegate {
         let tdsKey = DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName
         let notificationsTriggeringReload = [
             PreserveLogins.Notifications.loginDetectionStateChanged,
-            AppUserDefaults.Notifications.doNotSellStatusChange
+            AppUserDefaults.Notifications.doNotSellStatusChange,
+            AutofillLoginSession.Notifications.devicePasscodeStatusChanged
         ]
         if updateEvent.changes[tdsKey]?.contains(.unprotectedSites) == true
             || notificationsTriggeringReload.contains(where: {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201462886803403/1203476071420168/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
This is a fix for when the device passcode was changed to be enabled or disabled while the app was running in background, the app was not aware of this and would incorrectly display the autofill key

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Enable device passcode and save an autofill login 
2. Open a tab on the login page of the saved autofill login. Confirm the autofill key symbol is present
3. Minimise the app and from the iOS Settings app disable the device passcode
4. Bring the app back to foreground and confirm the webpage reloads and the autofill key is no longer present
5. Minimise and again bring the app back to foreground and confirm the webpage does NOT reload this time
6. Minimise the app and from the iOS Settings app re-enable the device passcode
7.  Bring the app back to foreground and confirm the webpage reloads and the autofill key is present and that you are prompted to use autofill to login 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
