### PR TITLE
Open NetP status view from notifications

### DIFF
--- a/Core/NetworkProtectionNotificationIdentifier.swift
+++ b/Core/NetworkProtectionNotificationIdentifier.swift
@@ -1,0 +1,28 @@
+//
+//  NetworkProtectionNotificationIdentifier.swift
+//  DuckDuckGo
+//
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum NetworkProtectionNotificationIdentifier: String {
+    case reconnecting = "network-protection.notification.reconnecting"
+    case reconnected = "network-protection.notification.reconnected"
+    case connectionFailure = "network-protection.notification.connection-failure"
+    case superseded = "network-protection.notification.superseded"
+    case test = "network-protection.notification.test"
+}

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -759,6 +759,7 @@
 		EE50053029C3BA0800AE0773 /* InternalUserStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE50052F29C3BA0800AE0773 /* InternalUserStore.swift */; };
 		EE72CA852A862D000043B5B3 /* NetworkProtectionDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72CA842A862D000043B5B3 /* NetworkProtectionDebugViewController.swift */; };
 		EE7917912A83DE93008DFF28 /* CombineTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7917902A83DE93008DFF28 /* CombineTestUtilities.swift */; };
+		EE7A92872AC6DE4700832A36 /* NetworkProtectionNotificationIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7A92862AC6DE4700832A36 /* NetworkProtectionNotificationIdentifier.swift */; };
 		EE8594992A44791C008A6D06 /* NetworkProtectionTunnelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8594982A44791C008A6D06 /* NetworkProtectionTunnelController.swift */; };
 		EE8E568A2A56BCE400F11DCA /* NetworkProtection in Frameworks */ = {isa = PBXBuildFile; productRef = EE8E56892A56BCE400F11DCA /* NetworkProtection */; };
 		EEEB80A32A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEB80A22A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift */; };
