### PR TITLE
Automatically run the script when PR is merged to release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Make App Store Connect Release
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       destination:
@@ -11,10 +11,15 @@ on:
         options:
         - appstore
         - testflight
+  pull_request:
+    branches:
+    - release/**
+    - '!release/**-' # filter out PRs matching that pattern
+    types: [closed]
 
 jobs:
   make-release:
-
+    if: github.event.action == 0 || github.event.pull_request.merged == true # empty string returns 0; for case when workflow is triggered manually
     runs-on: macos-12
     name: Make App Store Connect Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,14 @@ jobs:
 
     steps:
 
+    - name: Set destination output
+      id: destination
+      run: |
+        INPUT_DESTINATION=${{ github.event.inputs.destination }}
+        echo "destination=${INPUT_DESTINATION:-"appstore"}" >> $GITHUB_OUTPUT
+
     - name: Assert release branch
-      if: github.event.inputs.destination == 'appstore'
+      if: steps.destination.outputs.destination == 'appstore'
       run: |
         case "${{ github.ref }}" in
           *release/*) ;;
@@ -61,12 +67,12 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-      run: bundle exec fastlane release_${{ github.event.inputs.destination }}
+      run: bundle exec fastlane release_${{ steps.destination.outputs.destination }}
 
     - name: Send Mattermost message
       env:
         WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        DESTINATION: ${{ github.event.inputs.destination }}
+        DESTINATION: ${{ steps.destination.outputs.destination }}
       run: |
         export MM_USER_HANDLE=$(base64 -d <<< ${{ secrets.MM_HANDLES_BASE64 }} | jq ".${{ github.actor }}" | tr -d '"')
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203782011321071/f

**Description**:

We want to have an option to either trigger release workflow manually or automatically when the PR is being merged to the release branch. This PR targets that.

**Steps to test this PR**:
1. Check if manual trigger still works.
2. Create release/x.y.z base branch and another release/x.y.z-changes branch, create PR with some changes and close it by merging the changes - see if automatic trigger works.
3. Create release/x.y.z base branch and another release/x.y.z-changes branch, create PR with some changes and close it without merging - workflow should not start.
4. Create release/x.y.z-changes base branch and another whatever branch, create PR with some changes and close it by merging the changes - workflow should not start.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
