### PR TITLE
Updates BSK version and fixes a tester issue in iOS

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8877,8 +8877,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = c687e3decad2f01dd04b0b0ed92fcb7050155995;
+				kind = exactVersion;
+				version = 77.3.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8878,7 +8878,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 98d52799ee42805ac3c74184f100a678dd5e52b7;
+				revision = c687e3decad2f01dd04b0b0ed92fcb7050155995;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8877,8 +8877,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 77.2.0;
+				kind = revision;
+				revision = 98d52799ee42805ac3c74184f100a678dd5e52b7;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "98d52799ee42805ac3c74184f100a678dd5e52b7",
+          "revision": "c687e3decad2f01dd04b0b0ed92fcb7050155995",
           "version": null
         }
       },

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "c687e3decad2f01dd04b0b0ed92fcb7050155995",
-          "version": null
+          "revision": "6246a822793012c22e5c032db92662e88b268c14",
+          "version": "77.3.1"
         }
       },
       {
@@ -156,7 +156,7 @@
       },
       {
         "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit",
+        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
         "state": {
           "branch": null,
           "revision": "4684440d03304e7638a2c8086895367e90987463",

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "42b073f8a26165e8b328a5f72501abfecdd4c666",
-          "version": "77.2.0"
+          "revision": "98d52799ee42805ac3c74184f100a678dd5e52b7",
+          "version": null
         }
       },
       {

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -101,10 +101,10 @@ final class NetworkProtectionTunnelController: TunnelController {
 
         // Temporary investigation to see if connection tester is causing energy use issues
         // To be removed with https://app.asana.com/0/0/1205418028628990/f
-        options[NetworkProtectionOptionKey.connectionTesterEnabled] = "false" as NSString
+        options[NetworkProtectionOptionKey.connectionTesterEnabled] = NSNumber(value: false)
 
         if let optionKey = Self.enabledSimulationOption?.optionKey {
-            options[optionKey] = NetworkProtectionOptionValue.true
+            options[optionKey] = NSNumber(value: true)
             Self.enabledSimulationOption = nil
         }
 


### PR DESCRIPTION
Network Protection: Connection Tester

Task/Issue URL: https://app.asana.com/0/0/1205465612515847/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/489
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1581

## Description

Fixes startup options reset, and improves the options loading logic so we can easily unit test it.

## Testing

### Test the connection tester

1. Connect your device via USB to test the app
2. Open Console.app and start logging from your device
3. Filter by "Network Protection: Connection Tester"
4. Run the app
5. Start NetP
6. Make sure you see a message stating the connection tester is disabled.

### Test the connection

1. Run the app
2. Connect NetP and make sure the connection works fine.
3. Try clearing the invite, and inserting a new one and ensuring the connection works fine. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
