### PR TITLE
Increase test timeout

### DIFF
--- a/DuckDuckGoTests/AutoconsentMessageProtocolTests.swift
+++ b/DuckDuckGoTests/AutoconsentMessageProtocolTests.swift
@@ -133,7 +133,7 @@ final class AutoconsentMessageProtocolTests: XCTestCase {
             },
             message: message
         )
-        waitForExpectations(timeout: 5.0)
+        waitForExpectations(timeout: 15.0)
     }
 
     @MainActor

--- a/IntegrationTests/AutoconsentBackgroundTests.swift
+++ b/IntegrationTests/AutoconsentBackgroundTests.swift
@@ -116,7 +116,7 @@ final class AutoconsentBackgroundTests: XCTestCase {
         waitForExpectations(timeout: 4)
 
         let expectation = expectation(description: "Async call")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             webview.evaluateJavaScript("window.getComputedStyle(banner).display === 'none'", in: nil, in: .page,
                                        completionHandler: { result in
                 switch result {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205237866452338/1205348294602039/f

**Description**:
Increase test timeout for one of the autoconsent tests that may be lagging due to depending on webview script execution on the simulator in the cloud.

**Steps to test this PR**:
1. Make sure that the PR unit tests complete.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
