### PR TITLE
iOS InContext Email Protection promotion config updates

### DIFF
--- a/Core/ContentBlocking.swift
+++ b/Core/ContentBlocking.swift
@@ -37,13 +37,15 @@ public final class ContentBlocking {
 
     private init(privacyConfigurationManager: PrivacyConfigurationManaging? = nil) {
         let internalUserDecider = DefaultInternalUserDecider(store: InternalUserStore())
+        let statisticsStore = StatisticsUserDefaults()
         let privacyConfigurationManager = privacyConfigurationManager
             ?? PrivacyConfigurationManager(fetchedETag: UserDefaultsETagStorage().loadEtag(for: .privacyConfiguration),
                                            fetchedData: FileStore().loadAsData(for: .privacyConfiguration),
                                            embeddedDataProvider: AppPrivacyConfigurationDataProvider(),
                                            localProtection: DomainsProtectionUserDefaultsStore(),
                                            errorReporting: Self.debugEvents,
-                                           internalUserDecider: internalUserDecider)
+                                           internalUserDecider: internalUserDecider,
+                                           installDate: statisticsStore.installDate)
         self.privacyConfigurationManager = privacyConfigurationManager
 
         trackerDataManager = TrackerDataManager(etag: UserDefaultsETagStorage().loadEtag(for: .trackerDataSet),

--- a/Core/LocaleExtension.swift
+++ b/Core/LocaleExtension.swift
@@ -27,4 +27,8 @@ extension Locale {
          "MC", "MD", "ME", "MK", "MT", "NL", "NO", "PL", "PT", "RO", "RS", "RU", "SE", "SI", "SK",
          "SM", "TR", "UA", "GB", "VA"].contains(regionCode)
     }
+
+    public var isEnglishLanguage: Bool {
+        return Locale.preferredLanguages.first?.starts(with: "en") ?? false
+    }
 }

--- a/Core/LocaleExtension.swift
+++ b/Core/LocaleExtension.swift
@@ -29,6 +29,6 @@ extension Locale {
     }
 
     public var isEnglishLanguage: Bool {
-        return Locale.preferredLanguages.first?.starts(with: "en") ?? false
+        return Locale.preferredLanguages.first?.lowercased().starts(with: "en") ?? false
     }
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8412,7 +8412,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = ed6a0d0841eccfe6f2b5215075dcc8044ab973d7;
+				revision = a852f62d61f45d21ba83bbef8de9618559604a52;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "ed6a0d0841eccfe6f2b5215075dcc8044ab973d7",
+          "revision": "a852f62d61f45d21ba83bbef8de9618559604a52",
           "version": null
         }
       },

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -28,7 +28,7 @@ extension ContentScopeFeatureToggles {
     static var supportedFeaturesOniOS: ContentScopeFeatureToggles {
         let isAutofillEnabledInSettings = AutofillSettingStatus.isAutofillEnabledInSettings
         return ContentScopeFeatureToggles(emailProtection: true,
-                                   emailProtectionIncontextSignup: true,
+                                   emailProtectionIncontextSignup: featureFlagger.isFeatureOn(.incontextSignup) && Locale.current.isEnglishLanguage,
                                    credentialsAutofill: featureFlagger.isFeatureOn(.autofillCredentialInjecting) && isAutofillEnabledInSettings,
                                    identitiesAutofill: false,
                                    creditCardsAutofill: false,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1204936655327681/f
Tech Design URL:
CC:

**Description**:
Adds installedDays to privacy config to remotely control how many days since install that the iOS incontext email protection feature will be visible to users (currently set to less than 21 days). Also adds language restriction to limit feature to english speaking users

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Clean install app with device preferred language set to default English
2. Visit https://fill.dev/form/registration-email and confirm the grey dax icon is not present
3. In the app got to `Settings > Debug > Configuration Refresh Info` and tap both `Reset Etags` and `Reset Last Refresh Date`
4. In `AppURLs.swift` replace `privacyConfig` url with this: https://gist.githubusercontent.com/amddg44/51811d94ff3d30a229212635f6d7ae44/raw/f5f37195479feb9541cb634c2840cfb06512d378/incontext-config.json
5. Relaunch app & wait a few seconds for new config to download & save
6. Relaunch again so the updated config can be applied to ContentScopeFeatureToggles. Confirm the grey dax icon is now present
7. Change preferred language to any non english e.g. `French`
8. Go back to app and confirm the grey dax icon is not present
9. Change preferred language to another variation of english e.g. `English (UK)`
10. Go back to app and confirm the grey dax icon is present again
11. Go to `StatisticsUserDefaults.swift` and change `installDate` getter to return `Date(timeIntervalSinceNow: -(22 * 24 * 60 * 60))` (22 days ago)
12. Relaunch the app and confirm the grey dax icon is not present

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
