### PR TITLE
Disable NetP connection tester to investigate terminations

### DIFF
--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -103,9 +103,9 @@ final class NetworkProtectionTunnelController: TunnelController {
         // To be removed with https://app.asana.com/0/0/1205418028628990/f
         options[NetworkProtectionOptionKey.connectionTesterEnabled] = "false" as NSString
 
-        if Self.simulationOptions.isEnabled(.tunnelFailure) {
-            Self.simulationOptions.setEnabled(false, option: .tunnelFailure)
-            options[NetworkProtectionOptionKey.tunnelFailureSimulation] = NetworkProtectionOptionValue.true
+        if let optionKey = Self.enabledSimulationOption?.optionKey {
+            options[optionKey] = NetworkProtectionOptionValue.true
+            Self.enabledSimulationOption = nil
         }
 
         do {

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -99,9 +99,13 @@ final class NetworkProtectionTunnelController: TunnelController {
         options["activationAttemptId"] = UUID().uuidString as NSString
         options["authToken"] = try tokenStore.fetchToken() as NSString?
 
-        if let optionKey = Self.enabledSimulationOption?.optionKey {
-            options[optionKey] = NetworkProtectionOptionValue.true
-            Self.enabledSimulationOption = nil
+        // Temporary investigation to see if connection tester is causing energy use issues
+        // To be removed with https://app.asana.com/0/0/1205418028628990/f
+        options[NetworkProtectionOptionKey.connectionTesterEnabled] = "false" as NSString
+
+        if Self.simulationOptions.isEnabled(.tunnelFailure) {
+            Self.simulationOptions.setEnabled(false, option: .tunnelFailure)
+            options[NetworkProtectionOptionKey.tunnelFailureSimulation] = NetworkProtectionOptionValue.true
         }
 
         do {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205437127875013/f

**Description**:
The iOS VPN has been disconnecting in the background. We have some suspicions this could be due to CPU / energy usage or excessive wake-ups. The only thing that jumped out while profiling was the `NetworkProtectionConnectionTester` so I’m going to try disabling this to see if it has any impact.

**Steps to test this PR**:
1. Just check Network Protection works by following smoke test steps https://app.asana.com/0/0/1205201898139906/f

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
