### PR TITLE
Revert "Fix for autofill key still appearing when passcode is disabled"

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -319,7 +319,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         beginAuthentication()
         autoClear?.applicationWillMoveToForeground()
         showKeyboardIfSettingOn = true
-        AppDependencyProvider.shared.autofillLoginSession.checkDevicePasscodeStatus()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -30,7 +30,6 @@ extension ContentScopeFeatureToggles {
         let context = LAContext()
         var error: NSError?
         let canAuthenticate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
-        AppDependencyProvider.shared.autofillLoginSession.devicePasscodeEnabled = canAuthenticate
         return featureFlagger.isFeatureOn(.autofill) && appSettings.autofillCredentialsEnabled && canAuthenticate
     }
     

--- a/DuckDuckGo/AutofillLoginSession.swift
+++ b/DuckDuckGo/AutofillLoginSession.swift
@@ -26,10 +26,6 @@ class AutofillLoginSession {
         static let timeout: TimeInterval = 15
     }
 
-    public struct Notifications {
-        public static let devicePasscodeStatusChanged = Notification.Name("com.duckduckgo.app.AutofillLoginSession.devicePasscodeStatusChanged")
-    }
-
     private var sessionCreationDate: Date?
     private var sessionAccount: SecureVaultModels.WebsiteAccount?
     private let sessionTimeout: TimeInterval
@@ -54,8 +50,6 @@ class AutofillLoginSession {
         }
     }
 
-    var devicePasscodeEnabled: Bool?
-
     func startSession() {
         sessionCreationDate = Date()
     }
@@ -63,11 +57,5 @@ class AutofillLoginSession {
     func endSession() {
         sessionCreationDate = nil
         lastAccessedAccount = nil
-    }
-
-    func checkDevicePasscodeStatus() {
-        if let passcodeEnabled = devicePasscodeEnabled, passcodeEnabled != ContentScopeFeatureToggles.supportedFeaturesOniOS.credentialsAutofill {
-            NotificationCenter.default.post(name: Notifications.devicePasscodeStatusChanged, object: nil)
-        }
     }
 }

--- a/DuckDuckGo/ContentBlockingUpdating.swift
+++ b/DuckDuckGo/ContentBlockingUpdating.swift
@@ -83,7 +83,6 @@ public final class ContentBlockingUpdating {
             .combineLatest(onNotificationWithInitial(PreserveLogins.Notifications.loginDetectionStateChanged), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.doNotSellStatusChange), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.autofillEnabledChange), combine)
-            .combineLatest(onNotificationWithInitial(AutofillLoginSession.Notifications.devicePasscodeStatusChanged), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.textSizeChange), combine)
             .combineLatest(onNotificationWithInitial(AppUserDefaults.Notifications.didVerifyInternalUser), combine)
             .combineLatest(onNotificationWithInitial(StorageCacheProvider.didUpdateStorageCacheNotification)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1987,8 +1987,7 @@ extension TabViewController: UserContentControllerDelegate {
         let tdsKey = DefaultContentBlockerRulesListsSource.Constants.trackerDataSetRulesListName
         let notificationsTriggeringReload = [
             PreserveLogins.Notifications.loginDetectionStateChanged,
-            AppUserDefaults.Notifications.doNotSellStatusChange,
-            AutofillLoginSession.Notifications.devicePasscodeStatusChanged
+            AppUserDefaults.Notifications.doNotSellStatusChange
         ]
         if updateEvent.changes[tdsKey]?.contains(.unprotectedSites) == true
             || notificationsTriggeringReload.contains(where: {


### PR DESCRIPTION
Reverts duckduckgo/iOS#1420
More details here: https://app.asana.com/0/0/1203649445113660/1203656237740253/f

Steps to reproduce the issue introduced by the PR:
* Run app
* Navigate to any page.
* Background app for 10 seconds.
* Come back to app - page gets reloaded. (Page should not be reloaded now that this PR is reverted)
