### PR TITLE
Update BSK with autofill 9.1.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -8967,8 +8967,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 82.0.2;
+				kind = revision;
+				revision = 5e415e0f514ce4d76cac06f7eed86b68818cb13c;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205843087392114/1205843087392114
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.1.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/545

## Description
Updates Autofill to version [9.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/9.1.0).

### Autofill 9.1.0 release notes
## What's Changed
* Re-enable mutObs with better safeguards by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/403
* Bump zod from 3.22.2 to 3.22.4 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/395
* Workaround for pcsretirement by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/406


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/9.0.0...9.1.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).