### PR TITLE
Fix settings layout issue with "About" header too close to previous section

### DIFF
--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -66,7 +66,7 @@ class SettingsViewController: UITableViewController {
     
     private let syncSectionIndex = 1
     private let autofillSectionIndex = 2
-    private let debugSectionIndex = 7
+    private let debugSectionIndex = 8
 
     private lazy var emailManager = EmailManager()
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1204225292269139/f

**Description**:
Fix settings layout problem with the "About" section header being too close to the previous section. 
The issue is present when the user is not authenticated as an "internal user" (some of the cells/sections are hidden)

**Steps to test this PR**:
1. Open Settings and verify proper sizing of section footers and headers when not an "internal user"
2. Open Settings and verify proper sizing of section footers and headers when an "internal user"

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone 
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
