### PR TITLE
delete bookmark favicon if currently deleted bookmark is the last one left

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7417,8 +7417,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 2e2cf5bb9679ce6734eadae14d2b8643067cd3ad;
+				kind = exactVersion;
+				version = 51.3.0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -7417,8 +7417,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 51.2.2;
+				kind = revision;
+				revision = 2e2cf5bb9679ce6734eadae14d2b8643067cd3ad;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -52,6 +52,7 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
     @IBOutlet var searchBar: UISearchBar!
 
     private let bookmarksDatabase: CoreDataDatabase
+    private let favicons: Favicons
 
     /// Creating left and right toolbar UIBarButtonItems with customView so that 'Edit' button is centered
     private lazy var addFolderButton: UIButton = {
@@ -104,10 +105,12 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
     init?(coder: NSCoder,
           bookmarksDatabase: CoreDataDatabase,
           bookmarksSearch: BookmarksStringSearch,
-          parentID: NSManagedObjectID? = nil) {
+          parentID: NSManagedObjectID? = nil,
+          favicons: Favicons = Favicons.shared) {
         self.bookmarksDatabase = bookmarksDatabase
         self.searchDataSource = SearchBookmarksDataSource(searchEngine: bookmarksSearch)
         self.viewModel = BookmarkListViewModel(bookmarksDatabase: bookmarksDatabase, parentID: parentID)
+        self.favicons = favicons
         super.init(coder: coder)
     }
     
@@ -309,6 +312,11 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
                                           _ completion: @escaping (Bool) -> Void) {
 
         func delete() {
+            if let domain = bookmark.urlObject?.host?.droppingWwwPrefix(),
+                viewModel.countBookmarksForDomain(domain) == 1 {
+                favicons.removeBookmarkFavicon(forDomain: domain)
+            }
+
             let oldCount = viewModel.bookmarks.count
             viewModel.deleteBookmark(bookmark)
             let newCount = viewModel.bookmarks.count

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -312,7 +312,7 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
                                           _ completion: @escaping (Bool) -> Void) {
 
         func delete() {
-            if let domain = bookmark.urlObject?.host?.droppingWwwPrefix(),
+            if let domain = bookmark.urlObject?.host,
                 viewModel.countBookmarksForDomain(domain) == 1 {
                 favicons.removeBookmarkFavicon(forDomain: domain)
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:  https://app.asana.com/0/414235014887631/1204217694278073/f
Tech Design URL:
CC:

**Description**:

Ensures favicon for bookmark domain is deleted when that domain is now longer in the bookmarks database.

**Steps to test this PR**:
1. Add a bookmark for a domain
2. Check that favicon was saved to cache
3. Delete bookmark, ensure favicon was deleted
4. Add two bookmarks for the same domain (different URLs)
5. Check that one favicon was saved to cache
6. Delete one of the bookmarks, ensure the favicon is still in the cache
7. Delete the second bookmark, ensure the favicon is deleted

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
