### PR TITLE
iOS InContext Email Protection pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -428,6 +428,15 @@ extension Pixel {
         case syncBookmarksFailed
 
         case invalidPayload(Configuration)
+
+        case emailIncontextPromptDisplayed
+        case emailIncontextPromptConfirmed
+        case emailIncontextPromptDismissed
+        case emailIncontextPromptDismissedPersistent
+        case emailIncontextModalDisplayed
+        case emailIncontextModalDismissed
+        case emailIncontextModalExitEarly
+        case emailIncontextModalExitEarlyContinue
     }
     
 }
@@ -845,6 +854,16 @@ extension Pixel.Event {
         case .syncBookmarksFailed: return "m_d_sync_bookmarks_failed"
 
         case .invalidPayload(let configuration): return "m_d_\(configuration.rawValue)_invalid_payload".lowercased()
+
+        // MARK: - InContext Email Protection
+        case .emailIncontextPromptDisplayed: return "m_email_incontext_prompt_displayed"
+        case .emailIncontextPromptConfirmed: return "m_email_incontext_prompt_confirmed"
+        case .emailIncontextPromptDismissed: return "m_email_incontext_prompt_dismissed"
+        case .emailIncontextPromptDismissedPersistent: return "m_email_incontext_prompt_dismissed_persisted"
+        case .emailIncontextModalDisplayed: return "m_email_incontext_modal_displayed"
+        case .emailIncontextModalDismissed: return "m_email_incontext_modal_dismissed"
+        case .emailIncontextModalExitEarly: return "m_email_incontext_modal_exit_early"
+        case .emailIncontextModalExitEarlyContinue: return "m_email_incontext_modal_exit_early_continue"
         }
         
     }

--- a/DuckDuckGo/EmailSignupPromptViewController.swift
+++ b/DuckDuckGo/EmailSignupPromptViewController.swift
@@ -19,6 +19,7 @@
 
 import UIKit
 import SwiftUI
+import Core
 
 class EmailSignupPromptViewController: UIViewController {
 
@@ -55,6 +56,8 @@ class EmailSignupPromptViewController: UIViewController {
         self.view.backgroundColor = UIColor(designSystemColor: .surface)
 
         setupEmailSignupPromptView()
+
+        Pixel.fire(pixel: .emailIncontextPromptDisplayed)
     }
 
     private func setupEmailSignupPromptView() {
@@ -73,7 +76,7 @@ class EmailSignupPromptViewController: UIViewController {
 
 extension EmailSignupPromptViewController: UISheetPresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        // TODO - pixel
+        Pixel.fire(pixel: .emailIncontextPromptDismissed)
 
         completion(false)
     }
@@ -82,19 +85,23 @@ extension EmailSignupPromptViewController: UISheetPresentationControllerDelegate
 extension EmailSignupPromptViewController: EmailSignupPromptViewModelDelegate {
 
     func emailSignupPromptViewModelDidSelect(_ viewModel: EmailSignupPromptViewModel) {
+        Pixel.fire(pixel: .emailIncontextPromptConfirmed)
+
         dismiss(animated: true)
         completion(true)
     }
 
     func emailSignupPromptViewModelDidReject(_ viewModel: EmailSignupPromptViewModel) {
-
         inContextEmailSignupPromptDismissedPermanentlyAt = Date().timeIntervalSince1970
+        Pixel.fire(pixel: .emailIncontextPromptDismissedPersistent)
 
         completion(false)
         dismiss(animated: true)
     }
 
     func emailSignupPromptViewModelDidClose(_ viewModel: EmailSignupPromptViewModel) {
+        Pixel.fire(pixel: .emailIncontextPromptDismissed)
+
         completion(false)
         dismiss(animated: true)
     }

--- a/DuckDuckGo/EmailSignupViewController.swift
+++ b/DuckDuckGo/EmailSignupViewController.swift
@@ -143,6 +143,8 @@ class EmailSignupViewController: UIViewController {
 
         isModalInPresentation = true
         navigationController?.presentationController?.delegate = self
+
+        Pixel.fire(pixel: .emailIncontextModalDisplayed)
     }
 
 
@@ -229,7 +231,6 @@ class EmailSignupViewController: UIViewController {
     @objc
     private func onDuckDuckGoEmailSignIn(_ notification: Notification) {
         if signupStage != .complete {
-            // TODO - pixel
             completed(true)
         }
     }
@@ -262,7 +263,7 @@ class EmailSignupViewController: UIViewController {
 
     @objc
     private func cancelButtonPressed() {
-        // TODO - pixel
+        Pixel.fire(pixel: .emailIncontextModalDismissed)
         completed(false)
     }
 
@@ -272,7 +273,6 @@ class EmailSignupViewController: UIViewController {
     }
 
     private func emailSignupCompleted() {
-        // TODO - pixel
         completed(true)
     }
 
@@ -300,9 +300,12 @@ extension EmailSignupViewController: UIAdaptivePresentationControllerDelegate {
         if case .emailEntered = signupStage {
             let alert = UIAlertController(title: UserText.emailSignupExitEarlyAlertTitle, message: nil, preferredStyle: .alert)
 
-            let continueAction = UIAlertAction(title: UserText.emailSignupExitEarlyActionContinue, style: .default, handler: nil)
+            let continueAction = UIAlertAction(title: UserText.emailSignupExitEarlyActionContinue, style: .default) { _ in
+                Pixel.fire(pixel: .emailIncontextModalExitEarlyContinue)
+            }
 
             let cancelAction = UIAlertAction(title: UserText.emailSignupExitEarlyActionExit, style: .default) { [weak self] _ in
+                Pixel.fire(pixel: .emailIncontextModalExitEarly)
                 self?.completed(false)
             }
 
@@ -314,6 +317,7 @@ extension EmailSignupViewController: UIAdaptivePresentationControllerDelegate {
         } else if case .complete = signupStage {
             completed(true)
         } else {
+            Pixel.fire(pixel: .emailIncontextModalDismissed)
             completed(false)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1204874198702034/f
Tech Design URL:
CC:

**Description**:
Pixels for new inContext email protection prompt & sign in / up modal

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

### 1. For the signup prompt

<img src="https://github.com/duckduckgo/iOS/assets/91189922/266f76c2-35a0-4c90-a076-cc172fa2868c" width=200>

Confirm the following pixels fire:
1. `m_email_incontext_prompt_displayed` -> when the prompt is presented
2. `m_email_incontext_prompt_dismissed` -> for any dismiss action that is not tapping "Don't Show Again" e.g. tapping 'X' or swiping down on prompt
3. `m_email_incontext_prompt_confirmed` -> when tapping "Protect My Email" 
4. `m_email_incontext_prompt_dismissed_persisted` -> when tapping "Don't Show Again" 

### 2. For the modal sign-in / sign-up

<img src="https://github.com/duckduckgo/iOS/assets/91189922/98c4ca5e-3662-41e4-996c-983e47cdda04" width=200>

Confirm the following pixels fire:
1. `m_email_incontext_modal_displayed` -> when the modal is presented
2. `m_email_incontext_modal_dismissed` -> for any dismiss action before signing in / entering email in sign up. (Note, sign in & sign up pixels are already captured by web app)

### 3. For the modal sign-up exit early alert
<img src="https://github.com/duckduckgo/iOS/assets/91189922/dcea3e90-0f84-42ae-84f9-c646c05fb007" width=200>

Confirm the following pixels fire:

1. `m_email_incontext_modal_exit_early_continue` -> when tapping the "Continue Setup" alert button
2. `m_email_incontext_modal_exit_early` -> when tapping the "Exit Setup" alert button


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
