### PR TITLE
More lightweight logic for consecutive numbering of downloads with same filename

### DIFF
--- a/DuckDuckGo/DownloadManager.swift
+++ b/DuckDuckGo/DownloadManager.swift
@@ -171,7 +171,7 @@ class DownloadManager {
 
 extension DownloadManager {
     
-    private func convertToUniqueFilename(_ filename: String, counter: Int = 0) -> String {
+    private func convertToUniqueFilename(_ filename: String) -> String {
         let downloadingFilenames = Set(downloadList.map { $0.filename })
         let downloadedFilenames = Set(downloadsDirectoryFiles.map { $0.lastPathComponent })
         let list = downloadingFilenames.union(downloadedFilenames)
@@ -181,14 +181,15 @@ extension DownloadManager {
         
         let filePrefix = filename.dropping(suffix: fileExtension)
 
-        let newFilename = counter > 0 ? "\(filePrefix) \(counter)\(fileExtension)" : filename
-        
-        if list.contains(newFilename) {
-            let newSuffix = counter + 1
-            return convertToUniqueFilename(filename, counter: newSuffix)
-        } else {
-            return newFilename
-        }
+        var counter: Int = 0
+        var newFilename: String
+
+        repeat {
+            newFilename = counter > 0 ? "\(filePrefix) \(counter)\(fileExtension)" : filename
+            counter += 1
+        } while list.contains(newFilename)
+
+        return newFilename
     }
     
     private func filename(forSuggestedFilename suggestedFilename: String?, mimeType: String?) -> String {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1202604718284331/f

**Description**:
More lightweight logic for consecutive numbering of downloads with same filename. Earlier implementation used recurrent calls and had overhead that each call was using FileManager to get the downloads folder contents.

**Steps to test this PR**:
1. Try downloading the same file multiple times. Each following download should be appended with a consecutive number
2. Navigate to the downloads folder (with Folders app) and delete random numbered downloads.
3. Try downloading the same file multiple times again, the new downloads should fill the miss spots. 
4. Ensure the tests are passing

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
