### PR TITLE
Switch Sync environment to production

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -95,6 +95,8 @@ public struct UserDefaultsWrapper<T> {
         case appTPUsed = "com.duckduckgo.ios.appTrackingProtection.appTPUsed"
 
         case defaultBrowserUsageLastSeen = "com.duckduckgo.ios.default-browser-usage-last-seen"
+
+        case syncEnvironment = "com.duckduckgo.ios.sync-environment"
     }
 
     private let key: Key

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8877,8 +8877,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "dominik/sync-env-switcher";
-				kind = branch;
+				kind = exactVersion;
+				version = 78.0.0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8877,8 +8877,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 77.3.1;
+				branch = "dominik/sync-env-switcher";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": null,
-          "revision": "6246a822793012c22e5c032db92662e88b268c14",
-          "version": "77.3.1"
+          "branch": "dominik/sync-env-switcher",
+          "revision": "8b2c199ca8947623664a8329e9bae9c85158a05b",
+          "version": null
         }
       },
       {
@@ -156,7 +156,7 @@
       },
       {
         "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
+        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit",
         "state": {
           "branch": null,
           "revision": "4684440d03304e7638a2c8086895367e90987463",

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": "dominik/sync-env-switcher",
-          "revision": "82ec004df10ff8d0eaa7027daa3b5faed796a123",
-          "version": null
+          "branch": null,
+          "revision": "2a3dc29c9f0a2d90465a75afe47083a78ecaafe8",
+          "version": "78.0.0"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": "dominik/sync-env-switcher",
-          "revision": "8b2c199ca8947623664a8329e9bae9c85158a05b",
+          "revision": "1804e7d6cfe6700da6bd2686492eb14cc143138e",
           "version": null
         }
       },

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": "dominik/sync-env-switcher",
-          "revision": "db20d70b9ab2cbe3747fd83768cde9edf71798cc",
+          "revision": "82ec004df10ff8d0eaa7027daa3b5faed796a123",
           "version": null
         }
       },

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": "dominik/sync-env-switcher",
-          "revision": "1804e7d6cfe6700da6bd2686492eb14cc143138e",
+          "revision": "db20d70b9ab2cbe3747fd83768cde9edf71798cc",
           "version": null
         }
       },

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -200,7 +200,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         syncDataProviders = SyncDataProviders(bookmarksDatabase: bookmarksDatabase, secureVaultErrorReporter: SecureVaultErrorReporter.shared)
         let syncService = DDGSync(dataProvidersSource: syncDataProviders, errorEvents: SyncErrorHandler(), log: .syncLog, environment: environment)
-        syncService.initializeIfNeeded(isInternalUser: InternalUserStore().isInternalUser)
+        syncService.initializeIfNeeded()
         self.syncService = syncService
 
         let storyboard: UIStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)
@@ -267,7 +267,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
 
