### PR TITLE
Add dry-run feature flag to test incremental rollouts on iOS

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -445,6 +445,8 @@ extension Pixel {
         case emailIncontextModalDismissed
         case emailIncontextModalExitEarly
         case emailIncontextModalExitEarlyContinue
+
+        case incrementalRolloutTest
     }
     
 }
@@ -881,6 +883,8 @@ extension Pixel.Event {
         case .emailIncontextModalDismissed: return "m_email_incontext_modal_dismissed"
         case .emailIncontextModalExitEarly: return "m_email_incontext_modal_exit_early"
         case .emailIncontextModalExitEarlyContinue: return "m_email_incontext_modal_exit_early_continue"
+
+        case .incrementalRolloutTest: return "m_autofill_incremental_rollout_test"
         }
         
     }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8889,8 +8889,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 77.2.0;
+				branch = "anya/ios-phased-rollout-feature-flag-dry-run";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -691,6 +691,9 @@
 		C17B595A2A03AAD30055F2D1 /* PasswordGenerationPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17B59572A03AAD30055F2D1 /* PasswordGenerationPromptViewController.swift */; };
 		C17B595B2A03AAD30055F2D1 /* PasswordGenerationPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17B59582A03AAD30055F2D1 /* PasswordGenerationPromptView.swift */; };
 		C1963863283794A000298D4D /* BookmarksCachingSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1963862283794A000298D4D /* BookmarksCachingSearch.swift */; };
+		C1B0F63E2AB08904001EAF05 /* PhasedRolloutFeatureFlagTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0F63D2AB08904001EAF05 /* PhasedRolloutFeatureFlagTester.swift */; };
+		C1B0F6422AB08BE9001EAF05 /* MockPrivacyConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0F6412AB08BE9001EAF05 /* MockPrivacyConfiguration.swift */; };
+		C1B0F6442AB0D47A001EAF05 /* PhasedRolloutFeatureFlagTesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0F63F2AB08A53001EAF05 /* PhasedRolloutFeatureFlagTesterTests.swift */; };
 		C1B7B51C28941E980098FD6A /* HomeMessageViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B51B28941E980098FD6A /* HomeMessageViewModelBuilder.swift */; };
 		C1B7B52328941F2A0098FD6A /* RemoteMessagingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B51F28941F2A0098FD6A /* RemoteMessagingStore.swift */; };
 		C1B7B52428941F2A0098FD6A /* RemoteMessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B52028941F2A0098FD6A /* RemoteMessageRequest.swift */; };
@@ -2274,6 +2277,9 @@
 		C17B59572A03AAD30055F2D1 /* PasswordGenerationPromptViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordGenerationPromptViewController.swift; sourceTree = "<group>"; };
 		C17B59582A03AAD30055F2D1 /* PasswordGenerationPromptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordGenerationPromptView.swift; sourceTree = "<group>"; };
 		C1963862283794A000298D4D /* BookmarksCachingSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksCachingSearch.swift; sourceTree = "<group>"; };
+		C1B0F63D2AB08904001EAF05 /* PhasedRolloutFeatureFlagTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhasedRolloutFeatureFlagTester.swift; sourceTree = "<group>"; };
+		C1B0F63F2AB08A53001EAF05 /* PhasedRolloutFeatureFlagTesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhasedRolloutFeatureFlagTesterTests.swift; sourceTree = "<group>"; };
+		C1B0F6412AB08BE9001EAF05 /* MockPrivacyConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyConfiguration.swift; sourceTree = "<group>"; };
 		C1B7B51B28941E980098FD6A /* HomeMessageViewModelBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeMessageViewModelBuilder.swift; sourceTree = "<group>"; };
 		C1B7B51F28941F2A0098FD6A /* RemoteMessagingStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteMessagingStore.swift; sourceTree = "<group>"; };
 		C1B7B52028941F2A0098FD6A /* RemoteMessageRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteMessageRequest.swift; sourceTree = "<group>"; };
@@ -4745,6 +4751,7 @@
 				8536A1C7209AF2410050739E /* MockVariantManager.swift */,
 				31C7D71B27515A6300A95D0A /* MockVoiceSearchHelper.swift */,
 				CBDD5DE029A6741300832877 /* MockBundle.swift */,
