### PR TITLE
Fixes a retain cycle and a crasher

### DIFF
--- a/DuckDuckGo/BasicAuthenticationAlert.swift
+++ b/DuckDuckGo/BasicAuthenticationAlert.swift
@@ -24,7 +24,9 @@ class BasicAuthenticationAlert: UIAlertController {
     
     typealias LogInCompletion = (_ userName: String, _ password: String) -> Void
     typealias CancelCompletion = () -> Void
-    
+
+    private var didCallCompletion = false
+    private var cancelCompletion: CancelCompletion!
     var usernameField: UITextField!
     var passwordField: UITextField!
     var logInAction: UIAlertAction!
@@ -39,10 +41,12 @@ class BasicAuthenticationAlert: UIAlertController {
         } else {
             message = UserText.authAlertPlainConnectionMessage.format(arguments: host)
         }
-        
+
         self.init(title: UserText.authAlertTitle, message: message, preferredStyle: .alert)
         overrideUserInterfaceStyle()
-        
+
+        self.cancelCompletion = cancelCompletion
+
         let keyboardAppearance = ThemeManager.shared.currentTheme.keyboardAppearance
         addTextField { textField in
             textField.accessibilityLabel = "Username"
@@ -69,10 +73,17 @@ class BasicAuthenticationAlert: UIAlertController {
         passwordField.addTarget(self, action: #selector(onTextChanged), for: .allEditingEvents)
         
         logInAction = createLogInAction(with: logInCompletion)
-        addAction(title: UserText.actionCancel, style: .cancel) {
+        addAction(title: UserText.actionCancel, style: .cancel) { [weak self] in
+            self?.didCallCompletion = true
             cancelCompletion()
         }
         updateButtons()
+    }
+
+    deinit {
+        if !didCallCompletion {
+            cancelCompletion()
+        }
     }
 
     private func createLogInAction(with completion: @escaping LogInCompletion) -> UIAlertAction {
@@ -81,6 +92,7 @@ class BasicAuthenticationAlert: UIAlertController {
             guard let login = self.usernameField.text else { return }
             guard let password = self.passwordField.text else { return }
 
+            self.didCallCompletion = true
             completion(login, password)
         }
     }

--- a/DuckDuckGo/BasicAuthenticationAlert.swift
+++ b/DuckDuckGo/BasicAuthenticationAlert.swift
@@ -74,12 +74,13 @@ class BasicAuthenticationAlert: UIAlertController {
         }
         updateButtons()
     }
-    
+
     private func createLogInAction(with completion: @escaping LogInCompletion) -> UIAlertAction {
-        return addAction(title: UserText.authAlertLogInButtonTitle, style: .default) {
+        return addAction(title: UserText.authAlertLogInButtonTitle, style: .default) { [weak self] in
+            guard let self else { return }
             guard let login = self.usernameField.text else { return }
             guard let password = self.passwordField.text else { return }
-            
+
             completion(login, password)
         }
     }

--- a/DuckDuckGo/SaveToDownloadsAlert.swift
+++ b/DuckDuckGo/SaveToDownloadsAlert.swift
@@ -28,18 +28,28 @@ struct SaveToDownloadsAlert {
         let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
         let title = SaveToDownloadsAlert.makeTitle(downloadMetadata: downloadMetadata)
         let alert = UIAlertController(title: title, message: nil, preferredStyle: style)
+        var completionCalled = false
         alert.overrideUserInterfaceStyle()
 
         let saveToDownloadsAction = UIAlertAction(title: UserText.actionSaveToDownloads, style: .default) { _ in
             saveToDownloadsHandler()
+            completionCalled = true
         }
         
         let cancelAction = UIAlertAction(title: UserText.actionCancel, style: .cancel) { _ in
             cancelHandler?()
+            completionCalled = true
         }
 
         alert.addAction(saveToDownloadsAction)
         alert.addAction(cancelAction)
+
+        alert.onDeinit {
+            if !completionCalled {
+                cancelHandler?()
+            }
+        }
+
         return alert
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1203075050360157/f

Probably related to: https://github.com/duckduckgo/iOS/pull/1376

## Description:

This PR fixes:
- A retain cycle with auth alerts
- Because auth alerts are now released properly, we also fix a potential crasher that was being hidden by this bug.
- A potential crasher that could trigger when an alert is dismissed without being shown / the user taking action

| XCode-reported Bug | Stack trace from forcing the crash |
| --- | --- |
| <img width="1111" alt="Screenshot 2023-06-05 at 17 05 45" src="https://github.com/duckduckgo/iOS/assets/1836005/24130add-3c9f-4005-aaf1-2fcec83a4961"> | <img width="995" alt="Screenshot 2023-06-05 at 16 13 23" src="https://github.com/duckduckgo/iOS/assets/1836005/4531719a-c71e-4bbf-b5e1-528bfd2e105f"> |

## How to test:

### Help script to request basic auth

Save this to your desktop and run it using terminal to host a basic HTTP server that requests basic auth.  To run execute `python3 ~/Desktop/script.py`

```python
from http.server import BaseHTTPRequestHandler, HTTPServer

class MyHandler(BaseHTTPRequestHandler):
    def do_GET(self):
        self.send_response(401)
        self.send_header('WWW-Authenticate', 'Basic realm="Test"')
        self.end_headers()
        self.wfile.write(b'401 Unauthorized')

def run():
    server_address = ('', 8000)
    httpd = HTTPServer(server_address, MyHandler)
    print('Server running on http://localhost:8000')
    httpd.serve_forever()

if __name__ == '__main__':
    run()

```

### Retain Cycle Fix

#### To reproduce the issue:

1. Check out `develop`
2. Add a `deinit` method to `BasicAuthenticationAlert`, and place a `print()` instruction with a breakpoint on it
3. Run the script provided above in a terminal window in macOS
4. In the iOS browser, open the URL: `https://macos-ip-address:8000`
5. A basic auth alert should come up, dismiss it with either option

Notice that `deinit` is never called.

#### To test the fix:

1. Check out this branch.
2. Repeat the reproduction steps.

Notice that `deinit` is called.

### Auth Alert Crasher Fix

1. Check out `develop`
2. You need to run the auth script again in a terminal window
3. Make sure to include the retain cycle fix above, because in `develop` this alert is not really dismissing ever, and we need it to.
4. Add the following code right before [this line](https://github.com/duckduckgo/iOS/blob/f33110789c0e1eb112c996e9d3f5e96f549ade6b/DuckDuckGo/MainViewController.swift#L1682):

```swift
let myAlert = UIAlertController(title: "Testing", message: "Testing", preferredStyle: .alert)
self.present(myAlert, animated: true)
```

5. Run the app, and load the site hosted in the python script.

The app should crash.

#### To test the fix:

1. Repeat the step above in this branch.

You'll see the app won't crash.

### Download Alert Crasher Fix

#### To reproduce the issue:

1. Check out `develop`
7. Right before [this call](https://github.com/duckduckgo/iOS/blob/f33110789c0e1eb112c996e9d3f5e96f549ade6b/DuckDuckGo/TabViewController.swift#L1762), add the following code:

```swift
let myAlert = UIAlertController(title: "Testing", message: "Testing", preferredStyle: .alert)
self.present(myAlert, animated: true)
```

8. Run the app and go to download a file from a site (search for sample download files)

When you try to start the download the app should crash

#### To test the fix:

1. Repeat the step above in this branch.

You'll see the app won't crash.

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
