### PR TITLE
kill variant when receiving atb update

### DIFF
--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -134,6 +134,7 @@ public class StatisticsLoader {
     public func storeUpdateVersionIfPresent(_ atb: Atb) {
         if let updateVersion = atb.updateVersion {
             statisticsStore.atb = updateVersion
+            statisticsStore.variant = nil
             returnUserMeasurement.updateStoredATB(atb)
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1205887954648070/f
Tech Design URL:
CC:

**Description**:

Removes variant when a remote update to the installed ATB is retrieved.

**Steps to test this PR**:
1. Perform with a clean simulator `xcrun simctl erase all`
2. Ensure the DefaultManager will allocate a variant
3. Put a break point in StatisticsLoader.swift at line 83
4. Execute debugger command: `po self.statisticsStore.atb = "v230-5"` to set ATB to an old value
5. Allow execution to continue
6. Perform a search
7. Confirm that ATB is recent to the most recent value and that the variant has been removed - you can do this by using a proxy or by breakpointing on the StatisticsLoader in the completion of the `refreshSearchRetentionAtb` function 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
