### PR TITLE
NetP now clears the auth token in the extension + small bug fix.

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8873,8 +8873,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 76.1.0;
+				kind = revision;
+				revision = 0fd4f8aef9b93874f4bb782df47b75cddea118f0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8877,8 +8877,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = a6374fc2a81fad88213b5cceb193da84a87fcda9;
+				kind = exactVersion;
+				version = 77.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "fd65ad9ec0427df218b40caaa4404c31a1cee3e5",
-          "version": "76.1.0"
+          "revision": "0fd4f8aef9b93874f4bb782df47b75cddea118f0",
+          "version": null
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "a6374fc2a81fad88213b5cceb193da84a87fcda9",
-          "version": null
+          "revision": "49da07aebed9b6f94bfc9aac1fc9f916485a1800",
+          "version": "77.0.1"
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205416442924463/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/491
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1588

## Description

Integrates some changes from BSK that make NetP now clear the auth token in the extension when `resetAllState` is called.
Also fixes a small bugfix with a callback not being called when it should.

## Testing

Just make sure this builds and NetP connects fine.  There should really be no visible effect in using this for iOS.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
