### PR TITLE
Revert "Manage Favorites from Favorites Overlay"

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -130,28 +130,6 @@ class MainViewController: UIViewController {
     // Skip SERP flow (focusing on autocomplete logic) and prepare for new navigation when selecting search bar
     private var skipSERPFlow = true
     
-    private enum Constants {
-                
-        // Environment Keys/Values
-        static let environmentOnboardingKey = "ONBOARDING"
-        static let environmentOnboardingKeytrue = "true"
-        static let environmentOnboardingKeyfalse = "false"
-        
-        static let onboardingFlow = "DaxOnboarding"
-        static let bookmarksImage = "Bookmarks"
-        
-        // Segue Identifiers
-        static let bookmarksSegue = "Bookmarks"
-        static let bookmarksEditSegue = "BookmarksEdit"
-        static let bookmarksEditCurrentSegue = "BookmarksEditCurrent"
-        static let instructionsSegue = "instructions"
-        static let downloadsSegue = "Downloads"
-        static let reportBrokenSiteSegue = "ReportBrokenSite"
-        static let actionSheetDaxDialogSegue = "ActionSheetDaxDialog"
-        static let settingsSegue = "Settings"
-        static let showTabsSegue = "ShowTabs"
-    }
-    
     required init?(coder: NSCoder,
                    bookmarksDatabase: CoreDataDatabase) {
         self.bookmarksDatabase = bookmarksDatabase
@@ -219,7 +197,7 @@ class MainViewController: UIViewController {
     
     func startOnboardingFlowIfNotSeenBefore() {
         
-        guard ProcessInfo.processInfo.environment[Constants.environmentOnboardingKey] != Constants.environmentOnboardingKeyfalse else {
+        guard ProcessInfo.processInfo.environment["ONBOARDING"] != "false" else {
             // explicitly skip onboarding, e.g. for integration tests
             return
         }
@@ -227,10 +205,10 @@ class MainViewController: UIViewController {
         let settings = DefaultTutorialSettings()
         let showOnboarding = !settings.hasSeenOnboarding ||
             // explicitly show onboarding, can be set in the scheme > Run > Environment Variables
-        ProcessInfo.processInfo.environment[Constants.environmentOnboardingKey] == Constants.environmentOnboardingKeyfalse
+            ProcessInfo.processInfo.environment["ONBOARDING"] == "true"
         guard showOnboarding else { return }
 
-        let onboardingFlow = Constants.onboardingFlow
+        let onboardingFlow = "DaxOnboarding"
 
         performSegue(withIdentifier: onboardingFlow, sender: self)
     }
@@ -324,7 +302,7 @@ class MainViewController: UIViewController {
         omniBar.bookmarksButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self,
                                                                                   action: #selector(quickSaveBookmarkLongPress(gesture:))))
         gestureBookmarksButton.delegate = self
-        gestureBookmarksButton.image = UIImage(named: Constants.bookmarksImage)
+        gestureBookmarksButton.image = UIImage(named: "Bookmarks")
     }
     
     @objc func quickSaveBookmarkLongPress(gesture: UILongPressGestureRecognizer) {
@@ -403,11 +381,11 @@ class MainViewController: UIViewController {
         }
         controller.delegate = self
         
-        if segueIdentifier == Constants.bookmarksEditCurrentSegue,
+        if segueIdentifier == "BookmarksEditCurrent",
             let link = currentTab?.link,
             let bookmark = menuBookmarksViewModel.favorite(for: link.url) ?? menuBookmarksViewModel.bookmark(for: link.url) {
             controller.openEditFormWhenPresented(bookmark: bookmark)
-        } else if segueIdentifier == Constants.bookmarksEditSegue,
+        } else if segueIdentifier == "BookmarksEdit",
                   let bookmark = sender as? BookmarkEntity {
             controller.openEditFormWhenPresented(bookmark: bookmark)
         }
@@ -553,7 +531,7 @@ class MainViewController: UIViewController {
         wakeLazyFireButtonAnimator()
         
         if let spec = DaxDialogs.shared.fireButtonEducationMessage() {
-            performSegue(withIdentifier: Constants.actionSheetDaxDialogSegue, sender: spec)
+            performSegue(withIdentifier: "ActionSheetDaxDialog", sender: spec)
         } else {
             let alert = ForgetDataAlert.buildAlert(forgetTabsAndDataHandler: { [weak self] in
                 self?.forgetAllWithAnimation {}
@@ -567,7 +545,6 @@ class MainViewController: UIViewController {
         
         self.forgetAllWithAnimation {}
         self.dismiss(animated: true)
-        dismissOmniBar()
         if KeyboardSettings().onAppLaunch {
             self.enterSearch()
         }
@@ -582,13 +559,11 @@ class MainViewController: UIViewController {
     @IBAction func onBackPressed() {
         Pixel.fire(pixel: .tabBarBackPressed)
         currentTab?.goBack()
-        dismissOmniBar()
         refreshOmniBar()
     }
 
     @IBAction func onForwardPressed() {
         Pixel.fire(pixel: .tabBarForwardPressed)
-        dismissOmniBar()
         currentTab?.goForward()
     }
     
@@ -889,11 +864,11 @@ class MainViewController: UIViewController {
     }
     
     fileprivate func launchReportBrokenSite() {
-        performSegue(withIdentifier: Constants.reportBrokenSiteSegue, sender: self)
+        performSegue(withIdentifier: "ReportBrokenSite", sender: self)
     }
     
     fileprivate func launchDownloads() {
-        performSegue(withIdentifier: Constants.downloadsSegue, sender: self)
+        performSegue(withIdentifier: "Downloads", sender: self)
     }
     
     fileprivate func launchAutofillLogins(with currentTabUrl: URL? = nil) {
@@ -917,7 +892,7 @@ class MainViewController: UIViewController {
     }
     
     func launchSettings() {
-        performSegue(withIdentifier: Constants.settingsSegue, sender: self)
+        performSegue(withIdentifier: "Settings", sender: self)
     }
     
     func launchCookiePopupManagementSettings() {
@@ -931,7 +906,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func launchInstructions() {
-        performSegue(withIdentifier: Constants.instructionsSegue, sender: self)
+        performSegue(withIdentifier: "instructions", sender: self)
     }
 
     override func viewDidLayoutSubviews() {
@@ -1081,14 +1056,6 @@ class MainViewController: UIViewController {
         }
         
         Pixel.fire(pixel: pixel, withAdditionalParameters: pixelParameters, includedParameters: [.atb])
-    }
-    
-    private func installFavoritesOverlay() {
-        let favoritesOverlay = FavoritesOverlay(favoritesViewModel: favoritesViewModel)
-        favoritesOverlay.delegate = self
-        addChild(favoritesOverlay)
-        favoritesOverlay.view.frame = containerView.bounds
-        containerView.addSubview(favoritesOverlay.view)
     }
     
 }
@@ -1246,7 +1213,6 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func onMenuPressed() {
-        dismissOmniBar()
         if !DaxDialogs.shared.shouldShowFireButtonPulse {
             ViewHighlighter.hideAll()
         }
@@ -1281,17 +1247,18 @@ extension MainViewController: OmniBarDelegate {
             ViewHighlighter.hideAll()
         }
         hideSuggestionTray()
-        performSegue(withIdentifier: Constants.bookmarksSegue, sender: self)
+        performSegue(withIdentifier: "Bookmarks", sender: self)
     }
     
     func onBookmarkEdit() {
         ViewHighlighter.hideAll()
         hideSuggestionTray()
-        performSegue(withIdentifier: Constants.bookmarksEditCurrentSegue, sender: self)
+        performSegue(withIdentifier: "BookmarksEditCurrent", sender: self)
     }
     
     func onEnterPressed() {
         guard !suggestionTrayContainer.isHidden else { return }
+        
         suggestionTrayController?.willDismiss(with: omniBar.textField.text ?? "")
     }
 
@@ -1379,10 +1346,6 @@ extension MainViewController: FavoritesOverlayDelegate {
         }
         showHomeRowReminder()
     }
-    
-    func favoritesOverlay(_ controller: FavoritesOverlay, didRequestEditFavorite favorite: BookmarkEntity) {
-        performSegue(withIdentifier: Constants.bookmarksEditSegue, sender: favorite)
-    }
 }
 
 extension MainViewController: AutocompleteViewControllerDelegate {
@@ -1454,7 +1417,7 @@ extension MainViewController: HomeControllerDelegate {
     }
     
     func home(_ home: HomeViewController, didRequestEdit favorite: BookmarkEntity) {
-        performSegue(withIdentifier: Constants.bookmarksEditSegue, sender: favorite)
+        performSegue(withIdentifier: "BookmarksEdit", sender: favorite)
     }
     
     func home(_ home: HomeViewController, didRequestContentOverflow shouldOverflow: Bool) -> CGFloat {
@@ -1759,7 +1722,7 @@ extension MainViewController: TabSwitcherButtonDelegate {
                     
                 }
                 ViewHighlighter.hideAll()
-                self.performSegue(withIdentifier: Constants.showTabsSegue, sender: self)
+                self.performSegue(withIdentifier: "ShowTabs", sender: self)
             })
         }
     }

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -331,7 +331,6 @@ class OmniBar: UIView {
     }
 
     @discardableResult override func resignFirstResponder() -> Bool {
-        refreshState(state.onEditingStoppedState)
         return textField.resignFirstResponder()
     }
 
@@ -432,7 +431,6 @@ class OmniBar: UIView {
     }
     
     @IBAction func onCancelPressed(_ sender: Any) {
-        refreshState(state.onEditingStoppedState)
         omniDelegate?.onCancelPressed()
     }
     
@@ -486,7 +484,7 @@ extension OmniBar: UITextFieldDelegate {
         omniDelegate?.onTextFieldWillBeginEditing(self)
         return true
     }
-    
+
     func textFieldDidBeginEditing(_ textField: UITextField) {
         DispatchQueue.main.async {
             let highlightText = self.omniDelegate?.onTextFieldDidBeginEditing(self) ?? true
@@ -499,12 +497,14 @@ extension OmniBar: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        onQuerySubmitted()
         omniDelegate?.onEnterPressed()
-        refreshState(state.onEditingStoppedState)
         return true
     }
-    
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        omniDelegate?.onDismissed()
+        refreshState(state.onEditingStoppedState)
+    }
 }
 
 extension OmniBar: Themable {

--- a/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/DuckDuckGo/SuggestionTrayViewController.swift
@@ -214,7 +214,7 @@ class SuggestionTrayViewController: UIViewController {
     }
     
     private func installFavoritesOverlay(onInstall: @escaping () -> Void = {}) {
-        let controller = FavoritesOverlay(favoritesViewModel: favoritesModel)
+        let controller = FavoritesOverlay(viewModel: favoritesModel)
         controller.delegate = favoritesOverlayDelegate
         install(controller: controller, completion: onInstall)
         favoritesOverlay = controller


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1204370827577155/f

### Description:
Reverts duckduckgo/iOS#1539, allowing users to reorder favorites in the FavoritesOverlay, as it was causing crashes in some situations. (Original task:https://app.asana.com/0/414709148257752/1203858036570302/f)

### How to Test:
- Fire up the app (Make sure you have a few 'Favorites' added)
- Navigate to any website (Important ⚠️)
- Tap the Omnibar
- Long-Press on one of your favorites
- Observe nothing happens and there's no crash
- Long-press in the empty area of the collection view
- Observe nothing happens and there's no crash
---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**


