### PR TITLE
Enabled always-on by default

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -98,7 +98,7 @@ public struct UserDefaultsWrapper<T> {
 
         case syncEnvironment = "com.duckduckgo.ios.sync-environment"
 
-        case networkProtectionDebugOptionAlwaysOnEnabled = "com.duckduckgo.network-protection.always-on.enabled"
+        case networkProtectionDebugOptionAlwaysOnDisabled = "com.duckduckgo.network-protection.always-on.disabled"
     }
 
     private let key: Key

--- a/DuckDuckGo/NetworkProtectionDebugFeatures.swift
+++ b/DuckDuckGo/NetworkProtectionDebugFeatures.swift
@@ -21,6 +21,6 @@ import Foundation
 import Core
 
 final class NetworkProtectionDebugFeatures {
-    @UserDefaultsWrapper(key: .networkProtectionDebugOptionAlwaysOnEnabled, defaultValue: false)
-    var alwaysOnEnabled
+    @UserDefaultsWrapper(key: .networkProtectionDebugOptionAlwaysOnDisabled, defaultValue: false)
+    var alwaysOnDisabled
 }

--- a/DuckDuckGo/NetworkProtectionDebugViewController.swift
+++ b/DuckDuckGo/NetworkProtectionDebugViewController.swift
@@ -54,7 +54,7 @@ final class NetworkProtectionDebugViewController: UITableViewController {
     }
 
     enum DebugFeatureRows: Int, CaseIterable {
-        case enableAlwaysOn
+        case toggleAlwaysOn
     }
 
     enum SimulateFailureRows: Int, CaseIterable {
@@ -191,13 +191,13 @@ final class NetworkProtectionDebugViewController: UITableViewController {
 
     private func configure(_ cell: UITableViewCell, forDebugFeatureAtRow row: Int) {
         switch DebugFeatureRows(rawValue: row) {
-        case .enableAlwaysOn:
-            cell.textLabel?.text = "Enable Always On"
+        case .toggleAlwaysOn:
+            cell.textLabel?.text = "Always On"
 
-            if debugFeatures.alwaysOnEnabled {
-                cell.accessoryType = .checkmark
-            } else {
+            if debugFeatures.alwaysOnDisabled {
                 cell.accessoryType = .none
+            } else {
+                cell.accessoryType = .checkmark
             }
         default:
             break
@@ -206,8 +206,8 @@ final class NetworkProtectionDebugViewController: UITableViewController {
 
     private func didSelectDebugFeature(at indexPath: IndexPath) {
         switch DebugFeatureRows(rawValue: indexPath.row) {
-        case .enableAlwaysOn:
-            debugFeatures.alwaysOnEnabled.toggle()
+        case .toggleAlwaysOn:
+            debugFeatures.alwaysOnDisabled.toggle()
             tableView.reloadRows(at: [indexPath], with: .none)
         default:
             break

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -118,7 +118,7 @@ final class NetworkProtectionTunnelController: TunnelController {
             throw error
         }
 
-        if debugFeatures.alwaysOnEnabled {
+        if !debugFeatures.alwaysOnDisabled {
             Task {
                 try await enableOnDemand(tunnelManager: tunnelManager)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205573532958049/f

**Description**:

In this PR we enable always on by default, and change the debug menu option's title to just "Always On".

**Steps to test this PR**:

1. On a fresh install, run the app
2. Go to More Menu > Settings > Debug Menu > Network Protection and ensure Always On is enabled.
3. Connect NetP
4. Go to Settings.app > VPN > Tap on the (i) icon next to "DuckDuckGo Network Protection"
5. Ensure that "Connect On Demand" is enabled
6. Go back to our app and disconnect NetP.
7. Go to More Menu > Settings > Debug Menu > Network Protection and disable Always On.
8. Connect NetP
9. Go to Settings.app > VPN > Tap on the (i) icon next to "DuckDuckGo Network Protection"
10. Ensure that "Connect On Demand" is disabled

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
