### PR TITLE
Add fire button animation to increase feature engagement

### DIFF
--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -23,9 +23,8 @@ import Speech
 import BrowserServicesKit
 
 extension FeatureName {
-    
-    public static let fireButtonAnimation = FeatureName(rawValue: "fireButtonAnimation")
-    
+    // Define your feature e.g.:
+    // public static let experimentalFeature = FeatureName(rawValue: "experimentalFeature")
 }
 
 public struct VariantIOS: Variant {
@@ -52,8 +51,6 @@ public struct VariantIOS: Variant {
     
     // Note: Variants with `doNotAllocate` weight, should always be included so that previous installations are unaffected
     public static let defaultVariants: [Variant] = [
-        VariantIOS(name: "mc", weight: doNotAllocate, isIncluded: When.always, features: []),
-        VariantIOS(name: "ma", weight: doNotAllocate, isIncluded: When.always, features: [.fireButtonAnimation]),
         
         // SERP testing
         VariantIOS(name: "sc", weight: doNotAllocate, isIncluded: When.always, features: []),

--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -25,7 +25,6 @@ import BrowserServicesKit
 extension FeatureName {
     
     public static let fireButtonAnimation = FeatureName(rawValue: "fireButtonAnimation")
-    public static let fireButtonColor = FeatureName(rawValue: "fireButtonColor")
     
 }
 
@@ -55,7 +54,6 @@ public struct VariantIOS: Variant {
     public static let defaultVariants: [Variant] = [
         VariantIOS(name: "mc", weight: doNotAllocate, isIncluded: When.always, features: []),
         VariantIOS(name: "ma", weight: doNotAllocate, isIncluded: When.always, features: [.fireButtonAnimation]),
-        VariantIOS(name: "mf", weight: doNotAllocate, isIncluded: When.always, features: [.fireButtonColor]),
         
         // SERP testing
         VariantIOS(name: "sc", weight: doNotAllocate, isIncluded: When.always, features: []),

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -381,12 +381,6 @@ extension Pixel {
         case bookmarksMigrationCouldNotRemoveOldStore
         
         case invalidPayload(Configuration)
-      
-        case experimentDailyFireButtonTapped
-        case experimentDailyFireButtonDataCleared
-        
-        case experimentFireButtonAnimationTriggeredOnTabSwitcher
-        case experimentFireButtonEducationRestarted
     }
     
 }
@@ -759,12 +753,6 @@ extension Pixel.Event {
         case .bookmarksMigrationCouldNotRemoveOldStore: return "m_d_bookmarks_migration_could_not_remove_old_store"
 
         case .invalidPayload(let configuration): return "m_d_\(configuration.rawValue)_invalid_payload".lowercased()
-            
-        case .experimentDailyFireButtonTapped: return "m_d_experiment_daily_fire_button_tapped"
-        case .experimentDailyFireButtonDataCleared: return "m_d_experiment_daily_fire_button_data_cleared"
-
-        case .experimentFireButtonAnimationTriggeredOnTabSwitcher: return "m_d_experiment_fire_button_animation_triggered_on_tab_switcher"
-        case .experimentFireButtonEducationRestarted: return "m_d_experiment_fire_button_education_restarted"
         }
         
     }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		1E1D8B6A29953CE300C96994 /* autoconsent-test.js in Resources */ = {isa = PBXBuildFile; fileRef = 1E1D8B6729953CE200C96994 /* autoconsent-test.js */; };
 		1E1D8B6B29953CE300C96994 /* autoconsent-test-page.html in Resources */ = {isa = PBXBuildFile; fileRef = 1E1D8B6829953CE200C96994 /* autoconsent-test-page.html */; };
 		1E1D8B6C29953CE300C96994 /* autoconsent-test-page-banner.html in Resources */ = {isa = PBXBuildFile; fileRef = 1E1D8B6929953CE300C96994 /* autoconsent-test-page-banner.html */; };
-		1E1E9C87299EC92E001BDED7 /* FireButtonExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1E9C86299EC92E001BDED7 /* FireButtonExperiment.swift */; };
+		1E1E9C87299EC92E001BDED7 /* FireButtonAnimationTriggers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1E9C86299EC92E001BDED7 /* FireButtonAnimationTriggers.swift */; };
 		1E24295E293F57FA00584836 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E24295D293F57FA00584836 /* LottieView.swift */; };
 		1E242960293F585300584836 /* cookie-icon-animated-40-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1E24295F293F585300584836 /* cookie-icon-animated-40-light.json */; };
 		1E4DCF4627B6A33600961E25 /* DownloadsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4DCF4527B6A33600961E25 /* DownloadsListViewModel.swift */; };
