### PR TITLE
Fixes a crash when generating private duck addresses.

### DIFF
--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -298,7 +298,7 @@ extension TabViewController {
             Pixel.fire(pixel: .emailUserCreatedAlias, withAdditionalParameters: pixelParameters, includedParameters: [])
 
             emailManager.getAliasIfNeededAndConsume { alias, _ in
-                Task { @MainActor
+                Task { @MainActor in
                     guard let alias = alias else {
                         // we may want to communicate this failure to the user in the future
                         return

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -298,13 +298,15 @@ extension TabViewController {
             Pixel.fire(pixel: .emailUserCreatedAlias, withAdditionalParameters: pixelParameters, includedParameters: [])
 
             emailManager.getAliasIfNeededAndConsume { alias, _ in
-                guard let alias = alias else {
-                    // we may want to communicate this failure to the user in the future
-                    return
+                Task { @MainActor
+                    guard let alias = alias else {
+                        // we may want to communicate this failure to the user in the future
+                        return
+                    }
+                    let pasteBoard = UIPasteboard.general
+                    pasteBoard.string = emailManager.emailAddressFor(alias)
+                    ActionMessageView.present(message: UserText.emailBrowsingMenuAlert)
                 }
-                let pasteBoard = UIPasteboard.general
-                pasteBoard.string = emailManager.emailAddressFor(alias)
-                ActionMessageView.present(message: UserText.emailBrowsingMenuAlert)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1204015453166197/f
CC: @ayoy

**Description**:

This PR pushes a small change to fix a crasher caused by some UI code being executed in a background thread when it shouldn't have.

**Steps to test this PR**:
1. Check out  `develop`
2. Run the app
3. Tap More menu > "Generate Private Duck Address" many times.
4. Turn on airplane mode (if this step disconnects the Xcode debugger, turn off personal hotspot and start over)
5. Continue generating more addresses (it won't succeed but keep selecting the option.
6. Turn off airplane mode
7. Continue generating addresses (it's usually around this point that it fails for me).

Repeat the test using this branch and check you can't get the app to crash.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
