### PR TITLE
Localize the PacketTunnelProvider strings

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 		EE7917912A83DE93008DFF28 /* CombineTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7917902A83DE93008DFF28 /* CombineTestUtilities.swift */; };
 		EE8594992A44791C008A6D06 /* NetworkProtectionTunnelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8594982A44791C008A6D06 /* NetworkProtectionTunnelController.swift */; };
 		EE8E568A2A56BCE400F11DCA /* NetworkProtection in Frameworks */ = {isa = PBXBuildFile; productRef = EE8E56892A56BCE400F11DCA /* NetworkProtection */; };
+		EEDFE2DA2AC6ED4F00F0E19C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = EEDFE2DC2AC6ED4F00F0E19C /* Localizable.strings */; };
 		EEEB80A32A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEB80A22A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift */; };
 		EEF0F8CC2ABC832300630031 /* NetworkProtectionDebugFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF0F8CB2ABC832200630031 /* NetworkProtectionDebugFeatures.swift */; };
 		EEFAB4672A73C230008A38E4 /* NetworkProtectionTestUtils in Frameworks */ = {isa = PBXBuildFile; productRef = EEFAB4662A73C230008A38E4 /* NetworkProtectionTestUtils */; };
@@ -2351,6 +2352,31 @@
 		EE7917902A83DE93008DFF28 /* CombineTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestUtilities.swift; sourceTree = "<group>"; };
 		EE8594982A44791C008A6D06 /* NetworkProtectionTunnelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionTunnelController.swift; sourceTree = "<group>"; };
 		EEB8FDB92A990AEE00EBEDCF /* Configuration-Alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Configuration-Alpha.xcconfig"; path = "Configuration/Configuration-Alpha.xcconfig"; sourceTree = "<group>"; };
+		EEDFE2DB2AC6ED4F00F0E19C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2DD2AC6ED5B00F0E19C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2DE2AC6ED5F00F0E19C /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2DF2AC6ED6300F0E19C /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E02AC6ED7300F0E19C /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E12AC6ED7500F0E19C /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E22AC6ED7700F0E19C /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E32AC6ED7900F0E19C /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E42AC6ED9200F0E19C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E52AC6ED9200F0E19C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E62AC6ED9400F0E19C /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E72AC6ED9500F0E19C /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E82AC6ED9700F0E19C /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2E92AC6ED9A00F0E19C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2EA2AC6ED9D00F0E19C /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2EB2AC6ED9D00F0E19C /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2EC2AC6ED9E00F0E19C /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2ED2AC6ED9E00F0E19C /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2EE2AC6ED9F00F0E19C /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2EF2AC6EDA100F0E19C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2F02AC6EDA200F0E19C /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2F12AC6EDA300F0E19C /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2F22AC6EDA400F0E19C /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2F32AC6EDA500F0E19C /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		EEDFE2F42AC6EDA700F0E19C /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		EEEB80A22A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionPacketTunnelProvider.swift; sourceTree = "<group>"; };
 		EEF0F8CB2ABC832200630031 /* NetworkProtectionDebugFeatures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDebugFeatures.swift; sourceTree = "<group>"; };
 		EEFC6A5F2AC0F2F80065027D /* UserText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserText.swift; sourceTree = "<group>"; };
@@ -2616,6 +2642,7 @@
 				02025668298818B200E694E7 /* Info.plist */,
 				02025669298818B200E694E7 /* PacketTunnelProvider.entitlements */,
 				EEFC6A5F2AC0F2F80065027D /* UserText.swift */,
+				EEDFE2DC2AC6ED4F00F0E19C /* Localizable.strings */,
 			);
 			path = PacketTunnelProvider;
 			sourceTree = "<group>";
@@ -5605,6 +5632,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0262085C2A37915D006CB755 /* ios_blocklist_075.json in Resources */,
+				EEDFE2DA2AC6ED4F00F0E19C /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7460,6 +7488,38 @@
 				981685482521EEF100FA91A1 /* nb */,
 			);
 			name = OmniBar.xib;
