### PR TITLE
Fix for issue where content of shortlived tab is displayed in the wrong tab

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1463,6 +1463,8 @@ extension MainViewController: TabDelegate {
         newTab.openingTab = tab
         
         newTabAnimation {
+            guard self.tabManager.model.tabs.contains(newTab.tabModel) else { return }
+
             self.dismissOmniBar()
             self.addToView(tab: newTab)
             self.refreshOmniBar()


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1203660698549435/f
Tech Design URL:
CC:

**Description**:
Fix for webpages that launch a new tab which is immediately closed, resulting in the parent page displaying the closed tabs content

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open https://app.reputation.com/requests-unsubscribe?i=c1efb47f-6720-4e9c-a1c5-d7a781e942a7___2217848391121905&t=2622&email=me@mark-ingram.com in a new tab
2. Tap into the email text field (or anywhere on the page)
3. The webpage will load a new tab which is then immediately closed.
4. Confirm the original webpage content is still displayed (and not a white screen, which was the case before this fix)
5. Perform some regression tests by visiting another site where links create new tabs e.g. techmeme.com and confirm new tabs are opening correctly as before
6. Long press on a link and confirming opening tabs in a new tab and in background still work as before

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
