### PR TITLE
Fix for Autofill toast text incorrect when deleting login

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -25,7 +25,7 @@ import Combine
 
 protocol AutofillLoginDetailsViewControllerDelegate: AnyObject {
     func autofillLoginDetailsViewControllerDidSave(_ controller: AutofillLoginDetailsViewController, account: SecureVaultModels.WebsiteAccount?)
-    func autofillLoginDetailsViewControllerDelete(account: SecureVaultModels.WebsiteAccount)
+    func autofillLoginDetailsViewControllerDelete(account: SecureVaultModels.WebsiteAccount, title: String)
 }
 
 class AutofillLoginDetailsViewController: UIViewController {
@@ -309,8 +309,8 @@ extension AutofillLoginDetailsViewController: AutofillLoginDetailsViewModelDeleg
         present(alert, animated: true)
     }
 
-    func autofillLoginDetailsViewModelDelete(account: SecureVaultModels.WebsiteAccount) {
-        delegate?.autofillLoginDetailsViewControllerDelete(account: account)
+    func autofillLoginDetailsViewModelDelete(account: SecureVaultModels.WebsiteAccount, title: String) {
+        delegate?.autofillLoginDetailsViewControllerDelete(account: account, title: title)
         navigationController?.popViewController(animated: true)
     }
 

--- a/DuckDuckGo/AutofillLoginDetailsViewModel.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewModel.swift
@@ -26,7 +26,7 @@ import Core
 protocol AutofillLoginDetailsViewModelDelegate: AnyObject {
     func autofillLoginDetailsViewModelDidSave()
     func autofillLoginDetailsViewModelDidAttemptToSaveDuplicateLogin()
-    func autofillLoginDetailsViewModelDelete(account: SecureVaultModels.WebsiteAccount)
+    func autofillLoginDetailsViewModelDelete(account: SecureVaultModels.WebsiteAccount, title: String)
     func autofillLoginDetailsViewModelDismiss()
 }
 
@@ -252,7 +252,7 @@ final class AutofillLoginDetailsViewModel: ObservableObject {
             assertionFailure("Trying to delete account, but the account doesn't exist")
             return
         }
-        delegate?.autofillLoginDetailsViewModelDelete(account: account)
+        delegate?.autofillLoginDetailsViewModelDelete(account: account, title: headerViewModel.title)
     }
 
     func openUrl() {

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -236,8 +236,10 @@ final class AutofillLoginSettingsListViewController: UIViewController {
     }
 
     private func presentDeleteConfirmation(for title: String) {
-        ActionMessageView.present(message: title.isEmpty ? UserText.autofillLoginListLoginDeletedToastMessageNoTitle
-                                                         : UserText.autofillLoginListLoginDeletedToastMessage(for: title),
+        let message = title.isEmpty ? UserText.autofillLoginListLoginDeletedToastMessageNoTitle
+                                    : UserText.autofillLoginListLoginDeletedToastMessage(for: title)
+
+        ActionMessageView.present(message: message,
                                   actionTitle: UserText.actionGenericUndo,
                                   presentationLocation: .withoutBottomBar,
                                   onAction: {

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -236,7 +236,8 @@ final class AutofillLoginSettingsListViewController: UIViewController {
     }
 
     private func presentDeleteConfirmation(for title: String) {
-        ActionMessageView.present(message: UserText.autofillLoginListLoginDeletedToastMessage(for: title),
+        ActionMessageView.present(message: title.isEmpty ? UserText.autofillLoginListLoginDeletedToastMessageNoTitle
+                                                         : UserText.autofillLoginListLoginDeletedToastMessage(for: title),
                                   actionTitle: UserText.actionGenericUndo,
                                   presentationLocation: .withoutBottomBar,
                                   onAction: {
@@ -567,8 +568,7 @@ extension AutofillLoginSettingsListViewController: AutofillLoginDetailsViewContr
         }
     }
 
-    func autofillLoginDetailsViewControllerDelete(account: SecureVaultModels.WebsiteAccount) {
-        let title = account.title ?? ""
+    func autofillLoginDetailsViewControllerDelete(account: SecureVaultModels.WebsiteAccount, title: String) {
         let deletedSuccessfully = viewModel.delete(account)
 
         if deletedSuccessfully {

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -567,6 +567,7 @@ public struct UserText {
         let message = NSLocalizedString("autofill.logins.list.login-deleted-message", value: "Login for %@ deleted", comment: "Toast message when a login item is deleted")
         return message.format(arguments: title)
     }
+    public static let autofillLoginListLoginDeletedToastMessageNoTitle = NSLocalizedString("autofill.logins.list.login-deleted-message-no-title", value: "Login deleted", comment: "Toast message when a login item without a title is deleted")
 
     public static let autofillLoginDetailsEditTitlePlaceholder = NSLocalizedString("autofill.logins.details.edit.title-placeholder", value:"Title", comment: "Placeholder for title field on autofill login details")
     public static let autofillLoginDetailsEditUsernamePlaceholder = NSLocalizedString("autofill.logins.details.edit.username-placeholder", value:"username@example.com", comment: "Placeholder for userbane field on autofill login details")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -295,6 +295,9 @@
 /* Toast message when a login item is deleted */
 "autofill.logins.list.login-deleted-message" = "Login for %@ deleted";
 
+/* Toast message when a login item without a title is deleted */
+"autofill.logins.list.login-deleted-message-no-title" = "Login deleted";
+
 /* Placeholder for search field on autofill login listing */
 "autofill.logins.list.search-placeholder" = "Search Logins";
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1203782162439772/f
Tech Design URL:
CC:

**Description**:
This is a fix for when a login without a title is deleted, the correct toast message is displayed.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Note translations are not part of this PR

*Login with Title and Website*
1. Create an Autofill login with a Title and Website set
2. Delete the login from the Login details screen and confirm the toast message is `Login for <<Title>> deleted`. Tap undo on the toast
3. Delete the login from the main Autofill Settings screen and confirm the same toast message is displayed

*Login with Title only*
1. Create an Autofill login setting only the Title not the Website
2. Delete the login from the Login details screen and confirm the toast message is `Login for <<Title>> deleted`. Tap undo on the toast
3. Delete the login from the main Autofill Settings screen and confirm the same toast message is displayed

*Login with Website only*
1. Create an Autofill login setting only the Website not the Title
2. Delete the login from the Login details screen and confirm the toast message is `Login for <<Website>> deleted`. Tap undo on the toast
3. Delete the login from the main Autofill Settings screen and confirm the same toast message is displayed

*Login with no Title or Website set*
1. Create an Autofill login with both the Title and Website left empty
2. Delete the login from the Login details screen and confirm the toast message is `Login deleted`. Tap undo on the toast
3. Delete the login from the main Autofill Settings screen and confirm the same toast message is displayed


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
