### PR TITLE
Fix tracker animation being frozen when app is backgrounded during playback

### DIFF
--- a/DuckDuckGo/PrivacyInfoContainerView.swift
+++ b/DuckDuckGo/PrivacyInfoContainerView.swift
@@ -38,9 +38,10 @@ class PrivacyInfoContainerView: UIView {
         
         maskingView.round(corners: .allCorners, radius: 75)
         
-        trackers1Animation.contentMode = .scaleAspectFill
-        trackers2Animation.contentMode = .scaleAspectFill
-        trackers3Animation.contentMode = .scaleAspectFill
+        [trackers1Animation, trackers2Animation, trackers3Animation].forEach { animationView in
+            animationView.contentMode = .scaleAspectFill
+            animationView.backgroundBehavior = .pauseAndRestore
+        }
         
         loadAnimations(for: ThemeManager.shared.currentTheme)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1203552605455710/f

**Description**:
Fix tracker animation being frozen when app is backgrounded during playback and user returns to the app after couple of seconds.

**Steps to test this PR**:
1. Load or reload page containing trackers.
2. When the blocked tracker animation starts playing background the app.
3. Wait couple seconds.
4. Return to the app.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
