### PR TITLE
NetP invite code screen PR 1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -725,6 +725,9 @@
 		EA39B7E2268A1A35000C62CD /* privacy-reference-tests in Resources */ = {isa = PBXBuildFile; fileRef = EA39B7E1268A1A35000C62CD /* privacy-reference-tests */; };
 		EAB19EDA268963510015D3EA /* DomainMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */; };
 		EE0153E12A6EABE0002A8B26 /* NetworkProtectionConvenienceInitialisers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153E02A6EABE0002A8B26 /* NetworkProtectionConvenienceInitialisers.swift */; };
+		EE0153E62A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153E52A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift */; };
+		EE0153EB2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153EA2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift */; };
+		EE0153ED2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153EC2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift */; };
 		EE3B226B29DE0F110082298A /* MockInternalUserStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */; };
 		EE3B226C29DE0FD30082298A /* MockInternalUserStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */; };
 		EE4FB1862A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4FB1852A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift */; };
@@ -2281,6 +2284,9 @@
 		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "privacy-reference-tests"; path = "submodules/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
 		EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainMatchingTests.swift; sourceTree = "<group>"; };
 		EE0153E02A6EABE0002A8B26 /* NetworkProtectionConvenienceInitialisers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionConvenienceInitialisers.swift; sourceTree = "<group>"; };
+		EE0153E52A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionRootViewModel.swift; sourceTree = "<group>"; };
+		EE0153EA2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionRootViewModelTests.swift; sourceTree = "<group>"; };
+		EE0153EC2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionRootView.swift; sourceTree = "<group>"; };
 		EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalUserStoring.swift; sourceTree = "<group>"; };
 		EE4FB1852A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusView.swift; sourceTree = "<group>"; };
 		EE4FB1872A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewModel.swift; sourceTree = "<group>"; };
@@ -4228,6 +4234,15 @@
 			name = Helpers;
 			sourceTree = "<group>";
 		};
+		EE0153E22A6FE031002A8B26 /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				EE0153E52A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift */,
+				EE0153EC2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift */,
+			);
+			name = Root;
+			sourceTree = "<group>";
+		};
 		EE3B226929DE0EE10082298A /* FeatureFlags */ = {
 			isa = PBXGroup;
 			children = (
@@ -4250,6 +4265,7 @@
 			children = (
 				EEFE9C722A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift */,
 				EEFE9C742A603DAD005B0A26 /* MockNetworkProtectionTunnelControlling.swift */,
+				EE0153EA2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift */,
 			);
 			name = NetworkProtection;
 			sourceTree = "<group>";
@@ -4257,6 +4273,7 @@
 		EECD94B22A28B8580085C66E /* NetworkProtection */ = {
 			isa = PBXGroup;
 			children = (
+				EE0153E22A6FE031002A8B26 /* Root */,
 				EE0153DF2A6EABAF002A8B26 /* Helpers */,
 				EEFD562D2A65B68B00DAEC48 /* Invite */,
 				EECD94B32A28B96C0085C66E /* Status */,
@@ -6011,6 +6028,7 @@
 				F4C9FBF528340DDA002281CC /* AutofillInterfaceEmailTruncator.swift in Sources */,
 				1E016AB42949FEB500F21625 /* OmniBarNotificationViewModel.swift in Sources */,
 				6AC6DAB328804F97002723C0 /* BarsAnimator.swift in Sources */,
+				EE0153ED2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift in Sources */,
 				B60DFF072872B64B0061E7C2 /* JSAlertController.swift in Sources */,
 				981FED6E22025151008488D7 /* BlankSnapshotViewController.swift in Sources */,
 				98F3A1DC217B373E0011A0D4 /* DarkTheme.swift in Sources */,
@@ -6168,6 +6186,7 @@
 				020108AE29A7F91600644F9D /* AppTPTrackerCell.swift in Sources */,
 				983D71B12A286E810072E26D /* SyncDebugViewController.swift in Sources */,
 				F103073B1E7C91330059FEC7 /* BookmarksDataSource.swift in Sources */,
+				EE0153E62A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift in Sources */,
 				85864FBC24D31EF300E756FF /* SuggestionTrayViewController.swift in Sources */,
 				1EF24235273BB9D200DE3D02 /* IntervalSlider.swift in Sources */,
 				027F48782A4B663C001A1C6C /* AppTPFAQView.swift in Sources */,
@@ -6350,6 +6369,7 @@
 				C14882E427F20D9A00D59F0C /* BookmarksImporterTests.swift in Sources */,
 				8588026A24E424EE00C24AB6 /* AppWidthObserverTests.swift in Sources */,
 				8588026624E420BD00C24AB6 /* LargeOmniBarStateTests.swift in Sources */,
+				EE0153EB2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -728,6 +728,7 @@
 		EE0153E62A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153E52A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift */; };
 		EE0153EB2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153EA2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift */; };
 		EE0153ED2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153EC2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift */; };
+		EE0153EF2A70021E002A8B26 /* NetworkProtectionInviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153EE2A70021E002A8B26 /* NetworkProtectionInviteView.swift */; };
 		EE3B226B29DE0F110082298A /* MockInternalUserStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */; };
 		EE3B226C29DE0FD30082298A /* MockInternalUserStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */; };
 		EE4FB1862A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4FB1852A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift */; };
