### PR TITLE
Only hide the home screen logo if AppTP’s banner is displayed

### DIFF
--- a/DuckDuckGo/AppTPHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/AppTPHomeViewSectionRenderer.swift
@@ -33,6 +33,13 @@ class AppTPHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
     fileprivate lazy var featureFlagger = AppDependencyProvider.shared.featureFlagger
     
     private weak var controller: HomeViewController?
+
+    private var showAppTPHomeViewHeader: Bool {
+        let appTPEnabled = featureFlagger.isFeatureOn(.appTrackingProtection)
+        let appTPUsed = UserDefaults().bool(forKey: UserDefaultsWrapper<Any>.Key.appTPUsed.rawValue)
+
+        return appTPEnabled && appTPUsed
+    }
     
     let appTPHomeViewModel: AppTPHomeViewModel
     
@@ -43,11 +50,17 @@ class AppTPHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
     
     func install(into controller: HomeViewController) {
         self.controller = controller
-        hideLogo()
+        hideLogoIfAppTPIsEnabled()
     }
-    
-    private func hideLogo() {
-        controller?.hideLogo()
+
+    func refresh() {
+        hideLogoIfAppTPIsEnabled()
+    }
+
+    private func hideLogoIfAppTPIsEnabled() {
+        if showAppTPHomeViewHeader {
+            controller?.hideLogo()
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView,
@@ -70,9 +83,7 @@ class AppTPHomeViewSectionRenderer: NSObject, HomeViewSectionRenderer {
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let appTPUsed = UserDefaults().bool(forKey: UserDefaultsWrapper<Any>.Key.appTPUsed.rawValue)
-        let appTPEnabled = featureFlagger.isFeatureOn(.appTrackingProtection)
-        return appTPUsed && appTPEnabled ? 1 : 0
+        return showAppTPHomeViewHeader ? 1 : 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1204714559936174/f
Tech Design URL:
CC: @SlayterDev 

**Description**:

This PR updates the AppTP home row renderer to only hide the logo if AppTP's banner is visible.

Note that this currently doesn't do a good enough job of toggling the logo when AppTP's status changes, but we can address that in a follow-up PR – it's not critical right now as AppTP is disabled in release builds.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run a clean install of the app, and go through the onboarding flow the point where you get to an empty new tab page
2. Check that the Dax logo is visible
3. Turn on AppTP. To do this, you will need to update the DuckDuckGo app target to include the app extension - see screenshot below. You will also need to put the device in into internal user mode to get AppTP to show up in the settings.
4. Relaunch the app (a relaunch will not be required in the future, this is a separate bug - though I could probably squeeze in a quick fix here if desired.)
5. Check that the Dax logo is not visible

<img width="785" alt="CleanShot 2023-05-30 at 15 39 03@2x" src="https://github.com/duckduckgo/iOS/assets/183774/7669453c-0667-4d5f-8125-80d1c7045510">

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
