### PR TITLE
Autofill: Leave title blank by default

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsViewModel.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewModel.swift
@@ -76,7 +76,7 @@ final class AutofillLoginDetailsViewModel: ObservableObject {
         case .edit:
             return UserText.autofillLoginDetailsEditTitle
         case .view:
-            return title
+            return title.isEmpty ? address : title
         case .new:
             return UserText.autofillLoginDetailsNewTitle
         }

--- a/DuckDuckGo/AutofillLoginDetailsViewModel.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewModel.swift
@@ -117,9 +117,9 @@ final class AutofillLoginDetailsViewModel: ObservableObject {
         self.account = account
         username = account.username
         address = account.domain
-        title = account.name(tld: tld)
+        title =  account.title ?? ""
         notes = account.notes ?? ""
-        headerViewModel.updateData(with: account, tld: tld)
+        headerViewModel.updateData(with: account)
         setupPassword(with: account)
     }
     
@@ -270,8 +270,8 @@ final class AutofillLoginDetailsHeaderViewModel: ObservableObject {
     @Published var subtitle: String = ""
     @Published var domain: String = ""
     
-    func updateData(with account: SecureVaultModels.WebsiteAccount, tld: TLD) {
-        self.title = account.name(tld: tld)
+    func updateData(with account: SecureVaultModels.WebsiteAccount) {
+        self.title = account.name()
         self.subtitle = UserText.autofillLoginDetailsLastUpdated(for: (dateFormatter.string(from: account.lastUpdated)))
         self.domain = account.domain
     }

--- a/DuckDuckGo/AutofillLoginListItemViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListItemViewModel.swift
@@ -30,9 +30,9 @@ final class AutofillLoginListItemViewModel: Identifiable, Hashable {
     let subtitle: String
     let id = UUID()
 
-    internal init(account: SecureVaultModels.WebsiteAccount, tld: TLD) {
+    internal init(account: SecureVaultModels.WebsiteAccount) {
         self.account = account
-        self.title = account.name(tld: tld)
+        self.title = account.name()
         self.subtitle = account.username
         
         fetchImage()

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -167,7 +167,7 @@ final class AutofillLoginListViewModel: ObservableObject {
         
         if let query = query, query.count > 0 {
             filteredAccounts = filteredAccounts.filter { account in
-                if !account.name(tld: tld).lowercased().contains(query.lowercased()) &&
+                if !account.name().lowercased().contains(query.lowercased()) &&
                     !account.domain.lowercased().contains(query.lowercased()) &&
                     !account.username.lowercased().contains(query.lowercased()) {
                     return false
@@ -218,12 +218,12 @@ final class AutofillLoginListViewModel: ObservableObject {
             newSections.append(.enableAutofill)
 
             if !accountsToSuggest.isEmpty {
-                let accountItems = accountsToSuggest.map { AutofillLoginListItemViewModel(account: $0, tld: tld) }
+                let accountItems = accountsToSuggest.map { AutofillLoginListItemViewModel(account: $0) }
                 newSections.append(.credentials(title: UserText.autofillLoginListSuggested, items: accountItems))
             }
         }
 
-        let viewModelsGroupedByFirstLetter = accounts.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let viewModelsGroupedByFirstLetter = accounts.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
         let accountSections = viewModelsGroupedByFirstLetter.autofillLoginListSectionsForViewModelsSortedByTitle()
         
         newSections.append(contentsOf: accountSections)
@@ -305,14 +305,14 @@ extension AutofillLoginListItemViewModel: Comparable {
 
 internal extension Array where Element == SecureVaultModels.WebsiteAccount {
     
-    func autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: TLD) -> [String: [AutofillLoginListItemViewModel]] {
+    func autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter() -> [String: [AutofillLoginListItemViewModel]] {
         reduce(into: [String: [AutofillLoginListItemViewModel]]()) { result, account in
             
             // Unfortunetly, folding doesn't produce perfect results despite respecting the system locale
             // E.g. Romainian should treat letters with diacritics as seperate letters, but folding doesn't
             // Apple's own apps (e.g. contacts) seem to suffer from the same problem
             let key: String
-            if let firstChar = account.name(tld: tld).first,
+            if let firstChar = account.name().first,
                let deDistinctionedChar = String(firstChar).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil).first,
                deDistinctionedChar.isLetter {
                 
@@ -321,7 +321,7 @@ internal extension Array where Element == SecureVaultModels.WebsiteAccount {
                 key = AutofillLoginListSectionType.miscSectionHeading
             }
             
-            return result[key, default: []].append(AutofillLoginListItemViewModel(account: account, tld: tld))
+            return result[key, default: []].append(AutofillLoginListItemViewModel(account: account))
         }
     }
 }

--- a/DuckDuckGo/WebsiteAccountExtension.swift
+++ b/DuckDuckGo/WebsiteAccountExtension.swift
@@ -23,15 +23,11 @@ import Common
 
 extension SecureVaultModels.WebsiteAccount {
 
-    func name(tld: TLD) -> String {
+    func name() -> String {
         if let title = self.title, !title.isEmpty {
             return title
         } else {
-            if let domain = tld.eTLDplus1(self.domain) {
-                return domain
-            } else {
-                return self.domain.droppingWwwPrefix()
-            }
+            return domain
         }
     }
 }

--- a/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -60,7 +60,7 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
         let testData = [SecureVaultModels.WebsiteAccount(title: nil, username: "c", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "ç", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "C", domain: domain)]
-        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
         // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
         XCTAssertEqual(result.count, 1)
     }
@@ -76,7 +76,7 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
                         SecureVaultModels.WebsiteAccount(title: nil, username: "?????", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "&%$£$%", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "99999", domain: domain)]
-        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
         // All non letters should be grouped together
         XCTAssertEqual(result.count, 1)
     }
@@ -84,12 +84,12 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
     func testWhenCreatingSectionsThenTitlesWithinASectionAreSortedCorrectly() {
         let domain = "whateverNotImportantForThisTest"
         let testData = ["e": [
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephant", username: "1", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephants", username: "2", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "Elephant", username: "3", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "èlephant", username: "4", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "è", username: "5", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: nil, username: "ezy", domain: domain), tld: tld)]]
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephant", username: "1", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephants", username: "2", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "Elephant", username: "3", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "èlephant", username: "4", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "è", username: "5", domain: domain)),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: nil, username: "ezy", domain: domain))]]
         let result = testData.autofillLoginListSectionsForViewModelsSortedByTitle()
         if case .credentials(_, let viewModels) = result[0] {
             XCTAssertEqual(viewModels[0].title, "è")
@@ -112,7 +112,7 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
                         SecureVaultModels.WebsiteAccount(title: nil, username: "test", domain: "auth.test.example.com"),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "test", domain: "https://www.auth.example.com"),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "test", domain: "https://www.example.com")]
-        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter()
         // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
         XCTAssertEqual(result.count, 1)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1203927830097163/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Change the default save behaviour so that the title is blank by default and only set if the user explicitly sets it

Note - I'll be making the changes to saving the port in a separate PR. 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Create a new login, setting only the Website URL, leaving the title blank. 
2. Once saved the title should be the Website URL
3. Tap to Edit the saved login and the title should display placeholder text 'Title'
4. Leave the title blank and save. Confirm the title still displays the Website URL and in edit mode still displays placeholder text 'Title'
5. Edit the login and set a title. Save and confirm the login is displaying the newly set title.
6. Save a new login via a website login save prompt. Tap to view the saved login
7. Confirm the title is displaying placeholder text 'Title' by default when in edit mode

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
