### PR TITLE
Fix Privacy Dashboard related pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -39,7 +39,6 @@ extension Pixel {
         case privacyDashboardOpened
         case privacyDashboardProtectionDisabled
         case privacyDashboardProtectionEnabled
-        case privacyDashboardManageProtection
         case privacyDashboardReportBrokenSite
         case privacyDashboardPixelFromJS(rawPixel: String)
         
@@ -403,7 +402,6 @@ extension Pixel.Event {
 
         case .privacyDashboardProtectionDisabled: return "mp_wla"
         case .privacyDashboardProtectionEnabled: return "mp_wlr"
-        case .privacyDashboardManageProtection: return "mp_mw"
         case .privacyDashboardReportBrokenSite: return "mp_rb"
         case .privacyDashboardPixelFromJS(let rawPixel): return rawPixel
             

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -37,11 +37,6 @@ extension Pixel {
         case forgetAllDataCleared
         
         case privacyDashboardOpened
-        case privacyDashboardScorecard
-        case privacyDashboardEncryption
-        case privacyDashboardNetworks
-        case privacyDashboardPrivacyPractices
-        case privacyDashboardGlobalStats
         case privacyDashboardProtectionDisabled
         case privacyDashboardProtectionEnabled
         case privacyDashboardManageProtection
@@ -405,11 +400,7 @@ extension Pixel.Event {
         case .forgetAllDataCleared: return "mf_dc"
             
         case .privacyDashboardOpened: return "mp"
-        case .privacyDashboardScorecard: return "mp_c"
-        case .privacyDashboardEncryption: return "mp_e"
-        case .privacyDashboardNetworks: return "mp_n"
-        case .privacyDashboardPrivacyPractices: return "mp_p"
-        case .privacyDashboardGlobalStats: return "mp_s"
+
         case .privacyDashboardProtectionDisabled: return "mp_wla"
         case .privacyDashboardProtectionEnabled: return "mp_wlr"
         case .privacyDashboardManageProtection: return "mp_mw"

--- a/DuckDuckGo/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/PrivacyDashboardViewController.swift
@@ -95,6 +95,8 @@ private extension PrivacyDashboardViewController {
         contentBlockingManager.scheduleCompilation()
         
         privacyDashboardController.didStartRulesCompilation()
+        
+        Pixel.fire(pixel: enabled ? .privacyDashboardProtectionEnabled : .privacyDashboardProtectionDisabled)
     }
     
     func privacyDashboardCloseTappedHandler() {

--- a/DuckDuckGo/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/PrivacyDashboardViewController.swift
@@ -137,6 +137,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
     }
     
     func privacyDashboardControllerDidRequestShowReportBrokenSite(_ privacyDashboardController: PrivacyDashboardController) {
+        Pixel.fire(pixel: .privacyDashboardReportBrokenSite)
         performSegue(withIdentifier: "ReportBrokenSite", sender: self)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203568774648452/f

**Description**:
Fix Privacy Dashboard related pixels. Some of them become obsolete others were not fired in the new implementation.

Pixels removed:
- privacyDashboardScorecard
- privacyDashboardEncryption
- privacyDashboardNetworks
- privacyDashboardPrivacyPractices
- privacyDashboardGlobalStats
- privacyDashboardManageProtection

Pixels reintroduced:
- privacyDashboardProtectionDisabled
- privacyDashboardProtectionEnabled
- privacyDashboardReportBrokenSite

**Steps to test this PR**:
1. Check if removed pixels are no longer used.
2. Check if reintroduced pixel are fired correctly.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
