### PR TITLE
Fix Pixel appVersion format mismatch for launch vs crash

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -179,7 +179,7 @@ public class Pixel {
                             includedParameters: [QueryParameters] = [.atb, .appVersion],
                             onComplete: @escaping (Error?) -> Void = { _ in }) {
         var newParams = params
-        if includedParameters.contains(.appVersion) {
+        if includedParameters.contains(.appVersion) && params[PixelParameters.appVersion] == nil {
             newParams[PixelParameters.appVersion] = AppVersion.shared.versionAndBuildNumber
         }
         if isDebugBuild {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -344,7 +344,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 Pixel.fire(pixel: .appLaunch, withAdditionalParameters: [
                     PixelParameters.widgetError: "1",
                     PixelParameters.widgetErrorCode: "\((error as NSError).code)",
-                    PixelParameters.widgetErrorDomain: (error as NSError).domain
+                    PixelParameters.widgetErrorDomain: (error as NSError).domain,
+                    // appVersion without build number due to mismatch with crash version format
+                    PixelParameters.appVersion: AppVersion.shared.versionNumber
                 ])
                 
             case .success(let widgetInfo):

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -159,4 +159,19 @@ class PixelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testWhenAppVersionPassedAsParamOverridesAdditionalParams() {
+        let expectation = XCTestExpectation()
+        let params = [PixelParameters.appVersion: "1.2.3"]
+
+        stub(condition: isHost(host) && isPath("/t/ml_ios_phone")) { request -> HTTPStubsResponse in
+            XCTAssertEqual("1.2.3", request.url?.getParameter(named: PixelParameters.appVersion))
+            expectation.fulfill()
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        Pixel.fire(pixel: .appLaunch, forDeviceType: .phone, withAdditionalParameters: params)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205691485107802/f

**Description**:

The crashes are not shown in the Crash per launches/version board because the format of the version we report with the crash pixel has changed. We used to report the full version, including the build number (so, 4 numbers in the version), but starting from 7.92.0 it looks like we report only 3 numbers. Since we still send the full version number for Launches (ml.ios.*), the query fails.
- It’s related to this PR: https://github.com/duckduckgo/iOS/pull/2046.
- We can monitor crashes for 7.92.0 in Kibana.

**Steps to test this PR**:
1. Launch the app with the debugger attached
2. Look in the console and observe the message `Pixel fired ml ["appVersion": "7.93.0”]`

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