+				C1B0F6412AB08BE9001EAF05 /* MockPrivacyConfiguration.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -5072,6 +5079,7 @@
 				C1BF0BA629B63E0400482B73 /* AutofillLoginUI */,
 				F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */,
 				C1D21E2E293A599C006E5A05 /* AutofillLoginSessionTests.swift */,
+				C1B0F63F2AB08A53001EAF05 /* PhasedRolloutFeatureFlagTesterTests.swift */,
 			);
 			name = Autofill;
 			sourceTree = "<group>";
@@ -5091,6 +5099,7 @@
 				C17B59552A03AAC40055F2D1 /* PasswordGeneration */,
 				31951E9328230D8900CAF535 /* Shared */,
 				F407605428131923006B1E0B /* SaveLogin */,
+				C1B0F63D2AB08904001EAF05 /* PhasedRolloutFeatureFlagTester.swift */,
 			);
 			name = Autofill;
 			sourceTree = "<group>";
@@ -6267,6 +6276,7 @@
 				98B31292218CCB8C00E54DE1 /* AppDependencyProvider.swift in Sources */,
 				02C57C4B2514FEFB009E5129 /* DoNotSellSettingsViewController.swift in Sources */,
 				02A54A9C2A097C95000C8FED /* AppTPHomeViewSectionRenderer.swift in Sources */,
+				C1B0F63E2AB08904001EAF05 /* PhasedRolloutFeatureFlagTester.swift in Sources */,
 				8540BBA22440857A00017FE4 /* PreserveLoginsWorker.swift in Sources */,
 				85DFEDF924CF3D0E00973FE7 /* TabsBarCell.swift in Sources */,
 				F17922DB1E717C8D006E3D97 /* Suggestion.swift in Sources */,
@@ -6343,6 +6353,7 @@
 				F1D796F41E7C2A410019D451 /* BookmarksDelegate.swift in Sources */,
 				C1B7B52428941F2A0098FD6A /* RemoteMessageRequest.swift in Sources */,
 				1E8AD1D727C2E24E00ABA377 /* DownloadsListRowViewModel.swift in Sources */,
+				C1B0F6422AB08BE9001EAF05 /* MockPrivacyConfiguration.swift in Sources */,
 				1E865AF0272042DB001C74F3 /* TextSizeSettingsViewController.swift in Sources */,
 				8524CC9A246DA81700E59D45 /* FullscreenDaxDialogViewController.swift in Sources */,
 				F17669D71E43401C003D3222 /* MainViewController.swift in Sources */,
@@ -6422,6 +6433,7 @@
 				987130C5294AAB9F00AB05E0 /* BookmarkEditorViewModelTests.swift in Sources */,
 				8341D807212D5E8D000514C2 /* HashExtensionTest.swift in Sources */,
 				C1D21E2F293A599C006E5A05 /* AutofillLoginSessionTests.swift in Sources */,
