### PR TITLE
ensure primary action pixels fire in Mac promo experiment

### DIFF
--- a/DuckDuckGo/HomeMessageView.swift
+++ b/DuckDuckGo/HomeMessageView.swift
@@ -142,10 +142,9 @@ struct HomeMessageView: View {
             let foreground: Color = model.actionStyle == .cancel ? .cancelButtonForeground : .primaryButtonText
             let background: Color = model.actionStyle == .cancel ? .cancelButtonBackground : .button
             Button {
+                model.action()
                 if case .share(let url, let title) = model.actionStyle {
                     activityItem = TitledURLActivityItem(url, title)
-                } else {
-                    model.action()
                 }
             } label: {
                 HStack {

--- a/DuckDuckGo/MacPromoViewController.swift
+++ b/DuckDuckGo/MacPromoViewController.swift
@@ -155,6 +155,7 @@ struct MacPromoView: View {
                     .padding(.bottom, 24)
 
                 Button {
+                    model.controller?.experiment.sheetPrimaryActionClicked()
                     activityItem = model.activityItem
                 } label: {
                     HStack {

--- a/DuckDuckGo/RemoteMessageRequest.swift
+++ b/DuckDuckGo/RemoteMessageRequest.swift
@@ -27,9 +27,7 @@ public struct RemoteMessageRequest {
 
     private var endpoint: URL {
         #if DEBUG
-        #warning("Restore sample before merging")
-        // return URL(string: "https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/main/samples/ios/sample1.json")!
-        return URL(string: "https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/brindy/mac-promo-exp2/live/ios-config/ios-config.json")!
+        return URL(string: "https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/main/samples/ios/sample1.json")!
         #else
         return URL(string: "https://staticcdn.duckduckgo.com/remotemessaging/config/staging/ios-config.json")!
         #endif


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1204632216628999/f
Tech Design URL:
CC:

**Description**:

Fire pixels from primary actions when using share message type.

**Steps to test this PR**:
1. Check the sheet fires the `m_macpromo_primary_action_clicked` pixel
2. Check the message files the `m_remote_message_primary_action_clicked` pixel

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
