### PR TITLE
Fix for duplicated "atb" in Pixel request

### DIFF
--- a/DuckDuckGo/BrokenSiteInfo.swift
+++ b/DuckDuckGo/BrokenSiteInfo.swift
@@ -104,7 +104,6 @@ public struct BrokenSiteInfo {
             Keys.tds: tdsETag?.trimmingCharacters(in: CharacterSet(charactersIn: "\"")) ?? "",
             Keys.blockedTrackers: blockedTrackerDomains.joined(separator: ","),
             Keys.surrogates: installedSurrogates.joined(separator: ","),
-            Keys.atb: StatisticsUserDefaults().atb ?? "",
             Keys.os: systemVersion,
             Keys.manufacturer: manufacturer,
             Keys.model: model,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205754960806321/f

**Description**:

This change removes the custom `atb` value added in the specific pixel request in favour of the one added automatically to every pixel request. This should maintain the 

**Steps to test this PR**:
1. Send a "broken site feedback"
2. Check the Pixel sent in console, the Pixel contains only one `atb` between URL and params

```
Printing description of url:
▿ https://improving.duckduckgo.com/t/epbf_ios_phone?atb=v402-3mg
  - _url : https://improving.duckduckgo.com/t/epbf_ios_phone?atb=v402-3mg

Pixel fired epbf ["siteUrl": "https://federicocappelli.com/", "surrogates": "", "siteType": "mobile", "gpc": "true", "upgradedHttps": "false", "category": "other", "model": "iPhone", "manufacturer": "Apple", "description": "TESTING, IGNORE", "tds": "A_\"3a50d09fd78a893f1a284051d1f777de", "os": "17.0.1", "blockedTrackers": "", "urlParametersRemoved": "false", "ampUrl": "", "protectionsState": "1"]
```

**Device Testing**:

* iPhone 15
* iPad 10th Gen