### PR TITLE
NetP Status View Server Info + Share feedback

### DIFF
--- a/DuckDuckGo/NetworkProtectionConvenienceInitialisers.swift
+++ b/DuckDuckGo/NetworkProtectionConvenienceInitialisers.swift
@@ -30,6 +30,13 @@ extension ConnectionStatusObserverThroughSession {
     }
 }
 
+extension ConnectionServerInfoObserverThroughSession {
+    convenience init() {
+        self.init(platformNotificationCenter: .default,
+                  platformDidWakeNotification: UIApplication.didBecomeActiveNotification)
+    }
+}
+
 extension NetworkProtectionKeychainTokenStore {
     convenience init() {
         // Error events to be added as part of https://app.asana.com/0/1203137811378537/1205112639044115/f

--- a/DuckDuckGo/NetworkProtectionRootView.swift
+++ b/DuckDuckGo/NetworkProtectionRootView.swift
@@ -36,8 +36,7 @@ struct NetworkProtectionRootView: View {
             NetworkProtectionInviteView(model: inviteViewModel)
         case .status:
             NetworkProtectionStatusView(
-                statusModel: NetworkProtectionStatusViewModel(),
-                inviteModel: inviteViewModel
+                statusModel: NetworkProtectionStatusViewModel()
             )
         }
     }

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -610,12 +610,14 @@ In addition to the details entered into this form, your app issue report will co
     public static let netPNavTitle = NSLocalizedString("netP.title", value: "Network Protection", comment: "Title for the Network Protection feature")
     public static let netPCellConnected = NSLocalizedString("netP.cell.connected", value: "Connected", comment: "String indicating NetP is connected when viewed from the settings screen")
     public static let netPCellDisconnected = NSLocalizedString("netP.cell.disconnected", value: "Not connected", comment: "String indicating NetP is disconnected when viewed from the settings screen")
+
     static let netPInviteTitle = NSLocalizedString("network.protection.invite.dialog.title", value: "You're invited to try Network Protection", comment: "Title for the network protection invite screen")
     static let netPInviteMessage = NSLocalizedString("network.protection.invite.dialog.message", value: "Enter your invite code to get started.", comment: "Message for the network protection invite dialog")
     static let netPInviteFieldPrompt = NSLocalizedString("network.protection.invite.field.prompt", value: "Invite Code", comment: "Prompt for the network protection invite code text field")
     static let netPInviteSuccessTitle = NSLocalizedString("network.protection.invite.success.title", value: "Success! You’re in.", comment: "Title for the network protection invite success view")
     static let netPInviteSuccessMessage = NSLocalizedString("network.protection.invite.success.message", value: "Hide your location from websites and conceal your online activity from Internet providers and others on your network.", comment: "Message for the network protection invite success view")
     static let netPInviteOnlyMessage = NSLocalizedString("network.protection.invite.only.message", value: "DuckDuckGo Network Protection is currently invite-only.", comment: "Message explaining that netP is invite only")
+    
     static let netPStatusViewTitle = NSLocalizedString("network.protection.status.view.title", value: "Network Protection", comment: "Title label text for the status view when netP is disconnected")
     static let netPStatusHeaderTitleOff = NSLocalizedString("network.protection.status.header.title.off", value: "Network Protection is Off", comment: "Header title label text for the status view when netP is disconnected")
     static let netPStatusHeaderTitleOn = NSLocalizedString("network.protection.status.header.title.on", value: "Network Protection is On", comment: "Header title label text for the status view when netP is connected")
@@ -627,6 +629,10 @@ In addition to the details entered into this form, your app issue report will co
         let localized = NSLocalizedString("network.protection.status.connected.format", value: "Connected - %@", comment: "The label for when NetP VPN is connected plus the length of time connected as a formatter HH:MM:SS string")
         return String(format: localized, timeLapsedString)
     }
+    static let netPStatusViewLocation = NSLocalizedString("network.protection.status.view.location", value: "Location", comment: "Location label shown in NetworkProtection's status view.")
+    static let netPStatusViewIPAddress = NSLocalizedString("network.protection.status.view.ip.address", value: "IP Address", comment: "IP Address label shown in NetworkProtection's status view.")
+    static let netPStatusViewConnectionDetails = NSLocalizedString("network.protection.status.view.connection.details", value: "Connection Details", comment: "Connection details label shown in NetworkProtection's status view.")
+    static let netPStatusViewShareFeedback = NSLocalizedString("network.protection.status.menu.share.feedback", value: "Share Feedback", comment: "The status view 'Share Feedback' button which is shown inline on the status view after the \(netPInviteOnlyMessage) text")
 
     static let inviteDialogSubmitButton = NSLocalizedString("invite.dialog.submit.button", value: "Submit", comment: "Submit button on an invite dialog")
     static let inviteDialogGetStartedButton = NSLocalizedString("invite.dialog.get.started.button", value: "Get Started", comment: "Get Started button on an invite dialog")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1354,6 +1354,18 @@ https://duckduckgo.com/mac";
 /* Header title label text for the status view when netP is connected */
 "network.protection.status.header.title.on" = "Network Protection is On";
 
+/* The status view 'Share Feedback' button which is shown inline on the status view after the \(netPInviteOnlyMessage) text */
+"network.protection.status.menu.share.feedback" = "Share Feedback";
+
+/* Connection details label shown in NetworkProtection's status view. */
+"network.protection.status.view.connection.details" = "Connection Details";
+
+/* IP Address label shown in NetworkProtection's status view. */
+"network.protection.status.view.ip.address" = "IP Address";
+
+/* Location label shown in NetworkProtection's status view. */
+"network.protection.status.view.location" = "Location";
+
 /* Title label text for the status view when netP is disconnected */
 "network.protection.status.view.title" = "Network Protection";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205084446087078/f

**Description**:
This is the third and final design implementation task in the overarching Network Protection Status View task and covers just the server info / connection details view plus the share feedback link (just because it turned out to be way simpler than anticipated.

**Steps to test the Connection Details View**:
1. (If you haven’t followed the steps in [Network Protection iOS Smoke Tests: Invite Code flow](https://app.asana.com/0/0/1205201898139908) already, do so.)
2. Switch the toggle to activate Network Protection and **check that the Connection Details view matches [the designs](https://www.figma.com/file/zuCBX2UpJpS8CgtcmpU1hf/Network-Protection-for-iOS?type=design&node-id=252-21943&mode=design&t=Z7gEv95kIs3uMn7e-0)** 
4. Finally switch the toggle one more time to **check that the Connection Details hide again**

**Steps to test the Share Feedback link**:
1.  **Check that the ...Invite only... - Share Feedback prompt is still visible and matches the designs**
2. Tap the Share Feedback prompt
3. **Check that it takes you to the Asana form**

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
