### PR TITLE
Application background and lock status checks for SecureVault access

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -644,6 +644,7 @@
 		B6BA95E828924730004ABA20 /* JSAlertController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6BA95E728924730004ABA20 /* JSAlertController.storyboard */; };
 		B6CB93E5286445AB0090FEB4 /* Base64DownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CB93E4286445AB0090FEB4 /* Base64DownloadSession.swift */; };
 		C111B26927F579EF006558B1 /* BookmarkOrFolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C111B26827F579EF006558B1 /* BookmarkOrFolderTests.swift */; };
+		C13B32D22A0E750700A59236 /* AutofillSettingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */; };
 		C14882DA27F2011C00D59F0C /* BookmarksExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14882D727F2011C00D59F0C /* BookmarksExporter.swift */; };
 		C14882DC27F2011C00D59F0C /* BookmarksImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14882D927F2011C00D59F0C /* BookmarksImporter.swift */; };
 		C14882E327F20D9A00D59F0C /* BookmarksExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14882E127F20D9A00D59F0C /* BookmarksExporterTests.swift */; };
@@ -2174,6 +2175,7 @@
 		B6BA95E728924730004ABA20 /* JSAlertController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = JSAlertController.storyboard; sourceTree = "<group>"; };
 		B6CB93E4286445AB0090FEB4 /* Base64DownloadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64DownloadSession.swift; sourceTree = "<group>"; };
 		C111B26827F579EF006558B1 /* BookmarkOrFolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkOrFolderTests.swift; sourceTree = "<group>"; };
+		C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutofillSettingStatus.swift; sourceTree = "<group>"; };
 		C14882D727F2011C00D59F0C /* BookmarksExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksExporter.swift; sourceTree = "<group>"; };
 		C14882D927F2011C00D59F0C /* BookmarksImporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksImporter.swift; sourceTree = "<group>"; };
 		C14882E127F20D9A00D59F0C /* BookmarksExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksExporterTests.swift; sourceTree = "<group>"; };
@@ -4864,6 +4866,7 @@
 			children = (
 				F4147353283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift */,
 				C1D21E2C293A5965006E5A05 /* AutofillLoginSession.swift */,
+				C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */,
 				319A370F28299A850079FBCE /* PasswordHider.swift */,
 				31C70B5428045E3500FB6AD1 /* SecureVaultErrorReporter.swift */,
 				31951E94282310FF00CAF535 /* WebsiteAccountExtension.swift */,
@@ -5879,6 +5882,7 @@
 				1EEC460627A9499600E75FCB /* DownloadsList.swift in Sources */,
 				85B9CB8921AEBDD5009001F1 /* FavoriteHomeCell.swift in Sources */,
 				98999D5922FDA41500CBBE1B /* BasicAuthenticationAlert.swift in Sources */,
