### PR TITLE
Properly send compile rules result pixel including app state

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -132,6 +132,8 @@ class TabViewController: UIViewController {
     let bookmarksDatabase: CoreDataDatabase
     lazy var faviconUpdater = BookmarkFaviconUpdater(bookmarksDatabase: bookmarksDatabase, tab: tabModel, favicons: Favicons.shared)
 
+    let id: String = UUID().uuidString
+
     public var url: URL? {
         willSet {
             if newValue != url {
@@ -859,7 +861,7 @@ class TabViewController: UIViewController {
         userContentController.removeAllContentRuleLists()
         temporaryDownloadForPreviewedFile?.cancel()
         removeObservers()
-        rulesCompilationMonitor.tabWillClose(self)
+        rulesCompilationMonitor.tabWillClose(id)
     }
 
 }
@@ -1323,10 +1325,10 @@ extension TabViewController: WKNavigationDelegate {
         }
 
         Task {
-            rulesCompilationMonitor.tabWillWaitForRulesCompilation(self)
+            rulesCompilationMonitor.tabWillWaitForRulesCompilation(id)
             showProgressIndicator()
             await userContentController.awaitContentBlockingAssetsInstalled()
-            rulesCompilationMonitor.reportTabFinishedWaitingForRules(self)
+            rulesCompilationMonitor.reportTabFinishedWaitingForRules(id)
 
             await MainActor.run(body: completion)
         }
@@ -1464,10 +1466,10 @@ extension TabViewController: WKNavigationDelegate {
     private func prepareForContentBlocking() async {
         // Ensure Content Blocking Assets (WKContentRuleList&UserScripts) are installed
         if !userContentController.contentBlockingAssetsInstalled {
-            rulesCompilationMonitor.tabWillWaitForRulesCompilation(self)
+            rulesCompilationMonitor.tabWillWaitForRulesCompilation(id)
             showProgressIndicator()
             await userContentController.awaitContentBlockingAssetsInstalled()
-            rulesCompilationMonitor.reportTabFinishedWaitingForRules(self)
+            rulesCompilationMonitor.reportTabFinishedWaitingForRules(id)
         } else {
             rulesCompilationMonitor.reportNavigationDidNotWaitForRules()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203979634198833/f

**Description**:
Include information about the onboarding state in the pixel.

**Steps to test this PR**:
1. Run the app for the first time and open a page see what pixel do we send on any page load. It should be m_compilation_result_\(result)_time_\(waitTime)_state_onboarding
2. Kill the app.
3. Run the app for the second time and see that pixel we send should be m_compilation_result_\(result)_time_\(waitTime)_state_regular

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
