### PR TITLE
Renaming of favicons .bookmarks cache

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -300,8 +300,8 @@
 		84E341961E2F7EFB00BDBA6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E341951E2F7EFB00BDBA6F /* AppDelegate.swift */; };
 		84E3419B1E2F7EFB00BDBA6F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84E341991E2F7EFB00BDBA6F /* Main.storyboard */; };
 		84E341A01E2F7EFB00BDBA6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84E3419E1E2F7EFB00BDBA6F /* LaunchScreen.storyboard */; };
-		85010502292FB1000033978F /* BookmarkFaviconUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85010501292FB1000033978F /* BookmarkFaviconUpdater.swift */; };
-		85010504292FFB080033978F /* BookmarkFaviconUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85010503292FFB080033978F /* BookmarkFaviconUpdaterTests.swift */; };
+		85010502292FB1000033978F /* FireproofFaviconUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85010501292FB1000033978F /* FireproofFaviconUpdater.swift */; };
+		85010504292FFB080033978F /* FireproofFaviconUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85010503292FFB080033978F /* FireproofFaviconUpdaterTests.swift */; };
 		85011867290028C400BDEE27 /* BookmarksDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8501186529001D6900BDEE27 /* BookmarksDatabase.swift */; };
 		850250B520D80419002199C7 /* AtbAndVariantCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850250B420D80419002199C7 /* AtbAndVariantCleanupTests.swift */; };
 		850365F323DE087800D0F787 /* UIImageViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850365F223DE087800D0F787 /* UIImageViewExtension.swift */; };
@@ -1238,8 +1238,8 @@
 		84E341A11E2F7EFB00BDBA6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84E341A61E2F7EFB00BDBA6F /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		84E341AC1E2F7EFB00BDBA6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		85010501292FB1000033978F /* BookmarkFaviconUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFaviconUpdater.swift; sourceTree = "<group>"; };
-		85010503292FFB080033978F /* BookmarkFaviconUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFaviconUpdaterTests.swift; sourceTree = "<group>"; };
+		85010501292FB1000033978F /* FireproofFaviconUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireproofFaviconUpdater.swift; sourceTree = "<group>"; };
+		85010503292FFB080033978F /* FireproofFaviconUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireproofFaviconUpdaterTests.swift; sourceTree = "<group>"; };
 		8501186529001D6900BDEE27 /* BookmarksDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BookmarksDatabase.swift; path = ../DuckDuckGo/BookmarksDatabase.swift; sourceTree = "<group>"; };
 		850250B220D803F4002199C7 /* AtbAndVariantCleanup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AtbAndVariantCleanup.swift; path = ../Core/AtbAndVariantCleanup.swift; sourceTree = "<group>"; };
 		850250B420D80419002199C7 /* AtbAndVariantCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtbAndVariantCleanupTests.swift; sourceTree = "<group>"; };
@@ -4319,7 +4319,7 @@
 				31B524562715BB23002225AB /* WebJSAlert.swift */,
 				B60DFF062872B64B0061E7C2 /* JSAlertController.swift */,
 				B6BA95E728924730004ABA20 /* JSAlertController.storyboard */,
-				85010501292FB1000033978F /* BookmarkFaviconUpdater.swift */,
+				85010501292FB1000033978F /* FireproofFaviconUpdater.swift */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -4327,7 +4327,7 @@
 		F13B4BF71F18C9E800814661 /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
-				85010503292FFB080033978F /* BookmarkFaviconUpdaterTests.swift */,
+				85010503292FFB080033978F /* FireproofFaviconUpdaterTests.swift */,
 				8565A34C1FC8DFE400239327 /* LaunchTabNotificationTests.swift */,
 				984D035F24AF49160066CFB8 /* TabPreviewsSourceTests.swift */,
 				F13B4BFA1F18E3D900814661 /* TabsModelPersistenceExtensionTests.swift */,