+				C13B32D22A0E750700A59236 /* AutofillSettingStatus.swift in Sources */,
 				F4F6DFB426E6B63700ED7E12 /* BookmarkFolderCell.swift in Sources */,
 				851B12CC22369931004781BC /* AtbAndVariantCleanup.swift in Sources */,
 				85F2FFCF2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift in Sources */,

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -24,16 +24,9 @@ import BrowserServicesKit
 extension ContentScopeFeatureToggles {
     
     static let featureFlagger = AppDependencyProvider.shared.featureFlagger
-    static let appSettings = AppDependencyProvider.shared.appSettings
-    
-    static var isAutofillEnabledInSettings: Bool {
-        let context = LAContext()
-        var error: NSError?
-        let canAuthenticate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
-        return appSettings.autofillCredentialsEnabled && canAuthenticate
-    }
-    
+
     static var supportedFeaturesOniOS: ContentScopeFeatureToggles {
+        let isAutofillEnabledInSettings = AutofillSettingStatus.isAutofillEnabledInSettings
         ContentScopeFeatureToggles(emailProtection: true,
                                    credentialsAutofill: featureFlagger.isFeatureOn(.autofillCredentialInjecting) && isAutofillEnabledInSettings,
                                    identitiesAutofill: false,

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -27,7 +27,7 @@ extension ContentScopeFeatureToggles {
 
     static var supportedFeaturesOniOS: ContentScopeFeatureToggles {
         let isAutofillEnabledInSettings = AutofillSettingStatus.isAutofillEnabledInSettings
-        ContentScopeFeatureToggles(emailProtection: true,
+        return ContentScopeFeatureToggles(emailProtection: true,
                                    credentialsAutofill: featureFlagger.isFeatureOn(.autofillCredentialInjecting) && isAutofillEnabledInSettings,
                                    identitiesAutofill: false,
                                    creditCardsAutofill: false,

--- a/DuckDuckGo/AutofillSettingStatus.swift
+++ b/DuckDuckGo/AutofillSettingStatus.swift
@@ -1,0 +1,33 @@
+//
+//  AutofillSettingStatus.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import LocalAuthentication
+
+struct AutofillSettingStatus {
+
+    static let appSettings = AppDependencyProvider.shared.appSettings
+
+    static var isAutofillEnabledInSettings: Bool {
+        let context = LAContext()
+        var error: NSError?
+        let canAuthenticate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
+        return appSettings.autofillCredentialsEnabled && canAuthenticate
+    }
+}

--- a/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -113,7 +113,7 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
     private func initSecureVault() -> SecureVault? {
         if featureFlagger.isFeatureOn(.autofillCredentialInjecting) && AutofillSettingStatus.isAutofillEnabledInSettings {
             if secureVault == nil {
-                secureVault = try? SecureVaultFactory.default.makeVault(errorReporter: nil)
+                secureVault = try? SecureVaultFactory.default.makeVault(errorReporter: SecureVaultErrorReporter.shared)
             }
             return secureVault
         }

--- a/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -113,7 +113,7 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
     private func initSecureVault() -> SecureVault? {
         if featureFlagger.isFeatureOn(.autofillCredentialInjecting) && AutofillSettingStatus.isAutofillEnabledInSettings {
             if secureVault == nil {
-                secureVault = try? SecureVaultFactory.default.makeVault(errorReporter: SecureVaultErrorReporter.shared)
+                secureVault = try? SecureVaultFactory.default.makeVault(errorReporter: nil)
             }
             return secureVault
         }

--- a/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -53,15 +53,16 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
     }
 
     let context: NSManagedObjectContext
-    let secureVault: SecureVault?
+    var secureVault: SecureVault?
     let tab: TabNotifying
     let favicons: FaviconProviding
 
-    init(bookmarksDatabase: CoreDataDatabase, tab: TabNotifying, favicons: FaviconProviding, secureVaultEnabled: Bool) {
+    private let featureFlagger = AppDependencyProvider.shared.featureFlagger
+
+    init(bookmarksDatabase: CoreDataDatabase, tab: TabNotifying, favicons: FaviconProviding) {
         self.context = bookmarksDatabase.makeContext(concurrencyType: .mainQueueConcurrencyType)
         self.tab = tab
         self.favicons = favicons
-        self.secureVault = secureVaultEnabled ? try? SecureVaultFactory.default.makeVault(errorReporter: SecureVaultErrorReporter.shared) : nil
 
         super.init()
         registerForNotifications()
@@ -109,8 +110,18 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
         return result
     }
 
+    private func initSecureVault() -> SecureVault? {
+        if featureFlagger.isFeatureOn(.autofillCredentialInjecting) && AutofillSettingStatus.isAutofillEnabledInSettings {
+            if secureVault == nil {
+                secureVault = try? SecureVaultFactory.default.makeVault(errorReporter: SecureVaultErrorReporter.shared)
+            }
+            return secureVault
+        }
+        return nil
+    }
+
     private func autofillLoginExists(for domain: String) -> Bool {
-        guard let secureVault = secureVault else {
+        guard let secureVault = initSecureVault() else {
             return false
         }
 

--- a/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -57,11 +57,11 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
     let tab: TabNotifying
     let favicons: FaviconProviding
 
-    init(bookmarksDatabase: CoreDataDatabase, tab: TabNotifying, favicons: FaviconProviding) {
+    init(bookmarksDatabase: CoreDataDatabase, tab: TabNotifying, favicons: FaviconProviding, secureVaultEnabled: Bool) {
         self.context = bookmarksDatabase.makeContext(concurrencyType: .mainQueueConcurrencyType)
         self.tab = tab
         self.favicons = favicons
-        secureVault = try? SecureVaultFactory.default.makeVault(errorReporter: SecureVaultErrorReporter.shared)
+        self.secureVault = secureVaultEnabled ? try? SecureVaultFactory.default.makeVault(errorReporter: SecureVaultErrorReporter.shared) : nil
 
         super.init()
         registerForNotifications()

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -38,7 +38,8 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
         case .initFailed(let error):
             // Silencing pixel reporting for error -25308 (attempt to access keychain while the device was locked)
             // as per https://app.asana.com/0/30173902528854/1204557908133145/f, at least temporarily
-            if let secureVaultError = error as? SecureVaultError,
+            if isBackgrounded,
+               let secureVaultError = error as? SecureVaultError,
                let userInfo = secureVaultError.errorUserInfo["NSUnderlyingError"] as? NSError,
                userInfo.code == -25308 {
                 os_log("SecureVault attempt to access keystore while device is locked: %@",

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -36,6 +36,14 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
                            PixelParameters.appVersion: AppVersion.shared.versionAndBuildNumber]
         switch error {
         case .initFailed(let error):
+            // Silencing pixel reporting for error -25308 (attempt to access keychain while the device was locked)
+            // as per https://app.asana.com/0/30173902528854/1204557908133145/f, at least temporarily
+            if let secureVaultError = error as? SecureVaultError,
+               let userInfo = secureVaultError.errorUserInfo["NSUnderlyingError"] as? NSError,
+               userInfo.code == -25308 {
+                os_log("SecureVault attempt to access keystore while device is locked: %@", log: .generalLog, type: .debug, error.localizedDescription)
+                return
+            }
             Pixel.fire(pixel: .secureVaultInitFailedError, error: error, withAdditionalParameters: pixelParams)
         case .failedToOpenDatabase(let error):
             Pixel.fire(pixel: .secureVaultFailedToOpenDatabaseError, error: error, withAdditionalParameters: pixelParams)

--- a/DuckDuckGo/SecureVaultErrorReporter.swift
+++ b/DuckDuckGo/SecureVaultErrorReporter.swift
@@ -41,7 +41,10 @@ final class SecureVaultErrorReporter: SecureVaultErrorReporting {
             if let secureVaultError = error as? SecureVaultError,
                let userInfo = secureVaultError.errorUserInfo["NSUnderlyingError"] as? NSError,
                userInfo.code == -25308 {
-                os_log("SecureVault attempt to access keystore while device is locked: %@", log: .generalLog, type: .debug, error.localizedDescription)
+                os_log("SecureVault attempt to access keystore while device is locked: %@",
+                       log: .generalLog,
+                       type: .debug,
+                       error.localizedDescription)
                 return
             }
             Pixel.fire(pixel: .secureVaultInitFailedError, error: error, withAdditionalParameters: pixelParams)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -134,8 +134,7 @@ class TabViewController: UIViewController {
     let bookmarksDatabase: CoreDataDatabase
     lazy var faviconUpdater = FireproofFaviconUpdater(bookmarksDatabase: bookmarksDatabase,
                                                       tab: tabModel,
-                                                      favicons: Favicons.shared,
-                                                      secureVaultEnabled: secureVaultManagerIsEnabledStatus(vaultManager))
+                                                      favicons: Favicons.shared)
 
     public var url: URL? {
         willSet {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2385,8 +2385,7 @@ extension TabViewController: SecureVaultManagerDelegate {
             Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenEnabledAndBackgrounded,
                        withAdditionalParameters: [PixelParameters.isBackgrounded: "true"])
         }
-        let isBackgroundedAndLocked = isBackgrounded && !UIApplication.shared.isProtectedDataAvailable
-        return isEnabled && !isBackgroundedAndLocked
+        return isEnabled
     }
     
     func secureVaultManager(_ vault: SecureVaultManager, promptUserToStoreAutofillData data: AutofillData) {

--- a/DuckDuckGoTests/FireproofFaviconUpdaterTests.swift
+++ b/DuckDuckGoTests/FireproofFaviconUpdaterTests.swift
@@ -56,7 +56,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
     }
 
     func testWhenBookmarkDoesNotExist_ThenImageNotReplacement() {
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: nil)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -70,7 +70,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
     func testWhenBookmarkExistsButNoImage_ThenImageNotReplacement() throws {
         try createBookmark()
 
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: nil)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -87,7 +87,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         image = UIImage()
         let url = URL(string: "https://example.com/favicon.ico")!
 
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: url)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -104,7 +104,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         image = UIImage()
         let url = URL(string: "https://example.com/favicon.ico")!
 
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "www.example.com", withUrl: url)
 
         XCTAssertEqual(loadFaviconDomain, "www.example.com")

--- a/DuckDuckGoTests/FireproofFaviconUpdaterTests.swift
+++ b/DuckDuckGoTests/FireproofFaviconUpdaterTests.swift
@@ -56,7 +56,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
     }
 
     func testWhenBookmarkDoesNotExist_ThenImageNotReplacement() {
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: nil)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -70,7 +70,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
     func testWhenBookmarkExistsButNoImage_ThenImageNotReplacement() throws {
         try createBookmark()
 
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: nil)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -87,7 +87,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         image = UIImage()
         let url = URL(string: "https://example.com/favicon.ico")!
 
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "example.com", withUrl: url)
 
         XCTAssertEqual(loadFaviconDomain, "example.com")
@@ -104,7 +104,7 @@ class FireproofFaviconUpdaterTests: XCTestCase, TabNotifying, FaviconProviding {
         image = UIImage()
         let url = URL(string: "https://example.com/favicon.ico")!
 
-        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self)
+        let updater = FireproofFaviconUpdater(bookmarksDatabase: db, tab: self, favicons: self, secureVaultEnabled: false)
         updater.faviconUserScript(FaviconUserScript(), didRequestUpdateFaviconForHost: "www.example.com", withUrl: url)
 
         XCTAssertEqual(loadFaviconDomain, "www.example.com")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/30173902528854/1204557908133145/f
Tech Design URL:
CC:

**Description**:
Added check for app + device state (background, locked) in order to determine whether or not secureVault should accessed + applied same logic check to FireproofFaviconUpdater  

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Start by testing on device with Feature flag disabled i.e. no access to Autofill and open an empty tab
2. Set a breakpoint in `FireproofFaviconUpdater` on `super.init()`
3. Launch app normally and confirm `secureVaultEnabled` is `false` and `secureVault` is `nil`
4. Simulating the case of UIApplication.shared.isProtectedDataAvailable is false consistently was a little tricky to replicate and requires some code modification (see screenshot below)
 - Add `Thread.sleep(forTimeInterval: 10)` before this line:  
`let isBackgroundedAndLocked = isBackgrounded && !UIApplication.shared.isProtectedDataAvailable` 
-  Add an expression watch on `UIApplication.shared.isProtectedDataAvailable`
- Set breakpoints as in screenshot
7. Run the app. When the first breakpoint hits, minimise the app and lock the screen and then allow the app to continue running
8. Confirm `UIApplication.shared.isProtectedDataAvailable` is false and allow app to continue
9. In `FireproofFaviconUpdater` confirm `secureVaultEnabled` is `false` and `secureVault` is `nil`
10. Enable the feature flag access to Autofill
11. Repeat the above steps confirming that this time when app is open and running secureVaultEnabled` is `true` and `secureVault` is initialised 
12. And confirm the when app is minimised and locked secureVaultEnabled` is `false` and `secureVault` is `nil`

![image](https://github.com/duckduckgo/iOS/assets/91189922/8fe80b94-331e-4922-a948-3162ee53579f)



<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
