### PR TITLE
Add missed strings for NetP notifications

### DIFF
--- a/PacketTunnelProvider/en.lproj/Localizable.strings
+++ b/PacketTunnelProvider/en.lproj/Localizable.strings
@@ -10,3 +10,6 @@
 /* The body of the notification shown when Network Protection reconnects successfully */
 "network.protection.success.notification.body" = "Network Protection is On. Your location and online activity are protected.";
 
+/* The body of the notification shown when Network Protection connects successfully with the city + state/country as formatted parameter */
+"network.protection.success.notification.subtitle.including.serverLocation" = "Routing device traffic through \(serverLocation).";
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205678855704711/f

**Description**:

Forgot some strings from #2073 

**Steps to test this PR**:
1. Make sure you’re internal user
2. Go to Settings -> Network Protection and start Network Protection
3. Start Network Protection allowing notificaitons
4. **Observe a notification is shown and the strings look fine.**

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
