### PR TITLE
Optimizing the logins list screen

### DIFF
--- a/DuckDuckGo/AutofillLoginListItemViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListItemViewModel.swift
@@ -23,7 +23,6 @@ import UIKit
 import Common
 
 final class AutofillLoginListItemViewModel: Identifiable, Hashable {
-    @Published var image = UIImage(systemName: "globe")!
     
     var preferredFaviconLetters: String {
         let accountName = self.account.name(tld: tld, autofillDomainNameUrlMatcher: urlMatcher)
@@ -47,20 +46,6 @@ final class AutofillLoginListItemViewModel: Identifiable, Hashable {
         self.title = account.name(tld: tld, autofillDomainNameUrlMatcher: autofillDomainNameUrlMatcher)
         self.subtitle = account.username ?? ""
         self.urlMatcher = autofillDomainNameUrlMatcher
-        fetchImage()
-    }
-    
-    private func fetchImage() {
-        FaviconsHelper.loadFaviconSync(forDomain: account.domain,
-                                       usingCache: .fireproof,
-                                       useFakeFavicon: true,
-                                       preferredFakeFaviconLetters: preferredFaviconLetters) { image, _ in
-            if let image = image {
-                self.image = image
-            } else {
-                self.image = UIImage(systemName: "globe")!
-            }
-        }
     }
     
     static func == (lhs: AutofillLoginListItemViewModel, rhs: AutofillLoginListItemViewModel) -> Bool {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1205258271017091/f
Tech Design URL:
CC:

**Description**:
Removes unused legacy favicon code that was impacting screen loading times

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Set up a very large dataset (minimum 1500) of logins for testing
2. On existing `develop` branch code, run up the app and attempt to access the Logins screen. Note the long pause between tapping on `Logins` and the screen actually segueing & loading
3. Run up this PR and repeat step 2. The delay should be significantly reduced
4. Smoke test favicons lightly by opening in tabs the sites for some of the Logins that have a placeholder favicon
5. Go back to the Logins screen and confirm the favicons have been updated from placeholders to actual site favicons

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
