### PR TITLE
Fix bug preventing closing most bottom tab on the list mode tab switcher

### DIFF
--- a/DuckDuckGo/TabViewCell.swift
+++ b/DuckDuckGo/TabViewCell.swift
@@ -144,9 +144,15 @@ class TabViewCell: UICollectionViewCell, Themable {
     
     @IBAction func deleteTab() {
         guard let tab = tab else { return }
-        guard collectionReorderRecognizer == nil || collectionReorderRecognizer?.state == .possible else { return }
+        guard isNotReordering(with: collectionReorderRecognizer) else { return }
 
         self.delegate?.deleteTab(tab: tab)
+    }
+
+    private func isNotReordering(with gestureRecognizer: UIGestureRecognizer?) -> Bool {
+        guard let gestureRecognizer = gestureRecognizer else { return true }
+        let inactiveStates: [UIGestureRecognizer.State] = [.possible, .failed, .cancelled, .ended]
+        return inactiveStates.contains(gestureRecognizer.state)
     }
     
     func decorate(with theme: Theme) {}


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/0/414709148257752/1204864937185468/f

**Description**:
Fix bug preventing closing tab that is at the most bottom position on the tab switcher in a list mode. Fix by broadening the list of states when we assume the gesture recognizer to be inactive.


**Steps to test this PR**:
1. Open multiple tabs
2. Open tab switcher
3. Toggle the list mode
4. Tap on the "x" button on the very last tab on the list.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
