### PR TITLE
Fix to design system updated affecting remote message layout

### DIFF
--- a/DuckDuckGo/HomeMessageView.swift
+++ b/DuckDuckGo/HomeMessageView.swift
@@ -37,29 +37,29 @@ struct HomeMessageView: View {
     let viewModel: HomeMessageViewModel
     
     var body: some View {
-        VStack(spacing: Const.Spacing.titleAndSubtitle) {
-            HStack(alignment: .top) {
-                Spacer()
+        ZStack {
+            closeButtonHeader
+                .offset(x: Const.Padding.buttonHorizontal, y: -Const.Padding.buttonHorizontal)
+            VStack(spacing: Const.Spacing.titleAndSubtitle) {
+                HStack(alignment: .top) {
+                    VStack(spacing: 0) {
+                        topText
+                        image
+                        title
+                    }
+                    .padding([.leading, .trailing], Const.Padding.textHorizontalInset)
+                }
+
                 VStack(spacing: 0) {
-                    topText
-                    image
-                    title
+                    subtitle
+                    HStack {
+                        buttons
+                    }
+                    .padding(.top, Const.Spacing.subtitleAndButtons)
                 }
-                .offset(x: Const.Size.closeButtonWidth / 2, y: 0)
-                .layoutPriority(1)
-                Spacer()
-                closeButton
             }
-            
-            VStack(spacing: 0) {
-                subtitle
-                HStack {
-                    buttons
-                }
-                .padding(.top, Const.Spacing.subtitleAndButtons)
-            }
+            .multilineTextAlignment(.center)
         }
-        .multilineTextAlignment(.center)
         .padding()
         .background(RoundedRectangle(cornerRadius: Const.Radius.corner)
                         .fill(Color.background)
@@ -68,13 +68,27 @@ struct HomeMessageView: View {
                                 x: 0,
                                 y: Const.Offset.shadowVertical))
     }
+
+    private var closeButtonHeader: some View {
+        VStack {
+            HStack {
+                Spacer()
+                closeButton
+                    .padding(0)
+            }
+            Spacer()
+        }
+    }
     
     private var closeButton: some View {
-        Button(action: { viewModel.onDidClose(.close) },
-               label: { Image("Close-24") })
-            .layoutPriority(2)
-            .offset(x: Const.Offset.closeButton,
-                    y: -Const.Offset.closeButton)
+        Button {
+            viewModel.onDidClose(.close)
+        } label: {
+            Image("Close-24")
+                .foregroundColor(.primary)
+        }
+        .frame(width: Const.Size.buttonWidth, height: Const.Size.buttonWidth)
+        .contentShape(Rectangle())
     }
     
     private var topText: some View {
@@ -155,6 +169,7 @@ private enum Const {
         static let buttonHorizontal: CGFloat = 16
         static let buttonVertical: CGFloat = 9
         static let buttonVerticalInset: CGFloat = 8
+        static let textHorizontalInset: CGFloat = 30
     }
     
     enum Spacing {
@@ -165,12 +180,10 @@ private enum Const {
     }
     
     enum Size {
-        static let maxImageWidth: CGFloat = 64
-        static let closeButtonWidth: CGFloat = 24
+        static let buttonWidth: CGFloat = 44
     }
     
     enum Offset {
-        static let closeButton: CGFloat = 6
         static let shadowVertical: CGFloat = 2
     }
 }

--- a/DuckDuckGo/HomeMessageView.swift
+++ b/DuckDuckGo/HomeMessageView.swift
@@ -87,7 +87,7 @@ struct HomeMessageView: View {
             Image("Close-24")
                 .foregroundColor(.primary)
         }
-        .frame(width: Const.Size.buttonWidth, height: Const.Size.buttonWidth)
+        .frame(width: Const.Size.closeButtonWidth, height: Const.Size.closeButtonWidth)
         .contentShape(Rectangle())
     }
     
@@ -180,7 +180,7 @@ private enum Const {
     }
     
     enum Size {
-        static let buttonWidth: CGFloat = 44
+        static let closeButtonWidth: CGFloat = 44
     }
     
     enum Offset {

--- a/DuckDuckGo/HomeMessageView.swift
+++ b/DuckDuckGo/HomeMessageView.swift
@@ -41,14 +41,12 @@ struct HomeMessageView: View {
             closeButtonHeader
                 .offset(x: Const.Padding.buttonHorizontal, y: -Const.Padding.buttonHorizontal)
             VStack(spacing: Const.Spacing.titleAndSubtitle) {
-                HStack(alignment: .top) {
-                    VStack(spacing: 0) {
-                        topText
-                        image
-                        title
-                    }
-                    .padding([.leading, .trailing], Const.Padding.textHorizontalInset)
+                VStack(spacing: 0) {
+                    topText
+                    image
+                    title
                 }
+                .padding([.leading, .trailing], Const.Padding.textHorizontalInset)
 
                 VStack(spacing: 0) {
                     subtitle


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1204629679164422/f
Tech Design URL:
CC:

**Description**:
Design system changes have caused the close (X) icon to be hidden offscreen

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

*Please note - if you are testing on a first install of the app you will need to complete onboarding and then relaunch the app the see the first remote message*
1. Modify RemoteMessageRequest debug endpoint to this: https://jsonblob.com/api/1108727380679344128
2. Launch the app and open a new tab if not already on one; you should see the first remote message variant like this:
    <img width="456" alt="image" src="https://github.com/duckduckgo/iOS/assets/91189922/0bc7c899-2965-42de-b4f4-797a58c99e62">
3. Confirm the X button is visible and clickable 
4. After dismissing the remote message, relaunch the app 
5. You should see the second remote message variant like this:
    <img width="455" alt="image" src="https://github.com/duckduckgo/iOS/assets/91189922/c45e0826-9007-4f6e-9307-07848db4e42d">

6. Repeat steps 3 & 4
7. This time you should see the third remote message variant like this: 
    <img width="452" alt="image" src="https://github.com/duckduckgo/iOS/assets/91189922/f6ab3b94-2bad-4ed3-b124-035153a67864">

8. Repeat steps 3 & 4
9. This time you should see the fourth (and final) remote message variant:
    <img width="453" alt="image" src="https://github.com/duckduckgo/iOS/assets/91189922/893b0660-a994-4bf7-ad27-6653ff5e2e05">
 10. Confirm the X button is visible and clickable 


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
