### PR TITLE
Address Bar Spoofing Tests + Remediation

### DIFF
--- a/.maestro/security_tests/0_all.yaml
+++ b/.maestro/security_tests/0_all.yaml
@@ -1,0 +1,39 @@
+# all.yaml
+
+appId: com.duckduckgo.mobile.ios
+---
+
+# Set up 
+- clearState
+- launchApp
+- runFlow: 
+    when: 
+      visible: 
+        text: "Let’s Do It!"
+        index: 0
+    file: ../shared/onboarding.yaml
+
+# Load Site
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/"
+- pressKey: Enter
+
+# Manage onboarding
+- runFlow:
+    when:
+      visible:
+        text: "Got It"
+        index: 0
+    file: ../shared/onboarding_browsing.yaml
+
+# Run AddressBarSpoofing tests
+- runFlow: ./1_-_AddressBarSpoof,_basicauth.yaml
+- runFlow: ./2_-_AddressBarSpoof,_aboutblank.yaml
+- runFlow: ./3_-_AddressBarSpoof,_appschemes.yaml
+- runFlow: ./4_-_AddressBarSpoof,_b64_html.yaml
+- runFlow: ./5_-_AddressBarSpoof,_downloadpath.yaml
+- runFlow: ./6_-_AddressBarSpoof,_formaction.yaml
+- runFlow: ./7_-_AddressBarSpoof,_pagerewrite.yaml

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -1,0 +1,35 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+- doubleTapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+# Test 1 - using \u2028 character
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2028.html"
+- pressKey: Enter
+- tapOn: "run"
+- assertVisible: "Example Domain"
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+- tapOn:
+    id: "searchEntry"
+# Test 2 - using \u2029 character
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2029.html"
+- pressKey: Enter
+- tapOn: "run"
+- assertVisible: "Example Domain"
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+- tapOn:
+    id: "searchEntry"
+# Test 3 - using repeated " " space character
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-whitespace.html"
+- pressKey: Enter
+- tapOn: "run"
+- assertVisible: "Example Domain"
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -1,0 +1,17 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+- doubleTapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-rewrite.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This test is expected to load "about:blank" not spoof the address bar with duckduckgo.com with the spoofed content.
+- extendedWaitUntil:
+    visible: "Not DDG."  # Spoofed content is visible
+    timeout: 10000
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "about:blank"}

--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -1,0 +1,30 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+# Test 1
+- tapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-application-scheme.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This will try to open another app
+- assertVisible: "Cancel"
+- tapOn: "Cancel"
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "https://duckduckgo.com/"} # Should navigate directly here.
+- assertNotVisible: "Not DDG." # HTML content shouldn't be spoofed.
+- tapOn:
+    id: "searchEntry"
+# Test 2
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This will try to open another app
+- assertVisible: "Cancel"
+- tapOn: "Cancel"
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"}

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -1,0 +1,15 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This test is expected to do nothing: loading base64 encoded HTML content in a new tab is blocked.
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"}

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -1,0 +1,39 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
+- pressKey: Enter
+- tapOn: "Start"
+# Download Acceptance Flow:
+- extendedWaitUntil:
+    visible: "Save to Downloads"
+    timeout: 10000
+- tapOn: "Save to Downloads"
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "about:blank"} # Downloads should occur in empty origin.
+# Restart
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
+- pressKey: Enter
+# Download Cancel Flow:
+- tapOn: "Start"
+- extendedWaitUntil:
+    visible: "Cancel"  
+    timeout: 10000
+- tapOn: "Cancel"
+# Should be on about:blank
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "about:blank"}
+# Return to last test page
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
+- pressKey: Enter

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -1,0 +1,16 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"
+- pressKey: Enter
+- tapOn: "run"
+# Should navigate to duckduckgo.com without any spoofed HTML document content.
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "https://duckduckgo.com/"}
+- assertNotVisible: "Not DDG."

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -1,0 +1,16 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "searchEntry"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"
+- pressKey: Enter
+- tapOn: "Start"
+# Now check the address bar hasn't been updated too early resulting in spoofed content
+- copyTextFrom:
+    id: "searchEntry"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"}
+- assertNotVisible: "DDG." 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1205886249660032/f

**Description**:
In an attempt to reduce our exposure to address bar spoofing issues I'd like to introduce these 8 new maestro tests that test against privacy-test-pages for specific known address bar spoofing vulnerabilities. The core issue in iOS involves download links that perform 301/302 HTTP redirects - the address bar is incorrectly updated to the download URL even though the target URL has no associated HTML document, therefore we're left with a stale HTML document and a spoofed address bar. See more information here: https://app.asana.com/0/0/1205809497861069/f

In my proposed fix, we update the omnibar text value to "about:blank" when a file download prompt is shown. This is consistent with most other browsers, and the address bar should be correctly updated when there is a HTML document in the renderer, so it shouldn't impact other file downloads.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
(tested on iPhone 14 Pro with iOS 17.0.3 and the simulator, no UI changes so this should be sufficient)
1. run `maestro test .maestro/security_tests/0_all.yaml`
2. check all tests are passing
3. open the browser on https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html
4. tap on "Start"
5. tap on "Cancel"
6. ensure the address bar is still "about:blank" and not "staticcdn.duckduckgo.com..."
7. go back
8. tap on "Start"
9. tap "Save to Downloads"
10. check the address bar is "about:blank" and is not spoofed
11. now check normal downloads work as expected, navigate to https://filesamples.com/formats/bin
12. download the first file
13. check "about:blank" is shown in address bar briefly
14. tap either "Download" or "Cancel"
15. check the address bar value reverts to the correct origin