### PR TITLE
Autofill onByDefault rollout for new installs

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -28,6 +28,7 @@ public enum FeatureFlag: String {
     case autofillInlineIconCredentials
     case autofillAccessCredentialManagement
     case autofillPasswordGeneration
+    case autofillOnByDefault
     case incontextSignup
     case appTrackingProtection
     case networkProtection
@@ -48,6 +49,8 @@ extension FeatureFlag: FeatureFlagSourceProviding {
             return .remoteReleasable(.subfeature(AutofillSubfeature.accessCredentialManagement))
         case .autofillPasswordGeneration:
             return .remoteReleasable(.subfeature(AutofillSubfeature.autofillPasswordGeneration))
+        case .autofillOnByDefault:
+            return .remoteReleasable(.subfeature(AutofillSubfeature.onByDefault))
         case .incontextSignup:
             return .remoteReleasable(.feature(.incontextSignup))
         }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8955,8 +8955,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 80.4.1;
+				branch = "anya/autofill-on-default-flag";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": null,
-          "revision": "9dea0583dc6269971fb4728bd3efa1ed53f88306",
-          "version": "80.4.1"
+          "branch": "anya/autofill-on-default-flag",
+          "revision": "885f327b2fc1793eda26308fa3cb81995ba1b403",
+          "version": null
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
         "state": {
           "branch": null,
-          "revision": "8def15fe8a4c2fb76730f640507e9fd1d6c1f8a7",
-          "version": "4.32.0"
+          "revision": "74b6142c016be354144f28551de41b50c4864b1f",
+          "version": "4.37.0"
         }
       },
       {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -245,6 +245,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ThemeManager.shared.updateUserInterfaceStyle(window: window)
 
         appIsLaunching = true
+
+        // Temporary logic for rollout of Autofill as on by default for new installs only
+        if AppDependencyProvider.shared.appSettings.autofillIsNewInstallForOnByDefault == nil {
+            AppDependencyProvider.shared.appSettings.setAutofillIsNewInstallForOnByDefault()
+        }
+
         return true
     }
 

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -37,6 +37,8 @@ protocol AppSettings: AnyObject {
     var autofillCredentialsEnabled: Bool { get set }
     var autofillCredentialsSavePromptShowAtLeastOnce: Bool { get set }
     var autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary: Bool { get set }
+    var autofillIsNewInstallForOnByDefault: Bool? { get set }
+    func setAutofillIsNewInstallForOnByDefault()
 
     var voiceSearchEnabled: Bool { get set }
 

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -60,6 +60,7 @@ public class AppUserDefaults: AppSettings {
         static let currentFireButtonAnimationKey = "com.duckduckgo.app.currentFireButtonAnimationKey"
         
         static let autofillCredentialsEnabled = "com.duckduckgo.ios.autofillCredentialsEnabled"
+        static let autofillIsNewInstallForOnByDefault = "com.duckduckgo.ios.autofillIsNewInstallForOnByDefault"
     }
 
     private struct DebugKeys {
@@ -69,6 +70,8 @@ public class AppUserDefaults: AppSettings {
     private var userDefaults: UserDefaults? {
         return UserDefaults(suiteName: groupName)
     }
+
+    lazy var featureFlagger = AppDependencyProvider.shared.featureFlagger
 
     init(groupName: String = "group.com.duckduckgo.app") {
         self.groupName = groupName
@@ -182,16 +185,22 @@ public class AppUserDefaults: AppSettings {
             return
         }
         if !autofillCredentialsSavePromptShowAtLeastOnce {
-            autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary = true
-            autofillCredentialsEnabled = true
+            if let isNewInstall = autofillIsNewInstallForOnByDefault,
+               isNewInstall,
+               featureFlagger.isFeatureOn(.autofillOnByDefault) {
+                autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary = true
+                autofillCredentialsEnabled = true
+            }
         }
     }
     
     var autofillCredentialsEnabled: Bool {
         get {
-            // In future, we'll use setAutofillCredentialsEnabledAutomaticallyIfNecessary() here to automatically turn on autofill for people
-            // That haven't seen the save prompt before.
-            // For now, whilst internal testing is still happening, it's still set to default to be enabled
+            // setAutofillCredentialsEnabledAutomaticallyIfNecessary() used here to automatically turn on autofill for people if:
+            // 1. They haven't seen the save prompt before
+            // 2. They are a new install
+            // 3. The feature flag is enabled
+            setAutofillCredentialsEnabledAutomaticallyIfNecessary()
             return userDefaults?.object(forKey: Keys.autofillCredentialsEnabled) as? Bool ?? false
         }
         
@@ -205,7 +214,20 @@ public class AppUserDefaults: AppSettings {
     
     @UserDefaultsWrapper(key: .autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary, defaultValue: false)
     var autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary: Bool
-    
+
+    var autofillIsNewInstallForOnByDefault: Bool? {
+        get {
+            return userDefaults?.object(forKey: Keys.autofillIsNewInstallForOnByDefault) as? Bool
+        }
+        set {
+            userDefaults?.set(newValue, forKey: Keys.autofillIsNewInstallForOnByDefault)
+        }
+    }
+
+    func setAutofillIsNewInstallForOnByDefault() {
+        autofillIsNewInstallForOnByDefault = StatisticsUserDefaults().installDate == nil
+    }
+
     @UserDefaultsWrapper(key: .voiceSearchEnabled, defaultValue: false)
     var voiceSearchEnabled: Bool
 

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -27,6 +27,10 @@ class AppSettingsMock: AppSettings {
     
     var autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary: Bool = false
 
+    var autofillIsNewInstallForOnByDefault: Bool?
+
+    func setAutofillIsNewInstallForOnByDefault() { }
+
     var autocomplete: Bool = true
 
     var currentThemeName: DuckDuckGo.ThemeName = .systemDefault


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205296228305939/f
Tech Design URL:
CC:

**Description**:
Adds support for rolling out Autofill as on by default for new installs based on the incremental feature flag `onByDefault`

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Notes: 
This PR branches off of https://github.com/duckduckgo/iOS/pull/2032 which added a pixel parameter reporting the "on by default" state.
The rules for enabling Autofill as on by default are: 
 - User must be a new install (tracking this using userDefaults)
 - The subfeature phased rollout feature flag `onByDefault ` must enable the feature for them  
1. Clean install the app from `develop` and confirm that Autofill is **off** by default 
2. Switch to this branch and make the following code changes to test using the correct privacy config
3. Modify the embedded `ios-config.json` adding the `onByDefault` subfeature to the `autofill` json (see https://app.asana.com/0/0/1205590415076770/f)
```
            "onByDefault": {
                    "state": "enabled",
                    "minSupportedVersion": "7.91.0",
                    "rollout": {
                        "steps": [
                            {
                                "percent": 1.0
                            }
                        ]
                    }
                }
```
5. In `AppURLs` change the privacyConfig URL to anything else so the config isn't overwritten from the server e.g. `static let privacyConfig = URL(string: "\(staticBase)/trackerblocking/config/v3/ios-config-invalid.json")!`
6. Launch the app and confirm that Autofill is still off by default and note that Autofill pixels when accessing the Autofill screen contain the parameter `["default_state": "off"]`
7. Modify the `ios-config.json` steps and add rollout at 100% like so:
```
           "steps": [
                            {
                                "percent": 1.0
                            },
                            {
                                "percent": 100.0
                            },
                        ]
```
8. Launch the app again and confirm that the Autofill is still `off` by default (as reported by the pixel parameter)
9. Toggle the Autofill switch to turn Autofill on, relaunch the app and confirm that Autofill default state is still `off` (as reported by the pixel parameter)
10. Delete the app and reset `ios-config.json` to Step 3
11. Launch and confirm that (more than likely, since it's only at 1% rollout) that Autofill  default state is `off`
12. Repeat Step 7
13. Launch the app and confirm that this time Autofill is now `on` by default

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
