### PR TITLE
Pass testflight alpha group as an array to fastlane

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,8 +1,6 @@
 name: Make TestFlight Alpha Build
 
 on:
-  push:
-    branches: [ graeme/add-alpha-testflight-group-as-array ] # TODO: Remove this before merging
   workflow_dispatch:
     inputs:
       destination:
@@ -41,13 +39,12 @@ jobs:
 
     steps:
 
-    # - name: Assert develop branch
-    #   run: |
-    #     case "${{ github.ref }}" in
-    #       *develop) ;;
-    #       *) echo "👎 Not develop branch"; exit 1 ;;
-    #     esac
-    #   TODO: Uncomment before merging
+    - name: Assert develop branch
+      run: |
+        case "${{ github.ref }}" in
+          *develop) ;;
+          *) echo "👎 Not develop branch"; exit 1 ;;
+        esac
 
     - name: Register SSH keys for access to certificates
       uses: webfactory/ssh-agent@v0.7.0

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         app_version="$(cut -d ' ' -f 3 < Configuration/Version.xcconfig)"
         bundle exec fastlane increment_build_number_for_version version:$app_version app_identifier:"com.duckduckgo.mobile.ios.alpha"
-        bundle exec fastlane release_alpha groups:"${{ env.destination }}"
+        bundle exec fastlane release_alpha groups:["${{ env.destination }}"]
         build_version="$(xcodebuild -configuration Alpha -showBuildSettings | grep CURRENT_PROJECT_VERSION | tr -d 'CURRENT_PROJECT_VERSION =')"
         echo "dsyms_path=${{ github.workspace }}/DuckDuckGo-Alpha.app.dSYM.zip" >> $GITHUB_ENV
         echo "app_version=${app_version}" >> $GITHUB_ENV

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,6 +1,8 @@
 name: Make TestFlight Alpha Build
 
 on:
+  push:
+    branches: [ graeme/add-alpha-testflight-group-as-array ] # TODO: Remove this before merging
   workflow_dispatch:
     inputs:
       destination:
@@ -39,12 +41,13 @@ jobs:
 
     steps:
 
-    - name: Assert develop branch
-      run: |
-        case "${{ github.ref }}" in
-          *develop) ;;
-          *) echo "👎 Not develop branch"; exit 1 ;;
-        esac
+    # - name: Assert develop branch
+    #   run: |
+    #     case "${{ github.ref }}" in
+    #       *develop) ;;
+    #       *) echo "👎 Not develop branch"; exit 1 ;;
+    #     esac
+    #   TODO: Uncomment before merging
 
     - name: Register SSH keys for access to certificates
       uses: webfactory/ssh-agent@v0.7.0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,8 +135,7 @@ lane :release_alpha do |options|
   upload_to_testflight(
     api_key: get_api_key,
     groups: options[:groups],
-    skip_waiting_for_build_processing: true,
-    submit_beta_review: true
+    skip_waiting_for_build_processing: true
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -136,13 +136,13 @@ lane :release_alpha do |options|
     api_key: get_api_key,
     groups: options[:groups],
     skip_waiting_for_build_processing: true,
-    submit_beta_review: false
+    submit_beta_review: true
   )
 end
 
 desc 'Increment build number based on version in App Store Connect'
 lane :increment_build_number_for_version do |options|
-  app_identifier = "com.duckduckgo.mobile.ios"
+  app_identifier = "com.duckduckgo.mobile.ios" 
   if options[:app_identifier]
     app_identifier = options[:app_identifier]
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,13 +135,14 @@ lane :release_alpha do |options|
   upload_to_testflight(
     api_key: get_api_key,
     groups: options[:groups],
-    skip_waiting_for_build_processing: true
+    skip_waiting_for_build_processing: true,
+    submit_beta_review: false
   )
 end
 
 desc 'Increment build number based on version in App Store Connect'
 lane :increment_build_number_for_version do |options|
-  app_identifier = "com.duckduckgo.mobile.ios"
+  app_identifier = "com.duckduckgo.mobile.ios"  
   if options[:app_identifier]
     app_identifier = options[:app_identifier]
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,7 +142,7 @@ end
 
 desc 'Increment build number based on version in App Store Connect'
 lane :increment_build_number_for_version do |options|
-  app_identifier = "com.duckduckgo.mobile.ios"  
+  app_identifier = "com.duckduckgo.mobile.ios"
   if options[:app_identifier]
     app_identifier = options[:app_identifier]
   end


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205539796737793/f

**Description**:

We now have Alphas being distributed to TestFlight… but they seem to be ignoring the group. I’m trying passing this as an array as that’s what’s expected (was under the impression a string would also work, but [examples online ](https://github.com/fastlane/fastlane/pull/19735) seem to show potentially otherwise). 

**Steps to test this PR**:
1. Just check TestFlight to see if the last build from this PR got added to the Latest Alpha Group

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
