### PR TITLE
Improve Sync-related database cleaning logic

### DIFF
--- a/Core/BookmarksCleanupErrorHandling.swift
+++ b/Core/BookmarksCleanupErrorHandling.swift
@@ -26,11 +26,15 @@ public class BookmarksCleanupErrorHandling: EventMapping<BookmarksCleanupError> 
 
     public init() {
         super.init { event, _, _, _ in
-            let domainEvent = Pixel.Event.bookmarksCleanupFailed
-            let processedErrors = CoreDataErrorsParser.parse(error: event.cleanupError as NSError)
-            let params = processedErrors.errorPixelParameters
+            if event.cleanupError is BookmarksCleanupCancelledError {
+                Pixel.fire(pixel: .bookmarksCleanupAttemptedWhileSyncWasEnabled)
+            } else {
+                let domainEvent = Pixel.Event.bookmarksCleanupFailed
+                let processedErrors = CoreDataErrorsParser.parse(error: event.cleanupError as NSError)
+                let params = processedErrors.errorPixelParameters
 
-            Pixel.fire(pixel: domainEvent, error: event.cleanupError, withAdditionalParameters: params)
+                Pixel.fire(pixel: domainEvent, error: event.cleanupError, withAdditionalParameters: params)
+            }
         }
     }
 

--- a/Core/CredentialsCleanupErrorHandling.swift
+++ b/Core/CredentialsCleanupErrorHandling.swift
@@ -26,11 +26,15 @@ public class CredentialsCleanupErrorHandling: EventMapping<CredentialsCleanupErr
 
     public init() {
         super.init { event, _, _, _ in
-            let domainEvent = Pixel.Event.credentialsDatabaseCleanupFailed
-            let processedErrors = CoreDataErrorsParser.parse(error: event.cleanupError as NSError)
-            let params = processedErrors.errorPixelParameters
+            if event.cleanupError is CredentialsCleanupCancelledError {
+                Pixel.fire(pixel: .credentialsCleanupAttemptedWhileSyncWasEnabled)
+            } else {
+                let domainEvent = Pixel.Event.credentialsDatabaseCleanupFailed
+                let processedErrors = CoreDataErrorsParser.parse(error: event.cleanupError as NSError)
+                let params = processedErrors.errorPixelParameters
 
-            Pixel.fire(pixel: domainEvent, error: event.cleanupError, withAdditionalParameters: params)
+                Pixel.fire(pixel: domainEvent, error: event.cleanupError, withAdditionalParameters: params)
+            }
         }
     }
 

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -855,7 +855,7 @@ extension Pixel.Event {
         case .bookmarksCleanupFailed: return "m_d_bookmarks_cleanup_failed"
         case .bookmarksCleanupAttemptedWhileSyncWasEnabled: return "m_d_bookmarks_cleanup_attempted_while_sync_was_enabled"
 
-        case .credentialsDatabaseCleanupFailed: return "m_d_credentials_database_cleanup_failed"
+        case .credentialsDatabaseCleanupFailed: return "m_d_credentials_database_cleanup_failed_2"
         case .credentialsCleanupAttemptedWhileSyncWasEnabled: return "m_d_credentials_cleanup_attempted_while_sync_was_enabled"
 
         case .invalidPayload(let configuration): return "m_d_\(configuration.rawValue)_invalid_payload".lowercased()

--- a/Core/SyncBookmarksAdapter.swift
+++ b/Core/SyncBookmarksAdapter.swift
@@ -45,7 +45,7 @@ public final class SyncBookmarksAdapter {
         }
     }
 
