### PR TITLE
Hide Browsing menu when preparing animations to avoid UI glitches

### DIFF
--- a/DuckDuckGo/BrowsingMenu/BrowsingMenuAnimator.swift
+++ b/DuckDuckGo/BrowsingMenu/BrowsingMenuAnimator.swift
@@ -51,15 +51,21 @@ final class BrowsingMenuAnimator: NSObject, UIViewControllerAnimatedTransitionin
 
     func animatePresentation(from fromViewController: MainViewController, to toViewController: BrowsingMenuViewController, with transitionContext: UIViewControllerContextTransitioning) {
 
+        let fromSnapshot = fromViewController.view.snapshotView(afterScreenUpdates: false)
+
         toViewController.view.frame = transitionContext.containerView.bounds
         toViewController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         transitionContext.containerView.addSubview(toViewController.view)
+
+        if let fromSnapshot {
+            transitionContext.containerView.addSubview(fromSnapshot)
+        }
 
         toViewController.bindConstraints(to: fromViewController.currentTab?.webView)
         toViewController.view.layoutIfNeeded()
 
         let snapshot = toViewController.menuView.snapshotView(afterScreenUpdates: true)
-        if let snapshot = snapshot {
+        if let snapshot {
             snapshot.frame = Self.menuOriginFrameForAnimation(for: toViewController)
             snapshot.alpha = 0
             toViewController.menuView.superview?.addSubview(snapshot)
@@ -70,6 +76,7 @@ final class BrowsingMenuAnimator: NSObject, UIViewControllerAnimatedTransitionin
         toViewController.menuView.isHidden = true
 
         UIView.animate(withDuration: Constants.appearAnimationDuration, delay: 0, options: .curveEaseOut) {
+            fromSnapshot?.removeFromSuperview()
             snapshot?.frame = toViewController.menuView.frame
             snapshot?.alpha = 1
         } completion: { _ in


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1203462254653694/f
Tech Design URL:
CC:

**Description**:

Ensure Browsing menu won't be presented when it is being prepared for animation by temporarily hiding it behind current MainView snapshot.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Smoke tests of Browsing Menu on actual device. 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
