### PR TITLE
NetP feature usage pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -114,6 +114,9 @@ public struct PixelParameters {
     public static let keychainFieldName = "fieldName"
     public static let keychainErrorCode = errorCode
     public static let wireguardErrorCode = errorCode
+    public static let latency = "latency"
+    public static let server = "server"
+    public static let networkType = "network_type"
     public static let function = "function"
     public static let line = "line"
     public static let reason = "reason"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -294,6 +294,11 @@ extension Pixel {
 
         // MARK: Network Protection
 
+        case networkProtectionActiveUser
+
+        case networkProtectionRekeyCompleted
+        case networkProtectionLatency
+
         case networkProtectionTunnelConfigurationNoServerRegistrationInfo
         case networkProtectionTunnelConfigurationCouldNotSelectClosestServer
         case networkProtectionTunnelConfigurationCouldNotGetPeerPublicKey
@@ -779,6 +784,9 @@ extension Pixel.Event {
 
         // MARK: Network Protection pixels
 
+        case .networkProtectionActiveUser: return "m_netp_daily_active_d"
+        case .networkProtectionRekeyCompleted: return "m_netp_rekey_completed"
+        case .networkProtectionLatency: return "m_netp_latency"
         case .networkProtectionTunnelConfigurationNoServerRegistrationInfo: return "m_netp_tunnel_config_error_no_server_registration_info"
         case .networkProtectionTunnelConfigurationCouldNotSelectClosestServer: return "m_netp_tunnel_config_error_could_not_select_closest_server"
         case .networkProtectionTunnelConfigurationCouldNotGetPeerPublicKey: return "m_netp_tunnel_config_error_could_not_get_peer_public_key"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -300,7 +300,6 @@
 		56244C1D2A137B1900EDF259 /* WaitlistViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56244C1C2A137B1900EDF259 /* WaitlistViews.swift */; };
 		6AC6DAB328804F97002723C0 /* BarsAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6DAB228804F97002723C0 /* BarsAnimator.swift */; };
 		6AC98419288055C1005FA9CA /* BarsAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */; };
-		7B5E1F9E2AB9E1E900DA1172 /* NetworkProtectionDebugFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5E1F9D2AB9E1E900DA1172 /* NetworkProtectionDebugFeatures.swift */; };
 		83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */; };
 		83004E862193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */; };
 		83004E882193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E872193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift */; };
@@ -750,6 +749,7 @@
 		EE3B226C29DE0FD30082298A /* MockInternalUserStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3B226A29DE0F110082298A /* MockInternalUserStoring.swift */; };
 		EE41BD192A729E9C00546C57 /* NetworkProtectionInviteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41BD182A729E9C00546C57 /* NetworkProtectionInviteViewModelTests.swift */; };
 		EE458D0D2AB1DA4600FC651A /* EventMapping+NetworkProtectionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE458D0C2AB1DA4600FC651A /* EventMapping+NetworkProtectionError.swift */; };
+		EE458D142ABB652900FC651A /* NetworkProtectionDebugUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE458D132ABB652900FC651A /* NetworkProtectionDebugUtilities.swift */; };
 		EE4BE0092A740BED00CD6AA8 /* ClearTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4BE0082A740BED00CD6AA8 /* ClearTextField.swift */; };
 		EE4FB1862A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4FB1852A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift */; };
 		EE4FB1882A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4FB1872A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift */; };
@@ -760,6 +760,7 @@
 		EE8594992A44791C008A6D06 /* NetworkProtectionTunnelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8594982A44791C008A6D06 /* NetworkProtectionTunnelController.swift */; };
 		EE8E568A2A56BCE400F11DCA /* NetworkProtection in Frameworks */ = {isa = PBXBuildFile; productRef = EE8E56892A56BCE400F11DCA /* NetworkProtection */; };
 		EEEB80A32A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEB80A22A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift */; };
