### PR TITLE
NetP: Fix server location formatting

### DIFF
--- a/PacketTunnelProvider/UserText.swift
+++ b/PacketTunnelProvider/UserText.swift
@@ -28,7 +28,13 @@ final class UserText {
 
     static let networkProtectionConnectionSuccessNotificationBody = NSLocalizedString("network.protection.success.notification.body", value: "Network Protection is On. Your location and online activity are protected.", comment: "The body of the notification shown when Network Protection reconnects successfully")
 
-    static func networkProtectionConnectionSuccessNotificationBody(serverLocation: String) -> String { NSLocalizedString("network.protection.success.notification.subtitle.including.serverLocation", value: "Routing device traffic through \(serverLocation).", comment: "The body of the notification shown when Network Protection connects successfully with the city + state/country as formatted parameter")
+    static func networkProtectionConnectionSuccessNotificationBody(serverLocation: String) -> String {
+        let localized = NSLocalizedString(
+            "network.protection.success.notification.subtitle.including.serverLocation",
+            value: "Routing device traffic through %@.",
+            comment: "The body of the notification shown when Network Protection connects successfully with the city + state/country as formatted parameter"
+        )
+        return String(format: localized, serverLocation)
     }
 
     static let networkProtectionConnectionInterruptedNotificationBody = NSLocalizedString("network.protection.interrupted.notification.body", value: "Network Protection was interrupted. Attempting to reconnect now...", comment: "The body of the notification shown when Network Protection's connection is interrupted")

--- a/PacketTunnelProvider/en.lproj/Localizable.strings
+++ b/PacketTunnelProvider/en.lproj/Localizable.strings
@@ -11,5 +11,5 @@
 "network.protection.success.notification.body" = "Network Protection is On. Your location and online activity are protected.";
 
 /* The body of the notification shown when Network Protection connects successfully with the city + state/country as formatted parameter */
-"network.protection.success.notification.subtitle.including.serverLocation" = "Routing device traffic through \(serverLocation).";
+"network.protection.success.notification.subtitle.including.serverLocation" = "Routing device traffic through %@.";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205732209997242/f

**Description**:

The way I was formatting the localised string was definitely the wrong way to do it and stopped working as soon as the actual `strings` file was generated. I’ve fixed that.

**Steps to test this PR**:
1. Launch the app, make sure you’re internal and go to Settings -> Network Protection
2. Enabled Network protection (disable it first if it’s already enabled)
3. Check the notification and make sure it’s got the actual server location in it.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
