### PR TITLE
Fix for fireproof prompt blocking autofill save login prompt

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -116,7 +116,9 @@ class TabViewController: UIViewController {
     // Required to know when to disable autofill, see SaveLoginViewModel for details
     // Stored in memory on TabViewController for privacy reasons
     private var domainSaveLoginPromptLastShownOn: String?
+    // Required to prevent fireproof prompt presenting before autofill save login prompt
     private var saveLoginPromptLastDismissed: Date?
+    private var saveLoginPromptIsPresenting: Bool = false
 
     // If no trackers dax dialog was shown recently in this tab, ie without the user navigating somewhere else, e.g. backgrounding or tab switcher
     private var woShownRecently = false
@@ -1181,10 +1183,12 @@ extension TabViewController: WKNavigationDelegate {
         if preserveLoginsWorker?.handleLoginDetection(detectedURL: detectedLoginURL,
                                                       currentURL: url,
                                                       isAutofillEnabled: AutofillSettingStatus.isAutofillEnabledInSettings,
-                                                      saveLoginPromptLastDismissed: saveLoginPromptLastDismissed)
+                                                      saveLoginPromptLastDismissed: saveLoginPromptLastDismissed,
+                                                      saveLoginPromptIsPresenting: saveLoginPromptIsPresenting)
            ?? false {
             detectedLoginURL = nil
             saveLoginPromptLastDismissed = nil
+            saveLoginPromptIsPresenting = false
         }
     }
     
@@ -2303,6 +2307,8 @@ extension TabViewController: SecureVaultManagerDelegate {
                 }
             }
 
+            saveLoginPromptIsPresenting = true
+
             // Add a delay to allow propagation of pointer events to the page
             // see https://app.asana.com/0/1202427674957632/1202532842924584/f
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -2427,6 +2433,7 @@ extension TabViewController: SaveLoginViewControllerDelegate {
 
     private func saveCredentials(_ credentials: SecureVaultModels.WebsiteCredentials, withSuccessMessage message: String) {
         saveLoginPromptLastDismissed = Date()
+        saveLoginPromptIsPresenting = false
 
         do {
             let credentialID = try SaveAutofillLoginManager.saveCredentials(credentials,
@@ -2470,6 +2477,7 @@ extension TabViewController: SaveLoginViewControllerDelegate {
     func saveLoginViewControllerDidCancel(_ viewController: SaveLoginViewController) {
         viewController.dismiss(animated: true)
         saveLoginPromptLastDismissed = Date()
+        saveLoginPromptIsPresenting = false
     }
     
     func saveLoginViewController(_ viewController: SaveLoginViewController,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1200930669568058/1205353023203026/f
Tech Design URL:
CC:

**Description**:
On some sites the fireproof prompt triggers before the save login prompt is presented, blocking the save login prompt from being presented. 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Ensure both Autofill and "Ask to Fireproof sites on sign-in" settings are enabled
2. Open a new tab. 
3. Visit https://k-tuned.3dcartstores.com/myaccount.asp and attempt to login (can be with dummy credentials)
4. Ensure you are presented with the "Save Login" prompt, not the Fireproof prompt
5. Repeat this test with https://www.allrecipes.com/, navigating to the login with email page (can't link to it directly - sorry!)
6. Login to another site that you have a valid login for and that is not fireproofed e.g. netflix.com. Save the login when prompted
7. Logout and then log back in using your saved login when prompted
8. Confirm you are presented with the fireproof prompt

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
