### PR TITLE
Add authentication state check when enabling grace period

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsViewController.swift
+++ b/DuckDuckGo/AutofillLoginDetailsViewController.swift
@@ -109,7 +109,7 @@ class AutofillLoginDetailsViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if !authenticationNotRequired {
+        if !authenticationNotRequired && authenticator.state == .loggedIn {
             authenticator.authenticate()
         }
     }

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -149,7 +149,7 @@ final class AutofillLoginSettingsListViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if viewModel.authenticator.canAuthenticate() {
+        if viewModel.authenticator.canAuthenticate() && viewModel.authenticator.state == .loggedIn {
             AppDependencyProvider.shared.autofillLoginSession.startSession()
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1205462483244180/f
Tech Design URL:
CC:

**Description**:
Adds check of authenticator state when determining whether or not to enable the login grace period

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Attempt to access the Logins screen but do not authentication to succeed.
2. Cancel the biometric prompt and the Login screen should dismiss. 
3. Attempt to access the Logins screen again and confirm you are again prompted to authenticate
4. Minimise the app and again try to access the Logins screen and confirm you are again prompted to authenticate
5. Access the Logins screen and this time allow authentication to succeed. Confirm you can now see the list of logins
6. Back out of the Logins screen and immediately try to access it again. This time you should see the list of logins without an authentication prompt (grace period is active)
7. Back out of the Logins screen again and wait 20 seconds before attempting to access the screen again. This time you should be prompted to authenticate (grace period has expired)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
