### PR TITLE
Fix `PrivacyIconView` Accessibility Traits Refresh

### DIFF
--- a/DuckDuckGo/PrivacyIconView.swift
+++ b/DuckDuckGo/PrivacyIconView.swift
@@ -76,7 +76,7 @@ class PrivacyIconView: UIView {
         willSet {
             guard newValue != icon else { return }
             updateShieldImageView(for: newValue)
-            updateAccessibilityLabels(for: icon)
+            updateAccessibilityLabels(for: newValue)
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1204297690570751/f
GH Issue URL: https://github.com/duckduckgo/iOS/issues/1556
Tech Design URL: N/A
CC:

**Description**:
The PrivacyIconView is not refreshing the accessibility traits of the Dax Logo Image / Shield Button. This is mainly due to a typo on the `willSet` of the `private(set) var icon: PrivacyIcon`. Where the new value is not being sent to the method that updates the accessibility traits: `updateAccessibilityLabels(for icon: PrivacyIcon)`

**Steps to test this PR**:
1. Enable VoiceOver
2. Open DuckDuckGo and check accessibility hint of the Dax Logo - A11Y Should be OK
3. Search and Navigate to any website
4. Check Shield Button accessibility hint - A11Y Should be OK
5. Go back to the search results
6. Check Dax Logo Accessibility Hints - A11Y Should be OK

Fixed Behaviour:
https://user-images.githubusercontent.com/10634238/226862468-1d40d370-a9a0-473a-9754-682806338ffd.MOV

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