@@ -2287,6 +2288,7 @@
 		EE0153E52A6FE106002A8B26 /* NetworkProtectionRootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionRootViewModel.swift; sourceTree = "<group>"; };
 		EE0153EA2A6FF970002A8B26 /* NetworkProtectionRootViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionRootViewModelTests.swift; sourceTree = "<group>"; };
 		EE0153EC2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionRootView.swift; sourceTree = "<group>"; };
+		EE0153EE2A70021E002A8B26 /* NetworkProtectionInviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionInviteView.swift; sourceTree = "<group>"; };
 		EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalUserStoring.swift; sourceTree = "<group>"; };
 		EE4FB1852A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusView.swift; sourceTree = "<group>"; };
 		EE4FB1872A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewModel.swift; sourceTree = "<group>"; };
@@ -4295,6 +4297,7 @@
 			isa = PBXGroup;
 			children = (
 				EEFD562E2A65B6CA00DAEC48 /* NetworkProtectionInviteViewModel.swift */,
+				EE0153EE2A70021E002A8B26 /* NetworkProtectionInviteView.swift */,
 			);
 			name = Invite;
 			sourceTree = "<group>";
@@ -6054,6 +6057,7 @@
 				31C70B5528045E3500FB6AD1 /* SecureVaultErrorReporter.swift in Sources */,
 				F4CE6D1B257EA33C00D0A6AA /* FireButtonAnimator.swift in Sources */,
 				85582E0029D7409700E9AE35 /* SyncSettingsViewController+PDFRendering.swift in Sources */,
+				EE0153EF2A70021E002A8B26 /* NetworkProtectionInviteView.swift in Sources */,
 				9888F77B2224980500C46159 /* FeedbackViewController.swift in Sources */,
 				982686AD2600C0850011A8D6 /* ActionMessageView.swift in Sources */,
 				F446B9B5251150AC00324016 /* HomeMessageViewSectionRenderer.swift in Sources */,

--- a/DuckDuckGo/NetworkProtectionConvenienceInitialisers.swift
+++ b/DuckDuckGo/NetworkProtectionConvenienceInitialisers.swift
@@ -29,4 +29,11 @@ extension ConnectionStatusObserverThroughSession {
     }
 }
 
+extension NetworkProtectionKeychainTokenStore {
+    convenience init() {
+        // Error events to be added as part of https://app.asana.com/0/1203137811378537/1205112639044115/f
+        self.init(useSystemKeychain: false, errorEvents: nil)
+    }
+}
+
 #endif

--- a/DuckDuckGo/NetworkProtectionInviteView.swift
+++ b/DuckDuckGo/NetworkProtectionInviteView.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkProtectionRootView.swift
+//  NetworkProtectionInviteView.swift
 //  DuckDuckGo
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
@@ -17,29 +17,20 @@
 //  limitations under the License.
 //
 
-#if NETWORK_PROTECTION
-
 import SwiftUI
+import DesignResourcesKit
+import DuckUI
 
