### PR TITLE
Fix multiple dax dialogs

### DIFF
--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -163,6 +163,9 @@ final class DaxDialogs {
     private let variantManager: VariantManager
 
     private var nextHomeScreenMessageOverride: HomeScreenSpec?
+    
+    // So we can avoid showing two dialogs for the same page
+    private var lastURLDaxDialogReturnedFor: URL?
 
     /// Use singleton accessor, this is only accessible for tests
     init(settings: DaxDialogsSettings = DefaultDaxDialogsSettings(),
@@ -257,8 +260,19 @@ final class DaxDialogs {
         settings.fireButtonEducationShownOrExpired = true
         return ActionSheetSpec.fireButtonEducation
     }
+    
+    func nextBrowsingMessageIfShouldShow(for privacyInfo: PrivacyInfo) -> BrowsingSpec? {
+        guard privacyInfo.url != lastURLDaxDialogReturnedFor else { return nil }
+        
+        let message = nextBrowsingMessage(privacyInfo: privacyInfo)
+        if message != nil {
+            lastURLDaxDialogReturnedFor = privacyInfo.url
+        }
+        
+        return message
+    }
 
-    func nextBrowsingMessage(privacyInfo: PrivacyInfo) -> BrowsingSpec? {
+    private func nextBrowsingMessage(privacyInfo: PrivacyInfo) -> BrowsingSpec? {
         guard isEnabled, nextHomeScreenMessageOverride == nil else { return nil }
         guard let host = privacyInfo.domain else { return nil }
         

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -24,6 +24,7 @@ import BrowserServicesKit
 import Common
 import PrivacyDashboard
 
+// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 
 protocol EntityProviding {
@@ -404,3 +405,4 @@ final class DaxDialogs {
     }
 }
 // swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -232,6 +232,10 @@ final class DaxDialogs {
         nextHomeScreenMessageOverride = nil
     }
     
+    func clearHeldURLData() {
+        lastURLDaxDialogReturnedFor = nil
+    }
+    
     private var fireButtonPulseTimer: Timer?
     private static let timeToFireButtonExpire: TimeInterval = 1 * 60 * 60
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1790,6 +1790,8 @@ extension MainViewController: AutoClearWorker {
         }
         
         AutoconsentManagement.shared.clearCache()
+        
+        DaxDialogs.shared.clearHeldURLData()
     }
     
     func stopAllOngoingDownloads() {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1123,7 +1123,7 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
         
-        guard let spec = DaxDialogs.shared.nextBrowsingMessage(privacyInfo: privacyInfo) else {
+        guard let spec = DaxDialogs.shared.nextBrowsingMessageIfShouldShow(for: privacyInfo) else {
             
             if DaxDialogs.shared.shouldShowFireButtonPulse {
                 delegate?.tabDidRequestFireButtonPulse(tab: self)

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -238,6 +238,15 @@ final class DaxDialog: XCTestCase {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
         XCTAssertEqual(DaxDialogs.BrowsingSpec.afterSearch, onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ddg)))
     }
+    
+    func testWhenOnSamePageAndPresenceOfTrackersChangesThenShowOnlyOneMessage() {
+        let privacyInfo = makePrivacyInfo(url: URLs.example)
+        XCTAssertEqual(DaxDialogs.BrowsingSpec.withoutTrackers, onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
+        
+        let privacyInfoWithTrackers = makePrivacyInfo(url: URLs.google)
+        privacyInfo.trackerInfo = privacyInfoWithTrackers.trackerInfo
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
+    }
 
     func testWhenDimissedThenShowNothing() {
         onboarding.dismiss()

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -74,7 +74,7 @@ final class DaxDialog: XCTestCase {
         onboarding.resumeRegularFlow()
         XCTAssertNil(onboarding.nextHomeScreenMessage())
         XCTAssertEqual(settings.homeScreenMessagesSeen, 1)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.google)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.google)))
         XCTAssertEqual(onboarding.nextHomeScreenMessage(), .subsequent)
         XCTAssertEqual(settings.homeScreenMessagesSeen, 2)
     }
@@ -122,11 +122,11 @@ final class DaxDialog: XCTestCase {
             XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
             
             // Assert the expected case
-            XCTAssertEqual(testCase.expected, onboarding.nextBrowsingMessage(privacyInfo: privacyInfo), line: UInt(testCase.line))
+            XCTAssertEqual(testCase.expected, onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo), line: UInt(testCase.line))
             
             // Also assert the we don't see the message on subsequent calls
             XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-            XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo), line: UInt(testCase.line))
+            XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo), line: UInt(testCase.line))
         }
         
     }
