### PR TITLE
Fixes connection reassertion and provides a mechanism to make the tester simulate a failure

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8944,7 +8944,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 91a44e4ca50d4ffe27dd15ff8ab81a6aab0dac12;
+				revision = b36c82700cd47716ae4401757e07c848496d040d;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "91a44e4ca50d4ffe27dd15ff8ab81a6aab0dac12",
+          "revision": "b36c82700cd47716ae4401757e07c848496d040d",
           "version": null
         }
       },
@@ -156,7 +156,7 @@
       },
       {
         "package": "TrackerRadarKit",
-        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit",
+        "repositoryURL": "https://github.com/duckduckgo/TrackerRadarKit.git",
         "state": {
           "branch": null,
           "revision": "4684440d03304e7638a2c8086895367e90987463",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205601368549677/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/518
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1689

**Description**:

This is a PR I'm opening targetting the parent PR with suggested changes.

This PR:
- Fixes the reassertion logic
- Proposes a different mechanism to make the tester fail and recover that mimicks more closely how it'll look like in real life.

## Testing

1. Start Network Protection (Settings -> Network Protection)
2. **Observe the notifications permission prompt**. Agree to this.
3. Go to the Debug menu and simulate a connection interruption (Settings -> Debug -> Network Protection -> Simulate Connection Interruption)
4. **Observe the interruption notification**
5. Go back to Network Protection settings
6. **Observe the status is reconnecting**
7. Wait for and **observer the reconnected notification.**
8. Go back to the Debug menu and send a test notification
9. **Observe the test notification**

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
