### PR TITLE
Fix for 'Cookies managed' notification to properly fade out

### DIFF
--- a/DuckDuckGo/OmniBarNotificationAnimator.swift
+++ b/DuckDuckGo/OmniBarNotificationAnimator.swift
@@ -53,13 +53,17 @@ final class OmniBarNotificationAnimator: NSObject {
                     omniBar.textField.alpha = 1
                     omniBar.privacyInfoContainer.alpha = 1
                 }
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2 * fadeDuration) {
+                    omniBar.notificationContainer.removePreviousNotification()
+                }
             }
         }
     }
     
     func cancelAnimations(in omniBar: OmniBar) {
         omniBar.privacyInfoContainer.alpha = 0
-        omniBar.notificationContainer.stopAnimation()
+        omniBar.notificationContainer.removePreviousNotification()
         omniBar.textField.alpha = 1
         omniBar.privacyInfoContainer.alpha = 1
     }

--- a/DuckDuckGo/OmniBarNotificationAnimator.swift
+++ b/DuckDuckGo/OmniBarNotificationAnimator.swift
@@ -33,6 +33,7 @@ final class OmniBarNotificationAnimator: NSObject {
         omniBar.textField.alpha = 0
         
         let fadeDuration = Constants.Duration.fade
+        let animationStartOffset = 2 * fadeDuration
         
         UIView.animate(withDuration: fadeDuration) {
             omniBar.privacyInfoContainer.alpha = 0
@@ -42,7 +43,7 @@ final class OmniBarNotificationAnimator: NSObject {
             omniBar.notificationContainer.alpha = 1
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2 * fadeDuration) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + animationStartOffset) {
             
             omniBar.notificationContainer.startAnimation {
                 UIView.animate(withDuration: fadeDuration) {

--- a/DuckDuckGo/OmniBarNotificationContainerView.swift
+++ b/DuckDuckGo/OmniBarNotificationContainerView.swift
@@ -30,7 +30,7 @@ final class OmniBarNotificationContainerView: UIView {
     var currentNotificationController: UIHostingController<OmniBarNotification>?
     
     func prepareAnimation(_ type: OmniBarNotificationType) {
-        cleanUpPreviousNotification()
+        removePreviousNotification()
         
         let viewModel = makeNotificationViewModel(for: type)
         let notificationViewController = UIHostingController(rootView: OmniBarNotification(viewModel: viewModel),
@@ -46,16 +46,11 @@ final class OmniBarNotificationContainerView: UIView {
     
     func startAnimation(completion: @escaping () -> Void) {
         currentNotificationController?.rootView.viewModel.showNotification(completion: { [weak self] in
-            self?.cleanUpPreviousNotification()
             completion()
         })
     }
-    
-    func stopAnimation() {
-        cleanUpPreviousNotification()
-    }
-    
-    private func cleanUpPreviousNotification() {
+
+    func removePreviousNotification() {
         guard let currentNotificationController = currentNotificationController else { return }
         
         currentNotificationController.willMove(toParent: nil)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1203967747887450/f

**Description**:
Cookies managed notification appears with a fade-in but is not fading-out after completion. The reason to this behaviour was that on completion it was removed from the view hierarchy too early.

**Steps to test this PR**:
1. Enable "Manage Cookie Pop-ups" in app's settings.
2. Clear cookies.
3. Navigate to as website showing a cookie consent prompt
4. When the pop up is managed the notification should properly animate in the address bar.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