+		EEF0F8CC2ABC832300630031 /* NetworkProtectionDebugFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF0F8CB2ABC832200630031 /* NetworkProtectionDebugFeatures.swift */; };
 		EEFAB4672A73C230008A38E4 /* NetworkProtectionTestUtils in Frameworks */ = {isa = PBXBuildFile; productRef = EEFAB4662A73C230008A38E4 /* NetworkProtectionTestUtils */; };
 		EEFD562F2A65B6CA00DAEC48 /* NetworkProtectionInviteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD562E2A65B6CA00DAEC48 /* NetworkProtectionInviteViewModel.swift */; };
 		EEFE9C732A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFE9C722A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift */; };
@@ -2335,6 +2336,7 @@
 		EE3B98EC2A963538002F63A0 /* PacketTunnelProviderAlpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PacketTunnelProviderAlpha.entitlements; sourceTree = "<group>"; };
 		EE41BD182A729E9C00546C57 /* NetworkProtectionInviteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionInviteViewModelTests.swift; sourceTree = "<group>"; };
 		EE458D0C2AB1DA4600FC651A /* EventMapping+NetworkProtectionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventMapping+NetworkProtectionError.swift"; sourceTree = "<group>"; };
+		EE458D132ABB652900FC651A /* NetworkProtectionDebugUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDebugUtilities.swift; sourceTree = "<group>"; };
 		EE4BE0082A740BED00CD6AA8 /* ClearTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearTextField.swift; sourceTree = "<group>"; };
 		EE4FB1852A28CE7200E5CBA7 /* NetworkProtectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusView.swift; sourceTree = "<group>"; };
 		EE4FB1872A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewModel.swift; sourceTree = "<group>"; };
@@ -2345,6 +2347,7 @@
 		EE8594982A44791C008A6D06 /* NetworkProtectionTunnelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionTunnelController.swift; sourceTree = "<group>"; };
 		EEB8FDB92A990AEE00EBEDCF /* Configuration-Alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Configuration-Alpha.xcconfig"; path = "Configuration/Configuration-Alpha.xcconfig"; sourceTree = "<group>"; };
 		EEEB80A22A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionPacketTunnelProvider.swift; sourceTree = "<group>"; };
+		EEF0F8CB2ABC832200630031 /* NetworkProtectionDebugFeatures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDebugFeatures.swift; sourceTree = "<group>"; };
 		EEFD562E2A65B6CA00DAEC48 /* NetworkProtectionInviteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionInviteViewModel.swift; sourceTree = "<group>"; };
 		EEFE9C722A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewModelTests.swift; sourceTree = "<group>"; };
 		F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksDataSource.swift; sourceTree = "<group>"; };
@@ -3353,14 +3356,6 @@
 			name = AppTrackingProtection;
 			sourceTree = "<group>";
 		};
-		7B5E1F9C2AB9E1D000DA1172 /* DebugFeatures */ = {
-			isa = PBXGroup;
-			children = (
-				7B5E1F9D2AB9E1E900DA1172 /* NetworkProtectionDebugFeatures.swift */,
-			);
-			name = DebugFeatures;
-			sourceTree = "<group>";
-		};
 		830FA79B1F8E81FB00FCE105 /* ContentBlocker */ = {
 			isa = PBXGroup;
 			children = (
@@ -3522,6 +3517,7 @@
 				83ED3B8D1FA8E63700B47556 /* README.md */,
 				83ED3B8C1FA8E61D00B47556 /* ManualTestsScript.md */,
 				85A313962028E78A00327D00 /* release_notes.txt */,
+				EEF0F8CA2ABC82E100630031 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -4353,6 +4349,15 @@
 			name = FeatureFlags;
 			sourceTree = "<group>";
 		};
+		EE458D122ABB651500FC651A /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				EEF0F8CB2ABC832200630031 /* NetworkProtectionDebugFeatures.swift */,
+				EE458D132ABB652900FC651A /* NetworkProtectionDebugUtilities.swift */,
+			);
+			name = Debug;
+			sourceTree = "<group>";
+		};
 		EE50052C29C3692700AE0773 /* FeatureFlags */ = {
 			isa = PBXGroup;
 			children = (
@@ -4375,7 +4380,7 @@
 		EECD94B22A28B8580085C66E /* NetworkProtection */ = {
 			isa = PBXGroup;
 			children = (
-				7B5E1F9C2AB9E1D000DA1172 /* DebugFeatures */,
+				EE458D122ABB651500FC651A /* Debug */,
 				EE0153E22A6FE031002A8B26 /* Root */,
 				EE0153DF2A6EABAF002A8B26 /* Helpers */,
 				EEFD562D2A65B68B00DAEC48 /* Invite */,
@@ -4392,6 +4397,14 @@
 				EE4FB1872A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift */,
 			);
 			name = Status;
+			sourceTree = "<group>";
+		};
+		EEF0F8CA2ABC82E100630031 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				7B5E1F9D2AB9E1E900DA1172 /* NetworkProtectionDebugFeatures.swift */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		EEFD562D2A65B68B00DAEC48 /* Invite */ = {
@@ -6141,7 +6154,6 @@
 				98AA92B32456FBE100ED4B9E /* SearchFieldContainerView.swift in Sources */,
 				3157B43827F4C8490042D3D7 /* FaviconsHelper.swift in Sources */,
 				85F200042216F5D8006BB258 /* FindInPageView.swift in Sources */,
-				7B5E1F9E2AB9E1E900DA1172 /* NetworkProtectionDebugFeatures.swift in Sources */,
 				8548D95E25262B1B005AAE49 /* ViewHighlighter.swift in Sources */,
 				F4D7221026F29A70007D6193 /* BookmarkDetailsCell.swift in Sources */,
 				F1617C131E572E0300DEDCAF /* TabSwitcherViewController.swift in Sources */,
@@ -6156,6 +6168,7 @@
 				3157B43327F497E90042D3D7 /* SaveLoginView.swift in Sources */,
 				F17922E01E71BB59006E3D97 /* AutocompleteViewControllerDelegate.swift in Sources */,
 				0290472529E8496A0008FE3C /* AppTPActivityIconView.swift in Sources */,
+				EE458D142ABB652900FC651A /* NetworkProtectionDebugUtilities.swift in Sources */,
 				8528AE7C212EF4A200D0BD74 /* AppRatingPrompt.swift in Sources */,
 				CB2A7EEF283D185100885F67 /* RulesCompilationMonitor.swift in Sources */,
 				1EEF12502851016B003DDE57 /* PrivacyIconAndTrackersAnimator.swift in Sources */,
@@ -6166,6 +6179,7 @@
 				1E016AB42949FEB500F21625 /* OmniBarNotificationViewModel.swift in Sources */,
 				6AC6DAB328804F97002723C0 /* BarsAnimator.swift in Sources */,
 				EE0153ED2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift in Sources */,
+				EEF0F8CC2ABC832300630031 /* NetworkProtectionDebugFeatures.swift in Sources */,
 				B60DFF072872B64B0061E7C2 /* JSAlertController.swift in Sources */,
 				981FED6E22025151008488D7 /* BlankSnapshotViewController.swift in Sources */,
 				98F3A1DC217B373E0011A0D4 /* DarkTheme.swift in Sources */,

--- a/DuckDuckGo/NetworkProtectionDebugUtilities.swift
+++ b/DuckDuckGo/NetworkProtectionDebugUtilities.swift
@@ -1,0 +1,41 @@
+//
+//  NetworkProtectionDebugUtilities.swift
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import Foundation
+
+#if NETWORK_PROTECTION
+import NetworkProtection
+import NetworkExtension
+
+/// Utility code to help implement our debug menu options for Network Protection.
+///
+final class NetworkProtectionDebugUtilities {
+
+    // MARK: - Registation Key
+
+    func expireRegistrationKeyNow() async {
+        guard let activeSession = try? await ConnectionSessionUtilities.activeSession() else {
+            return
+        }
+
+        try? activeSession.sendProviderMessage(.expireRegistrationKey)
+    }
+}
+
+#endif

--- a/DuckDuckGo/NetworkProtectionDebugUtilities.swift
+++ b/DuckDuckGo/NetworkProtectionDebugUtilities.swift
@@ -1,5 +1,6 @@
 //
 //  NetworkProtectionDebugUtilities.swift
+//  DuckDuckGo
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
 //

--- a/DuckDuckGo/NetworkProtectionDebugViewController.swift
+++ b/DuckDuckGo/NetworkProtectionDebugViewController.swift
@@ -33,7 +33,9 @@ final class NetworkProtectionDebugViewController: UITableViewController {
     private let titles = [
         Sections.keychain: "Keychain",
         Sections.debugFeature: "Debug Features",
-        Sections.simulateFailure: "Simulate Failure"
+        Sections.simulateFailure: "Simulate Failure",
+        Sections.registrationKey: "Registration Key"
+
     ]
 
     enum Sections: Int, CaseIterable {
@@ -41,6 +43,7 @@ final class NetworkProtectionDebugViewController: UITableViewController {
         case keychain
         case debugFeature
         case simulateFailure
+        case registrationKey
 
     }
 
@@ -60,6 +63,12 @@ final class NetworkProtectionDebugViewController: UITableViewController {
         case controllerFailure
         case crashFatalError
         case crashMemory
+
+    }
+
+    enum RegistrationKeyRows: Int, CaseIterable {
+
+        case expireNow
 
     }
 
@@ -109,6 +118,10 @@ final class NetworkProtectionDebugViewController: UITableViewController {
 
         case .simulateFailure:
             configure(cell, forSimulateFailureAtRow: indexPath.row)
+
+        case .registrationKey:
+            configure(cell, forRegistrationKeyRow: indexPath.row)
+
         case.none:
             break
         }
@@ -121,6 +134,7 @@ final class NetworkProtectionDebugViewController: UITableViewController {
         case .keychain: return KeychainRows.allCases.count
         case .debugFeature: return DebugFeatureRows.allCases.count
         case .simulateFailure: return SimulateFailureRows.allCases.count
+        case .registrationKey: return RegistrationKeyRows.allCases.count
         case .none: return 0
 
         }
@@ -137,6 +151,8 @@ final class NetworkProtectionDebugViewController: UITableViewController {
             didSelectDebugFeature(at: indexPath)
         case .simulateFailure:
             didSelectSimulateFailure(at: indexPath)
+        case .registrationKey:
+            didSelectRegistationKeyAction(at: indexPath)
         case .none:
             break
         }
@@ -194,6 +210,28 @@ final class NetworkProtectionDebugViewController: UITableViewController {
             debugFeatures.alwaysOnEnabled.toggle()
             tableView.reloadRows(at: [indexPath], with: .none)
         default:
+            break
+        }
+    }
+
+    // MARK: Registration Key
+
+    private func configure(_ cell: UITableViewCell, forRegistrationKeyRow row: Int) {
+        switch RegistrationKeyRows(rawValue: row) {
+        case .expireNow:
+            cell.textLabel?.text = "Expire Now"
+        case .none:
+            break
+        }
+    }
+
+    private func didSelectRegistationKeyAction(at indexPath: IndexPath) {
+        switch RegistrationKeyRows(rawValue: indexPath.row) {
+        case .expireNow:
+            Task {
+                await NetworkProtectionDebugUtilities().expireRegistrationKeyNow()
+            }
+        case .none:
             break
         }
     }

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -106,10 +106,6 @@ final class NetworkProtectionTunnelController: TunnelController {
         options["activationAttemptId"] = UUID().uuidString as NSString
         options["authToken"] = try tokenStore.fetchToken() as NSString?
 
-        // Temporary investigation to see if connection tester is causing energy use issues
-        // To be removed with https://app.asana.com/0/0/1205418028628990/f
-        options[NetworkProtectionOptionKey.connectionTesterEnabled] = NSNumber(value: false)
-
         if let optionKey = Self.enabledSimulationOption?.optionKey {
             options[optionKey] = NSNumber(value: true)
             Self.enabledSimulationOption = nil

--- a/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
@@ -37,7 +37,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 PixelParameters.server: server,
                 PixelParameters.networkType: networkType.rawValue
             ]
-            Pixel.fire(pixel: .networkProtectionLatency)
+            Pixel.fire(pixel: .networkProtectionLatency, withAdditionalParameters: params)
         case .rekeyCompleted:
             Pixel.fire(pixel: .networkProtectionRekeyCompleted)
         }

--- a/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
@@ -25,7 +25,22 @@ import Core
 // Initial implementation for initial Network Protection tests. Will be fleshed out with https://app.asana.com/0/1203137811378537/1204630829332227/f
 final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
-    private static var packetTunnelProviderEvents: EventMapping<PacketTunnelProvider.Event> = .init { _, _, _, _ in
+    // MARK: - PacketTunnelProvider.Event reporting
+
+    private static var packetTunnelProviderEvents: EventMapping<PacketTunnelProvider.Event> = .init { event, _, _, _ in
+        switch event {
+        case .userBecameActive:
+            DailyPixel.fire(pixel: .networkProtectionActiveUser)
+        case .reportLatency(ms: let ms, server: let server, networkType: let networkType):
+            let params = [
+                PixelParameters.latency: String(ms),
+                PixelParameters.server: server,
+                PixelParameters.networkType: networkType.rawValue
+            ]
+            Pixel.fire(pixel: .networkProtectionLatency)
+        case .rekeyCompleted:
+            Pixel.fire(pixel: .networkProtectionRekeyCompleted)
+        }
     }
 
     // MARK: - Error Reporting

--- a/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
@@ -21,6 +21,7 @@ import Foundation
 import NetworkProtection
 import Common
 import Core
+import Networking
 
 // Initial implementation for initial Network Protection tests. Will be fleshed out with https://app.asana.com/0/1203137811378537/1204630829332227/f
 final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
@@ -159,6 +160,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                    debugEvents: Self.networkProtectionDebugEvents(controllerErrorStore: errorStore),
                    providerEvents: Self.packetTunnelProviderEvents)
         startMonitoringMemoryPressureEvents()
+        APIRequest.Headers.setUserAgent(DefaultUserAgentManager.duckDuckGoUserAgent)
     }
 
     private func startMonitoringMemoryPressureEvents() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205537962077888/f

**Description**:

Pixels for determining performance and how often users are using the VPN.

- Network Protection daily active user: `m_netp_daily_active_d `
- Latency: `m_netp_latency`
  - Trigger: Sent periodically from the NetP extension
  - Parameters:
    - `latency`: An integer value representing the user's latency in milliseconds
    - `server`: The identifier of the server, taken from the NetP server list
    - `network_type`: The user's network type (one of cell, wifi, eth)
- Rekey:` m_netp_rekey_completed`

**Steps to test this PR**:
1. Put a breakpoint in the `Pixel.fire(pixelNamed…` function at L: 203
2. Run the PacketTunnelProvider in debug
3. Start Network Protection (Settings -> Network Protection)
4. Ensure PacketTunnelProvider is attached to the debugger
5. Ensure that a request is made intermittently with the latency pixel (and all params)
6. Switch to cellular: ensure a request is made with the network_type Pixel.
7. The daily active user pixel could be hard to test without adding a print / log of some kind.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
