### PR TITLE
Specify iOS version as an argument to the `xcodebuild` run

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild \
           -scheme "DuckDuckGo" \
-          -destination "platform=iOS Simulator,name=iPhone 14" \
+          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
           -derivedDataPath "DerivedData"
 
     - name: Setup tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild test \
           -scheme "AtbUITests" \
-          -destination "platform=iOS Simulator,name=iPhone 14" \
+          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
           -derivedDataPath "DerivedData" \
           | xcbeautify --report junit --report-path . --junit-report-filename unittests.xml
 
@@ -74,7 +74,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild test \
           -scheme "FingerprintingUITests" \
-          -destination "platform=iOS Simulator,name=iPhone 14" \
+          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
           -derivedDataPath "DerivedData" \
           | xcbeautify --report junit --report-path . --junit-report-filename unittests.xml
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on: 
   push:
-    branches: [ develop, "release/**", "michal/ci-failure-logs" ]
+    branches: [ develop, "release/**" ]
   pull_request:
     branches: [ develop, "release/**" ]
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,3 +90,9 @@ jobs:
       with:
         report_paths: unittests.xml
 
+    - name: Upload failed test log
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        path: DerivedData/Logs/Test/Test-DuckDuckGo-*.xcresult
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild test \
           -scheme "DuckDuckGo" \
-          -destination "platform=iOS Simulator,name=iPhone 14" \
+          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
           -derivedDataPath "DerivedData" \
           DDG_SLOW_COMPILE_CHECK_THRESHOLD=250 \
           | xcbeautify --report junit --report-path . --junit-report-filename unittests.xml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,9 +90,3 @@ jobs:
       with:
         report_paths: unittests.xml
 
-    - name: Upload failed test log
-      uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        path: DerivedData/Logs/Test/Test-DuckDuckGo-*.xcresult
-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on: 
   push:
-    branches: [ develop, "release/**" ]
+    branches: [ develop, "release/**", "michal/ci-failure-logs" ]
   pull_request:
     branches: [ develop, "release/**" ]
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205194825986261/f

**Description**:
GitHub updated the macOS 13 runner that defaults to iOS 17 beta simulators for Xcode 14.3.1 CI jobs when no version is explicitly provided. This results in slow build and unstable tests.
As a workaround we can specify an iOS version as an argument to the `xcodebuild`.

**Steps to test this PR**:
1. Make sure that the tests on CI succeed


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
