### PR TITLE
Replace Autofill background access check with protected data check

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -95,6 +95,7 @@ public struct PixelParameters {
     public static let bookmarkCount = "bco"
     
     public static let isBackgrounded = "is_backgrounded"
+    public static let isDataProtected = "is_data_protected"
     
     public static let isInternalUser = "is_internal_user"
     

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -251,9 +251,8 @@ extension Pixel {
         case secureVaultInitFailedError
         case secureVaultFailedToOpenDatabaseError
         
-        // The pixels are for debugging a specific problem and should be removed when resolved
-        // https://app.asana.com/0/0/1202498365125439/f
-        case secureVaultIsEnabledCheckedWhenEnabledAndBackgrounded
+        // Replacing secureVaultIsEnabledCheckedWhenEnabledAndBackgrounded with data protection check
+        case secureVaultIsEnabledCheckedWhenEnabledAndDataProtected
         
         // MARK: Ad Click Attribution pixels
         
@@ -691,7 +690,7 @@ extension Pixel.Event {
         case .secureVaultInitFailedError: return "m_secure-vault_error_init-failed"
         case .secureVaultFailedToOpenDatabaseError: return "m_secure-vault_error_failed-to-open-database"
             
-        case .secureVaultIsEnabledCheckedWhenEnabledAndBackgrounded: return "m_secure-vault_is-enabled-checked_when-enabled-and-backgrounded_2"
+        case .secureVaultIsEnabledCheckedWhenEnabledAndDataProtected: return "m_secure-vault_is-enabled-checked_when-enabled-and-data-protected"
             
         // MARK: Ad Click Attribution pixels
             

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2284,10 +2284,10 @@ extension TabViewController: SecureVaultManagerDelegate {
         let isEnabled = AutofillSettingStatus.isAutofillEnabledInSettings &&
                         featureFlagger.isFeatureOn(.autofillCredentialInjecting) &&
                         !isLinkPreview
-        let isBackgrounded = UIApplication.shared.applicationState == .background
-        if isEnabled && isBackgrounded {
-            Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenEnabledAndBackgrounded,
-                       withAdditionalParameters: [PixelParameters.isBackgrounded: "true"])
+        let isDataProtected = !UIApplication.shared.isProtectedDataAvailable
+        if isEnabled && isDataProtected {
+            Pixel.fire(pixel: .secureVaultIsEnabledCheckedWhenEnabledAndDataProtected,
+                       withAdditionalParameters: [PixelParameters.isDataProtected: "true"])
         }
         return isEnabled
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205478345694790/f
Tech Design URL:
CC:

**Description**:
Replacing the Autofill background access check pixel with new protected data check pixel to reduce noise from false positives

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. In `AppDelegate` add this code to `application(_:performFetchWithCompletionHandler)`: 
        ```let manager = SecureVaultManager(includePartialAccountMatches: true,
                                         tld: AppDependencyProvider.shared.storageCache.tld)
        mainViewController?.currentTab?.secureVaultManagerIsEnabledStatus(manager, forType: .password)```
2. Testing on device, run up the app and visit any website 
3. Check that pixel `m_secure-vault_is-enabled-checked_when-enabled-and-data-protected` does not fire while the site is loading
4. Lock the phone screen and wait a few seconds 
5. Via XCode Debug menu, simulate a background fetch which will trigger the code in step 1. 
6. Confirm that when there is no access to protected data, the new pixel is fired

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
