### PR TITLE
disable updating device name when item is selected

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -108,7 +108,9 @@ public struct SyncSettingsView: View {
             }
         }
         .onReceive(timer) { _ in
-            model.delegate?.refreshDevices(clearDevices: false)
+            if selectedDevice == nil {
+                model.delegate?.refreshDevices(clearDevices: false)
+            }
         }
 
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1204643115101944/f
Tech Design URL:
CC:

**Description**:

Stops updating the device list when editing / viewing a device detail.

**Steps to test this PR**:
1. Turn on sync
2. Start editing device name.  
3. Wait 5-10 seconds.  
4. Save device name

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
