### PR TITLE
Improvements to prepare_release script

### DIFF
--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -22,6 +22,26 @@ assert_ios_directory() {
 	fi
 }
 
+assert_fastlane_installed() {
+	if ! command -v bundle &> /dev/null; then
+		die "💥 Error: Bundle is not installed. See: https://app.asana.com/0/1202500774821704/1203766784006610/f"
+	fi
+
+	if ! bundle show fastlane &> /dev/null; then
+		die "💥 Error: Fastlane is not installed. See: https://app.asana.com/0/1202500774821704/1203766784006610/f"
+	fi
+}
+
+assert_gh_installed_and_authenticated() {
+	if ! command -v gh &> /dev/null; then
+		die "💥 Error: GitHub CLI is not installed. See: https://app.asana.com/0/1202500774821704/1203791243007683/f"
+	fi
+
+	if ! gh auth status 2>&1 | grep -q "✓ Logged in to github.com"; then
+		echo "💥 Error: GitHub CLI is not authenticated. See: https://app.asana.com/0/1202500774821704/1203791243007683/f"
+	fi
+}
+
 print_usage_and_exit() {
 	local reason=$1
 
@@ -160,6 +180,8 @@ create_pull_request() {
 
 main() {
 	assert_ios_directory
+	assert_fastlane_installed
+	assert_gh_installed_and_authenticated
 	read_command_line_arguments "$@"
 	stash
 	assert_clean_state


### PR DESCRIPTION
- Remove updating metadata from the script
- Add assertions for bundler, fastlane and gh cli

Task/Issue URL: https://app.asana.com/0/414709148257752/1203900113130121/f

**Description**:
1. Remove the update metadata step.
2. Assert bundle, fastlane and gh cli are installed.

**Steps to test this PR**:
1. Run the script - it should execute as before.
2. Log out from GH GLI - the script should fail on assert gh cli.
3. Copy the script to some other cloned repo (without fastlane) - the script should fail on assert fastlane.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
