### PR TITLE
Fix for Logins search bar animation glitch when accessed from Settings

### DIFF
--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -112,6 +112,7 @@ final class AutofillLoginSettingsListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = UserText.autofillLoginListTitle
+        extendedLayoutIncludesOpaqueBars = true
         setupCancellables()
         installSubviews()
         installConstraints()
@@ -325,9 +326,14 @@ final class AutofillLoginSettingsListViewController: UIViewController {
             navigationItem.rightBarButtonItems = [addBarButtonItem]
             addBarButtonItem.isEnabled = false
         case .authLocked:
-            navigationItem.rightBarButtonItems = [editButtonItem, addBarButtonItem]
-            addBarButtonItem.isEnabled = false
-            editButtonItem.isEnabled = false
+            if viewModel.hasAccountsSaved {
+                navigationItem.rightBarButtonItems = [editButtonItem, addBarButtonItem]
+                addBarButtonItem.isEnabled = false
+                editButtonItem.isEnabled = false
+            } else {
+                navigationItem.rightBarButtonItems = [addBarButtonItem]
+                addBarButtonItem.isEnabled = false
+            }
         case .empty:
             navigationItem.rightBarButtonItems = [addBarButtonItem]
             addBarButtonItem.isEnabled = true
@@ -346,7 +352,9 @@ final class AutofillLoginSettingsListViewController: UIViewController {
             }
         case .searching, .searchingNoResults:
             navigationItem.searchController = searchController
-        case .empty, .authLocked, .noAuthAvailable:
+        case .authLocked:
+            navigationItem.searchController = viewModel.authenticationNotRequired && viewModel.hasAccountsSaved ? searchController : nil
+        case .empty, .noAuthAvailable:
             navigationItem.searchController = nil
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1204694963467802/f
Tech Design URL:
CC:

**Description**:
Fix for search bar animation glitch when accessing the Logins screen from Settings when recently authenticated 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Add a login and access the Logins screen from Settings performing device authentication (biometric / pin code). Confirm the search bar displays without any animation glitch (where the search bar first appears over the enable Autofill cell)
2. Back out to the Settings screen and tap back into the Logins screen; confirm the search bar presentation animation is like the 'After' gif below
3. Smoke test accessing various login screen states from Settings e.g. no logins, multiple logins, search, search with no results and confirm nothing else has changed
4. Repeat smoke test accessing the Logins screen from the browsing menu

Before:
![Before](https://github.com/duckduckgo/iOS/assets/91189922/cea63e82-f11f-40e4-8905-c8acc7cce065)

After:
![After](https://github.com/duckduckgo/iOS/assets/91189922/8ec0062c-d82b-4f08-87ca-0ab0a5255dcb)


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
