### PR TITLE
Fix email deeplink

### DIFF
--- a/DuckDuckGo/AppDelegate+AppDeepLinks.swift
+++ b/DuckDuckGo/AppDelegate+AppDeepLinks.swift
@@ -35,7 +35,8 @@ extension AppDelegate {
             mainViewController.newTab(reuseExisting: true, allowingKeyboard: false)
 
         case .quickLink:
-            handleQuickLink(url, mainViewController)
+            let query = AppDeepLinkSchemes.query(fromQuickLink: url)
+            mainViewController.loadQueryInNewTab(query, reuseExisting: true)
 
         case .addFavorite:
             mainViewController.startAddFavoriteFlow()
@@ -64,14 +65,4 @@ extension AppDelegate {
 
         return true
     }
-
-    private func handleQuickLink(_ url: URL, _ mainViewController: MainViewController) {
-        let query = AppDeepLinkSchemes.query(fromQuickLink: url)
-        if let url = URL(string: query) {
-            mainViewController.loadUrlInNewTab(url, reuseExisting: true, inheritedAttribution: nil)
-        } else {
-            mainViewController.loadQueryInNewTab(query, reuseExisting: true)
-        }
-    }
-
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205632787359637/f

**Description**:
Fix deeplink issue with email protection.

**Steps to test this PR**:
1. Create a note with multiple types of urls and just queries (for example: https://example.com, http://example.com, www.example.com, example, duck)
2. Go to each of them, tap and hold, select share, then open in the DDG browser
3. Check if it’s correctly opening as searches or websites
4. Open the email protection -> Settings -> Email protection.
5. Check if it correctly opens the setup page

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17
