### PR TITLE
Update BSK with autofill 8.4.1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8927,8 +8927,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = c3287c0e996e2bb620ee7d3e38d54e137f550adc;
+				kind = exactVersion;
+				version = 80.2.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8927,8 +8927,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 80.2.0;
+				kind = revision;
+				revision = c3287c0e996e2bb620ee7d3e38d54e137f550adc;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "2bc934304fd9d5e2b51dfe78a0c95ba10f1ab5a5",
-          "version": "80.2.0"
+          "revision": "e955f958201a91ef353c55236361e095357e9505",
+          "version": "80.2.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/duckduckgo/duckduckgo-autofill.git",
         "state": {
           "branch": null,
-          "revision": "f3eccad8647fdba2b5d180a02a0513c61375b8fb",
-          "version": "8.4.0"
+          "revision": "55466f10a339843cb79a27af62d5d61c030740b2",
+          "version": "8.4.1"
         }
       },
       {
@@ -156,7 +156,7 @@
       },
       {
         "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit",
+        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
         "state": {
           "branch": null,
           "revision": "4684440d03304e7638a2c8086895367e90987463",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205602928782192/1205602928782192
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/517

## Description
Updates Autofill to version [8.4.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/8.4.1).

### Autofill 8.4.1 release notes
## What's Changed
* Precompile regexes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/382
* Add perf tests by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/383
* deps: remove deprecated content-scope-utils by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/384
* Update dependencies by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/368
* Fix perf regressions by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/385


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/8.4.0...8.4.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).