### PR TITLE
iPad OS: Present the sharesheet attached to the top of the Webview

### DIFF
--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -41,8 +41,8 @@ extension TabViewController {
         items.append(UIAction(title: UserText.actionShare,
                               image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
             guard let webView = self?.webView else { return }
-            let webViewCenter = Point(x: Int(webView.bounds.midX), y: Int(0))
-            self?.onShareAction(forUrl: url, atPoint: webViewCenter)
+            let shareSheetOrigin = Point(x: Int(webView.bounds.midX), y: Int(0))
+            self?.onShareAction(forUrl: url, atPoint: shareSheetOrigin)
         })
 
         return UIMenu(title: url.host?.droppingWwwPrefix() ?? "", children: items + providedElements)

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -40,7 +40,9 @@ extension TabViewController {
         })
         items.append(UIAction(title: UserText.actionShare,
                               image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
-            self?.onShareAction(forUrl: url, atPoint: nil)
+            guard let webView = self?.webView else { return }
+            let webViewCenter = Point(x: Int(webView.bounds.midX), y: Int(0))
+            self?.onShareAction(forUrl: url, atPoint: webViewCenter)
         })
 
         return UIMenu(title: url.host?.droppingWwwPrefix() ?? "", children: items + providedElements)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203464198507607/f

**Description**:
We were missing a Point to attach the ShareSheet, which caused it to truncate on iPad.

This fix will display the Share Sheet attached to the top of the WKWebview.

Ideally, we would want to attach the sheet to the link to tap the location that opened the preview menu, but for that, we would likely need to add some JS and maintain it. (See task discussion).

**Steps to test this PR**:
1. Launch the App on iPad
2. Search for something (eg. "Dogs")
3. Long press a link
4. Tap Share
5. Observe that the share sheet is displayed at the top-center of the webview

| Before         | After     |
|--------------|-----------|
|<img width="350" alt="Screenshot 2023-03-23 at 8 17 19 PM" src="https://user-images.githubusercontent.com/1156669/227324899-2fad783f-de2d-4d7d-a7fc-455b85629148.png">|<img width="350" alt="Screenshot 2023-03-23 at 8 16 38 PM" src="https://user-images.githubusercontent.com/1156669/227325557-752d26c5-f25d-42ee-a6d0-ca4bd464e539.png">|

**Device Testing**:

* [X ] iPad


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