@@ -5975,7 +5975,7 @@
 				B6CB93E5286445AB0090FEB4 /* Base64DownloadSession.swift in Sources */,
 				1EEF387D285B1A1100383393 /* TrackerImageCache.swift in Sources */,
 				3151F0EC27357FEE00226F58 /* VoiceSearchFeedbackViewModel.swift in Sources */,
-				85010502292FB1000033978F /* BookmarkFaviconUpdater.swift in Sources */,
+				85010502292FB1000033978F /* FireproofFaviconUpdater.swift in Sources */,
 				F1C4A70E1E57725800A6CA1B /* OmniBar.swift in Sources */,
 				981CA7EA2617797500E119D5 /* MainViewController+AddFavoriteFlow.swift in Sources */,
 				9872D205247DCAC100CEF398 /* TabPreviewsSource.swift in Sources */,
@@ -6150,7 +6150,7 @@
 				98DDF9F322C4029D00DE38DB /* InitHelpers.swift in Sources */,
 				B6AD9E3628D4510A0019CDE9 /* ContentBlockerRulesManagerMock.swift in Sources */,
 				F1E092C11E92A72E00732CCC /* UIColorExtensionTests.swift in Sources */,
-				85010504292FFB080033978F /* BookmarkFaviconUpdaterTests.swift in Sources */,
+				85010504292FFB080033978F /* FireproofFaviconUpdaterTests.swift in Sources */,
 				F1D477C91F2139410031ED49 /* SmallOmniBarStateTests.swift in Sources */,
 				987130C9294AAB9F00AB05E0 /* BookmarkUtilsTests.swift in Sources */,
 				C1BF0BA929B63E2200482B73 /* AutofillLoginPromptViewModelTests.swift in Sources */,

