### PR TITLE
Autofill Logins Auth friction improvements

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -104,6 +104,8 @@ class AutofillLoginDetailsViewController: UIViewController {
         super.viewWillDisappear(animated)
         if isMovingFromParent {
             AppDependencyProvider.shared.autofillLoginSession.lastAccessedAccount = nil
+        } else if authenticator.canAuthenticate() {
+            AppDependencyProvider.shared.autofillLoginSession.startSession()
         }
     }
 

--- a/DuckDuckGo/AutofillLoginListAuthenticator.swift
+++ b/DuckDuckGo/AutofillLoginListAuthenticator.swift
@@ -52,13 +52,6 @@ final class AutofillLoginListAuthenticator {
     func authenticate(completion: ((AuthError?) -> Void)? = nil) {
        
         if state == .loggedIn {
-            AppDependencyProvider.shared.autofillLoginSession.startSession()
-            completion?(nil)
-            return
-        }
-
-        if AppDependencyProvider.shared.autofillLoginSession.isValidSession {
-            state = .loggedIn
             completion?(nil)
             return
         }
@@ -76,7 +69,6 @@ final class AutofillLoginListAuthenticator {
                 DispatchQueue.main.async {
                     if success {
                         self.state = .loggedIn
-                        AppDependencyProvider.shared.autofillLoginSession.startSession()
                         completion?(nil)
                     } else {
                         os_log("Failed to authenticate: %s", log: generalLog, type: .debug, error?.localizedDescription ?? "nil error")

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -92,7 +92,7 @@ final class AutofillLoginListViewModel: ObservableObject {
         self.tld = tld
         self.currentTabUrl = currentTabUrl
         updateData()
-        authenticationNotRequired = !hasAccountsSaved
+        authenticationNotRequired = !hasAccountsSaved || AppDependencyProvider.shared.autofillLoginSession.isValidSession
         setupCancellables()
     }
     

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -120,6 +120,13 @@ final class AutofillLoginSettingsListViewController: UIViewController {
         authenticate()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if viewModel.authenticator.canAuthenticate() {
+            AppDependencyProvider.shared.autofillLoginSession.startSession()
+        }
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1203570655543385/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Two small enhancements to the Autofill logins screens related to reducing auth friction flow: 
1. No longer briefly showing the locked UI screen when authentication is not required 
2. Changing the Autofill login session 15 seconds timeout to begin when leaving the Autofill screens, as opposed to when entering 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Ensure you have at least one Autofill login saved
2. Access the Autofill logins screen and confirm you see the usual lock screen and are prompted to authenticate
3. Back out of the screen, then go back in. You should immediately see your saved logins and not be prompted to authenticate
4. Minimise the app, then re-access the Autofill screens. Confirm you see the usual lock screen and are prompted to authenticate
5. Wait 10 seconds, then back out of the Autofill screens. Wait another 10 seconds, then re-access the Autofill screens. You should immediately see your saved logins and not be prompted to authenticate
6. Back out of the Autofill screens again. Wait 15 - 16 seconds, then re-access the Autofill screens. Confirm you see the usual lock screen and are prompted to authenticate

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