+			sourceTree = "<group>";
+		};
+		EEDFE2DC2AC6ED4F00F0E19C /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EEDFE2DB2AC6ED4F00F0E19C /* en */,
+				EEDFE2DD2AC6ED5B00F0E19C /* bg */,
+				EEDFE2DE2AC6ED5F00F0E19C /* da */,
+				EEDFE2DF2AC6ED6300F0E19C /* cs */,
+				EEDFE2E02AC6ED7300F0E19C /* nl */,
+				EEDFE2E12AC6ED7500F0E19C /* et */,
+				EEDFE2E22AC6ED7700F0E19C /* hr */,
+				EEDFE2E32AC6ED7900F0E19C /* fi */,
+				EEDFE2E42AC6ED9200F0E19C /* fr */,
+				EEDFE2E52AC6ED9200F0E19C /* de */,
+				EEDFE2E62AC6ED9400F0E19C /* el */,
+				EEDFE2E72AC6ED9500F0E19C /* hu */,
+				EEDFE2E82AC6ED9700F0E19C /* it */,
+				EEDFE2E92AC6ED9A00F0E19C /* lv */,
+				EEDFE2EA2AC6ED9D00F0E19C /* lt */,
+				EEDFE2EB2AC6ED9D00F0E19C /* nb */,
+				EEDFE2EC2AC6ED9E00F0E19C /* pl */,
+				EEDFE2ED2AC6ED9E00F0E19C /* pt */,
+				EEDFE2EE2AC6ED9F00F0E19C /* ro */,
+				EEDFE2EF2AC6EDA100F0E19C /* ru */,
+				EEDFE2F02AC6EDA200F0E19C /* sk */,
+				EEDFE2F12AC6EDA300F0E19C /* sl */,
+				EEDFE2F22AC6EDA400F0E19C /* es */,
+				EEDFE2F32AC6EDA500F0E19C /* sv */,
+				EEDFE2F42AC6EDA700F0E19C /* tr */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 		F176699D1E40BC86003D3222 /* Settings.storyboard */ = {

--- a/PacketTunnelProvider/bg.lproj/Localizable.strings
+++ b/PacketTunnelProvider/bg.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/cs.lproj/Localizable.strings
+++ b/PacketTunnelProvider/cs.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/da.lproj/Localizable.strings
+++ b/PacketTunnelProvider/da.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/de.lproj/Localizable.strings
+++ b/PacketTunnelProvider/de.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/el.lproj/Localizable.strings
+++ b/PacketTunnelProvider/el.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/en.lproj/Localizable.strings
+++ b/PacketTunnelProvider/en.lproj/Localizable.strings
@@ -1,0 +1,12 @@
+/* The body of the notification shown when Network Protection fails to reconnect */
+"network.protection.failure.notification.body" = "Network Protection failed to connect. Please try again later.";
+
+/* The body of the notification shown when Network Protection's connection is interrupted */
+"network.protection.interrupted.notification.body" = "Network Protection was interrupted. Attempting to reconnect now...";
+
+/* The title of the notifications shown from Network Protection */
+"network.protection.notification.title" = "DuckDuckGo";
+
+/* The body of the notification shown when Network Protection reconnects successfully */
+"network.protection.success.notification.body" = "Network Protection is On. Your location and online activity are protected.";
+

--- a/PacketTunnelProvider/es.lproj/Localizable.strings
+++ b/PacketTunnelProvider/es.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/et.lproj/Localizable.strings
+++ b/PacketTunnelProvider/et.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/fi.lproj/Localizable.strings
+++ b/PacketTunnelProvider/fi.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/fr.lproj/Localizable.strings
+++ b/PacketTunnelProvider/fr.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/hr.lproj/Localizable.strings
+++ b/PacketTunnelProvider/hr.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/hu.lproj/Localizable.strings
+++ b/PacketTunnelProvider/hu.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/it.lproj/Localizable.strings
+++ b/PacketTunnelProvider/it.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/lt.lproj/Localizable.strings
+++ b/PacketTunnelProvider/lt.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/lv.lproj/Localizable.strings
+++ b/PacketTunnelProvider/lv.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/nb.lproj/Localizable.strings
+++ b/PacketTunnelProvider/nb.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/nl.lproj/Localizable.strings
+++ b/PacketTunnelProvider/nl.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/pl.lproj/Localizable.strings
+++ b/PacketTunnelProvider/pl.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/pt.lproj/Localizable.strings
+++ b/PacketTunnelProvider/pt.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/ro.lproj/Localizable.strings
+++ b/PacketTunnelProvider/ro.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/ru.lproj/Localizable.strings
+++ b/PacketTunnelProvider/ru.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/sk.lproj/Localizable.strings
+++ b/PacketTunnelProvider/sk.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/sl.lproj/Localizable.strings
+++ b/PacketTunnelProvider/sl.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/sv.lproj/Localizable.strings
+++ b/PacketTunnelProvider/sv.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/PacketTunnelProvider/tr.lproj/Localizable.strings
+++ b/PacketTunnelProvider/tr.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* 
+  Localizable.strings
+  DuckDuckGo
+
+  Created by Graeme Arthur on 29/09/2023.
+  Copyright © 2023 DuckDuckGo. All rights reserved.
+*/

--- a/scripts/loc_update.sh
+++ b/scripts/loc_update.sh
@@ -5,7 +5,7 @@ script_dir=$(dirname "$(readlink -f "$0")")
 base_dir="${script_dir}/.."
 
 # Add target sub-directories here when needed
-set -- "${base_dir}/DuckDuckGo" "${base_dir}/Widgets"
+set -- "${base_dir}/DuckDuckGo" "${base_dir}/Widgets" "${base_dir}/PacketTunnelProvider"
 
 for dir in "$@"; do
 	echo "Processing ${dir}"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205615016293286/f

**Description**:

I added some strings to the PacketTunnelProvider target for the [iOS: Network Protection Notifications](https://app.asana.com/0/0/1205174565657101) project. They will need localized using the helper script we have for this.

**Steps to test this PR**:
I’d say testing this is optional as it’s all feature flagged, the localizations will take some time and I’ve added a [follow-up task](https://app.asana.com/0/0/1205615016293287/f) to check they’ve worked

1. Launch the app, go to Settings -> Debug and ensure you are set as an Internal User
2. Go to Settings -> Network Protection and make sure the VPN is running
3. Go to Settings -> Debug -> Network Protection and select Connection Interruption
4. **When the notification shows, check the strings are showing**

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
