### PR TITLE
Update BSK with autofill 6.2.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7131,8 +7131,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 43.0.2;
+				kind = revision;
+				revision = 06475e1719dda23453368ad7a57db262d84d67ff;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203845335740047/1203845335740047
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/222

## Description
Updates Autofill to version [6.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.2.0).

### Autofill 6.2.0 release notes
## What's Changed
* Send autofill pixels on macOS by @sixers in https://github.com/duckduckgo/duckduckgo-autofill/pull/249


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.1.2...6.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).