@@ -136,114 +136,114 @@ final class DaxDialog: XCTestCase {
         privacyInfo.trackerInfo.addDetectedTracker(detectedTrackerFrom(URLs.google, pageUrl: URLs.example.absoluteString),
                                                    onPageWithURL: URLs.example)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
     }
 
     func testWhenMajorTrackerShownThenFireEducationShown() {
         let privacyInfo = makePrivacyInfo(url: URLs.google)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
     }
 
     func testWhenSearchShownThenNoTrackersIsShown() {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.ddg)))
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ddg)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
     }
 
     func testWhenMajorTrackerShownThenNoTrackersIsNotShown() {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.facebook)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.facebook)))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
     }
 
     func testWhenTrackersShownThenNoTrackersIsNotShown() {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.amazon)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.amazon)))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
     }
     
     func testWhenMajorTrackerShownThenOwnedByIsNotShown() {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.facebook)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.facebook)))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.ownedByFacebook)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ownedByFacebook)))
     }
 
     func testWhenSecondTimeOnSiteThatIsOwnedByFacebookThenShowNothingAfterFireEducation() {
         let privacyInfo = makePrivacyInfo(url: URLs.ownedByFacebook)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
 
     func testWhenFirstTimeOnSiteThatIsOwnedByFacebookThenShowOwnedByMajorTrackingMessage() {
         let privacyInfo = makePrivacyInfo(url: URLs.ownedByFacebook)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
         XCTAssertEqual(DaxDialogs.BrowsingSpec.siteOwnedByMajorTracker.format(args: "instagram.com", "Facebook", 39.0),
-                       onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+                       onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
 
     func testWhenSecondTimeOnSiteThatIsMajorTrackerThenShowNothingAfterFireEducation() {
         let privacyInfo = makePrivacyInfo(url: URLs.facebook)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
 
     func testWhenFirstTimeOnFacebookThenShowMajorTrackingMessage() {
         let privacyInfo = makePrivacyInfo(url: URLs.facebook)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
         XCTAssertEqual(DaxDialogs.BrowsingSpec.siteIsMajorTracker.format(args: "Facebook", URLs.facebook.host ?? ""),
-                       onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+                       onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
 
     func testWhenFirstTimeOnGoogleThenShowMajorTrackingMessage() {
         let privacyInfo = makePrivacyInfo(url: URLs.google)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
         XCTAssertEqual(DaxDialogs.BrowsingSpec.siteIsMajorTracker.format(args: "Google", URLs.google.host ?? ""),
-                       onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+                       onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
 
     func testWhenSecondTimeOnPageWithNoTrackersThenTrackersThenShowFireEducation() {
         let privacyInfo = makePrivacyInfo(url: URLs.example)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
 
     func testWhenFirstTimeOnPageWithNoTrackersThenTrackersThenShowNoTrackersMessage() {
         let privacyInfo = makePrivacyInfo(url: URLs.example)
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertEqual(DaxDialogs.BrowsingSpec.withoutTrackers, onboarding.nextBrowsingMessage(privacyInfo: privacyInfo))
+        XCTAssertEqual(DaxDialogs.BrowsingSpec.withoutTrackers, onboarding.nextBrowsingMessageIfShouldShow(for: privacyInfo))
     }
     
     func testWhenSecondTimeOnSearchPageThenShowNothing() {
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.ddg)))
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.ddg)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ddg)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ddg)))
     }
     
     func testWhenFirstTimeOnSearchPageThenShowSearchPageMessage() {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
-        XCTAssertEqual(DaxDialogs.BrowsingSpec.afterSearch, onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.ddg)))
+        XCTAssertEqual(DaxDialogs.BrowsingSpec.afterSearch, onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ddg)))
     }
 
     func testWhenDimissedThenShowNothing() {
         onboarding.dismiss()
         XCTAssertNil(onboarding.nextHomeScreenMessage())
         XCTAssertEqual(settings.homeScreenMessagesSeen, 0)
-        XCTAssertNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
     }
     
@@ -251,7 +251,7 @@ final class DaxDialog: XCTestCase {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
         XCTAssertNotNil(onboarding.nextHomeScreenMessage())
         XCTAssertEqual(settings.homeScreenMessagesSeen, 1)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
         XCTAssertEqual(DaxDialogs.HomeScreenSpec.subsequent, onboarding.nextHomeScreenMessage())
         XCTAssertEqual(settings.homeScreenMessagesSeen, 2)
@@ -263,7 +263,7 @@ final class DaxDialog: XCTestCase {
         XCTAssertFalse(onboarding.shouldShowFireButtonPulse)
         XCTAssertNotNil(onboarding.nextHomeScreenMessage())
         XCTAssertEqual(settings.homeScreenMessagesSeen, 1)
-        XCTAssertNotNil(onboarding.nextBrowsingMessage(privacyInfo: makePrivacyInfo(url: URLs.example)))
+        XCTAssertNotNil(onboarding.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.example)))
         XCTAssertTrue(onboarding.shouldShowFireButtonPulse)
         XCTAssertEqual(DaxDialogs.HomeScreenSpec.subsequent, onboarding.nextHomeScreenMessage())
         XCTAssertEqual(settings.homeScreenMessagesSeen, 2)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1204534039597636/f
Tech Design URL:
CC:

**Description**:
Stops multiple dax dialogs being shown for the same page back to back

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Before you start, go to YouTube.com on a fresh install and makes sure you do not see the YouTube tracking/cookies popup, since this stops the original bug from manifesting 
1. On a fresh install, go straight to YouTube.com and ensure only one dax dialog is show. Make sure you do not see the YouTube tracking/cookies popup
2. Continue browsing to a page where trackers load immediately, and ensure you still get the trackers found dax dialog.
3. On a fresh install, search for something, make sure you get the correct dialog. Go to some other page, and make sure you get the correct dialog for if there are or aren't trackers. Then make sure you get the fire button pulse

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
