### PR TITLE
Temporarily disable cookie consent Dax dialog presentation

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2124,8 +2124,12 @@ extension TabViewController: AutoconsentUserScriptDelegate {
         privacyInfo?.cookieConsentManaged = cookieConsentStatus
     }
     
+    // Disabled temporarily as a result of https://app.asana.com/0/1203936086921904/1204496002772588/f
+    private var cookieConsentDaxDialogPresentationAllowed: Bool { false }
+    
     func autoconsentUserScript(_ script: AutoconsentUserScript, didRequestAskingUserForConsent completion: @escaping (Bool) -> Void) {
-        guard Locale.current.isRegionInEurope,
+        guard cookieConsentDaxDialogPresentationAllowed,
+              Locale.current.isRegionInEurope,
               !isShowingFullScreenDaxDialog else { return }
         
         let viewModel = CookieConsentDaxDialogViewModel(okAction: {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1204496002772588/f
Tech Design URL:
CC:

**Description**:
Temporarily disable cookie consent Dax dialog presentation

**Steps to test this PR**:
1. Prepare setup for showing initial CPM Dax dialog:
- clean install OR clear cookies & reset autoconsent flags (Settings -> Debug Menu -> Reset Autoconsent Settings)
- device’s region needs to be in Europe
- if outside EU using VPN with European country may be helpful
- in case of clean install complete onboarding (but do not navigate to website with cookie consent pop-up as part of it)
2. BEFORE: navigate to site that shows cookie consent pop-up -> CPM Dax dialog should be presented asking for opt-in
3. AFTER: navigate to site that shows cookie consent pop-up -> CPM Dax dialog should NOT be presented

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