@@ -2349,6 +2350,7 @@
 		EE50052F29C3BA0800AE0773 /* InternalUserStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalUserStore.swift; sourceTree = "<group>"; };
 		EE72CA842A862D000043B5B3 /* NetworkProtectionDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDebugViewController.swift; sourceTree = "<group>"; };
 		EE7917902A83DE93008DFF28 /* CombineTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestUtilities.swift; sourceTree = "<group>"; };
+		EE7A92862AC6DE4700832A36 /* NetworkProtectionNotificationIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionNotificationIdentifier.swift; sourceTree = "<group>"; };
 		EE8594982A44791C008A6D06 /* NetworkProtectionTunnelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionTunnelController.swift; sourceTree = "<group>"; };
 		EEB8FDB92A990AEE00EBEDCF /* Configuration-Alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Configuration-Alpha.xcconfig"; path = "Configuration/Configuration-Alpha.xcconfig"; sourceTree = "<group>"; };
 		EEEB80A22A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionPacketTunnelProvider.swift; sourceTree = "<group>"; };
@@ -4394,6 +4396,14 @@
 			name = NetworkProtection;
 			sourceTree = "<group>";
 		};
+		EE7A92852AC6DE2500832A36 /* NetworkProtection */ = {
+			isa = PBXGroup;
+			children = (
+				EE7A92862AC6DE4700832A36 /* NetworkProtectionNotificationIdentifier.swift */,
+			);
+			name = NetworkProtection;
+			sourceTree = "<group>";
+		};
 		EECD94B22A28B8580085C66E /* NetworkProtection */ = {
 			isa = PBXGroup;
 			children = (
@@ -4669,6 +4679,7 @@
 		F143C2E51E4A4CD400CFDE3A /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				EE7A92852AC6DE2500832A36 /* NetworkProtection */,
 				4B470ED4299C484B0086EBDC /* AppTrackingProtection */,
 				F1CE42A71ECA0A520074A8DF /* Bookmarks */,
 				837774491F8E1ECE00E17A29 /* ContentBlocker */,
@@ -6693,6 +6704,7 @@
 				85F21DC621145DD5002631A6 /* global.swift in Sources */,
 				F41C2DA326C1925700F9A760 /* BookmarksAndFolders.xcdatamodeld in Sources */,
 				F4F6DFBA26EFF28A00ED7E12 /* BookmarkObjects.swift in Sources */,
+				EE7A92872AC6DE4700832A36 /* NetworkProtectionNotificationIdentifier.swift in Sources */,
 				836A941D247F23C600BF8EF5 /* UserAgentManager.swift in Sources */,
 				4B83397329AFB8D2003F7EA9 /* AppTrackingProtectionFeedbackModel.swift in Sources */,
 				85CA53A824BB343700A6288C /* Favicons.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -677,8 +677,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
-            if response.notification.request.identifier == WindowsBrowserWaitlist.notificationIdentitier {
+            let identifier = response.notification.request.identifier
+            if identifier == WindowsBrowserWaitlist.notificationIdentitier {
                 presentWindowsBrowserWaitlistSettingsModal()
+            } else if NetworkProtectionNotificationIdentifier(rawValue: identifier) != nil {
+                presentNetworkProtectionStatusSettingsModal()
             }
         }
 
@@ -689,7 +692,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let waitlistViewController = WindowsWaitlistViewController(nibName: nil, bundle: nil)
         presentSettings(with: waitlistViewController)
     }
-    
+
+    private func presentNetworkProtectionStatusSettingsModal() {
+        let networkProtectionRoot = NetworkProtectionRootViewController()
+        presentSettings(with: networkProtectionRoot)
+    }
+
     private func presentSettings(with viewController: UIViewController) {
         guard let window = window, let rootViewController = window.rootViewController as? MainViewController else { return }
 
@@ -703,5 +711,4 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             navigationController?.pushViewController(viewController, animated: true)
         }
     }
-
 }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -680,9 +680,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let identifier = response.notification.request.identifier
             if identifier == WindowsBrowserWaitlist.notificationIdentitier {
                 presentWindowsBrowserWaitlistSettingsModal()
-            } else if NetworkProtectionNotificationIdentifier(rawValue: identifier) != nil {
+            }
+
+#if NETWORK_PROTECTION
+            if NetworkProtectionNotificationIdentifier(rawValue: identifier) != nil {
                 presentNetworkProtectionStatusSettingsModal()
             }
+#endif
         }
 
         completionHandler()
@@ -693,10 +697,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         presentSettings(with: waitlistViewController)
     }
 
+#if NETWORK_PROTECTION
     private func presentNetworkProtectionStatusSettingsModal() {
         let networkProtectionRoot = NetworkProtectionRootViewController()
         presentSettings(with: networkProtectionRoot)
     }
+#endif
 
     private func presentSettings(with viewController: UIViewController) {
         guard let window = window, let rootViewController = window.rootViewController as? MainViewController else { return }

--- a/DuckDuckGo/NetworkProtectionRootViewController.swift
+++ b/DuckDuckGo/NetworkProtectionRootViewController.swift
@@ -23,7 +23,7 @@ import SwiftUI
 
 final class NetworkProtectionRootViewController: UIHostingController<NetworkProtectionRootView> {
 
-    init(inviteCompletion: @escaping () -> Void) {
+    init(inviteCompletion: @escaping () -> Void = { }) {
         let rootView = NetworkProtectionRootView(inviteCompletion: inviteCompletion)
         super.init(rootView: rootView)
     }

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -420,7 +420,7 @@ class SettingsViewController: UITableViewController {
         // This will be tidied up as part of https://app.asana.com/0/0/1205084446087078/f
         let rootViewController = NetworkProtectionRootViewController { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-            let newRootViewController = NetworkProtectionRootViewController { }
+            let newRootViewController = NetworkProtectionRootViewController()
             self?.pushNetP(newRootViewController)
         }
         pushNetP(rootViewController)

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionUNNotificationPresenter.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionUNNotificationPresenter.swift
@@ -19,6 +19,7 @@
 
 import UIKit
 import NetworkProtection
+import Core
 
 /// This class takes care of requesting the presentation of notifications using UNNotificationCenter
 ///
@@ -72,29 +73,29 @@ final class NetworkProtectionUNNotificationPresenter: NSObject, NetworkProtectio
     func showTestNotification() {
         // Debug only string. Doesn't need localized
         let content = notificationContent(body: "Test notification")
-        showNotification(content)
+        showNotification(.test, content)
     }
 
     func showReconnectedNotification() {
         let content = notificationContent(body: UserText.networkProtectionConnectionSuccessNotificationBody)
-        showNotification(content)
+        showNotification(.reconnected, content)
     }
 
     func showReconnectingNotification() {
         let content = notificationContent(body: UserText.networkProtectionConnectionInterruptedNotificationBody)
-        showNotification(content)
+        showNotification(.reconnecting, content)
     }
 
     func showConnectionFailureNotification() {
         let content = notificationContent(body: UserText.networkProtectionConnectionFailureNotificationBody)
-        showNotification(content)
+        showNotification(.connectionFailure, content)
     }
 
     func showSupersededNotification() {
     }
 
-    private func showNotification(_ content: UNNotificationContent) {
-        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: .none)
+    private func showNotification(_ identifier: NetworkProtectionNotificationIdentifier, _ content: UNNotificationContent) {
+        let request = UNNotificationRequest(identifier: identifier.rawValue, content: content, trigger: .none)
 
         requestAlertAuthorization { authorized in
             guard authorized else {
@@ -107,9 +108,7 @@ final class NetworkProtectionUNNotificationPresenter: NSObject, NetworkProtectio
 }
 
 extension NetworkProtectionUNNotificationPresenter: UNUserNotificationCenterDelegate {
-
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
         return .banner
     }
-
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205614408194312/f

**Description**:

As part of [iOS: Network Protection Notifications](https://app.asana.com/0/0/1205174565657101), we should make sure the Network Protection Status view is opened when tapping a notification triggered by the extension.

**Steps to test this PR**:
1. Launch the app, go to Settings -> Debug and ensure you are set as an Internal User
2. Go to Settings -> Network Protection and make sure the VPN is running
3. Go to Settings -> Debug -> Network Protection and select Connection Interruption
4. Kill the app straight after doing this
5. When you see the interruption notification, tap it
6. **The DDG app should open and you should be navigated to the status view**
7. Repeat steps 3 & 4
8. This time, ignore the interruption notification and wait for the reconnected one.
9. Verify step 6 again

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
