### PR TITLE
Disable NetP errors temporarily

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -82,19 +82,6 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
         setUpStatusMessagePublishers()
         setUpDisableTogglePublisher()
         setUpServerInfoPublishers()
-
-        errorObserver.publisher
-            .map {
-                $0.map { _ in
-                    ErrorItem(
-                        title: UserText.netPStatusViewErrorConnectionFailedTitle,
-                        message: UserText.netPStatusViewErrorConnectionFailedMessage
-                    )
-                }
-            }
-            .receive(on: DispatchQueue.main)
-            .assign(to: \.error, onWeaklyHeld: self)
-            .store(in: &cancellables)
     }
 
     private func setUpIsConnectedStatePublishers() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205738923620234/f
Tech Design URL:
CC:

**Description**:

A proper fix for the regular erroneous NetP errors is almost ready. However, in the meantime, to reduce the reports we’re getting, this disables all errors as it seems at the moment they are mostly useless. The UI was mainly added for design review of the internal MVP project which has long passed.

**Steps to test this PR**:
1. Go to Settings -> Debug -> Internal User and make sure that’s checked
2. Go to Settings -> Debug -> Network Protection and select tunnelFailure
3. Go to Settings -> Network Protection and toggle connected to On (you may need to swap this step with 2)
4. **Observe there is no error shown** 

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
