### PR TITLE
Show QRCode when state is not inactive, ie enabled.

### DIFF
--- a/DuckDuckGo/Suggestion.swift
+++ b/DuckDuckGo/Suggestion.swift
@@ -31,11 +31,6 @@ struct Suggestion {
     let suggestion: String
     let url: URL?
     
-    init(source: Source, suggestion: String, url: URL?) {
-        self.source = source
-        self.suggestion = suggestion
-        self.url = url
-    }
 }
 
 struct AutocompleteEntry: Decodable {

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -63,11 +63,13 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] authState in
                 self?.rootView.model.isSyncEnabled = authState != .inactive
+                guard authState != .inactive, let recoveryCode = self?.recoveryCode else { return }
+                self?.rootView.model.syncEnabled(recoveryCode: recoveryCode)
             }
             .store(in: &cancellables)
 
         rootView.model.delegate = self
-        navigationItem.title = "Sync" // TODO externalise
+        navigationItem.title = UserText.syncTitle
     }
 
     override func viewDidLoad() {

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -49,22 +49,17 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
 
     var cancellables = Set<AnyCancellable>()
 
+    // For some reason, on iOS 14, the viewDidLoad wasn't getting called so do some setup here
     convenience init() {
         self.init(rootView: SyncSettingsView(model: SyncSettingsViewModel()))
 
-        // For some reason, on iOS 14, the viewDidLoad wasn't getting called so do some setup here
-        if syncService.authState == .active {
-            rootView.model.syncEnabled(recoveryCode: recoveryCode)
-            refreshDevices()
-        }
+        refreshForState(syncService.authState)
 
         syncService.authStatePublisher
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] authState in
-                self?.rootView.model.isSyncEnabled = authState != .inactive
-                guard authState != .inactive, let recoveryCode = self?.recoveryCode else { return }
-                self?.rootView.model.syncEnabled(recoveryCode: recoveryCode)
+                self?.refreshForState(authState)
             }
             .store(in: &cancellables)
 
@@ -80,6 +75,14 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         connector = nil
+    }
+
+    func refreshForState(_ authState: SyncAuthState) {
+        rootView.model.isSyncEnabled = authState != .inactive
+        if authState != .inactive {
+            rootView.model.syncEnabled(recoveryCode: recoveryCode)
+            refreshDevices()
+        }
     }
 
     func dismissPresentedViewController() {

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -679,6 +679,7 @@ In addition to the details entered into this form, your app issue report will co
     }
     public static let syncRemoveDeviceConfirmAction = "Remove"
     public static let syncCodeCopied = "Recovery Code copied"
+    public static let syncTitle = "Sync"
 
     // Autofill Password Generation Prompt
     public static let autofillPasswordGenerationPromptTitle = NSLocalizedString("autofill.password-generation-prompt.title", value:"Use generated password from DuckDuckGo?", comment: "Title for prompt to use suggested strong password for creating a login")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1204908735628471/f
Tech Design URL:
CC:

**Description**:

Show QRCode when state is not inactive, ie enabled.

**Steps to test this PR**:
1. Turn on Sync
2. Exit Settings
3. Enter Settings > Sync
4. A working QR Code should be visible

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
