### PR TITLE
Update BSK with autofill 7.2.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8190,8 +8190,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 58.1.1;
+				kind = revision;
+				revision = fd86f09bd058d394dfc1c651105930929c1d713c;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204742406448900/1204742406448900
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.2.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/377

## Description
Updates Autofill to version [7.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/7.2.0).

### Autofill 7.2.0 release notes
## What's Changed
* Fix Windows UI line bug by @greyivy in https://github.com/duckduckgo/duckduckgo-autofill/pull/325
* Remove separator above Duck Address whenever it's first item by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/329
* macOS support for in-context signup by @alistairjcbrown in https://github.com/duckduckgo/duckduckgo-autofill/pull/317
* Other minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/328


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/7.1.0...7.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).