### PR TITLE
Update BSK with autofill 6.5.1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8186,8 +8186,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 1f65d0546778f51e1c3a7eb174a94b46d63c2aac;
+				kind = exactVersion;
+				version = 57.4.4;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8186,8 +8186,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 57.4.2;
+				kind = revision;
+				revision = 1f65d0546778f51e1c3a7eb174a94b46d63c2aac;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "1f2509d528ea5b382676956a7a09b804fd0366da",
-          "version": "57.4.2"
+          "revision": "6c2dd1700d94c4f26222e36ca48a86b840df85c7",
+          "version": "57.4.4"
         }
       },
       {
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "DesignResourcesKit",
-        "repositoryURL": "https://github.com/duckduckgo/DesignResourcesKit",
-        "state": {
-          "branch": null,
-          "revision": "4c78cf0808e1aad20245e27b1a7d42c3357420eb",
-          "version": "1.0.0"
-        }
-      },
-      {
         "package": "Autofill",
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "4aee97d550112ba6551e61ea8019fb1f1a2d3af7",
-          "version": "6.4.3"
+          "revision": "8f403fad4f6ccf18a3900fc560f43067a527ac9f",
+          "version": "6.5.1"
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204538113123465/1204538113123465
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.1
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/344

## Description
Updates Autofill to version [6.5.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/6.5.1).

### Autofill 6.5.1 release notes
## What's Changed
* Disable pixel for all platforms but extension by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/309
* Fix release script for BSK by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/310

Included in 6.5.0:
- Improve debugging by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/293
- Reduce the calls on check position when there are many mutations by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/288
- Window release fetch tags before checkout by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/296
- Autofill compare generated test suites by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/283
- Update release scripts with latest Apple tooling by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/299
- Add temporary incontext_eligible pixel by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/304
- Fix double-click issue by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/306
- Fix a whole bunch of existing failing test cases by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/308


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/6.5.0...6.5.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).