### PR TITLE
Ensure Autofill is off by default

### DIFF
--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -187,7 +187,7 @@ public class AppUserDefaults: AppSettings {
             // In future, we'll use setAutofillCredentialsEnabledAutomaticallyIfNecessary() here to automatically turn on autofill for people
             // That haven't seen the save prompt before.
             // For now, whilst internal testing is still happening, it's still set to default to be enabled
-            return userDefaults?.object(forKey: Keys.autofillCredentialsEnabled) as? Bool ?? true
+            return userDefaults?.object(forKey: Keys.autofillCredentialsEnabled) as? Bool ?? false
         }
         
         set {

--- a/DuckDuckGoTests/AppUserDefaultsTests.swift
+++ b/DuckDuckGoTests/AppUserDefaultsTests.swift
@@ -88,6 +88,11 @@ class AppUserDefaultsTests: XCTestCase {
         
         XCTAssertEqual(appUserDefaults.currentThemeName, .systemDefault)
     }
+
+    func testDefaultAutofillStateIsFalse() {
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        XCTAssertFalse(appUserDefaults.autofillCredentialsEnabled)
+    }
     
     /*
      These tests aren't required until we make autofill default to off, and then enable turning it on automatically


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204558657522442/f
Tech Design URL:
CC:

**Description**:

The code which was merged into production for the Autofill release had Autofill set to "enabled by default”. This should not be the case. It should be off by default. This PR addresses that.

**Steps to test this PR**:
1. Use a proxy to stub the ios-config response to enable Autofill for the current app version (make sure headers are correctly set*)
2. Make a clean build of the iOS app.
3. Launch the app (you may have to kill and relaunch for the feature flag setting to take effect).
4. Go to Settings -> Logins
5. The switch should be off.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
