### PR TITLE
NetP connection notifications improvements

### DIFF
--- a/Core/NetworkProtectionNotificationIdentifier.swift
+++ b/Core/NetworkProtectionNotificationIdentifier.swift
@@ -20,9 +20,7 @@
 import Foundation
 
 public enum NetworkProtectionNotificationIdentifier: String {
-    case reconnecting = "network-protection.notification.reconnecting"
-    case reconnected = "network-protection.notification.reconnected"
-    case connectionFailure = "network-protection.notification.connection-failure"
+    case connection = "network-protection.notification.connection"
     case superseded = "network-protection.notification.superseded"
     case test = "network-protection.notification.test"
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8909,8 +8909,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 80ed3060b655aec43c542d3bd3f75b6ac04063c1;
+				kind = exactVersion;
+				version = 81.0.0;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8909,8 +8909,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 80.4.1;
+				kind = revision;
+				revision = 80ed3060b655aec43c542d3bd3f75b6ac04063c1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "9dea0583dc6269971fb4728bd3efa1ed53f88306",
-          "version": "80.4.1"
+          "revision": "80ed3060b655aec43c542d3bd3f75b6ac04063c1",
+          "version": null
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/duckduckgo/content-scope-scripts",
         "state": {
           "branch": null,
-          "revision": "8def15fe8a4c2fb76730f640507e9fd1d6c1f8a7",
-          "version": "4.32.0"
+          "revision": "74b6142c016be354144f28551de41b50c4864b1f",
+          "version": "4.37.0"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "80ed3060b655aec43c542d3bd3f75b6ac04063c1",
-          "version": null
+          "revision": "5a77dc747a1bee25947b1d3ae3831922be05fd22",
+          "version": "81.0.0"
         }
       },
       {

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionUNNotificationPresenter.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionUNNotificationPresenter.swift
@@ -84,23 +84,22 @@ final class NetworkProtectionUNNotificationPresenter: NSObject, NetworkProtectio
             body = UserText.networkProtectionConnectionSuccessNotificationBody
         }
         let content = notificationContent(body: body)
-        showNotification(.reconnected, content)
+        showNotification(.connection, content)
     }
 
     func showConnectionNotification(serverLocation: String?) {
-        
         let content = notificationContent(body: UserText.networkProtectionConnectionSuccessNotificationBody)
-        showNotification(.reconnected, content)
+        showNotification(.connection, content)
     }
 
     func showReconnectingNotification() {
         let content = notificationContent(body: UserText.networkProtectionConnectionInterruptedNotificationBody)
-        showNotification(.reconnecting, content)
+        showNotification(.connection, content)
     }
 
     func showConnectionFailureNotification() {
         let content = notificationContent(body: UserText.networkProtectionConnectionFailureNotificationBody)
-        showNotification(.connectionFailure, content)
+        showNotification(.connection, content)
     }
 
     func showSupersededNotification() {

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionUNNotificationPresenter.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionUNNotificationPresenter.swift
@@ -76,7 +76,19 @@ final class NetworkProtectionUNNotificationPresenter: NSObject, NetworkProtectio
         showNotification(.test, content)
     }
 
-    func showReconnectedNotification() {
+    func showConnectedNotification(serverLocation: String?) {
+        let body: String
+        if let serverLocation {
+            body = UserText.networkProtectionConnectionSuccessNotificationBody(serverLocation: serverLocation)
+        } else {
+            body = UserText.networkProtectionConnectionSuccessNotificationBody
+        }
+        let content = notificationContent(body: body)
+        showNotification(.reconnected, content)
+    }
+
+    func showConnectionNotification(serverLocation: String?) {
+        
         let content = notificationContent(body: UserText.networkProtectionConnectionSuccessNotificationBody)
         showNotification(.reconnected, content)
     }

--- a/PacketTunnelProvider/UserText.swift
+++ b/PacketTunnelProvider/UserText.swift
@@ -28,6 +28,9 @@ final class UserText {
 
     static let networkProtectionConnectionSuccessNotificationBody = NSLocalizedString("network.protection.success.notification.body", value: "Network Protection is On. Your location and online activity are protected.", comment: "The body of the notification shown when Network Protection reconnects successfully")
 
+    static func networkProtectionConnectionSuccessNotificationBody(serverLocation: String) -> String { NSLocalizedString("network.protection.success.notification.subtitle.including.serverLocation", value: "Routing device traffic through \(serverLocation).", comment: "The body of the notification shown when Network Protection connects successfully with the city + state/country as formatted parameter")
+    }
+
     static let networkProtectionConnectionInterruptedNotificationBody = NSLocalizedString("network.protection.interrupted.notification.body", value: "Network Protection was interrupted. Attempting to reconnect now...", comment: "The body of the notification shown when Network Protection's connection is interrupted")
 
     static let networkProtectionConnectionFailureNotificationBody = NSLocalizedString("network.protection.failure.notification.body", value: "Network Protection failed to connect. Please try again later.", comment: "The body of the notification shown when Network Protection fails to reconnect")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205656863843386/f

**Description**:

On testing the Network Protection notifications on iOS, we decided to make a few UX tweaks:
Show the same connection notifications when the user connects manually as well as when they reconnect after an interruption
Include the server location in the body text of these notifications
On iOS, replace old notifications about the connection with the latest one to remove confusion about current connection status.

**Steps to test this PR**:
1. Build this branch
2. If NetP is already started, stop it (Settings -> Network Protection)
3. Start NetP
4. **Observe the connection notification including the server location**
5. Go to Settings -> Debug -> Network Protection
6. Trigger a Connection Interruption
7. **Observe the interruption notification which is then replaced by the connection one**

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [x] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
