### PR TITLE
Fix country code for United Kingdom

### DIFF
--- a/Core/LocaleExtension.swift
+++ b/Core/LocaleExtension.swift
@@ -25,6 +25,6 @@ extension Locale {
         ["AD", "AL", "AT", "AZ", "BA", "BE", "BG", "BY", "CH", "CY", "CZ", "DE", "DK", "EE", "ES",
          "FI", "FR", "GE", "GI", "GR", "HR", "HU", "IE", "IS", "IT", "KZ", "LI", "LT", "LU", "LV",
          "MC", "MD", "ME", "MK", "MT", "NL", "NO", "PL", "PT", "RO", "RS", "RU", "SE", "SI", "SK",
-         "SM", "TR", "UA", "UK", "VA"].contains(regionCode)
+         "SM", "TR", "UA", "GB", "VA"].contains(regionCode)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1204005526478359/f

**Description**:
In the Locale extension we check against list of region codes to verify if current one is within Europe. By mistake the code for United Kingdom is listed as "UK" instead of "GB".

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
