### PR TITLE
Merges the latest from BSK

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9057,8 +9057,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 82.2.1;
+				kind = revision;
+				revision = 7d54b3832e8578f853aa5e5b70afb5465c7351e4;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "0ac6d8e2153bec4ddd4e983915da6db09fcbed05",
-          "version": "82.2.1"
+          "revision": "7d54b3832e8578f853aa5e5b70afb5465c7351e4",
+          "version": null
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1205916787911888/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/552
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1817

## Description

No changes for iOS, just integrates some macOS changes to NetP from BSK.  This PR just ensures nothing breaks for iOS in terms of building.

## Testing

Double check in the code that none of the changes to BSK affect iOS.  iOS is using different mecanisms for resetting NetP state so it should be good.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
