### PR TITLE
Fixes the format in a log call

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8194,8 +8194,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 9bcc28ac2983c1d6c6b793ce85d1bc618f859712;
+				kind = exactVersion;
+				version = 59.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8194,8 +8194,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 59.0.0;
+				kind = revision;
+				revision = 9bcc28ac2983c1d6c6b793ce85d1bc618f859712;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "9bcc28ac2983c1d6c6b793ce85d1bc618f859712",
-          "version": null
+          "revision": "a1c93d250ef926172e7f1030ed1c572daf9614c2",
+          "version": "59.0.1"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "97ba4cb21ae879aff65d70888deca31c4e4dfdbd",
-          "version": "59.0.0"
+          "revision": "9bcc28ac2983c1d6c6b793ce85d1bc618f859712",
+          "version": null
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204785816528431/f
BSK: https://github.com/duckduckgo/BrowserServicesKit/pull/379
macOS: https://github.com/duckduckgo/macos-browser/pull/1249

## Description

Fixes a string formatting issue that crashes the app in debug builds, when Bookmarks logging is ON.

## Testing:

### Reproduction steps:
- Check out develop
- Launch the app (debug builds only, with Bookmarks logging enabled, which I think is ON by default on iOS)
- Bookmark a page
- Delete the bookmark
- Kill the app
- Reopen the app

You should see the app crash.

### Test fix:

- Check out this branch
- Repeat the test above

The app should not crash.

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