-    public func updateDatabaseCleanupSchedule(shouldEnable: Bool) {
+    public func cleanUpDatabaseAndUpdateSchedule(shouldEnable: Bool) {
         databaseCleaner.cleanUpDatabaseNow()
         if shouldEnable {
             databaseCleaner.scheduleRegularCleaning()

--- a/Core/SyncCredentialsAdapter.swift
+++ b/Core/SyncCredentialsAdapter.swift
@@ -42,7 +42,7 @@ public final class SyncCredentialsAdapter {
         )
     }
 
-    public func updateDatabaseCleanupSchedule(shouldEnable: Bool) {
+    public func cleanUpDatabaseAndUpdateSchedule(shouldEnable: Bool) {
         databaseCleaner.cleanUpDatabaseNow()
         if shouldEnable {
             databaseCleaner.scheduleRegularCleaning()

--- a/Core/SyncCredentialsAdapter.swift
+++ b/Core/SyncCredentialsAdapter.swift
@@ -38,7 +38,7 @@ public final class SyncCredentialsAdapter {
             secureVaultFactory: secureVaultFactory,
             secureVaultErrorReporter: secureVaultErrorReporter,
             errorEvents: CredentialsCleanupErrorHandling(),
-            log: .passwordManager
+            log: .generalLog
         )
     }
 

--- a/Core/SyncDataProviders.swift
+++ b/Core/SyncDataProviders.swift
@@ -47,7 +47,11 @@ public class SyncDataProviders: DataProvidersSource {
         return providers.compactMap { $0 as? DataProviding }
     }
 
-    public func setUpDatabaseCleaners(syncService: DDGSync) {
+    public func setUpDatabaseCleanersIfNeeded(syncService: DDGSync) {
+        guard !isDatabaseCleanersSetUp else {
+            return
+        }
+
         bookmarksAdapter.databaseCleaner.isSyncActive = { [weak syncService] in
             syncService?.authState == .active
         }
@@ -72,6 +76,8 @@ public class SyncDataProviders: DataProvidersSource {
             credentialsAdapter.databaseCleaner.cleanUpDatabaseNow()
             credentialsAdapter.databaseCleaner.scheduleRegularCleaning()
         }
+
+        isDatabaseCleanersSetUp = true
     }
 
     public init(
@@ -108,6 +114,7 @@ public class SyncDataProviders: DataProvidersSource {
     }
 
     private var isSyncMetadaDatabaseLoaded: Bool = false
+    private var isDatabaseCleanersSetUp: Bool = false
     private var syncMetadata: SyncMetadataStore?
     private var syncAuthStateDidChangeCancellable: AnyCancellable?
 

--- a/Core/SyncDataProviders.swift
+++ b/Core/SyncDataProviders.swift
@@ -66,15 +66,13 @@ public class SyncDataProviders: DataProvidersSource {
 
         syncAuthStateDidChangeCancellable = syncAuthStateDidChangePublisher
             .sink { [weak self] isSyncDisabled in
-                self?.credentialsAdapter.updateDatabaseCleanupSchedule(shouldEnable: isSyncDisabled)
-                self?.bookmarksAdapter.updateDatabaseCleanupSchedule(shouldEnable: isSyncDisabled)
+                self?.credentialsAdapter.cleanUpDatabaseAndUpdateSchedule(shouldEnable: isSyncDisabled)
+                self?.bookmarksAdapter.cleanUpDatabaseAndUpdateSchedule(shouldEnable: isSyncDisabled)
             }
 
         if syncService.authState == .inactive {
-            bookmarksAdapter.databaseCleaner.cleanUpDatabaseNow()
-            bookmarksAdapter.databaseCleaner.scheduleRegularCleaning()
-            credentialsAdapter.databaseCleaner.cleanUpDatabaseNow()
-            credentialsAdapter.databaseCleaner.scheduleRegularCleaning()
+            credentialsAdapter.cleanUpDatabaseAndUpdateSchedule(shouldEnable: true)
+            bookmarksAdapter.cleanUpDatabaseAndUpdateSchedule(shouldEnable: true)
         }
 
         isDatabaseCleanersSetUp = true

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8809,8 +8809,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "dominik/fix-sync-metadata-cleanup";
-				kind = branch;
+				kind = exactVersion;
+				version = 75.0.4;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8809,8 +8809,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 75.0.2;
+				branch = "dominik/fix-sync-metadata-cleanup";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": "dominik/fix-sync-metadata-cleanup",
-          "revision": "82d5ff61312d535fc6df88f3a0ca28ec01420f9c",
-          "version": null
+          "branch": null,
+          "revision": "02e87697d9e8d897bde0a913b7ed5b0943cbe993",
+          "version": "75.0.4"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": null,
-          "revision": "8d4c3d884762d954183a9496961b87d254b43539",
-          "version": "75.0.2"
+          "branch": "dominik/fix-sync-metadata-cleanup",
+          "revision": "82d5ff61312d535fc6df88f3a0ca28ec01420f9c",
+          "version": null
         }
       },
       {
@@ -156,7 +156,7 @@
       },
       {
         "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
+        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit",
         "state": {
           "branch": null,
           "revision": "4684440d03304e7638a2c8086895367e90987463",

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -194,9 +194,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         syncDataProviders = SyncDataProviders(bookmarksDatabase: bookmarksDatabase, secureVaultErrorReporter: SecureVaultErrorReporter.shared)
         let syncService = DDGSync(dataProvidersSource: syncDataProviders, errorEvents: SyncErrorHandler(), log: .syncLog)
         syncService.initializeIfNeeded(isInternalUser: InternalUserStore().isInternalUser)
-        if application.applicationState == .active {
-            syncDataProviders.setUpDatabaseCleanersIfNeeded(syncService: syncService)
-        }
         self.syncService = syncService
 
         let storyboard: UIStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -59,7 +59,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private var showKeyboardIfSettingOn = true
     private var lastBackgroundDate: Date?
 
-    private(set) var syncService: DDGSyncing!
+    private(set) var syncService: DDGSync!
     private(set) var syncDataProviders: SyncDataProviders!
     private var syncDidFinishCancellable: AnyCancellable?
     private var syncStateCancellable: AnyCancellable?
@@ -69,16 +69,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        #if targetEnvironment(simulator)
+#if targetEnvironment(simulator)
         if ProcessInfo.processInfo.environment["UITESTING"] == "true" {
             // Disable hardware keyboards.
             let setHardwareLayout = NSSelectorFromString("setHardwareLayout:")
             UITextInputMode.activeInputModes
-                // Filter `UIKeyboardInputMode`s.
+            // Filter `UIKeyboardInputMode`s.
                 .filter({ $0.responds(to: setHardwareLayout) })
                 .forEach { $0.perform(setHardwareLayout, with: nil) }
         }
-        #endif
+#endif
 
         // Can be removed after a couple of versions
         cleanUpMacPromoExperiment2()
@@ -113,13 +113,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         removeEmailWaitlistState()
-                
+
         Database.shared.loadStore { context, error in
             guard let context = context else {
                 
                 let parameters = [PixelParameters.applicationState: "\(application.applicationState.rawValue)",
                                   PixelParameters.dataAvailability: "\(application.isProtectedDataAvailable)"]
-                        
+
                 switch error {
                 case .none:
                     fatalError("Could not create database stack: Unknown Error")
@@ -194,7 +194,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         syncDataProviders = SyncDataProviders(bookmarksDatabase: bookmarksDatabase, secureVaultErrorReporter: SecureVaultErrorReporter.shared)
         let syncService = DDGSync(dataProvidersSource: syncDataProviders, errorEvents: SyncErrorHandler(), log: .syncLog)
         syncService.initializeIfNeeded(isInternalUser: InternalUserStore().isInternalUser)
-        syncDataProviders.setUpDatabaseCleaners(syncService: syncService)
+        if application.applicationState == .active {
+            syncDataProviders.setUpDatabaseCleanersIfNeeded(syncService: syncService)
+        }
         self.syncService = syncService
 
         let storyboard: UIStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)
@@ -262,6 +264,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         guard !testing else { return }
 
         syncService.initializeIfNeeded(isInternalUser: InternalUserStore().isInternalUser)
+        syncDataProviders.setUpDatabaseCleanersIfNeeded(syncService: syncService)
 
         if !(overlayWindow?.rootViewController is AuthenticationViewController) {
             removeOverlay()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1205315938732113/f

**Description**:
Only clean database when sync is inactive at app startup.
Delay database cleaning until app becomes active in case it starts in background.
Update credentialsDatabaseCleanupFailed pixel name to remove noise caused by users remaining on current version.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the app from Xcode while Sync is not active
2. Verify that bookmarks and credentials database cleanup was attempted ("No bookmarks pending deletion" and "No syncable credentials metadata pending deletion" messages appear in the log).
3. Enable Sync, verify that bookmarks and credentials cleanup was attempted, then quit the app.
4. Relaunch the app, verify that bookmarks and credentials cleanup was **not** attempted.
5. Disable Sync, verify that bookmarks and credentials cleanup was attempted.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