-struct NetworkProtectionRootView: View {
-    let model = NetworkProtectionRootViewModel()
+struct NetworkProtectionInviteView: View {
+    @ObservedObject var model: NetworkProtectionInviteViewModel
 
     var body: some View {
-        switch model.initialViewKind {
-        case .invite:
-            NetworkProtectionInviteView(model: NetworkProtectionInviteViewModel())
-        case .status:
-            NetworkProtectionStatusView(
-                statusModel: NetworkProtectionStatusViewModel(), inviteModel: NetworkProtectionInviteViewModel()
-            )
-        }
+        Text("Coming soon")
     }
 }
 
-struct NetworkProtectionRootView_Previews: PreviewProvider {
+struct NetworkProtectionInviteView_Previews: PreviewProvider {
     static var previews: some View {
-        NetworkProtectionRootView()
+        NetworkProtectionInviteView(model: NetworkProtectionInviteViewModel())
     }
 }
-
-#endif

--- a/DuckDuckGo/NetworkProtectionRootView.swift
+++ b/DuckDuckGo/NetworkProtectionRootView.swift
@@ -1,0 +1,45 @@
+//
+//  NetworkProtectionRootView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if NETWORK_PROTECTION
+
+import SwiftUI
+
+struct NetworkProtectionRootView: View {
+    let model = NetworkProtectionRootViewModel()
+
+    var body: some View {
+        switch model.initialViewKind {
+        case .invite:
+            Text("TODO")
+        case .status:
+            NetworkProtectionStatusView(
+                statusModel: NetworkProtectionStatusViewModel(), inviteModel: NetworkProtectionInviteViewModel()
+            )
+        }
+    }
+}
+
+struct NetworkProtectionRootView_Previews: PreviewProvider {
+    static var previews: some View {
+        NetworkProtectionRootView()
+    }
+}
+
+#endif

--- a/DuckDuckGo/NetworkProtectionRootViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionRootViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  NetworkProtectionRootViewModel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if NETWORK_PROTECTION
+
+import Foundation
+import NetworkProtection
+
+enum NetworkProtectionInitialViewKind {
+    case invite
+    case status
+}
+
+final class NetworkProtectionRootViewModel: ObservableObject {
+    var initialViewKind: NetworkProtectionInitialViewKind
+
+    init(featureVisibility: NetworkProtectionFeatureVisibility = NetworkProtectionKeychainTokenStore()) {
+        initialViewKind = featureVisibility.isFeatureActivated ? .status : .invite
+    }
+}
+
+#endif

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -457,12 +457,11 @@ class SettingsViewController: UITableViewController {
 
 #if NETWORK_PROTECTION
     private func showNetP() {
-        let statusView = NetworkProtectionStatusView(
-            statusModel: NetworkProtectionStatusViewModel(),
-            inviteModel: NetworkProtectionInviteViewModel()
-        )
+        let statusView = NetworkProtectionRootView()
+        let hostingController = UIHostingController(rootView: statusView)
+        hostingController.view.backgroundColor = UIColor(Color(designSystemColor: .background))
         navigationController?.pushViewController(
-            UIHostingController(rootView: statusView),
+            hostingController,
             animated: true
         )
     }

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1264,6 +1264,19 @@ https://duckduckgo.com/mac";
 /* Title for the Network Protection feature */
 "netP.title" = "Network Protection";
 
+/* Message for the network protection invite dialog */
+"network.protection.invite.dialog.message" = "Enter your invite code to get started.";
+
+/* Title for the network protection invite screen */
+"network.protection.invite.dialog.title" = "You're invited to try Network Protection";
+
+/* Prompt for the network protection invite code text field */
+"network.protection.invite.field.prompt" = "Invite Code";
+
+/* Message for the network protection invite success view
+   Title for the network protection invite success view */
+"network.protection.invite.success.title" = "Success! You’re in.";
+
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";
 

--- a/DuckDuckGoTests/NetworkProtectionRootViewModelTests.swift
+++ b/DuckDuckGoTests/NetworkProtectionRootViewModelTests.swift
@@ -1,0 +1,44 @@
+//
+//  NetworkProtectionRootViewModelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import DuckDuckGo
+import NetworkProtection
+
+final class NetworkProtectionRootViewModelTests: XCTestCase {
+
+    func test_initialViewKind_featureVisibilityFalse_isInvite() {
+        let featureVisibility = MockNetworkProtectionFeatureVisibility()
+        featureVisibility.isFeatureActivated = false
+        let viewModel = NetworkProtectionRootViewModel(featureVisibility: featureVisibility)
+        XCTAssertEqual(viewModel.initialViewKind, .invite)
+    }
+
+    func test_initialViewKind_featureVisibilityTrue_isStatus() {
+        let featureVisibility = MockNetworkProtectionFeatureVisibility()
+        featureVisibility.isFeatureActivated = true
+        let viewModel = NetworkProtectionRootViewModel(featureVisibility: featureVisibility)
+        XCTAssertEqual(viewModel.initialViewKind, .status)
+    }
+}
+
+final class MockNetworkProtectionFeatureVisibility: NetworkProtectionFeatureVisibility {
+    var isFeatureActivated: Bool = false
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205084446087083/f
Tech Design URL:
CC:

**Description**:

First PR for the NetP Invite Code flow. You can find designs in the linked task above. This first PR is just to add a root view which will choose between either the (initially empty) Invite or the Status View.

**Steps to test this PR**:
1. Check out this branch
2. Go to Build Phases and in Embed App Extensions, add the PacketTunnelProvider
3. Run on a real device
4. Ensure you’re authenticated as internal
5. Navigate to the Settings
6. Select **Network Protection**
7. If you’ve already enabled it, tap the button to clear the invite code then navigate back and select the NetP item again
8. You should see an empty screen (actual implementation to come in #1883  )

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [x] iOS 14
* [ ] iOS 15
* [x] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
