### PR TITLE
Autofill fix to allow first manually added login to be editable

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -233,7 +233,9 @@ class AutofillLoginDetailsViewController: UIViewController {
 
     private func updateNavigationBarButtons() {
         switch authenticator.state {
-        case .loggedOut, .notAvailable:
+        case .loggedOut:
+            navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = authenticationNotRequired }
+        case .notAvailable:
             navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = false }
         case .loggedIn:
             navigationItem.rightBarButtonItems?.forEach { $0.isEnabled = true }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1203705339477109/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Fixes an issue where after manually adding a first Autofill login, the Edit button was disabled

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. From a fresh install manually create a new Autofill login. Confirm that it can be edited.
2. Perform a few smoke test steps like saving a new autofill login via the save prompt, tapping to view it and confirm it is editable
3. Minimise the app, then go back into the Autofill screens and tap into a couple of the saved logins confirming that Auth still prompts correctly and the Edit button is in the correct state

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