-        syncService.initializeIfNeeded(isInternalUser: InternalUserStore().isInternalUser)
+        syncService.initializeIfNeeded()
         syncDataProviders.setUpDatabaseCleanersIfNeeded(syncService: syncService)
 
         if !(overlayWindow?.rootViewController is AuthenticationViewController) {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -191,8 +191,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // MARK: Sync initialisation
 
+        let environment = ServerEnvironment(
+            UserDefaultsWrapper(
+                key: .syncEnvironment,
+                defaultValue: ServerEnvironment.production.description
+            ).wrappedValue
+        ) ?? .production
+
         syncDataProviders = SyncDataProviders(bookmarksDatabase: bookmarksDatabase, secureVaultErrorReporter: SecureVaultErrorReporter.shared)
-        let syncService = DDGSync(dataProvidersSource: syncDataProviders, errorEvents: SyncErrorHandler(), log: .syncLog)
+        let syncService = DDGSync(dataProvidersSource: syncDataProviders, errorEvents: SyncErrorHandler(), log: .syncLog, environment: environment)
         syncService.initializeIfNeeded(isInternalUser: InternalUserStore().isInternalUser)
         self.syncService = syncService
 

--- a/DuckDuckGo/SyncDebugViewController.swift
+++ b/DuckDuckGo/SyncDebugViewController.swift
@@ -29,13 +29,15 @@ class SyncDebugViewController: UITableViewController {
 
     private let titles = [
         Sections.info: "Info",
-        Sections.models: "Models"
+        Sections.models: "Models",
+        Sections.environment: "Environment"
     ]
 
     enum Sections: Int, CaseIterable {
 
         case info
         case models
+        case environment
 
     }
 
@@ -48,6 +50,12 @@ class SyncDebugViewController: UITableViewController {
     enum ModelRows: Int, CaseIterable {
 
         case bookmarks
+
+    }
+
+    enum EnvironmentRows: Int, CaseIterable {
+
+        case toggle
 
     }
 
@@ -85,6 +93,7 @@ class SyncDebugViewController: UITableViewController {
         return titles[section]
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
 
@@ -120,6 +129,17 @@ class SyncDebugViewController: UITableViewController {
                 break
             }
 
+        case .environment:
+            switch EnvironmentRows(rawValue: indexPath.row) {
+            case .toggle:
+                let targetEnvironment: ServerEnvironment = sync.serverEnvironment == .production ? .development : .production
+                cell.textLabel?.text = sync.serverEnvironment.description
+                cell.detailTextLabel?.text = "Click to switch to \(targetEnvironment)"
+
+            case .none:
+                break
+            }
+
         default: break
         }
 
@@ -130,6 +150,7 @@ class SyncDebugViewController: UITableViewController {
         switch Sections(rawValue: section) {
         case .info: return InfoRows.allCases.count
         case .models: return ModelRows.allCases.count
+        case .environment: return EnvironmentRows.allCases.count
         case .none: return 0
         }
     }
@@ -142,10 +163,29 @@ class SyncDebugViewController: UITableViewController {
                 sync.scheduler.requestSyncImmediately()
             default: break
             }
+        case .environment:
+            switch EnvironmentRows(rawValue: indexPath.row) {
+            case .toggle:
+                let targetEnvironment: ServerEnvironment = sync.serverEnvironment == .production ? .development : .production
+                sync.updateServerEnvironment(targetEnvironment)
+                tableView.reloadSections(.init(integer: indexPath.section), with: .automatic)
+            default: break
+            }
         default: break
         }
 
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
+}
+
+extension ServerEnvironment: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .development:
+            return "Development"
+        case .production:
+            return "Production"
+        }
+    }
 }

--- a/DuckDuckGo/SyncDebugViewController.swift
+++ b/DuckDuckGo/SyncDebugViewController.swift
@@ -168,6 +168,7 @@ class SyncDebugViewController: UITableViewController {
             case .toggle:
                 let targetEnvironment: ServerEnvironment = sync.serverEnvironment == .production ? .development : .production
                 sync.updateServerEnvironment(targetEnvironment)
+                UserDefaults.standard.set(targetEnvironment.description, forKey: UserDefaultsWrapper<String>.Key.syncEnvironment.rawValue)
                 tableView.reloadSections(.init(integer: indexPath.section), with: .automatic)
             default: break
             }
@@ -177,15 +178,4 @@ class SyncDebugViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
-}
-
-extension ServerEnvironment: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .development:
-            return "Development"
-        case .production:
-            return "Production"
-        }
-    }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205489036222324/f

**Description**:
This patch switches default server environment for Sync to production and adds environment switcher
to the Debug menu.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the app and identify as internal user
2. Enable Sync, verify that requests are being sent to the production endpoint (sync.duckduckgo.com)
3. Go to Debug menu -> Sync Info -> Environment
4. Verify that it shows that Production is active and it offers you to switch to Development
5. Switch to Development
6. Verify that you have been logged out of Sync
7. Enable Sync, verify that requests are being sent to the development endpoint (dev-sync-use.duckduckgo.com)
8. Go to Debug menu -> Sync -> Environment
9. Verify that it shows that Development is active and it offers you to switch to Production
10. Restart the app, verify that you're still on Development environment.
11. Switch back to Production and verify that you've been logged out.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
