### PR TITLE
Autofill changes how URLs are stored and match suggestions

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7362,8 +7362,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 46.2.0;
+				branch = "autofill/anya/subdomains-url-changes";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo/AutofillLoginListItemViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListItemViewModel.swift
@@ -30,9 +30,9 @@ final class AutofillLoginListItemViewModel: Identifiable, Hashable {
     let subtitle: String
     let id = UUID()
 
-    internal init(account: SecureVaultModels.WebsiteAccount, tld: TLD) {
+    internal init(account: SecureVaultModels.WebsiteAccount, tld: TLD, autofillDomainNameUrlMatcher: AutofillDomainNameUrlMatcher) {
         self.account = account
-        self.title = account.name(tld: tld)
+        self.title = account.name(tld: tld, autofillDomainNameUrlMatcher: autofillDomainNameUrlMatcher)
         self.subtitle = account.username
         
         fetchImage()

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -198,18 +198,15 @@ final class AutofillLoginListViewModel: ObservableObject {
     }
 
     private func fetchSuggestedAccounts() -> [SecureVaultModels.WebsiteAccount] {
-        guard let url = currentTabUrl,
-              let host = url.host,
-              let secureVault = secureVault else {
+        guard let currentUrl = currentTabUrl else {
             return []
         }
 
-        do {
-            return try secureVault.accountsFor(domain: host)
-        } catch {
-            os_log("Failed to fetch suggested accounts")
-            return []
+        let suggestedAccounts = accounts.filter { account in
+            return autofillDomainNameUrlMatcher.isMatchingForAutofill(currentSite: currentUrl.absoluteString, savedSite: account.domain, tld: tld)
         }
+
+        return suggestedAccounts
     }
 
     private func makeSections(with accounts: [SecureVaultModels.WebsiteAccount]) -> [AutofillLoginListSectionType] {
@@ -284,7 +281,7 @@ final class AutofillLoginListViewModel: ObservableObject {
 
         return (sectionsToDelete: sectionsToDelete, rowsToDelete: rowsToDelete)
     }
-    
+
     @discardableResult
     func delete(_ account: SecureVaultModels.WebsiteAccount) -> Bool {
         guard let secureVault = secureVault,

--- a/DuckDuckGo/WebsiteAccountExtension.swift
+++ b/DuckDuckGo/WebsiteAccountExtension.swift
@@ -23,15 +23,11 @@ import Common
 
 extension SecureVaultModels.WebsiteAccount {
 
-    func name(tld: TLD) -> String {
+    func name(tld: TLD, autofillDomainNameUrlMatcher: AutofillDomainNameUrlMatcher) -> String {
         if let title = self.title, !title.isEmpty {
             return title
         } else {
-            if let domain = tld.eTLDplus1(self.domain) {
-                return domain
-            } else {
-                return self.domain.droppingWwwPrefix()
-            }
+            return autofillDomainNameUrlMatcher.cleanRawUrl(domain)
         }
     }
 }

--- a/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -131,13 +131,15 @@ class AutofillLoginListSectionTypeTests: XCTestCase {
 class AutofillLoginListItemViewModelTests: XCTestCase {
 
     let tld = TLD()
+    let autofillUrlMatcher = AutofillDomainNameUrlMatcher()
 
     func testWhenCreatingViewModelsThenDiacriticsGroupedCorrectly() {
         let domain = "whateverNotImportantForThisTest"
         let testData = [SecureVaultModels.WebsiteAccount(title: nil, username: "c", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "ç", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "C", domain: domain)]
-        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld,
+                                                                                             autofillDomainNameUrlMatcher: autofillUrlMatcher)
         // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
         XCTAssertEqual(result.count, 1)
     }
@@ -153,7 +155,8 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
                         SecureVaultModels.WebsiteAccount(title: nil, username: "?????", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "&%$£$%", domain: domain),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "99999", domain: domain)]
-        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld,
+                                                                                             autofillDomainNameUrlMatcher: autofillUrlMatcher)
         // All non letters should be grouped together
         XCTAssertEqual(result.count, 1)
     }
@@ -161,12 +164,24 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
     func testWhenCreatingSectionsThenTitlesWithinASectionAreSortedCorrectly() {
         let domain = "whateverNotImportantForThisTest"
         let testData = ["e": [
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephant", username: "1", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephants", username: "2", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "Elephant", username: "3", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "èlephant", username: "4", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "è", username: "5", domain: domain), tld: tld),
-            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: nil, username: "ezy", domain: domain), tld: tld)]]
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephant", username: "1", domain: domain),
+                                           tld: tld,
+                                           autofillDomainNameUrlMatcher: autofillUrlMatcher),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "elephants", username: "2", domain: domain),
+                                           tld: tld,
+                                           autofillDomainNameUrlMatcher: autofillUrlMatcher),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "Elephant", username: "3", domain: domain),
+                                           tld: tld,
+                                           autofillDomainNameUrlMatcher: autofillUrlMatcher),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "èlephant", username: "4", domain: domain),
+                                           tld: tld,
+                                           autofillDomainNameUrlMatcher: autofillUrlMatcher),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: "è", username: "5", domain: domain),
+                                           tld: tld,
+                                           autofillDomainNameUrlMatcher: autofillUrlMatcher),
+            AutofillLoginListItemViewModel(account: SecureVaultModels.WebsiteAccount(title: nil, username: "ezy", domain: domain),
+                                           tld: tld,
+                                           autofillDomainNameUrlMatcher: autofillUrlMatcher)]]
         let result = testData.autofillLoginListSectionsForViewModelsSortedByTitle()
         if case .credentials(_, let viewModels) = result[0] {
             XCTAssertEqual(viewModels[0].title, "è")
@@ -189,7 +204,8 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
                         SecureVaultModels.WebsiteAccount(title: nil, username: "test", domain: "auth.test.example.com"),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "test", domain: "https://www.auth.example.com"),
                         SecureVaultModels.WebsiteAccount(title: nil, username: "test", domain: "https://www.example.com")]
-        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld)
+        let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld,
+                                                                                             autofillDomainNameUrlMatcher: autofillUrlMatcher)
         // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
         XCTAssertEqual(result.count, 1)
     }

--- a/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -207,6 +207,6 @@ class AutofillLoginListItemViewModelTests: XCTestCase {
         let result = testData.autofillLoginListItemViewModelsForAccountsGroupedByFirstLetter(tld: tld,
                                                                                              autofillDomainNameUrlMatcher: autofillUrlMatcher)
         // Diacritics should be grouped with the root letter (in most cases), and grouping should be case insensative
-        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.count, 5)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1203927830097159/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Autofill URL changes to normalize URLs to save only host:port as well as support for subdomain matching for suggestions 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

**URL store changes**
1.  Go to https://fill.dev/form/login-simple
2. Login and store the credentials
3. Check the website URL saved is `fill.dev`
4. Add a new login manually and set the Website URL to something like `https://www.example.com?params=123`
5. Save and check the website URL saved is `example.com`
6. Add a new login manually with a port, setting the Website URL to something like `https://www.example.com:123`
7. Save and check the website URL saved is `example.com:123`

**URL matching changes**
1. Add a login for `fill.dev`
2. Visit `fill.dev/form/login-simple` and confirms it prompts to autofill as normal
3. Open Autofill login list screen; verify it is listed as a suggested site
4. Edit the login and append a port to the URL (e.g., `fill.dev:9000`)
6. Visit the login page again (refreshing if required); verify you are not prompted to autofill (as ports don't match)
7. Open Autofill login list screen; confrim it is not listed as a suggested site

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
