### PR TITLE
Update autofill to 6.5.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8186,8 +8186,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 1b58d1a15b0f5b6e0f59a61116d9f68930abb773;
+				kind = exactVersion;
+				version = 57.4.3;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8186,8 +8186,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 57.4.2;
+				kind = revision;
+				revision = 1b58d1a15b0f5b6e0f59a61116d9f68930abb773;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "1b58d1a15b0f5b6e0f59a61116d9f68930abb773",
-          "version": null
+          "revision": "3baef814ab04831b71b4bc6bf75720d1dbd3b176",
+          "version": "57.4.3"
         }
       },
       {
@@ -26,15 +26,6 @@
           "branch": null,
           "revision": "801b7f23476f797c6eaa72b070e6c80abb82801a",
           "version": "4.4.4"
-        }
-      },
-      {
-        "package": "DesignResourcesKit",
-        "repositoryURL": "https://github.com/duckduckgo/DesignResourcesKit",
-        "state": {
-          "branch": null,
-          "revision": "4c78cf0808e1aad20245e27b1a7d42c3357420eb",
-          "version": "1.0.0"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "1f2509d528ea5b382676956a7a09b804fd0366da",
-          "version": "57.4.2"
+          "revision": "1b58d1a15b0f5b6e0f59a61116d9f68930abb773",
+          "version": null
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
-          "version": "6.4.3"
+          "revision": "4648da359313c218ec130cc4f63364b095e2e064",
+          "version": "6.5.0"
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1204530982219497/f
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.0


## Description
Updates Autofill to version [6.5.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.0).

### Autofill 6.5.0 release notes
## What's Changed
* Improve debugging by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/293
* Reduce the calls on check position when there are many mutations by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/288
* Window release fetch tags before checkout by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/296
* Autofill compare generated test suites by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/283
* Update release scripts with latest Apple tooling by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/299
* Add temporary incontext_eligible pixel by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/304
* Fix double-click issue by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/306
* Fix a whole bunch of existing failing test cases by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/308

## New Contributors
* @greyivy made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/283

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.4.3...6.5.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).