### PR TITLE
Adding 'protectionsState' to breakage form submission

### DIFF
--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -24,6 +24,11 @@ public struct BrokenSiteInfo {
 
     static let allowedQueryReservedCharacters =  CharacterSet(charactersIn: ",")
 
+    enum ProtectionsState: String {
+        case enabled = "1"
+        case disabled = "0"
+    }
+
     private struct Keys {
         static let url = "siteUrl"
         static let category = "category"
@@ -40,6 +45,7 @@ public struct BrokenSiteInfo {
         static let gpc = "gpc"
         static let ampUrl = "ampUrl"
         static let urlParametersRemoved = "urlParametersRemoved"
+        static let protectionsState = "protectionsState"
     }
     
     private let url: URL?
@@ -54,12 +60,14 @@ public struct BrokenSiteInfo {
     private let manufacturer: String
     private let systemVersion: String
     private let gpc: Bool
-    
+    private let protectionsState: ProtectionsState
+
     public init(url: URL?, httpsUpgrade: Bool,
                 blockedTrackerDomains: [String], installedSurrogates: [String],
                 isDesktop: Bool, tdsETag: String?,
                 ampUrl: String?,
                 urlParametersRemoved: Bool,
+                protected: Bool,
                 model: String = UIDevice.current.model,
                 manufacturer: String = "Apple",
                 systemVersion: String = UIDevice.current.systemVersion,
@@ -76,7 +84,8 @@ public struct BrokenSiteInfo {
         self.model = model
         self.manufacturer = manufacturer
         self.systemVersion = systemVersion
-        
+        self.protectionsState = protected ? .enabled : .disabled
+
         if let gpcParam = gpc {
             self.gpc = gpcParam
         } else {
@@ -101,7 +110,8 @@ public struct BrokenSiteInfo {
             Keys.model: model,
             Keys.gpc: gpc ? "true" : "false",
             Keys.ampUrl: ampUrl ?? "",
-            Keys.urlParametersRemoved: urlParametersRemoved ? "true" : "false"
+            Keys.urlParametersRemoved: urlParametersRemoved ? "true" : "false",
+            Keys.protectionsState: protectionsState.rawValue
         ]
         
         Pixel.fire(pixel: .brokenSiteReport,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -866,7 +866,10 @@ class TabViewController: UIViewController {
         
     public func getCurrentWebsiteInfo() -> BrokenSiteInfo {
         let blockedTrackerDomains = privacyInfo?.trackerInfo.trackersBlocked.compactMap { $0.domain } ?? []
-        
+
+        let configuration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig
+        let protected = configuration.isFeature(.contentBlocking, enabledForDomain: url?.host)
+
         return BrokenSiteInfo(url: url,
                               httpsUpgrade: httpsForced,
                               blockedTrackerDomains: blockedTrackerDomains,
@@ -874,7 +877,8 @@ class TabViewController: UIViewController {
                               isDesktop: tabModel.isDesktop,
                               tdsETag: ContentBlocking.shared.contentBlockingManager.currentMainRules?.etag ?? "",
                               ampUrl: linkProtection.lastAMPURLString,
-                              urlParametersRemoved: linkProtection.urlParametersRemoved)
+                              urlParametersRemoved: linkProtection.urlParametersRemoved,
+                              protected: protected)
     }
     
     public func print() {

--- a/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -75,6 +75,7 @@ final class BrokenSiteReportingTests: XCTestCase {
                                             tdsETag: test.blocklistVersion,
                                             ampUrl: nil,
                                             urlParametersRemoved: false,
+                                            protected: true,
                                             model: test.model ?? "",
                                             manufacturer: test.manufacturer ?? "",
                                             systemVersion: test.os ?? "",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205839123798771/f
Tech Design URL:
CC:

**Description**:

Adds a new parameter to breakage form submissions

- [x] added the param when the form is submitted from the privacy dashboard 
- [x] added the param when the form is submitted from the native feedback form

**Steps to test this PR**:
1. submit the breakage form either the dashboard, or the native menu
2. verify that the param `protectionsState` has either a "0" or "1" value based on the rules mentioned in the Asana task.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