--- a/DuckDuckGo/BookmarkDetailsCell.swift
+++ b/DuckDuckGo/BookmarkDetailsCell.swift
@@ -73,7 +73,7 @@ class BookmarkDetailsCell: UITableViewCell {
     
     func setUrlString(_ urlString: String?) {
         let url = URL(string: urlString ?? "")
-        faviconImageView.loadFavicon(forDomain: url?.host, usingCache: .bookmarks)
+        faviconImageView.loadFavicon(forDomain: url?.host, usingCache: .fireproof)
         self.urlString = urlString
     }
     

--- a/DuckDuckGo/BookmarkFoldersTableViewController.swift
+++ b/DuckDuckGo/BookmarkFoldersTableViewController.swift
@@ -172,7 +172,7 @@ class BookmarkFoldersViewController: UITableViewController {
         cell.urlTextField.addTarget(self, action: #selector(urlTextFieldDidChange(_:)), for: .editingChanged)
         cell.urlTextField.addTarget(self, action: #selector(urlTextFieldDidReturn), for: .editingDidEndOnExit)
 
-        cell.faviconImageView.loadFavicon(forDomain: viewModel?.bookmark.urlObject?.host, usingCache: .bookmarks)
+        cell.faviconImageView.loadFavicon(forDomain: viewModel?.bookmark.urlObject?.host, usingCache: .fireproof)
 
         cell.selectionStyle = .none
         cell.title = viewModel?.bookmark.title

--- a/DuckDuckGo/BookmarksDataSource.swift
+++ b/DuckDuckGo/BookmarksDataSource.swift
@@ -50,7 +50,7 @@ class BookmarksDataSource: NSObject, UITableViewDataSource {
             return cell
         } else {
             let cell = BookmarksViewControllerCellFactory.makeBookmarkCell(tableView, forIndexPath: indexPath)
-            cell.faviconImageView.loadFavicon(forDomain: bookmark.urlObject?.host, usingCache: .bookmarks)
+            cell.faviconImageView.loadFavicon(forDomain: bookmark.urlObject?.host, usingCache: .fireproof)
             cell.titleLabel.text = bookmark.title
             cell.favoriteImageViewContainer.isHidden = !bookmark.isFavorite
             return cell
@@ -91,7 +91,7 @@ class SearchBookmarksDataSource: NSObject, UITableViewDataSource {
         }
 
         let cell = BookmarksViewControllerCellFactory.makeBookmarkCell(tableView, forIndexPath: indexPath)
-        cell.faviconImageView.loadFavicon(forDomain: results[indexPath.row].url.host, usingCache: .bookmarks)
+        cell.faviconImageView.loadFavicon(forDomain: results[indexPath.row].url.host, usingCache: .fireproof)
         cell.titleLabel.text = results[indexPath.row].title
         cell.favoriteImageViewContainer.isHidden = !results[indexPath.row].isFavorite
         return cell

--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -161,7 +161,7 @@ public class Favicons {
         }
     }
 
-    public func replaceBookmarksFavicon(forDomain domain: String?, withImage image: UIImage) {
+    public func replaceFireproofFavicon(forDomain domain: String?, withImage image: UIImage) {
         
         guard let domain = domain,
               let resource = defaultResource(forDomain: domain),
@@ -207,10 +207,8 @@ public class Favicons {
     }
 
     public func removeBookmarkFavicon(forDomain domain: String) {
-
         guard !PreserveLogins.shared.isAllowed(fireproofDomain: domain) else { return }
         removeFavicon(forDomain: domain, fromCache: .fireproof)
-
     }
 
     public func removeFireproofFavicon(forDomain domain: String) {

--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -193,10 +193,6 @@ public class Favicons {
         }
     }
 
-    func isFaviconCachedForBookmarks(forDomain domain: String, resource: ImageResource) -> Bool {
-        return Constants.fireproofCache.isCached(forKey: resource.cacheKey)
-    }
-
     public func clearCache(_ cacheType: CacheType) {
         Constants.caches[cacheType]?.clearDiskCache()
     }

--- a/DuckDuckGo/FavoriteHomeCell.swift
+++ b/DuckDuckGo/FavoriteHomeCell.swift
@@ -108,7 +108,7 @@ class FavoriteHomeCell: UICollectionViewCell {
                                                            bold: false)
         iconImage?.image = fakeFavicon
 
-        iconImage?.loadFavicon(forDomain: domain, usingCache: .bookmarks, useFakeFavicon: false) { image, _ in
+        iconImage?.loadFavicon(forDomain: domain, usingCache: .fireproof, useFakeFavicon: false) { image, _ in
             guard let image = image else {
                 iconImage?.image = fakeFavicon
                 return

--- a/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -1,5 +1,5 @@
 //
-//  BookmarkFaviconUpdater.swift
+//  FireproofFaviconUpdater.swift
 //  DuckDuckGo
 //
 //  Copyright © 2022 DuckDuckGo. All rights reserved.
@@ -31,7 +31,7 @@ extension Tab: TabNotifying {}
 protocol FaviconProviding {
 
     func loadFavicon(forDomain domain: String, fromURL url: URL?, intoCache cacheType: Favicons.CacheType, completion: ((UIImage?) -> Void)?)
-    func replaceBookmarksFavicon(forDomain domain: String?, withImage: UIImage)
+    func replaceFireproofFavicon(forDomain domain: String?, withImage: UIImage)
 
 }
 
@@ -43,7 +43,7 @@ extension Favicons: FaviconProviding {
 
 }
 
-class BookmarkFaviconUpdater: NSObject, FaviconUserScriptDelegate {
+class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
 
     let context: NSManagedObjectContext
     let tab: TabNotifying
@@ -65,7 +65,7 @@ class BookmarkFaviconUpdater: NSObject, FaviconUserScriptDelegate {
             guard self.bookmarkExists(for: host),
                   let image = image else { return }
 
-            self.favicons.replaceBookmarksFavicon(forDomain: host, withImage: image)
+            self.favicons.replaceFireproofFavicon(forDomain: host, withImage: image)
         }
 
     }

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -269,7 +269,7 @@ extension HomeViewController: FavoritesHomeViewSectionRendererDelegate {
     func favoritesRenderer(_ renderer: FavoritesHomeViewSectionRenderer, didSelect favorite: BookmarkEntity) {
         guard let url = favorite.urlObject else { return }
         Pixel.fire(pixel: .homeScreenFavouriteLaunched)
-        Favicons.shared.loadFavicon(forDomain: url.host, intoCache: .bookmarks, fromCache: .tabs)
+        Favicons.shared.loadFavicon(forDomain: url.host, intoCache: .fireproof, fromCache: .tabs)
         delegate?.home(self, didRequestUrl: url)
     }
     

--- a/DuckDuckGo/ImageCacheDebugViewController.swift
+++ b/DuckDuckGo/ImageCacheDebugViewController.swift
@@ -82,7 +82,7 @@ class ImageCacheDebugViewController: UITableViewController {
         case .bookmarks:
             let bookmark = bookmarksAndFavorites[indexPath.row]
             cell.textLabel?.text = bookmark.urlObject?.host
-            cell.imageView?.loadFavicon(forDomain: bookmark.urlObject?.host, usingCache: .bookmarks) {
+            cell.imageView?.loadFavicon(forDomain: bookmark.urlObject?.host, usingCache: .fireproof) {
                 cell.imageView?.image = $1 ? self.imageNotFound : $0 ?? self.imageError
                 cell.detailTextLabel?.text = self.describe($1 ? nil : $0)
             }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1343,7 +1343,7 @@ extension MainViewController: FavoritesOverlayDelegate {
         Pixel.fire(pixel: .homeScreenFavouriteLaunched)
         homeController?.chromeDelegate = nil
         dismissOmniBar()
-        Favicons.shared.loadFavicon(forDomain: url.host, intoCache: .bookmarks, fromCache: .tabs)
+        Favicons.shared.loadFavicon(forDomain: url.host, intoCache: .fireproof, fromCache: .tabs)
         if url.isBookmarklet() {
             executeBookmarklet(url)
         } else {

--- a/DuckDuckGo/PreserveLoginsSettingsViewController.swift
+++ b/DuckDuckGo/PreserveLoginsSettingsViewController.swift
@@ -183,7 +183,7 @@ class PreserveLoginsSettingsViewController: UITableViewController {
             fatalError("Cell should be dequeued")
         }
         cell.label.textColor = theme.tableCellTextColor
-        cell.faviconImage.loadFavicon(forDomain: model[index], usingCache: .bookmarks)
+        cell.faviconImage.loadFavicon(forDomain: model[index], usingCache: .fireproof)
         cell.label?.text = model[index].droppingWwwPrefix()
         cell.decorate(with: theme)
         return cell

--- a/DuckDuckGo/PreserveLoginsWorker.swift
+++ b/DuckDuckGo/PreserveLoginsWorker.swift
@@ -73,7 +73,7 @@ struct PreserveLoginsWorker {
     private func addDomain(_ domain: String) {
         guard let controller = controller else { return }
         PreserveLogins.shared.addToAllowed(domain: domain)
-        Favicons.shared.loadFavicon(forDomain: domain, intoCache: .bookmarks, fromCache: .tabs)
+        Favicons.shared.loadFavicon(forDomain: domain, intoCache: .fireproof, fromCache: .tabs)
         PreserveLoginsAlert.showFireproofEnabledMessage(usingController: controller, worker: self, forDomain: domain)
     }
 

--- a/DuckDuckGo/RootDebugViewController.swift
+++ b/DuckDuckGo/RootDebugViewController.swift
@@ -146,7 +146,7 @@ class DiagnosticReportDataSource: UIActivityItemProvider {
     func imageCacheReport() -> String {
         """
         ## Image Cache Report
-        Bookmark Cache: \(Favicons.Constants.caches[.bookmarks]?.count ?? -1)
+        Bookmark Cache: \(Favicons.Constants.caches[.fireproof]?.count ?? -1)
         Tabs Cache: \(Favicons.Constants.caches[.tabs]?.count ?? -1)
         """
     }

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -266,7 +266,7 @@ class TabSwitcherViewController: UIViewController {
             guard let link = tab.link else { return }
             if viewModel.bookmark(for: link.url) == nil {
                 viewModel.createBookmark(title: link.displayTitle, url: link.url)
-                favicons.loadFavicon(forDomain: link.url.host, intoCache: .bookmarks, fromCache: .tabs)
+                favicons.loadFavicon(forDomain: link.url.host, intoCache: .fireproof, fromCache: .tabs)
                 newCount += 1
             }
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -132,7 +132,7 @@ class TabViewController: UIViewController {
     let userAgentManager: UserAgentManager = DefaultUserAgentManager.shared
     
     let bookmarksDatabase: CoreDataDatabase
-    lazy var faviconUpdater = BookmarkFaviconUpdater(bookmarksDatabase: bookmarksDatabase, tab: tabModel, favicons: Favicons.shared)
+    lazy var faviconUpdater = FireproofFaviconUpdater(bookmarksDatabase: bookmarksDatabase, tab: tabModel, favicons: Favicons.shared)
 
     public var url: URL? {
         willSet {

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -215,7 +215,7 @@ extension TabViewController {
                                            with bookmarksInterface: MenuBookmarksInteracting) {
         Pixel.fire(pixel: .browsingMenuAddToBookmarks)
         bookmarksInterface.createBookmark(title: link.title ?? "", url: link.url)
-        favicons.loadFavicon(forDomain: link.url.host, intoCache: .bookmarks, fromCache: .tabs)
+        favicons.loadFavicon(forDomain: link.url.host, intoCache: .fireproof, fromCache: .tabs)
 
         ActionMessageView.present(message: UserText.webSaveBookmarkDone,
                                   actionTitle: UserText.actionGenericEdit, onAction: {
@@ -260,7 +260,7 @@ extension TabViewController {
     private func performAddFavoriteAction(for link: Link,
                                           with bookmarksInterface: MenuBookmarksInteracting) {
         bookmarksInterface.createOrToggleFavorite(title: link.title ?? "", url: link.url)
-        favicons.loadFavicon(forDomain: link.url.host, intoCache: .bookmarks, fromCache: .tabs)
+        favicons.loadFavicon(forDomain: link.url.host, intoCache: .fireproof, fromCache: .tabs)
         WidgetCenter.shared.reloadAllTimelines()
         
         ActionMessageView.present(message: UserText.webSaveFavoriteDone, actionTitle: UserText.actionGenericUndo, onAction: {

--- a/DuckDuckGoTests/FaviconsTests.swift
+++ b/DuckDuckGoTests/FaviconsTests.swift
@@ -44,8 +44,8 @@ class FaviconsTests: XCTestCase {
 
         Favicons.Constants.tabsCache.clearDiskCache()
         Favicons.Constants.tabsCache.clearMemoryCache()
-        Favicons.Constants.bookmarksCache.clearDiskCache()
-        Favicons.Constants.bookmarksCache.clearMemoryCache()
+        Favicons.Constants.fireproofCache.clearDiskCache()
+        Favicons.Constants.fireproofCache.clearMemoryCache()
         
         _ = DefaultUserAgentManager.shared
     }
@@ -125,8 +125,8 @@ class FaviconsTests: XCTestCase {
 
         XCTAssertFalse(favicons.isFaviconCachedForBookmarks(forDomain: Constants.exampleDomain, resource: resource))
 
-        Favicons.Constants.bookmarksCache.store(image, forKey: resource.cacheKey) { _ in
-            XCTAssertTrue(Favicons.Constants.bookmarksCache.isCached(forKey: resource.cacheKey))
+        Favicons.Constants.fireproofCache.store(image, forKey: resource.cacheKey) { _ in
+            XCTAssertTrue(Favicons.Constants.fireproofCache.isCached(forKey: resource.cacheKey))
             XCTAssertTrue(self.favicons.isFaviconCachedForBookmarks(forDomain: Constants.exampleDomain, resource: resource))
             expectation.fulfill()
         }

--- a/DuckDuckGoTests/FaviconsTests.swift
+++ b/DuckDuckGoTests/FaviconsTests.swift
@@ -123,11 +123,8 @@ class FaviconsTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(favicons.isFaviconCachedForBookmarks(forDomain: Constants.exampleDomain, resource: resource))
-
         Favicons.Constants.fireproofCache.store(image, forKey: resource.cacheKey) { _ in
             XCTAssertTrue(Favicons.Constants.fireproofCache.isCached(forKey: resource.cacheKey))
-            XCTAssertTrue(self.favicons.isFaviconCachedForBookmarks(forDomain: Constants.exampleDomain, resource: resource))
             expectation.fulfill()
         }
 

--- a/DuckDuckGoTests/FireproofFaviconUpdaterTests.swift
+++ b/DuckDuckGoTests/FireproofFaviconUpdaterTests.swift
@@ -1,5 +1,5 @@
 //
-//  BookmarkFaviconUpdaterTests.swift
+//  FireproofFaviconUpdaterTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2022 DuckDuckGo. All rights reserved.
@@ -24,7 +24,7 @@ import Persistence
 import Core
 import Bookmarks
 
-class BookmarkFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
+class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
 
     var db: CoreDataDatabase!
 
@@ -56,7 +56,7 @@ class BookmarkFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
     }
 
     func testWhenBookmarkDoesNotExist_ThenImageNotReplacement() {
-        let updater = BookmarkFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: nil)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -70,7 +70,7 @@ class BookmarkFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
     func testWhenBookmarkExistsButNoImage_ThenImageNotReplacement() throws {
         try createBookmark()
 
-        let updater = BookmarkFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: nil)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -87,7 +87,7 @@ class BookmarkFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         image = UIImage()
         let url = URL(string: "https://example.com/favicon.ico")!
 
-        let updater = BookmarkFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: url)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -104,7 +104,7 @@ class BookmarkFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         image = UIImage()
         let url = URL(string: "https://example.com/favicon.ico")!
 
-        let updater = BookmarkFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "www.example.com", withUrl: url)
 
         XCTAssertEqual(loadFaviconDomain, "www.example.com")
@@ -126,7 +126,7 @@ class BookmarkFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         completion?(image)
     }
 
-    func replaceBookmarksFavicon(forDomain domain: String?, withImage: UIImage) {
+    func replaceFireproofFavicon(forDomain domain: String?, withImage: UIImage) {
         replaceFaviconCalled = true
     }
 

--- a/Widgets/Widgets.swift
+++ b/Widgets/Widgets.swift
@@ -131,7 +131,7 @@ class Provider: TimelineProvider {
         guard let domain = domain else { return nil }
 
         let key = Favicons.createHash(ofDomain: domain)
-        guard let cacheUrl = Favicons.CacheType.bookmarks.cacheLocation() else { return nil }
+        guard let cacheUrl = Favicons.CacheType.fireproof.cacheLocation() else { return nil }
 
         // Slight leap here to avoid loading Kingisher as a library for the widgets.
         // Once dependency management is fixed, link it and use Favicons directly.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1204422898101805/f
Tech Design URL:
CC:

**Description**:
Updating the `.bookmarks` favicon cache name to `.fireproof` to reflect that multiple sources are / will be saving to this cache, not only bookmarks

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Before installing this build on simulator ensure you have an existing build with a number of bookmarks saved with favicons loaded and some fireproofed sites
2. Run up this build and smoke test bookmark favicons confirming there is no change in behaviour
3. Smoke test fireproofing some sites and confirm there is no change in favicon behaviour
4. Go to the `favicons fireproof location` logged in console and confirm there is only a `com.onevcat.Kingfisher.ImageCache.fireproof` folder containing fireproof favicons and that there is no `com.onevcat.Kingfisher.ImageCache.bookmarks` folder

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
