### PR TITLE
Fix AppTP tracker sort and show toast

### DIFF
--- a/DuckDuckGo/AppTPManageTrackersView.swift
+++ b/DuckDuckGo/AppTPManageTrackersView.swift
@@ -29,6 +29,14 @@ struct AppTPManageTrackersView: View {
         viewModel.changeState(for: domain, blocking: isBlocking)
     }
     
+    func restoreDefaults() {
+        viewModel.resetAllowlist()
+        DispatchQueue.main.async {
+            ActionMessageView.present(message: UserText.appTPRestoreDefaultsToast,
+                                      presentationLocation: .withoutBottomBar)
+        }
+    }
+    
     var loadingState: some View {
         VStack {
             SwiftUI.ProgressView()
@@ -48,7 +56,7 @@ struct AppTPManageTrackersView: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         Section {
                             Button(action: {
-                                viewModel.resetAllowlist()
+                                restoreDefaults()
                             }, label: {
                                 HStack {
                                     Spacer()

--- a/DuckDuckGo/AppTPManageTrackersViewModel.swift
+++ b/DuckDuckGo/AppTPManageTrackersViewModel.swift
@@ -51,7 +51,7 @@ class AppTPManageTrackersViewModel: ObservableObject {
             newList.append(tracker)
         }
         // Sort the list by Tracker Network then by domain
-        newList.sort(by: { ($0.trackerOwner, $0.domain) < ($1.trackerOwner, $1.domain) })
+        newList.sort(by: { ($0.trackerOwner.lowercased(), $0.domain) < ($1.trackerOwner.lowercased(), $1.domain) })
         Task { @MainActor in
             trackerList = newList
         }

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -518,6 +518,7 @@ public struct UserText {
     
     public static let appTPJustNow = NSLocalizedString("appTP.justNow", value: "just now", comment: "Text indicating the tracking event occured 'just now'. Example: Last attempt 'just now'")
     public static let appTPRestoreDefaults = NSLocalizedString("appTP.restoreDefualts", value: "Restore Defaults", comment: "Button to restore the blocklist to its default state.")
+    public static let appTPRestoreDefaultsToast = NSLocalizedString("appTP.restoreDefaultsToast", value: "Protection restored to default settings", comment: "Toast notification diplayed aftering restoing the blocklist to default")
     public static let appTPManageTrackers = NSLocalizedString("appTP.manageTrackers", value: "Manage Trackers", comment: "View to manage trackers for AppTP. Allows the user to turn trackers on or off.")
     public static let appTPBlockTracker = NSLocalizedString("appTP.blockTrackerText", value: "Block this tracker", comment: "Text label for switch that turns blocking on or off for a tracker")
     

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -202,6 +202,9 @@
 /* Title for 'Report an Issue' alert. */
 "appTP.reportAlert.title" = "Report an Issue?";
 
+/* Toast notification diplayed aftering restoing the blocklist to default */
+"appTP.restoreDefaultsToast" = "Protection restored to default settings";
+
 /* Button to restore the blocklist to its default state. */
 "appTP.restoreDefualts" = "Restore Defaults";
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1203881841413756/1204456266799291/f
Tech Design URL:
CC:

**Description**:
This PR fixes the Manage Trackers sort in AppTP to be case insensitive. It also displays a toast when resetting the blocklist.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go to AppTP -> Manage Trackers
2. Click "Restore Defaults". You should see a toast displayed.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [x] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
