### PR TITLE
switch to true|false for protectionsState param

### DIFF
--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -24,11 +24,6 @@ public struct BrokenSiteInfo {
 
     static let allowedQueryReservedCharacters =  CharacterSet(charactersIn: ",")
 
-    enum ProtectionsState: String {
-        case enabled = "1"
-        case disabled = "0"
-    }
-
     private struct Keys {
         static let url = "siteUrl"
         static let category = "category"
@@ -60,14 +55,14 @@ public struct BrokenSiteInfo {
     private let manufacturer: String
     private let systemVersion: String
     private let gpc: Bool
-    private let protectionsState: ProtectionsState
+    private let protectionsState: Bool
 
     public init(url: URL?, httpsUpgrade: Bool,
                 blockedTrackerDomains: [String], installedSurrogates: [String],
                 isDesktop: Bool, tdsETag: String?,
                 ampUrl: String?,
                 urlParametersRemoved: Bool,
-                protected: Bool,
+                protectionsState: Bool,
                 model: String = UIDevice.current.model,
                 manufacturer: String = "Apple",
                 systemVersion: String = UIDevice.current.systemVersion,
@@ -84,7 +79,7 @@ public struct BrokenSiteInfo {
         self.model = model
         self.manufacturer = manufacturer
         self.systemVersion = systemVersion
-        self.protectionsState = protected ? .enabled : .disabled
+        self.protectionsState = protectionsState
 
         if let gpcParam = gpc {
             self.gpc = gpcParam
@@ -111,7 +106,7 @@ public struct BrokenSiteInfo {
             Keys.gpc: gpc ? "true" : "false",
             Keys.ampUrl: ampUrl ?? "",
             Keys.urlParametersRemoved: urlParametersRemoved ? "true" : "false",
-            Keys.protectionsState: protectionsState.rawValue
+            Keys.protectionsState: protectionsState ? "true" : "false"
         ]
         
         Pixel.fire(pixel: .brokenSiteReport,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -868,7 +868,7 @@ class TabViewController: UIViewController {
         let blockedTrackerDomains = privacyInfo?.trackerInfo.trackersBlocked.compactMap { $0.domain } ?? []
 
         let configuration = ContentBlocking.shared.privacyConfigurationManager.privacyConfig
-        let protected = configuration.isFeature(.contentBlocking, enabledForDomain: url?.host)
+        let protectionsState = configuration.isFeature(.contentBlocking, enabledForDomain: url?.host)
 
         return BrokenSiteInfo(url: url,
                               httpsUpgrade: httpsForced,
@@ -878,7 +878,7 @@ class TabViewController: UIViewController {
                               tdsETag: ContentBlocking.shared.contentBlockingManager.currentMainRules?.etag ?? "",
                               ampUrl: linkProtection.lastAMPURLString,
                               urlParametersRemoved: linkProtection.urlParametersRemoved,
-                              protected: protected)
+                              protectionsState: protectionsState)
     }
     
     public func print() {

--- a/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -75,7 +75,7 @@ final class BrokenSiteReportingTests: XCTestCase {
                                             tdsETag: test.blocklistVersion,
                                             ampUrl: nil,
                                             urlParametersRemoved: false,
-                                            protected: true,
+                                            protectionsState: true,
                                             model: test.model ?? "",
                                             manufacturer: test.manufacturer ?? "",
                                             systemVersion: test.os ?? "",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1205915950517976/f
Tech Design URL:
CC:

**Description**:

Switching to true|false instead of 1|0 for cross-platform consistency. See the parent task https://app.asana.com/0/1201141132935289/1205644489547731


### Steps to test this PR

- [ ] Submit the breakage form with protections on
- [ ] Verify that the breakage form pixel param `protectionsState` is the string `true`
- [ ] Submit the breakage form with protections off
- [ ] Verify that the breakage form pixel param `protectionsState` is the string `false`

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