@@ -871,7 +871,7 @@
 		1E1D8B6729953CE200C96994 /* autoconsent-test.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "autoconsent-test.js"; sourceTree = "<group>"; };
 		1E1D8B6829953CE200C96994 /* autoconsent-test-page.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "autoconsent-test-page.html"; sourceTree = "<group>"; };
 		1E1D8B6929953CE300C96994 /* autoconsent-test-page-banner.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "autoconsent-test-page-banner.html"; sourceTree = "<group>"; };
-		1E1E9C86299EC92E001BDED7 /* FireButtonExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireButtonExperiment.swift; sourceTree = "<group>"; };
+		1E1E9C86299EC92E001BDED7 /* FireButtonAnimationTriggers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireButtonAnimationTriggers.swift; sourceTree = "<group>"; };
 		1E24295D293F57FA00584836 /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		1E24295F293F585300584836 /* cookie-icon-animated-40-light.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "cookie-icon-animated-40-light.json"; sourceTree = "<group>"; };
 		1E4DCF4527B6A33600961E25 /* DownloadsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsListViewModel.swift; sourceTree = "<group>"; };
@@ -2348,7 +2348,6 @@
 		1E1E9C85299EC913001BDED7 /* Experiments */ = {
 			isa = PBXGroup;
 			children = (
-				1E1E9C86299EC92E001BDED7 /* FireButtonExperiment.swift */,
 			);
 			name = Experiments;
 			sourceTree = "<group>";
@@ -4215,6 +4214,7 @@
 				1EA414B529CC67C3007DF955 /* flame-dark.json */,
 				1EC5FE5C29B0F081004C13F5 /* FireBarButtonItem.swift */,
 				1EDA34E329CD9913003A44EC /* FireButton.swift */,
+				1E1E9C86299EC92E001BDED7 /* FireButtonAnimationTriggers.swift */,
 				310742A52848CD780012660B /* BackForwardMenuHistoryItem.swift */,
 				85864FBB24D31EF300E756FF /* SuggestionTrayViewController.swift */,
 				8577A1C4255D2C0D00D43FCD /* HitTestingToolbar.swift */,
@@ -5350,7 +5350,7 @@
 				986C7FA724171C6000A3557D /* BrokenSiteCategories.swift in Sources */,
 				98DA6ECA2181E41F00E65433 /* ThemeManager.swift in Sources */,
 				1E016AB6294A5EB100F21625 /* CustomDaxDialog.swift in Sources */,
-				1E1E9C87299EC92E001BDED7 /* FireButtonExperiment.swift in Sources */,
+				1E1E9C87299EC92E001BDED7 /* FireButtonAnimationTriggers.swift in Sources */,
 				F1CA3C3B1F045B65005FADB3 /* Authenticator.swift in Sources */,
 				CBD4F13D279EBFA000B20FD7 /* HomeMessageCollectionViewCell.swift in Sources */,
 				8505836D219F424500ED4EDB /* Point.swift in Sources */,

--- a/DuckDuckGo/AboutViewController.swift
+++ b/DuckDuckGo/AboutViewController.swift
@@ -31,10 +31,6 @@ class AboutViewController: UIViewController {
         super.viewDidLoad()
                 
         applyTheme(ThemeManager.shared.currentTheme)
-        
-        #warning("only for testing - remove this")
-        AppUserDefaults().wasFireButtonEverTapped = false
-        AppUserDefaults().wasFireButtonEducationRestarted = false
     }
 
     @IBAction func onPrivacyLinkTapped(_ sender: UIButton) {

--- a/DuckDuckGo/AboutViewController.swift
+++ b/DuckDuckGo/AboutViewController.swift
@@ -31,6 +31,10 @@ class AboutViewController: UIViewController {
         super.viewDidLoad()
                 
         applyTheme(ThemeManager.shared.currentTheme)
+        
+        #warning("only for testing - remove this")
+        AppUserDefaults().wasFireButtonEverTapped = false
+        AppUserDefaults().wasFireButtonEducationRestarted = false
     }
 
     @IBAction func onPrivacyLinkTapped(_ sender: UIButton) {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -241,7 +241,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             onApplicationLaunch(application)
         }
         
-        FireButtonExperiment.restartFireButtonEducationIfNeeded()
+        FireButton.restartFireButtonEducationIfNeeded()
 
         mainViewController?.showBars()
         mainViewController?.didReturnFromBackground()

--- a/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/DuckDuckGo/BlankSnapshotViewController.swift
@@ -187,8 +187,6 @@ extension BlankSnapshotViewController: Themable {
         tabsButton.tintColor = theme.barTintColor
         
         menuButton.decorate(with: theme)
-        
-        FireButtonExperiment.decorateFireButton(fireButton: fireButton, for: theme)
     }
     
 }

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -242,6 +242,7 @@ final class DaxDialogs {
             fireButtonPulseTimer = Timer(timeInterval: timerTime, repeats: false) { _ in
                 self.settings.fireButtonEducationShownOrExpired = true
                 ViewHighlighter.hideAll()
+                FireButton.stopAllFireButtonAnimations()
             }
             RunLoop.current.add(fireButtonPulseTimer!, forMode: RunLoop.Mode.common)
         }
@@ -249,6 +250,7 @@ final class DaxDialogs {
     
     func fireButtonPulseCancelled() {
         fireButtonPulseTimer?.invalidate()
+        fireButtonPulseTimer = nil
         settings.fireButtonEducationShownOrExpired = true
     }
     

--- a/DuckDuckGo/FireButtonAnimationTriggers.swift
+++ b/DuckDuckGo/FireButtonAnimationTriggers.swift
@@ -33,9 +33,6 @@ extension FireButton {
     }
     
     private static func canAssumeFireButtonWasUsedBasedOnInstallDate() -> Bool {
-        #warning("only for testing - remove this")
-        return false
-        
         guard let installDate = StatisticsUserDefaults().installDate,
               let featureReleaseDate = calendarUTC.date(from: DateComponents(year: 2023, month: 4, day: 17))
         else { return false }
@@ -66,9 +63,6 @@ extension FireButton {
     }
     
     private static var isAtLeastThreeDaysFromInstallation: Bool {
-        #warning("only for testing - remove this")
-        return true
-        
         guard let installDate = StatisticsUserDefaults().installDate,
               let daysSinceInstall = calendarUTC.numberOfCalendarDaysBetween(installDate, and: Date())
         else { return false }

--- a/DuckDuckGo/FireButtonAnimationTriggers.swift
+++ b/DuckDuckGo/FireButtonAnimationTriggers.swift
@@ -1,5 +1,5 @@
 //
-//  FireButtonExperiment.swift
+//  FireButtonAnimationTriggers.swift
 //  DuckDuckGo
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
@@ -20,7 +20,7 @@
 import UIKit
 import Core
 
-final class FireButtonExperiment {
+extension FireButton {
     
     static let calendarUTC = {
         var calendarUTC = Calendar(identifier: .gregorian)

--- a/DuckDuckGo/FireButtonAnimationTriggers.swift
+++ b/DuckDuckGo/FireButtonAnimationTriggers.swift
@@ -37,7 +37,7 @@ extension FireButton {
         return false
         
         guard let installDate = StatisticsUserDefaults().installDate,
-              let featureReleaseDate = calendarUTC.date(from: DateComponents(year: 2023, month: 3, day: 29))
+              let featureReleaseDate = calendarUTC.date(from: DateComponents(year: 2023, month: 4, day: 17))
         else { return false }
 
         let isInstallDateBeforeFeatureDate = installDate < featureReleaseDate

--- a/DuckDuckGo/FireButtonAnimationTriggers.swift
+++ b/DuckDuckGo/FireButtonAnimationTriggers.swift
@@ -56,6 +56,8 @@ extension FireButton {
               isAtLeastThreeDaysFromInstallation
         else { return }
               
+        DaxDialogs.shared.fireButtonPulseCancelled()
+        
         DefaultDaxDialogsSettings().fireButtonEducationShownOrExpired = false
         DefaultDaxDialogsSettings().fireButtonPulseDateShown = nil
         

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -33,6 +33,9 @@ final class FireButtonExperiment {
     }
     
     private static func canAssumeFireButtonWasUsedBasedOnInstallDate() -> Bool {
+        #warning("only for testing - remove this")
+        return false
+        
         guard let installDate = StatisticsUserDefaults().installDate,
               let featureReleaseDate = calendarUTC.date(from: DateComponents(year: 2023, month: 3, day: 29))
         else { return false }
@@ -63,6 +66,9 @@ final class FireButtonExperiment {
     }
     
     private static var isAtLeastThreeDaysFromInstallation: Bool {
+        #warning("only for testing - remove this")
+        return true
+        
         guard let installDate = StatisticsUserDefaults().installDate,
               let daysSinceInstall = calendarUTC.numberOfCalendarDaysBetween(installDate, and: Date())
         else { return false }

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -32,8 +32,7 @@ final class FireButtonExperiment {
 
     public static func playFireButtonAnimationOnTabSwitcher(fireButton: FireButton,
                                                             tabCount: Int) {
-        guard isFireButtonAnimationFeatureEnabled,
-              tabCount > 1,
+        guard tabCount > 1,
               !wasFireButtonEverTapped
         else { return }
         
@@ -43,13 +42,7 @@ final class FireButtonExperiment {
     }
     
     public static func playFireButtonForOnboarding(fireButton: FireButton) {
-        guard isFireButtonAnimationFeatureEnabled else { return }
-        
         fireButton.playAnimation()
-    }
-    
-    private static var isFireButtonAnimationFeatureEnabled: Bool {
-        AppDependencyProvider.shared.variantManager.isSupported(feature: .fireButtonAnimation)
     }
     
     private static var wasFireButtonEverTapped: Bool {
@@ -61,8 +54,7 @@ final class FireButtonExperiment {
     }
     
     public static func restartFireButtonEducationIfNeeded() {
-        guard isFireButtonAnimationFeatureEnabled,
-              !wasFireButtonEducationRestarted,
+        guard !wasFireButtonEducationRestarted,
               !wasFireButtonEverTapped,
               isAtLeastThreeDaysFromInstallation
         else { return }

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -37,7 +37,7 @@ final class FireButtonExperiment {
     }
     
     public static func restartFireButtonEducationIfNeeded() {
-        guard !wasFireButtonEducationRestarted,
+        guard !AppUserDefaults().wasFireButtonEducationRestarted,
               !wasFireButtonEverTapped,
               isAtLeastThreeDaysFromInstallation
         else { return }
@@ -45,14 +45,6 @@ final class FireButtonExperiment {
         DefaultDaxDialogsSettings().fireButtonEducationShownOrExpired = false
         DefaultDaxDialogsSettings().fireButtonPulseDateShown = nil
         
-        storeThatFireButtonEducationWasRestarted()
-    }
-    
-    private static var wasFireButtonEducationRestarted: Bool {
-        AppUserDefaults().wasFireButtonEducationRestarted
-    }
-    
-    private static func storeThatFireButtonEducationWasRestarted() {
         AppUserDefaults().wasFireButtonEducationRestarted = true
     }
     

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -18,7 +18,6 @@
 //
 
 import UIKit
-import DuckUI
 import Core
 
 final class FireButtonExperiment {
@@ -91,29 +90,6 @@ final class FireButtonExperiment {
         return daysSinceInstall >= 3
     }
     
-    //
-    // MARK: - Experiment #2 - adding fire button color
-    //
-    
-     public static func decorateFireButton(fireButton: UIBarButtonItem, for theme: Theme) {
-         guard isFireButtonColorFeatureEnabled else { return }
-
-         fireButton.tintColor = fireButtonFillColor(for: theme)
-     }
-
-     public static func decorateFireButton(fireButton: UIButton, for theme: Theme) {
-         guard isFireButtonColorFeatureEnabled else { return }
-
-         fireButton.tintColor = fireButtonFillColor(for: theme)
-     }
-    
-    private static var isFireButtonColorFeatureEnabled: Bool {
-         AppDependencyProvider.shared.variantManager.isSupported(feature: .fireButtonColor)
-     }
-
-     private static func fireButtonFillColor(for theme: Theme) -> UIColor {
-         theme.currentImageSet == .light ? .redBase : .red40
-     }
 }
 
 extension Calendar {

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -37,8 +37,6 @@ final class FireButtonExperiment {
         else { return }
         
         fireButton.playAnimation()
-        
-        Pixel.fire(pixel: .experimentFireButtonAnimationTriggeredOnTabSwitcher, includedParameters: [.atb])
     }
     
     private static var wasFireButtonEverTapped: Bool {
@@ -59,7 +57,6 @@ final class FireButtonExperiment {
         DefaultDaxDialogsSettings().fireButtonPulseDateShown = nil
         
         storeThatFireButtonEducationWasRestarted()
-        Pixel.fire(pixel: .experimentFireButtonEducationRestarted, includedParameters: [.atb])
     }
     
     private static var wasFireButtonEducationRestarted: Bool {

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -41,10 +41,6 @@ final class FireButtonExperiment {
         Pixel.fire(pixel: .experimentFireButtonAnimationTriggeredOnTabSwitcher, includedParameters: [.atb])
     }
     
-    public static func playFireButtonForOnboarding(fireButton: FireButton) {
-        fireButton.playAnimation()
-    }
-    
     private static var wasFireButtonEverTapped: Bool {
         AppUserDefaults().wasFireButtonEverTapped
     }

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -29,7 +29,21 @@ final class FireButtonExperiment {
     }()
     
     public static var wasFireButtonEverTapped: Bool {
-        AppUserDefaults().wasFireButtonEverTapped
+        AppUserDefaults().wasFireButtonEverTapped ? true : canAssumeFireButtonWasUsedBasedOnInstallDate()
+    }
+    
+    private static func canAssumeFireButtonWasUsedBasedOnInstallDate() -> Bool {
+        guard let installDate = StatisticsUserDefaults().installDate,
+              let featureReleaseDate = calendarUTC.date(from: DateComponents(year: 2023, month: 3, day: 29))
+        else { return false }
+
+        let isInstallDateBeforeFeatureDate = installDate < featureReleaseDate
+        
+        if isInstallDateBeforeFeatureDate {
+            storeThatFireButtonWasTapped()
+        }
+        
+        return isInstallDateBeforeFeatureDate
     }
     
     public static func storeThatFireButtonWasTapped() {
@@ -55,7 +69,6 @@ final class FireButtonExperiment {
 
         return daysSinceInstall >= 3
     }
-    
 }
 
 extension Calendar {

--- a/DuckDuckGo/FireButtonExperiment.swift
+++ b/DuckDuckGo/FireButtonExperiment.swift
@@ -28,18 +28,7 @@ final class FireButtonExperiment {
         return calendarUTC
     }()
     
-    // MARK: - Experiment #1 - adding fire button animation
-
-    public static func playFireButtonAnimationOnTabSwitcher(fireButton: FireButton,
-                                                            tabCount: Int) {
-        guard tabCount > 1,
-              !wasFireButtonEverTapped
-        else { return }
-        
-        fireButton.playAnimation()
-    }
-    
-    private static var wasFireButtonEverTapped: Bool {
+    public static var wasFireButtonEverTapped: Bool {
         AppUserDefaults().wasFireButtonEverTapped
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1844,7 +1844,7 @@ extension MainViewController: AutoClearWorker {
             ViewHighlighter.showIn(window, focussedOnView: view)
             
             if let fireButton = view as? FireButton {
-                FireButtonExperiment.playFireButtonForOnboarding(fireButton: fireButton)
+                fireButton.playAnimation()
             }
         }
     }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -983,6 +983,7 @@ class MainViewController: UIViewController {
             ViewHighlighter.hideAll()
         }
         DaxDialogs.shared.fireButtonPulseCancelled()
+        FireButton.stopAllFireButtonAnimations()
         hideSuggestionTray()
         currentTab?.dismiss()
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -523,7 +523,6 @@ class MainViewController: UIViewController {
 
     @IBAction func onFirePressed() {
         Pixel.fire(pixel: .forgetAllPressedBrowsing)
-        DailyPixel.fire(pixel: .experimentDailyFireButtonTapped)
         FireButton.stopAllFireButtonAnimations()
         
         FireButtonExperiment.storeThatFireButtonWasTapped()
@@ -1797,7 +1796,6 @@ extension MainViewController: AutoClearWorker {
     func forgetAllWithAnimation(transitionCompletion: (() -> Void)? = nil, showNextDaxDialog: Bool = false) {
         let spid = Instruments.shared.startTimedEvent(.clearingData)
         Pixel.fire(pixel: .forgetAllExecuted)
-        DailyPixel.fire(pixel: .experimentDailyFireButtonDataCleared)
         
         self.tabCountInfo = tabManager.makeTabCountInfo()
         

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1885,8 +1885,6 @@ extension MainViewController: Themable {
         findInPageView.decorate(with: theme)
         
         logoText.tintColor = theme.ddgTextTintColor
-        
-        FireButtonExperiment.decorateFireButton(fireButton: fireButton, for: theme)
     }
     
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -525,7 +525,7 @@ class MainViewController: UIViewController {
         Pixel.fire(pixel: .forgetAllPressedBrowsing)
         FireButton.stopAllFireButtonAnimations()
         
-        FireButtonExperiment.storeThatFireButtonWasTapped()
+        FireButton.storeThatFireButtonWasTapped()
         
         wakeLazyFireButtonAnimator()
         

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -167,7 +167,7 @@ class TabSwitcherViewController: UIViewController {
                 ViewHighlighter.showIn(window, focussedOnView: view)
                 
                 if let fireButton = view as? FireButton {
-                    FireButtonExperiment.playFireButtonForOnboarding(fireButton: fireButton)
+                    fireButton.playAnimation()
                 }
             }
         } else {

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -312,7 +312,6 @@ class TabSwitcherViewController: UIViewController {
 
     @IBAction func onFirePressed(sender: AnyObject) {
         Pixel.fire(pixel: .forgetAllPressedTabSwitching)
-        DailyPixel.fire(pixel: .experimentDailyFireButtonTapped)
         FireButton.stopAllFireButtonAnimations()
         
         FireButtonExperiment.storeThatFireButtonWasTapped()

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -171,12 +171,11 @@ class TabSwitcherViewController: UIViewController {
                 }
             }
         } else {
-            guard let fireButton = !topFireButton.isHidden ? topFireButton : fireButton.button,
-                  tabsModel.count > 1,
-                  !FireButton.wasFireButtonEverTapped
-            else { return }
-            
-            fireButton.playAnimation()
+            guard let fireButton = !topFireButton.isHidden ? topFireButton : fireButton.button else { return }
+           
+            if tabsModel.count > 1 && !FireButton.wasFireButtonEverTapped {
+                fireButton.playAnimation()
+            }
         }
     }
     

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -508,9 +508,6 @@ extension TabSwitcherViewController: Themable {
         
         toolbar.barTintColor = theme.barBackgroundColor
         toolbar.tintColor = theme.barTintColor
-        
-        FireButtonExperiment.decorateFireButton(fireButton: fireButton, for: theme)
-        FireButtonExperiment.decorateFireButton(fireButton: topFireButton, for: theme)
                 
         collectionView.reloadData()
     }

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -171,10 +171,12 @@ class TabSwitcherViewController: UIViewController {
                 }
             }
         } else {
-            guard let button = !topFireButton.isHidden ? topFireButton : fireButton.button else { return }
+            guard let fireButton = !topFireButton.isHidden ? topFireButton : fireButton.button,
+                  tabsModel.count > 1,
+                  !FireButtonExperiment.wasFireButtonEverTapped
+            else { return }
             
-            FireButtonExperiment.playFireButtonAnimationOnTabSwitcher(fireButton: button,
-                                                                      tabCount: tabsModel.count)
+            fireButton.playAnimation()
         }
     }
     

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -173,7 +173,7 @@ class TabSwitcherViewController: UIViewController {
         } else {
             guard let fireButton = !topFireButton.isHidden ? topFireButton : fireButton.button,
                   tabsModel.count > 1,
-                  !FireButtonExperiment.wasFireButtonEverTapped
+                  !FireButton.wasFireButtonEverTapped
             else { return }
             
             fireButton.playAnimation()
@@ -316,7 +316,7 @@ class TabSwitcherViewController: UIViewController {
         Pixel.fire(pixel: .forgetAllPressedTabSwitching)
         FireButton.stopAllFireButtonAnimations()
         
-        FireButtonExperiment.storeThatFireButtonWasTapped()
+        FireButton.storeThatFireButtonWasTapped()
         
         if DaxDialogs.shared.shouldShowFireButtonPulse {
             let spec = DaxDialogs.shared.fireButtonEducationMessage()

--- a/DuckDuckGo/TabsBarViewController.swift
+++ b/DuckDuckGo/TabsBarViewController.swift
@@ -95,7 +95,7 @@ class TabsBarViewController: UIViewController {
     @IBAction func onFireButtonPressed() {
         FireButton.stopAllFireButtonAnimations()
         
-        FireButtonExperiment.storeThatFireButtonWasTapped()
+        FireButton.storeThatFireButtonWasTapped()
         
         if DaxDialogs.shared.shouldShowFireButtonPulse {
             delegate?.tabsBarDidRequestFireEducationDialog(self)

--- a/DuckDuckGo/TabsBarViewController.swift
+++ b/DuckDuckGo/TabsBarViewController.swift
@@ -93,7 +93,6 @@ class TabsBarViewController: UIViewController {
     }
 
     @IBAction func onFireButtonPressed() {
-        DailyPixel.fire(pixel: .experimentDailyFireButtonTapped)
         FireButton.stopAllFireButtonAnimations()
         
         FireButtonExperiment.storeThatFireButtonWasTapped()

--- a/DuckDuckGo/TabsBarViewController.swift
+++ b/DuckDuckGo/TabsBarViewController.swift
@@ -286,8 +286,6 @@ extension TabsBarViewController: Themable {
         fireButton.decorate(with: theme)
         tabSwitcherButton.decorate(with: theme)
         
-        FireButtonExperiment.decorateFireButton(fireButton: fireButton, for: theme)
-        
         collectionView.reloadData()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1204368707591434/f

**Description**:
Add fire button animation to increase feature engagement. This PR removes earlier experiment setup. It introduces no functional or visual changes.  
This is a follow up to https://github.com/duckduckgo/iOS/pull/1566

**Steps to test this PR**:
1. Verify that fire button animation is triggered during fire button onboarding pulse
2. Verify that fire button animation is triggered when entering tab switcher when there are more than 2 tabs and fire button wasn't ever tapped.
3. Verify that the fire button onboarding is restarted when returning to the app after at least 3 days and if fire button wasn't ever tapped.
4. Verify that the above triggers fail if app's install date is earlier than 2023-04-17.

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
