### PR TITLE
Fix some issues with NetP pixels

### DIFF
--- a/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
@@ -22,6 +22,7 @@ import NetworkProtection
 import Common
 import Core
 import Networking
+import NetworkExtension
 
 // Initial implementation for initial Network Protection tests. Will be fleshed out with https://app.asana.com/0/1203137811378537/1204630829332227/f
 final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
@@ -146,6 +147,19 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             }
             completionHandler(error)
         }
+    }
+
+    public override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        switch reason {
+        case .appUpdate, .userInitiated:
+            break
+        default:
+            DailyPixel.fireDailyAndCount(
+                pixel: .networkProtectionDisconnected,
+                withAdditionalParameters: [PixelParameters.reason: String(reason.rawValue)]
+            )
+        }
+        super.stopTunnel(with: reason, completionHandler: completionHandler)
     }
 
     @objc init() {

--- a/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtectionPacketTunnelProvider.swift
@@ -175,9 +175,9 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 case DispatchSource.MemoryPressureEvent.normal:
                     break
                 case DispatchSource.MemoryPressureEvent.warning:
-                    Pixel.fire(pixel: .networkProtectionMemoryWarning)
+                    DailyPixel.fire(pixel: .networkProtectionMemoryWarning)
                 case DispatchSource.MemoryPressureEvent.critical:
-                    Pixel.fire(pixel: .networkProtectionMemoryCritical)
+                    DailyPixel.fire(pixel: .networkProtectionMemoryCritical)
                 default:
                     break
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205551137818435/f
Tech Design URL:
CC:

**Description**:

I made a couple of mistakes when initially adding the error pixels for Network Protection. This addresses those mistakes:
- Not sending the disconnect pixel
- Not making the memory warnings daily

**Steps to test this PR**:
- Found both of these quite hard to test to be honest

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
