### PR TITLE
Improve cleanup of observations.db

### DIFF
--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -246,19 +246,27 @@ public class WebCacheManager {
     }
 
     private func removeObservationsData() {
-        guard let bundleID = Bundle.main.bundleIdentifier else {
-            return
+        if let pool = getValidDatabasePool() {
+            removeObservationsData(from: pool)
+        } else {
+            os_log("Could not find valid pool to clear observations data", log: .generalLog, type: .debug)
         }
-
-        let databaseURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("WebKit/\(bundleID)/WebsiteData/ResourceLoadStatistics/observations.db")
-
-        guard let pool = try? DatabasePool(path: databaseURL.absoluteString) else {
-            return
-        }
-
-        removeObservationsData(from: pool)
     }
+
+    func getValidDatabasePool() -> DatabasePool? {
+        let bundleID = Bundle.main.bundleIdentifier ?? ""
+
+        let databaseURLs = [
+            FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+                       .appendingPathComponent("WebKit/WebsiteData/ResourceLoadStatistics/observations.db",
+           FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+                       .appendingPathComponent("WebKit/\(bundleID)/WebsiteData/ResourceLoadStatistics/observations.db"),
+            )
+        ]
+
+        return databaseURLs.lazy.compactMap({ try? DatabasePool(path: $0.absoluteString) }).first
+    }
+
 
     private func removeObservationsData(from pool: DatabasePool) {
          do {

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -258,10 +258,9 @@ public class WebCacheManager {
 
         let databaseURLs = [
             FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-                       .appendingPathComponent("WebKit/WebsiteData/ResourceLoadStatistics/observations.db",
-           FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
-                       .appendingPathComponent("WebKit/\(bundleID)/WebsiteData/ResourceLoadStatistics/observations.db"),
-            )
+                       .appendingPathComponent("WebKit/WebsiteData/ResourceLoadStatistics/observations.db"),
+            FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+                       .appendingPathComponent("WebKit/\(bundleID)/WebsiteData/ResourceLoadStatistics/observations.db")
         ]
 
         return databaseURLs.lazy.compactMap({ try? DatabasePool(path: $0.absoluteString) }).first

--- a/DuckDuckGoTests/WebCacheManagerTests.swift
+++ b/DuckDuckGoTests/WebCacheManagerTests.swift
@@ -149,6 +149,11 @@ class WebCacheManagerTests: XCTestCase {
         
         XCTAssertEqual(dataStore.removeAllDataCalledCount, 1)
     }
+
+    func testWhenAccessingObservationsDbThenValidDatabasePoolIsReturned() {
+        let pool = WebCacheManager.shared.getValidDatabasePool()
+        XCTAssertNotNil(pool, "DatabasePool should not be nil")
+    }
             
     // MARK: Mocks
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1205463416606413/f
Tech Design URL:
CC:

**Description**:
Adds an additional path to check for location of observations.db

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Testing on device, enable App Privacy Report if not already enabled (iOS Settings > Privacy & Security > App Privacy Report)
2. In the app visit a number of sites that make a lot of calls to other urls e.g. cnbc.com, bloomberg.com, cnn.com 
3. Go back to the App Privacy Report and the activity should all be logged there
4. In Xcode download the container for the app and navigate to `observations.db` (should be  in /AppData/Library/WebKit/WebsiteData/ResourceLoadStatistics)
5. Check the data stored in the db either using an app like DB Browser for SQLite or by running this command in terminal `sqlite3 observations.db "select (select COUNT(*) FROM ObservedDomains)"` and note the row count
6. In the app, tap the burn button
7. Go back to the App Privacy Report and almost everything should be cleared (there may be 1 or 2 leftovers but it shouldn't be many). 
8. Navigate back to the app and then back to App Privacy Report and confirm there is no change in the data reported from the previous step (except maybe some DDG api calls)
9. Download the app container again and confirm that `observations.db` is now empty

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