+				C1B0F6442AB0D47A001EAF05 /* PhasedRolloutFeatureFlagTesterTests.swift in Sources */,
 				85D2187924BF6B8B004373D2 /* FaviconSourcesProviderTests.swift in Sources */,
 				1E8146AD28C8ABF000D1AF63 /* TrackerAnimationLogicTests.swift in Sources */,
 				B6AD9E3A28D456820019CDE9 /* PrivacyConfigurationManagerMock.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8893,8 +8893,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "anya/ios-phased-rollout-feature-flag-dry-run";
-				kind = branch;
+				kind = exactVersion;
+				version = 78.2.0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": "anya/ios-phased-rollout-feature-flag-dry-run",
-          "revision": "dc5296e73c58596285ccad6303c9e6335d9fbec5",
-          "version": null
+          "branch": null,
+          "revision": "8ba1d3b7f3e2291fc344cd5b83b66c1336e35a32",
+          "version": "78.2.0"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": null,
-          "revision": "42b073f8a26165e8b328a5f72501abfecdd4c666",
-          "version": "77.2.0"
+          "branch": "anya/ios-phased-rollout-feature-flag-dry-run",
+          "revision": "dc5296e73c58596285ccad6303c9e6335d9fbec5",
+          "version": null
         }
       },
       {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -257,6 +257,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         })
     }
 
+    // Temporary feature flag tester, to validate that phased rollouts are working as intended.
+     // This is to be removed before the end of August 2023.
+     lazy var featureFlagTester: PhasedRolloutFeatureFlagTester = {
+         return PhasedRolloutFeatureFlagTester()
+     }()
+
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
 
@@ -309,6 +315,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         syncService.scheduler.notifyAppLifecycleEvent()
+
+        featureFlagTester.sendFeatureFlagEnabledPixelIfNecessary()
     }
 
     private func fireAppLaunchPixel() {

--- a/DuckDuckGo/PhasedRolloutFeatureFlagTester.swift
+++ b/DuckDuckGo/PhasedRolloutFeatureFlagTester.swift
@@ -1,0 +1,84 @@
+//
+//  PhasedRolloutFeatureFlagTester.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Foundation
+import BrowserServicesKit
+import Core
+
+protocol PhasedRolloutPixelSender: AnyObject {
+    func sendPixel(completion: @escaping (Error?) -> Void)
+}
+
+final class DefaultPhasedRolloutPixelSender: PhasedRolloutPixelSender {
+    func sendPixel(completion: @escaping (Error?) -> Void) {
+        Pixel.fire(pixel: .incrementalRolloutTest) { error in
+            completion(error)
+        }
+    }
+}
+
+final class PhasedRolloutFeatureFlagTester {
+
+    enum Constants {
+        static let hasSentPixelKey = "network-protection.incremental-feature-flag-test.has-sent-pixel"
+    }
+
+    static let shared = PhasedRolloutFeatureFlagTester()
+
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let pixelSender: PhasedRolloutPixelSender
+    private let userDefaults: UserDefaults
+
+    init(privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager,
+         pixelSender: PhasedRolloutPixelSender = DefaultPhasedRolloutPixelSender(),
+         userDefaults: UserDefaults = .standard) {
+        self.privacyConfigurationManager = privacyConfigurationManager
+        self.pixelSender = pixelSender
+        self.userDefaults = userDefaults
+    }
+
+    func sendFeatureFlagEnabledPixelIfNecessary(completion: (() -> Void)? = nil) {
+        guard !hasSentPixelBefore(), privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(IncrementalRolloutTestSubfeature2.rollout) else {
+            completion?()
+            return
+        }
+
+        markPixelAsSent()
+
+        pixelSender.sendPixel { [weak self] error in
+            if error != nil {
+                self?.markPixelAsUnsent()
+            }
+
+            completion?()
+        }
+    }
+
+    private func hasSentPixelBefore() -> Bool {
+        return userDefaults.bool(forKey: Constants.hasSentPixelKey)
+    }
+
+    private func markPixelAsSent() {
+        userDefaults.setValue(true, forKey: Constants.hasSentPixelKey)
+    }
+
+    private func markPixelAsUnsent() {
+        userDefaults.removeObject(forKey: Constants.hasSentPixelKey)
+    }
+
+}

--- a/DuckDuckGoTests/MockPrivacyConfiguration.swift
+++ b/DuckDuckGoTests/MockPrivacyConfiguration.swift
@@ -1,0 +1,74 @@
+//
+//  MockPrivacyConfiguration.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+import Combine
+
+class MockPrivacyConfiguration: PrivacyConfiguration {
+
+    var isSubfeatureKeyEnabled: ((any PrivacySubfeature, AppVersionProvider) -> Bool)?
+    func isSubfeatureEnabled(_ subfeature: any PrivacySubfeature, versionProvider: AppVersionProvider, randomizer: (Range<Double>) -> Double) -> Bool {
+        isSubfeatureKeyEnabled?(subfeature, versionProvider) ?? false
+    }
+
+    var identifier: String = "MockPrivacyConfiguration"
+    var userUnprotectedDomains: [String] = []
+    var tempUnprotectedDomains: [String] = []
+    var trackerAllowlist: PrivacyConfigurationData.TrackerAllowlist = .init(entries: [:],
+                                                                            state: PrivacyConfigurationData.State.enabled)
+    var exceptionsList: (PrivacyFeature) -> [String] = { _ in [] }
+    var featureSettings: PrivacyConfigurationData.PrivacyFeature.FeatureSettings = [:]
+
+    func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] { exceptionsList(featureKey) }
+    var isFeatureKeyEnabled: ((PrivacyFeature, AppVersionProvider) -> Bool)?
+    func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider) -> Bool {
+        isFeatureKeyEnabled?(featureKey, versionProvider) ?? true
+    }
+    func isFeature(_ feature: PrivacyFeature, enabledForDomain: String?) -> Bool { true }
+    func isProtected(domain: String?) -> Bool { true }
+    func isUserUnprotected(domain: String?) -> Bool { false }
+    func isTempUnprotected(domain: String?) -> Bool { false }
+    func isInExceptionList(domain: String?, forFeature featureKey: PrivacyFeature) -> Bool { false }
+    func settings(for feature: PrivacyFeature) -> PrivacyConfigurationData.PrivacyFeature.FeatureSettings { featureSettings }
+    func userEnabledProtection(forDomain: String) {}
+    func userDisabledProtection(forDomain: String) {}
+}
+
+@objc(MockPrivacyConfigurationManager)
+class MockPrivacyConfigurationManager: NSObject, PrivacyConfigurationManaging {
+    var embeddedConfigData: BrowserServicesKit.PrivacyConfigurationManager.ConfigurationData {
+        fatalError("not implemented")
+    }
+
+    var fetchedConfigData: BrowserServicesKit.PrivacyConfigurationManager.ConfigurationData? {
+        fatalError("not implemented")
+    }
+
+    var currentConfig: Data {
+        Data()
+    }
+
+    func reload(etag: String?, data: Data?) -> BrowserServicesKit.PrivacyConfigurationManager.ReloadResult {
+        fatalError("not implemented")
+    }
+
+    var updatesPublisher: AnyPublisher<Void, Never> = Just(()).eraseToAnyPublisher()
+    var privacyConfig: PrivacyConfiguration = MockPrivacyConfiguration()
+}

--- a/DuckDuckGoTests/PhasedRolloutFeatureFlagTesterTests.swift
+++ b/DuckDuckGoTests/PhasedRolloutFeatureFlagTesterTests.swift
@@ -1,0 +1,153 @@
+//
+//  PhasedRolloutFeatureFlagTesterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import BrowserServicesKit
+@testable import DuckDuckGo
+
+private class MockPixelSender: PhasedRolloutPixelSender {
+
+    enum MockPixelSenderError: Error {
+        case mockPixelSenderError
+    }
+
+    let returnError: Bool
+    var receivedPixelCall: Bool = false
+
+    init(returnError: Bool = false) {
+        self.returnError = returnError
+    }
+
+    func sendPixel(completion: @escaping (Error?) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.receivedPixelCall = true
+
+            if self.returnError {
+                completion(MockPixelSenderError.mockPixelSenderError)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
+}
+
+final class PhasedRolloutFeatureFlagTesterTests: XCTestCase {
+
+    private static let testSuiteName = "\(#file)"
+
+    override func setUp() {
+        super.setUp()
+
+        let defaults = UserDefaults(suiteName: Self.testSuiteName)!
+        defaults.removePersistentDomain(forName: Self.testSuiteName)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        let defaults = UserDefaults(suiteName: Self.testSuiteName)!
+        defaults.removePersistentDomain(forName: Self.testSuiteName)
+    }
+
+    func testWhenAttemptingToSendPixel_AndRolloutSubfeatureIsDisabled_ThenPixelDoesNotSend() {
+        let mockManager = MockPrivacyConfigurationManager()
+        mockManager.privacyConfig = mockConfiguration(subfeatureEnabled: false)
+        let pixelSender = MockPixelSender(returnError: false)
+        let userDefaults = UserDefaults(suiteName: Self.testSuiteName)!
+
+        let tester = PhasedRolloutFeatureFlagTester(privacyConfigurationManager: mockManager,
+                                                    pixelSender: pixelSender,
+                                                    userDefaults: userDefaults)
+
+        let expectation = expectation(description: #function)
+        tester.sendFeatureFlagEnabledPixelIfNecessary {
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+
+        XCTAssertFalse(pixelSender.receivedPixelCall)
+        XCTAssertFalse(userDefaults.bool(forKey: PhasedRolloutFeatureFlagTester.Constants.hasSentPixelKey))
+    }
+
+    func testWhenAttemptingToSendPixel_AndRolloutSubfeatureIsEnabled_AndPixelHasNotBeenSentBefore_ThenPixelSends() {
+        let mockManager = MockPrivacyConfigurationManager()
+        mockManager.privacyConfig = mockConfiguration(subfeatureEnabled: true)
+        let pixelSender = MockPixelSender(returnError: false)
+        let userDefaults = UserDefaults(suiteName: Self.testSuiteName)!
+
+        let tester = PhasedRolloutFeatureFlagTester(privacyConfigurationManager: mockManager,
+                                                    pixelSender: pixelSender,
+                                                    userDefaults: userDefaults)
+
+        let expectation = expectation(description: #function)
+        tester.sendFeatureFlagEnabledPixelIfNecessary {
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+
+        XCTAssert(pixelSender.receivedPixelCall)
+        XCTAssert(userDefaults.bool(forKey: PhasedRolloutFeatureFlagTester.Constants.hasSentPixelKey))
+    }
+
+    func testWhenAttemptingToSendPixel_AndRolloutSubfeatureIsEnabled_AndPixelHasBeenSentBefore_ThenPixelDoesNotSend() {
+        let mockManager = MockPrivacyConfigurationManager()
+        mockManager.privacyConfig = mockConfiguration(subfeatureEnabled: true)
+        let pixelSender = MockPixelSender(returnError: false)
+        let userDefaults = UserDefaults(suiteName: Self.testSuiteName)!
+
+        let tester = PhasedRolloutFeatureFlagTester(privacyConfigurationManager: mockManager,
+                                                    pixelSender: pixelSender,
+                                                    userDefaults: userDefaults)
+
+        let firstExpectation = expectation(description: #function)
+        tester.sendFeatureFlagEnabledPixelIfNecessary {
+            firstExpectation.fulfill()
+        }
+        wait(for: [firstExpectation])
+
+        XCTAssert(pixelSender.receivedPixelCall)
+        XCTAssert(userDefaults.bool(forKey: PhasedRolloutFeatureFlagTester.Constants.hasSentPixelKey))
+
+        // Test the second call:
+
+        pixelSender.receivedPixelCall = false
+
+        let secondExpectation = expectation(description: #function)
+        tester.sendFeatureFlagEnabledPixelIfNecessary {
+            secondExpectation.fulfill()
+        }
+        wait(for: [secondExpectation])
+
+        XCTAssertFalse(pixelSender.receivedPixelCall)
+        XCTAssert(userDefaults.bool(forKey: PhasedRolloutFeatureFlagTester.Constants.hasSentPixelKey))
+    }
+
+    // MARK: - Mock Creation
+
+    private func mockConfiguration(subfeatureEnabled: Bool) -> PrivacyConfiguration {
+        let mockPrivacyConfiguration = MockPrivacyConfiguration()
+        mockPrivacyConfiguration.isSubfeatureKeyEnabled = { _, _ in
+            return subfeatureEnabled
+        }
+
+        return mockPrivacyConfiguration
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205431733474504/f
Tech Design URL:
CC:

**Description**:
This is the client-side PR for https://github.com/duckduckgo/BrowserServicesKit/pull/502

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Modify AppUrls.swift replacing the privacy config with this [custom one](https://gist.githubusercontent.com/amddg44/9ed9d3c20c85e0ec99263643fc480599/raw/d0fc0894d18f6f529ea161e2ffa912777f15cefb/ios-config-test-incremental-rollout.json) (FYI I'm using a gist as it provides an etag)
2. In PhasedRolloutFeatureFlagTester.swift add breakpoints to sendFeatureFlagEnabledPixelIfNecessary at lines 57 &  61
3. Launch the app and confirm the breakpoint hits at line 57 for the first run. I'm not sure of a better way to monitor userDefaults in the iOS app but can add these to the watch expressions:
- `userDefaults.bool(forKey: Constants.hasSentPixelKey)`
- `userDefaults.bool(forKey:"config.incrementalRolloutTest2.rollout.enabled")`
- `userDefaults.value(forKey:"config.incrementalRolloutTest2.rollout.lastRolloutCount") as? Int`
4. Confirm the test rollout pixel `m_autofill_incremental_rollout_test` in not fired
5. Once the custom privacy config file has downloaded, minimise and re-open the app
6. The new config should now be being used and depending on the randomiser will either see the `config.incrementalRolloutTest2.rollout.lastRolloutCount` set or `config.incrementalRolloutTest2.rollout.enabledconfig.incrementalRolloutTest.rollout.enabled` enabled
7. If enabled, confirm that pixel `m_autofill_incremental_rollout_test` is fired
8. If not enabled, confirm that pixel `m_autofill_incremental_rollout_test` is NOT fired. This code can be added somewhere on app launch to clear the lastRolloutCount and try again :) `userDefaults.removeObject(forKey: "config.incrementalRolloutTest2.rollout.lastRolloutCount")`

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
