### PR TITLE
Fix for WebCacheManager crash

### DIFF
--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -263,7 +263,12 @@ public class WebCacheManager {
                        .appendingPathComponent("WebKit/\(bundleID)/WebsiteData/ResourceLoadStatistics/observations.db")
         ]
 
-        return databaseURLs.lazy.compactMap({ try? DatabasePool(path: $0.absoluteString) }).first
+        guard let validURL = databaseURLs.first(where: { FileManager.default.fileExists(atPath: $0.path) }),
+              let pool = try? DatabasePool(path: validURL.absoluteString) else {
+            return nil
+        }
+
+        return pool
     }
 
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1205581661098084/f
Tech Design URL:
CC:

**Description**:
Fix for occasional crash that is happening when attempting to clear `observations.db` as part of tapping the fire button

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Testing on device visit a few websites
2. In the app go to `Settings > Debug > File Size Inspector > Application Container > Library > WebKit > WebsiteData > ResourceLoadStatistics` and tap on `observations.db` and confirm the tables have content reporting websites visited
3. Tap the fire button and confirm the app does not crash
4. Check the contents of `observations.db` again and confirm all the tables are now empty
5. Tap the fire button a couple of more times confirming that there is no crash

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
