### PR TITLE
Autofill prompt icon + copy updates

### DIFF
--- a/DuckDuckGo/AutofillLoginPromptView.swift
+++ b/DuckDuckGo/AutofillLoginPromptView.swift
@@ -44,7 +44,7 @@ struct AutofillLoginPromptView: View {
             VStack {
                 Spacer()
                     .frame(height: Const.Size.topPadding)
-                AutofillViews.WebsiteWithFavicon(accountDomain: viewModel.domain)
+                AutofillViews.AppIconHeader()
                 Spacer()
                     .frame(height: Const.Size.headlineTopPadding)
                 AutofillViews.Headline(title: viewModel.message)

--- a/DuckDuckGo/AutofillViews.swift
+++ b/DuckDuckGo/AutofillViews.swift
@@ -55,21 +55,6 @@ struct AutofillViews {
         }
     }
 
-    struct WebsiteWithFavicon: View {
-        let accountDomain: String
-
-        var body: some View {
-            HStack {
-                FaviconView(viewModel: FaviconViewModel(domain: accountDomain))
-                    .scaledToFit()
-                    .frame(width: Const.Size.logoImage, height: Const.Size.logoImage)
-                Text(accountDomain)
-                    .daxFootnoteRegular()
-                    .foregroundColor(Color(designSystemColor: .textSecondary))
-            }
-        }
-    }
-
     struct AppIconHeader: View {
         var body: some View {
             Image.appIcon

--- a/DuckDuckGo/AutofillViews.swift
+++ b/DuckDuckGo/AutofillViews.swift
@@ -70,6 +70,13 @@ struct AutofillViews {
         }
     }
 
+    struct AppIconHeader: View {
+        var body: some View {
+            Image.appIcon
+                .scaledToFit()
+        }
+    }
+
     struct Headline: View {
         let title: String
 
@@ -241,4 +248,5 @@ private enum Const {
 
 private extension Image {
     static let close = Image("Close-24")
+    static let appIcon = Image("WaitlistShareSheetLogo")
 }

--- a/DuckDuckGo/PasswordGenerationPromptView.swift
+++ b/DuckDuckGo/PasswordGenerationPromptView.swift
@@ -42,8 +42,12 @@ struct PasswordGenerationPromptView: View {
                 .zIndex(1)
 
                 VStack {
+                    Spacer()
+                        .frame(height: Const.Size.topPadding)
+                    AutofillViews.AppIconHeader()
+                    Spacer()
+                        .frame(height: Const.Size.headlineTopPadding)
                     AutofillViews.Headline(title: UserText.autofillPasswordGenerationPromptTitle)
-                        .padding(.top, Const.Size.topPadding)
                     if #available(iOS 16.0, *) {
                         passwordView
                             .padding([.top, .bottom], passwordVerticalPadding)
@@ -185,6 +189,7 @@ private enum Const {
         static let closeButtonOffsetPortrait: CGFloat = 44.0
         static let closeButtonOffsetPortraitSmallFrame: CGFloat = 16.0
         static let topPadding: CGFloat = 56.0
+        static let headlineTopPadding: CGFloat = 24.0
         static let ios15scrollOffset: CGFloat = 80.0
         static let passwordButtonSpacing: CGFloat = 10.0
         static let passwordPaddingHeight: CGFloat = 28.0

--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -46,10 +46,8 @@ struct SaveLoginView: View {
 
     private var title: String {
         switch layoutType {
-        case .newUser, .saveLogin:
+        case .newUser, .saveLogin, .savePassword:
             return UserText.autofillSaveLoginTitleNewUser
-        case .savePassword:
-            return UserText.autofillSavePasswordTitle
         case .updateUsername:
             return UserText.autofillUpdateUsernameTitle
         case .updatePassword:
@@ -59,9 +57,7 @@ struct SaveLoginView: View {
     
     private var confirmButton: String {
         switch layoutType {
-        case .newUser, .saveLogin:
-            return UserText.autofillSaveLoginSaveCTA
-        case .savePassword:
+        case .newUser, .saveLogin, .savePassword:
             return UserText.autofillSavePasswordSaveCTA
         case .updateUsername:
             return UserText.autofillUpdateUsernameSaveCTA
@@ -90,7 +86,7 @@ struct SaveLoginView: View {
             VStack {
                 Spacer()
                     .frame(height: Const.Size.topPadding)
-                AutofillViews.WebsiteWithFavicon(accountDomain: viewModel.accountDomain)
+                AutofillViews.AppIconHeader()
                 Spacer()
                     .frame(height: Const.Size.headlineTopPadding)
                 AutofillViews.Headline(title: title)

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -403,22 +403,20 @@ public struct UserText {
     
     public static let emptyDownloads = NSLocalizedString("downloads.downloads-list.empty", value: "No files downloaded yet", comment: "Empty downloads list placholder")
     
-    public static let autofillSaveLoginTitleNewUser = NSLocalizedString("autofill.save-login.new-user.title", value: "Do you want DuckDuckGo to save your Login?", comment: "Title displayed on modal asking for the user to save the login for the first time")
+    public static let autofillSaveLoginTitleNewUser = NSLocalizedString("autofill.save-login.new-user.title", value: "Do you want DuckDuckGo to save your password?", comment: "Title displayed on modal asking for the user to save the login for the first time")
     public static let autofillSaveLoginTitle = NSLocalizedString("autofill.save-login.title", value: "Save Login?", comment: "Title displayed on modal asking for the user to save the login")
     public static let autofillUpdateUsernameTitle = NSLocalizedString("autofill.update-usernamr.title", value: "Update username?", comment: "Title displayed on modal asking for the user to update the username")
 
-    public static let autofillSaveLoginMessageNewUser = NSLocalizedString("autofill.save-login.new-user.message", value: "Logins are stored securely on your device in the Logins menu.", comment: "Message displayed on modal asking for the user to save the login for the first time")
+    public static let autofillSaveLoginMessageNewUser = NSLocalizedString("autofill.save-login.new-user.message", value: "Passwords are stored securely on your device in the Logins menu.", comment: "Message displayed on modal asking for the user to save the login for the first time")
     public static let autofillSaveLoginNotNowCTA = NSLocalizedString("autofill.save-login.not-now.CTA", value: "Don’t Save", comment: "Cancel CTA displayed on modal asking for the user to save the login")
     public static let autofillSaveLoginNeverPromptCTA = NSLocalizedString("autofill.save-login.never-prompt.CTA", value:"Never Ask for This Site", comment: "CTA displayed on modal asking if the user never wants to be prompted to save a login for this website agin")
 
-    public static let autofillSavePasswordTitle = NSLocalizedString("autofill.save-password.title", value: "Save Password?", comment: "Title displayed on modal asking for the user to save the password")
     public static func autofillUpdatePassword(for title: String) -> String {
         let message = NSLocalizedString("autofill.update-password.title", value: "Update password for\n%@?", comment: "Title displayed on modal asking for the user to update the password")
         return message.format(arguments: title)
     }
-    public static let autoUpdatePasswordMessage = NSLocalizedString("autofill.update-password.message", value: "DuckDuckGo will update this stored Login on your device.", comment: "Message displayed on modal asking for the user to update the password")
+    public static let autoUpdatePasswordMessage = NSLocalizedString("autofill.update-password.message", value: "DuckDuckGo will update this stored password on your device.", comment: "Message displayed on modal asking for the user to update the password")
 
-    public static let autofillSaveLoginSaveCTA = NSLocalizedString("autofill.save-login.save.CTA", value: "Save Login", comment: "Confirm CTA displayed on modal asking for the user to save the login")
     public static let autofillSavePasswordSaveCTA = NSLocalizedString("autofill.save-password.save.CTA", value: "Save Password", comment: "Confirm CTA displayed on modal asking for the user to save the password")
     public static let autofillUpdatePasswordSaveCTA = NSLocalizedString("autofill.update-password.save.CTA", value: "Update Password", comment: "Confirm CTA displayed on modal asking for the user to update the password")
     public static let autofillShowPassword = NSLocalizedString("autofill.show-password", value: "Show Password", comment: "Accessibility title for a Show Password button displaying actial password instead of *****")
@@ -727,7 +725,7 @@ In addition to the details entered into this form, your app issue report will co
 
     public static let autofillLoginPromptAuthenticationCancelButton = NSLocalizedString("autofill.logins.prompt.auth.cancel", value:"Cancel", comment: "Cancel button for auth during login prompt")
     public static let autofillLoginPromptAuthenticationReason = NSLocalizedString("autofill.logins.prompt.auth.reason", value:"Unlock To Use Saved Login", comment: "Reason for auth during login prompt")
-    public static let autofillLoginPromptTitle = NSLocalizedString("autofill.logins.prompt.title", value:"Use a saved Login?", comment: "Title for autofill login prompt")
+    public static let autofillLoginPromptTitle = NSLocalizedString("autofill.logins.prompt.title", value:"Use a saved password?", comment: "Title for autofill login prompt")
     public static let autofillLoginPromptExactMatchTitle = NSLocalizedString("autofill.logins.prompt.exact.match.title", value:"From this website", comment: "Title for section of autofill logins that are an exact match to the current website")
     public static func autofillLoginPromptPartialMatchTitle(for type: String) -> String {
         let message = NSLocalizedString("autofill.logins.prompt.partial.match.title", value: "From %@", comment: "Title for section of autofill logins that are an approximate match to the current website")

--- a/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/DuckDuckGo/bg.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Парола за %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Да се използват ли запазените данни за вход?";
+"autofill.logins.prompt.title" = "Използване на запазена парола?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "за '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Потребителското име на личен Duck Address беше премахнато";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Данните за вход се съхраняват на сигурно място в менюто Данни за вход на Вашето устройство.";
+"autofill.save-login.new-user.message" = "Паролите се съхраняват на сигурно място в менюто Данни за вход на Вашето устройство.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Искате ли DuckDuckGo да запази данните за вход?";
+"autofill.save-login.new-user.title" = "Искате ли DuckDuckGo да запази Вашата парола?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Не записвай";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Запазване на данните за вход";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Запазване на данните за вход?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Запазване на паролата";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Запазване на паролата?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Показване на паролата";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ за управление на Вашите Duck Address на това устройство.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo ще актуализира запазените данни за вход във Вашето устройство.";
+"autofill.update-password.message" = "DuckDuckGo ще актуализира запазената парола във Вашето устройство.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Актуализиране на паролата";

--- a/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/DuckDuckGo/cs.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Heslo pro %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Použít uložené přihlášení?";
+"autofill.logins.prompt.title" = "Použít uložené heslo?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "pro „%@“";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Soukromé uživatelské jméno Duck Address je smazané";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Přihlašovací údaje jsou bezpečně uložené v zařízení v nabídce Přihlášení.";
+"autofill.save-login.new-user.message" = "Hesla jsou bezpečně uložená v zařízení v nabídce Přihlášení.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Má DuckDuckGo uložit přihlašovací údaje?";
+"autofill.save-login.new-user.title" = "Má DuckDuckGo uložit heslo?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Neukládat";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Uložit přihlašovací údaje";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Uložit přihlašovací údaje?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Uložit heslo";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Uložit heslo?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Zobrazit heslo";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ pro správu adres Duck Address na tomto zařízení.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo zaktualizuje toto uložené přihlášení ve tvém zařízení.";
+"autofill.update-password.message" = "DuckDuckGo aktualizuje tohle uložené heslo ve tvém zařízení.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Aktualizuj si heslo";

--- a/DuckDuckGo/da.lproj/Localizable.strings
+++ b/DuckDuckGo/da.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Adgangskode til %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Vil du bruge et gemt login?";
+"autofill.logins.prompt.title" = "Brug en gemt adgangskode?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "for '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Privat Duck Address-brugernavn blev fjernet";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Logins gemmes sikkert på din enhed i menuen Logins.";
+"autofill.save-login.new-user.message" = "Adgangskoder gemmes sikkert på din enhed i menuen Logins.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Skal DuckDuckGo gemme dit login?";
+"autofill.save-login.new-user.title" = "Skal DuckDuckGo gemme din adgangskode?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Gem ikke";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Gem login";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Gem login?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Gem adgangskode";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Gem adgangskode?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Vis adgangskode";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ for at administrere dine Duck-adresser på denne enhed.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo opdaterer dette gemte login på din enhed.";
+"autofill.update-password.message" = "DuckDuckGo opdaterer denne gemte adgangskode på din enhed.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Opdater adgangskode";

--- a/DuckDuckGo/de.lproj/Localizable.strings
+++ b/DuckDuckGo/de.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Passwort für %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Gespeicherte Anmeldedaten verwenden?";
+"autofill.logins.prompt.title" = "Gespeichertes Passwort verwenden?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "für „%@“";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Benutzername von Private Duck Address wurde entfernt";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Anmeldedaten werden sicher auf deinem Gerät im Anmeldedaten-Menü gespeichert.";
+"autofill.save-login.new-user.message" = "Passwörter werden sicher auf deinem Gerät im Anmeldedaten-Menü gespeichert.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Möchtest du, dass DuckDuckGo deine Anmeldedaten speichert?";
+"autofill.save-login.new-user.title" = "Möchtest du, dass DuckDuckGo dein Passwort speichert?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Nicht speichern";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Anmeldedaten speichern";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Anmeldedaten speichern?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Passwort speichern";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Passwort speichern?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Passwort anzeigen";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@, um deine Duck Addresses auf diesem Gerät zu verwalten.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo aktualisiert diese gespeicherten Anmeldedaten auf deinem Gerät.";
+"autofill.update-password.message" = "DuckDuckGo aktualisiert dieses gespeicherte Passwort auf deinem Gerät.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Passwort aktualisieren";

--- a/DuckDuckGo/el.lproj/Localizable.strings
+++ b/DuckDuckGo/el.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Κωδικός πρόσβασης για %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Χρήση αποθηκευμένων στοιχείων σύνδεσης;";
+"autofill.logins.prompt.title" = "Χρήση αποθηκευμένου κωδικού πρόσβασης;";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "για '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Το ιδιωτικό όνομα χρήστη Duck Address καταργήθηκε";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Οι συνδέσεις αποθηκεύονται με ασφάλεια στη συσκευή σας στο μενού Συνδέσεις.";
+"autofill.save-login.new-user.message" = "Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας στο μενού Συνδέσεις.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Θέλετε να αποθηκεύσει το DuckDuckGo τη σύνδεσή σας;";
+"autofill.save-login.new-user.title" = "Θέλετε το DuckDuckGo να αποθηκεύσει τον κωδικό πρόσβασής σας;";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Να μην αποθηκευτεί";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Αποθήκευση σύνδεσης";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Αποθήκευση σύνδεσης;";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Αποθήκευση κωδικού πρόσβασης";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Αποθήκευση κωδικού πρόσβασης;";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Εμφάνιση κωδικού πρόσβασης";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ για διαχείριση των διευθύνσεών σας Duck Address σε αυτήν τη συσκευή.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "Το DuckDuckGo θα ενημερώσει αυτήν την αποθηκευμένη σύνδεση στη συσκευή σας.";
+"autofill.update-password.message" = "Το DuckDuckGo θα ενημερώσει αυτόν τον αποθηκευμένο κωδικό πρόσβασης στη συσκευή σας.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Ενημέρωση κωδικού πρόσβασης";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -590,7 +590,7 @@
 "autofill.logins.prompt.password.button.title" = "Password for %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Use a saved Login?";
+"autofill.logins.prompt.title" = "Use a saved password?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "for '%@'";
@@ -644,25 +644,19 @@
 "autofill.save-login.never-prompt.CTA" = "Never Ask for This Site";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Logins are stored securely on your device in the Logins menu.";
+"autofill.save-login.new-user.message" = "Passwords are stored securely on your device in the Logins menu.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Do you want DuckDuckGo to save your Login?";
+"autofill.save-login.new-user.title" = "Do you want DuckDuckGo to save your password?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Don’t Save";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Save Login";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Save Login?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Save Password";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Save Password?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Show Password";
@@ -671,7 +665,7 @@
 "autofill.signin.to.manage" = "%@ to manage your Duck Addresses on this device.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo will update this stored Login on your device.";
+"autofill.update-password.message" = "DuckDuckGo will update this stored password on your device.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Update Password";

--- a/DuckDuckGo/es.lproj/Localizable.strings
+++ b/DuckDuckGo/es.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Contraseña para %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "¿Usar un inicio de sesión guardado?";
+"autofill.logins.prompt.title" = "¿Usar una contraseña guardada?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "para '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Se ha eliminado el nombre de usuario de la Duck Address privada";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Los inicios de sesión se almacenan de forma segura en tu dispositivo en el menú Inicios de sesión.";
+"autofill.save-login.new-user.message" = "Las contraseñas se almacenan de forma segura en tu dispositivo en el menú Inicios de sesión.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "¿Quieres que DuckDuckGo guarde tu inicio de sesión?";
+"autofill.save-login.new-user.title" = "¿Quieres que DuckDuckGo guarde tu contraseña?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "No guardar";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Guardar inicio de sesión";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "¿Guardar inicio de sesión?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Guardar contraseña";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "¿Guardar contraseña?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Mostrar contraseña";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ para gestionar tus Duck Addresses en este dispositivo.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo actualizará este inicio de sesión almacenado en tu dispositivo.";
+"autofill.update-password.message" = "DuckDuckGo actualizará esta contraseña almacenada en tu dispositivo.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Actualizar contraseña";

--- a/DuckDuckGo/et.lproj/Localizable.strings
+++ b/DuckDuckGo/et.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Parool veebisaidi %@ jaoks";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Kas kasutada salvestatud sisselogimisandmeid?";
+"autofill.logins.prompt.title" = "Kas kasutada salvestatud parooli?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "otsinguga '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Privaatse Duck Addressi kasutajanimi eemaldati";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Logisid hoitakse turvaliselt sinu seadmes logide menüüs.";
+"autofill.save-login.new-user.message" = "Paroole hoitakse turvaliselt sinu seadmes sisselogimisandmete menüüs.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Kas soovid, et DuckDuckGo salvestaks sinu sisselogimisandmed?";
+"autofill.save-login.new-user.title" = "Kas soovid, et DuckDuckGo salvestaks sinu parooli?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Ära salvesta";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Salvesta sisselogimisandmed";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Kas salvestada sisselogimisandmed?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Salvesta parool";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Kas salvestada parool?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Kuva parool";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@, et hallata selles seadmes oma Duck Addresse.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo värskendab need salvestatud sisselogimisandmed sinu seadmes.";
+"autofill.update-password.message" = "DuckDuckGo värskendab selle salvestatud parooli sinu seadmes.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Värskenda parooli";

--- a/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/DuckDuckGo/fi.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Sivuston %@ salasana";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Käytä tallennettuja kirjautumistietoja?";
+"autofill.logins.prompt.title" = "Käytetäänkö tallennettua salasanaa?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "kohteelle '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Yksityinen Duck Address -käyttäjätunnus on poistettu";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Kirjautumistiedot tallennetaan turvallisesti laitteellesi kirjautumistiedot-valikkoon.";
+"autofill.save-login.new-user.message" = "Salasanat tallennetaan turvallisesti laitteellesi kirjautumistiedot-valikkoon.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Haluatko, että DuckDuckGo tallentaa kirjautumistietosi?";
+"autofill.save-login.new-user.title" = "Haluatko, että DuckDuckGo tallentaa salasanasi?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Älä tallenna";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Tallenna kirjautumistiedot";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Tallennetaanko kirjautumistiedot?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Tallenna salasana";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Tallennetaanko salasana?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Näytä salasana";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ hallitaksesi Duck Address -osoitteita tällä laitteella.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo päivittää tämän laitteellesi tallennetun kirjautumistiedon.";
+"autofill.update-password.message" = "DuckDuckGo päivittää tämän tallennetun salasanan laitteellesi.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Päivitä salasana";

--- a/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/DuckDuckGo/fr.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Mot de passe pour %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Utiliser un identifiant enregistré ?";
+"autofill.logins.prompt.title" = "Utiliser un mot de passe enregistré ?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "pour '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Le nom d'utilisateur de la Duck Address privée a été supprimé";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Les identifiants de connexion sont stockés en toute sécurité sur votre appareil dans le menu Identifiants.";
+"autofill.save-login.new-user.message" = "Les mots de passe sont stockés en toute sécurité sur votre appareil dans le menu Identifiants.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Voulez-vous que DuckDuckGo enregistre votre identifiant ?";
+"autofill.save-login.new-user.title" = "Voulez-vous que DuckDuckGo enregistre votre mot de passe ?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Ne pas enregistrer";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Enregistrer l'identifiant";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Enregistrer l'identifiant ?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Enregistrer le mot de passe";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Enregistrer le mot de passe ?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Afficher le mot de passe";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ pour gérer vos Duck Addresses sur cet appareil.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo mettra à jour cet identifiant enregistré sur votre appareil.";
+"autofill.update-password.message" = "DuckDuckGo mettra à jour ce mot de passe enregistré sur votre appareil.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Modifier le mot de passe";

--- a/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/DuckDuckGo/hr.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Lozinka za %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Koristiti spremljene podatke za prijavu?";
+"autofill.logins.prompt.title" = "Koristiti spremljenu lozinku?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "za '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Korisničko ime privatne Duck Address adrese uklonjeno je";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Prijave su sigurno pohranjene na tvom uređaju u izborniku Prijave.";
+"autofill.save-login.new-user.message" = "Lozinke su sigurno pohranjene na tvom uređaju u izborniku Prijava.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Želiš li da DuckDuckGo spremi tvoju prijavu?";
+"autofill.save-login.new-user.title" = "Želiš li da DuckDuckGo spremi tvoju lozinku?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Nemoj spremiti";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Spremi prijavu";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Želiš li spremiti prijavu?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Spremi lozinku";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Želiš li spremiti lozinku?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Pokaži lozinku";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ za upravljanje tvojim Duck Address adresama na ovom uređaju.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo će ažurirati ovu spremljenu prijavu na tvom uređaju.";
+"autofill.update-password.message" = "DuckDuckGo će ažurirati ovu pohranjenu lozinku na tvom uređaju.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Ažuriraj lozinku";

--- a/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/DuckDuckGo/hu.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "%@ jelszava";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Mentett bejelentkezés használata?";
+"autofill.logins.prompt.title" = "Mentett jelszót használsz?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "erre: „%@“";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Privát Duck-cím felhasználóneve eltávolítva";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "A rendszer biztonságosan tárolja az eszköz Bejelentkezés menüjében elérhető bejelentkezési adatokat.";
+"autofill.save-login.new-user.message" = "A rendszer biztonságosan tárolja az eszköz Bejelentkezés menüjében elérhető jelszavakat.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "A DuckDuckGo mentse a bejelentkezést?";
+"autofill.save-login.new-user.title" = "A DuckDuckGo mentse a jelszót?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Mentés mellőzése";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Bejelentkezés mentése";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Mented a bejelentkezést?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Jelszó mentése";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Mented a jelszót?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Jelszó megjelenítése";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ a Duck-címek kezeléséhez ezen az eszközön.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "A DuckDuckGo frissíti az eszközödön ezt a tárolt bejelentkezést.";
+"autofill.update-password.message" = "A DuckDuckGo frissíti az eszközödön ezt a tárolt jelszót.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Jelszó frissítése";

--- a/DuckDuckGo/it.lproj/Localizable.strings
+++ b/DuckDuckGo/it.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Password per %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Usare i dati di accesso salvati?";
+"autofill.logins.prompt.title" = "Utilizzare una password salvata?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "per \"%@\"";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Il nome utente Private Duck Address è stato rimosso";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Gli accessi sono archiviati in modo sicuro sul tuo dispositivo nel menu Accessi.";
+"autofill.save-login.new-user.message" = "Le password sono archiviate in modo sicuro sul tuo dispositivo nel menu Accessi.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Vuoi che DuckDuckGo salvi i dati di accesso?";
+"autofill.save-login.new-user.title" = "Vuoi che DuckDuckGo salvi la password?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Non salvare";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Salva dati di accesso";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Salvare dati di accesso?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Salva password";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Salvare password?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Mostra password";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ per gestire i tuoi Duck Address su questo dispositivo.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo aggiornerà questi dati di accesso memorizzati sul tuo dispositivo.";
+"autofill.update-password.message" = "DuckDuckGo aggiornerà questa password memorizzata sul tuo dispositivo.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Aggiorna password";

--- a/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/DuckDuckGo/lt.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Slaptažodis, skirtas %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Naudoti išsaugotą prisijungimą?";
+"autofill.logins.prompt.title" = "Naudoti išsaugotą slaptažodį?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "„%@“";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Privatus „Duck Address“ naudotojo vardas buvo pašalintas";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Prisijungimai saugiai saugomi jūsų įrenginio meniu „Prisijungimai“.";
+"autofill.save-login.new-user.message" = "Slaptažodžiai saugiai saugomi jūsų įrenginio meniu „Prisijungimai“.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Ar norite, kad „DuckDuckGo“ išsaugotų jūsų prisijungimą?";
+"autofill.save-login.new-user.title" = "Ar norite, kad „DuckDuckGo“ išsaugotų jūsų slaptažodį?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Neišsaugokite";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Išsaugoti prisijungimą";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Išsaugoti prisijungimą?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Išsaugoti slaptažodį";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Išsaugoti slaptažodį?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Rodyti slaptažodį";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@, kad galėtumėte valdyti savo „Duck Address“ šiame įrenginyje.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "„DuckDuckGo“ atnaujins šį jūsų įrenginyje įrašytą prisijungimą.";
+"autofill.update-password.message" = "„DuckDuckGo“ atnaujins šį jūsų įrenginyje išsaugotą slaptažodį.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Atnaujinti slaptažodį";

--- a/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/DuckDuckGo/lv.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "%@ parole";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Vai izmantot saglabātos pieteikšanās datus?";
+"autofill.logins.prompt.title" = "Izmantot saglabāto paroli?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "meklējumam \"%@\"";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Privātās Duck adreses lietotājvārds tika noņemts";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Pieteikšanās dati tiek droši saglabāti tavā ierīcē, izvēlnē Pieteikšanās dati.";
+"autofill.save-login.new-user.message" = "Paroles tiek droši saglabātas tavā ierīcē, izvēlnē Pieteikšanās dati.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Vai vēlies, lai DuckDuckGo saglabātu tavus pieteikšanās datus?";
+"autofill.save-login.new-user.title" = "Vai vēlies, lai DuckDuckGo saglabātu tavu paroli?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Nesaglabāt";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Saglabāt pieteikšanās datus";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Saglabāt pieteikšanās datus?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Saglabāt paroli";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Saglabāt paroli?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Rādīt paroli";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@, lai pārvaldītu savas Duck adreses šajā ierīcē.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo atjauninās šos saglabātos pieteikšanās datus tavā ierīcē.";
+"autofill.update-password.message" = "DuckDuckGo atjauninās tavā ierīcē saglabāto paroli.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Atjaunināt paroli";

--- a/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/DuckDuckGo/nb.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Passord for %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Vil du bruke en lagret pålogging?";
+"autofill.logins.prompt.title" = "Vil du bruke et lagret passord?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "for «%@»";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Brukernavn for privat Duck-adresse ble fjernet";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Pålogginger lagres trygt på enheten din i påloggingsmenyen.";
+"autofill.save-login.new-user.message" = "Passord lagres trygt på enheten din i påloggingsmenyen.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Vil du at DuckDuckGo skal lagre påloggingen din?";
+"autofill.save-login.new-user.title" = "Vil du at DuckDuckGo skal lagre passordet ditt?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Ikke lagre";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Lagre påloggingen";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Vil du lagre påloggingen?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Lagre passordet";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Vil du lagre passordet?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Vis passord";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ for å administrere Duck-adressene dine på denne enheten.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo oppdaterer denne lagrede påloggingen på enheten din.";
+"autofill.update-password.message" = "DuckDuckGo oppdaterer dette lagrede passordet på enheten din.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Oppdater passordet";

--- a/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/DuckDuckGo/nl.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Wachtwoord voor %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Opgeslagen aanmeldgegevens gebruiken?";
+"autofill.logins.prompt.title" = "Een opgeslagen wachtwoord gebruiken?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "voor '%@'";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "De persoonlijke gebruikersnaam voor het Duck Address is verwijderd";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Aanmeldgegevens worden veilig opgeslagen op je apparaat in het menu 'Aanmeldingen'.";
+"autofill.save-login.new-user.message" = "Wachtwoorden worden veilig opgeslagen op je apparaat in het menu 'Aanmeldingen'.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Wil je dat DuckDuckGo je login opslaat?";
+"autofill.save-login.new-user.title" = "Wil je dat DuckDuckGo je wachtwoord opslaat?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Niet opslaan";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Login opslaan";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Login opslaan?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Wachtwoord opslaan";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Wachtwoord opslaan?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Wachtwoord weergeven";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ om je Duck-adressen op dit apparaat te beheren.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo werkt deze opgeslagen aanmeldgegevens op je apparaat bij.";
+"autofill.update-password.message" = "DuckDuckGo werkt dit opgeslagen wachtwoord op je apparaat bij.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Wachtwoord bijwerken";

--- a/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/DuckDuckGo/pl.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Hasło %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Czy chcesz użyć zapisanego loginu?";
+"autofill.logins.prompt.title" = "Użyć zapisanego hasła?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "dla frazy: %@";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Nazwa użytkownika prywatnego adresu Duck Address została usunięta";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Loginy są bezpiecznie przechowywane na Twoim urządzeniu w menu Loginy.";
+"autofill.save-login.new-user.message" = "Hasła są bezpiecznie przechowywane na Twoim urządzeniu w menu Loginy.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Czy chcesz zapisać dane logowania w DuckDuckGo?";
+"autofill.save-login.new-user.title" = "Czy chcesz zapisać hasło w DuckDuckGo?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Nie zapisuj";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Zapisz logowanie";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Zapisać logowanie?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Zapisz hasło";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Zapisać hasło?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Pokaż hasło";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@, aby zarządzać adresami Duck Address na tym urządzeniu.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo zaktualizuje ten zapisany login na Twoim urządzeniu.";
+"autofill.update-password.message" = "DuckDuckGo zaktualizuje to zapisane hasło na Twoim urządzeniu.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Aktualizuj hasło";

--- a/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/DuckDuckGo/pt.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Palavra-passe para % @";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Utilizar um início de sessão guardado?";
+"autofill.logins.prompt.title" = "Usar uma palavra-passe guardada?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "para \"%@\"";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "O nome de utilizador privado do Duck Address foi removido";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Os dados de início de sessão são armazenados de forma segura no teu dispositivo no menu Inícios de sessão.";
+"autofill.save-login.new-user.message" = "As palavras-passe são armazenadas de forma segura no teu dispositivo no menu Inícios de sessão.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Queres que o DuckDuckGo guarde o teu início de sessão?";
+"autofill.save-login.new-user.title" = "Queres que o DuckDuckGo guarde a tua palavra-passe?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Não guardes";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Guardar início de sessão";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Guardar início de sessão?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Guardar palavra-passe";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Guardar palavra-passe?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Mostrar palavra-passe";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ para gerires os teus Duck Addresses neste dispositivo.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "O DuckDuckGo vai atualizar este início de sessão armazenado no teu dispositivo.";
+"autofill.update-password.message" = "O DuckDuckGo vai atualizar esta palavra-passe armazenada no teu dispositivo.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Atualizar palavra-passe";

--- a/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/DuckDuckGo/ro.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Parola pentru %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Folosești datele de conectare salvate?";
+"autofill.logins.prompt.title" = "Folosești o parolă salvată?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "pentru „%@”";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Numele de utilizator pentru Duck Address privată a fost eliminat";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Conexiunile sunt stocate în siguranță pe dispozitivul dvs. în meniul Conectări.";
+"autofill.save-login.new-user.message" = "Parolele sunt stocate în siguranță pe dispozitivul dvs. în meniul Autentificări.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Dorești ca DuckDuckGo să îți salveze datele de autentificare?";
+"autofill.save-login.new-user.title" = "Dorești ca DuckDuckGo să-ți salveze parola?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Nu salva";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Salvează autentificarea";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Salvezi autentificarea?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Salvează parola";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Salvezi parola?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Arată parola";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ pentru a-ți gestiona adresele Duck Address pe acest dispozitiv.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo va actualiza aceste date de conectare stocate pe dispozitivul tău.";
+"autofill.update-password.message" = "DuckDuckGo va actualiza această parolă stocată pe dispozitivul tău.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Actualizează parola";

--- a/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/DuckDuckGo/ru.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Пароль %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Использовать сохраненный логин?";
+"autofill.logins.prompt.title" = "Использовать сохраненный пароль?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "по запросу «%@»";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Приватное имя пользователя Duck Address удалено";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Учетные данные надежно хранятся на вашем устройстве в меню «Логины».";
+"autofill.save-login.new-user.message" = "Пароли надежно хранятся на вашем устройстве в меню «Логины».";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Хотите, чтобы DuckDuckGo сохранил логин?";
+"autofill.save-login.new-user.title" = "Хотите, чтобы DuckDuckGo сохранил ваш пароль?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Не сохранять";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Сохранить логин";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Сохранить логин?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Сохранить пароль";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Сохранить пароль?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Показать пароль";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ для управления адресами Duck Address с этого устройства.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo обновит логин, сохраненный на вашем устройстве.";
+"autofill.update-password.message" = "DuckDuckGo обновит пароль, сохраненный на вашем устройстве.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Обновить пароль";

--- a/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/DuckDuckGo/sk.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Heslo pre %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Použiť uložené prihlasovacie údaje?";
+"autofill.logins.prompt.title" = "Použiť uložené heslo?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "pre „%@”";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Používateľské meno Private Duck Address bolo odstránené";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Prihlasovacie údaje sú bezpečne uložené v zariadení v ponuke Prihlásenia.";
+"autofill.save-login.new-user.message" = "Heslá sú bezpečne uložené na vašom zariadení v ponuke Prihlásenia.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Chcete, aby DuckDuckGo uložil vaše prihlasovacie údaje?";
+"autofill.save-login.new-user.title" = "Chcete, aby DuckDuckGo uložil vaše heslo?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Neukladať";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Uložiť prihlasovacie údaje";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Uložiť prihlasovacie údaje?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Uložiť heslo";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Uložiť heslo?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Zobraziť heslo";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ na správu vašich Duck adries na tomto zariadení.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo bude aktualizovať tieto uložené prihlasovacie údaje vo vašom zariadení.";
+"autofill.update-password.message" = "DuckDuckGo aktualizuje toto uložené heslo vo vašom zariadení.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Aktualizovať heslo";

--- a/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/DuckDuckGo/sl.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Geslo za %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Želite uporabiti shranjene podatke za prijavo?";
+"autofill.logins.prompt.title" = "Želite uporabiti shranjeno geslo?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "za »%@«";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Uporabniško ime za zasebni naslov Duck Address je bilo odstranjeno";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Prijave so varno shranjene v vaši napravi v meniju Prijave.";
+"autofill.save-login.new-user.message" = "Gesla so varno shranjena v napravi v meniju Prijave.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Ali želite, da DuckDuckGo shrani vašo prijavo?";
+"autofill.save-login.new-user.title" = "Ali želite, da DuckDuckGo shrani vaše geslo?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Ne shrani";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Shrani prijavo";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Želite shraniti prijavo?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Shrani geslo";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Želite shraniti geslo?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Prikaži geslo";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ za upravljanje naslovov Duck Address v tej napravi.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo bo posodobil to shranjeno prijavo v vaši napravi.";
+"autofill.update-password.message" = "DuckDuckGo bo posodobil to shranjeno geslo v vaši napravi.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Posodobitev gesla";

--- a/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/DuckDuckGo/sv.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "Lösenord för %@";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Använd sparad inloggning?";
+"autofill.logins.prompt.title" = "Vill du använda ett sparat lösenord?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "för ”%@”";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Användarnamn för privat Duck Address har tagits bort";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Inloggningar lagras säkert på din enhet i menyn Inloggningar.";
+"autofill.save-login.new-user.message" = "Lösenord lagras säkert på din enhet i menyn Inloggningar.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "Vill du att DuckDuckGo ska spara din inloggning?";
+"autofill.save-login.new-user.title" = "Vill du att DuckDuckGo ska spara ditt lösenord?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Spara inte";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Spara inloggning";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Spara inloggning?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Spara lösenord";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Spara lösenord?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Visa lösenord";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "%@ för att hantera Duck Addresses på denna enhet.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo uppdaterar den här lagrade inloggningen på din enhet.";
+"autofill.update-password.message" = "DuckDuckGo kommer att uppdatera det lagrade lösenordet på din enhet.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Uppdatera lösenord";

--- a/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/DuckDuckGo/tr.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "autofill.logins.prompt.password.button.title" = "%@ için parola";
 
 /* Title for autofill login prompt */
-"autofill.logins.prompt.title" = "Kayıtlı Giriş kullanılsın mı?";
+"autofill.logins.prompt.title" = "Kayıtlı bir şifre mi kullanıyorsunuz?";
 
 /* Subtitle displayed when there are no results on Autofill search, example : No Result (Title) for Duck (Subtitle) */
 "autofill.logins.search.no-results.subtitle" = "\"%@\" için";
@@ -614,25 +614,19 @@
 "autofill.removed.duck.address.title" = "Özel Duck Address kullanıcı adı kaldırıldı";
 
 /* Message displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.message" = "Giriş bilgileri cihazınızdaki Giriş Bilgileri menüsünde güvenli bir şekilde saklanır.";
+"autofill.save-login.new-user.message" = "Şifreler cihazınızdaki Oturum Açma menüsünde güvenli bir şekilde saklanır.";
 
 /* Title displayed on modal asking for the user to save the login for the first time */
-"autofill.save-login.new-user.title" = "DuckDuckGo'nun Girişinizi kaydetmesini istiyor musunuz?";
+"autofill.save-login.new-user.title" = "DuckDuckGo'nun şifrenizi kaydetmesini istiyor musunuz?";
 
 /* Cancel CTA displayed on modal asking for the user to save the login */
 "autofill.save-login.not-now.CTA" = "Kaydetme";
-
-/* Confirm CTA displayed on modal asking for the user to save the login */
-"autofill.save-login.save.CTA" = "Girişi Kaydet";
 
 /* Title displayed on modal asking for the user to save the login */
 "autofill.save-login.title" = "Giriş Kaydedilsin mi?";
 
 /* Confirm CTA displayed on modal asking for the user to save the password */
 "autofill.save-password.save.CTA" = "Şifre Kaydet";
-
-/* Title displayed on modal asking for the user to save the password */
-"autofill.save-password.title" = "Şifre Kaydedilsin mi?";
 
 /* Accessibility title for a Show Password button displaying actial password instead of ***** */
 "autofill.show-password" = "Parolayı göster";
@@ -641,7 +635,7 @@
 "autofill.signin.to.manage" = "Bu cihazdaki Duck Address'leri yönetmek için %@.";
 
 /* Message displayed on modal asking for the user to update the password */
-"autofill.update-password.message" = "DuckDuckGo, cihazınızdaki bu kayıtlı Giriş bilgisini güncelleyecektir.";
+"autofill.update-password.message" = "DuckDuckGo bu kayıtlı şifreyi cihazınızda güncelleyecektir.";
 
 /* Confirm CTA displayed on modal asking for the user to update the password */
 "autofill.update-password.save.CTA" = "Şifreyi Güncelle";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1205786958985456/f
Tech Design URL:
CC:

**Description**:
Removes the website favicon + url at the top of the autofill prompts and add app icon to the top of all autofill prompts. Also updates copy to replace the word `logins` with `passwords`

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Visit https://fill.dev/form/login-simple and enter any username & password
2. Confirm the `Save a Login` prompt has the same layout & copy as this:
<img width=200 src="https://github.com/duckduckgo/iOS/assets/91189922/d3904798-9ced-4219-92ac-e016715c3f70">

3. Tap `Save Password`
4. Go back to https://fill.dev/form/login-simple and confirm the `Use Saved Login` prompt has the same layout & copy as this: 
<img width=200 src="https://github.com/duckduckgo/iOS/assets/91189922/76599cd6-c5f4-4539-8858-82482627e48f">

5. On https://fill.dev/form/login-simple enter the username of your saved login, but enter a different password
6. Confirm the `Update Password` prompt has the same layout & copy as this: 
<img width=200 src="https://github.com/duckduckgo/iOS/assets/91189922/f4e44b0d-64a3-4bc2-a7cc-94e8365c6dd4">

7. Go to https://news.ycombinator.com/login and in the login form enter a dummy password and tap 'login'
8. Confirm the `Save Password` prompt has the same layout & copy as this: 
<img width=200 src="https://github.com/duckduckgo/iOS/assets/91189922/e29cf7e7-9e6c-487c-8d57-1861caea4b18">

9. Now enter a dummy username in the same form and tap 'login'
10. Confirm the `Update Username` prompt has the same layout & copy as this:  
<img width=200 src="https://github.com/duckduckgo/iOS/assets/91189922/116a2154-f372-4703-8caf-c499e8e7e366">

11. Visit https://fill.dev/form/registration-email and tap the key icon in the password field
12. Confirm the `Generated Password` prompt has the same layout & copy as this:  
<img width=200 src="https://github.com/duckduckgo/iOS/assets/91189922/a00cd71f-a97c-4a51-858b-5d6530e9c2d8">

13. Review the translated strings, confirming 4 have been modified and 2 (now unused) are deleted

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
