### PR TITLE
Fix URL deeplink

### DIFF
--- a/Core/AppDeepLinkSchemes.swift
+++ b/Core/AppDeepLinkSchemes.swift
@@ -45,10 +45,21 @@ public enum AppDeepLinkSchemes: String, CaseIterable {
     }
 
     public static func query(fromQuickLink url: URL) -> String {
-        return url.absoluteString
+        let query = url.absoluteString
             .replacingOccurrences(of: AppDeepLinkSchemes.quickLink.url.absoluteString,
                                   with: "",
                                   options: .caseInsensitive)
+
+        return AppDeepLinkSchemes.fixURLScheme(query)
     }
 
+    private static func fixURLScheme(_ urlString: String) -> String {
+        let pattern = "^https?//"
+
+        if urlString.range(of: pattern, options: .regularExpression) != nil {
+            return urlString.replacingOccurrences(of: "//", with: "://")
+        } else {
+            return urlString
+        }
+    }
 }

--- a/DuckDuckGo/AppDelegate+AppDeepLinks.swift
+++ b/DuckDuckGo/AppDelegate+AppDeepLinks.swift
@@ -31,13 +31,11 @@ extension AppDelegate {
             mainViewController.newTab(reuseExisting: true)
             mainViewController.enterSearch()
 
-
         case .favorites:
             mainViewController.newTab(reuseExisting: true, allowingKeyboard: false)
 
         case .quickLink:
-            let query = AppDeepLinkSchemes.query(fromQuickLink: url)
-            mainViewController.loadQueryInNewTab(query, reuseExisting: true)
+            handleQuickLink(url, mainViewController)
 
         case .addFavorite:
             mainViewController.startAddFavoriteFlow()
@@ -65,6 +63,15 @@ extension AppDelegate {
         }
 
         return true
+    }
+
+    private func handleQuickLink(_ url: URL, _ mainViewController: MainViewController) {
+        let query = AppDeepLinkSchemes.query(fromQuickLink: url)
+        if let url = URL(string: query) {
+            mainViewController.loadUrlInNewTab(url, reuseExisting: true, inheritedAttribution: nil)
+        } else {
+            mainViewController.loadQueryInNewTab(query, reuseExisting: true)
+        }
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205564554996541/f

**Description**:
Fix URL deeplink

**Steps to test this PR**:
1. See task for steps on how to reproduce the issue
2. Create a note with multiple types of urls and just queries (for example: https://example.com, http://example.com, www.example.com, example, duck)
3. Go to each of them, tap and hold, select share, then open in the DDG browser
4. Check if it’s correctly opening as searches or websites

* [x] iOS 15
* [x] iOS 16


