### PR TITLE
fix pass kit related crash on iPad

### DIFF
--- a/DuckDuckGo/FilePreviewHelper.swift
+++ b/DuckDuckGo/FilePreviewHelper.swift
@@ -33,7 +33,10 @@ struct FilePreviewHelper {
     
     static func canAutoPreviewMIMEType(_ mimeType: MIMEType) -> Bool {
         switch mimeType {
-        case .reality, .usdz, .passbook, .calendar:
+        case .passbook:
+            return UIDevice.current.userInterfaceIdiom == .phone
+
+        case .reality, .usdz, .calendar:
             return true
         default:
             return false

--- a/DuckDuckGo/PassKitPreviewHelper.swift
+++ b/DuckDuckGo/PassKitPreviewHelper.swift
@@ -34,8 +34,9 @@ class PassKitPreviewHelper: FilePreview {
         do {
             let data = try Data(contentsOf: self.filePath)
             let pass = try PKPass(data: data)
-            let controller = PKAddPassesViewController(pass: pass)!
-            viewController?.present(controller, animated: true)
+            if let controller = PKAddPassesViewController(pass: pass) {
+                viewController?.present(controller, animated: true)
+            }
         } catch {
             os_log("Can't present passkit: %s", type: .debug, error.localizedDescription)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205887954649227/f
Tech Design URL:
CC:

**Description**:

Prevents crash when accessing pass kit data on iPad

**Steps to test this PR**:

On iPad:

1. Visit https://www.passsource.com/pass/register.php?hashedSerialNumber=eNortjIysVJKtUyuMDR0TNFPTfUOSi_N1y_SN3QNtLVVsgZcMJqGCT8,&psRegisteredFlag=1&psMessage=&
2. Tap on 'add to wallet'
3. Save to downloads  
4. From downloads share to an iPhone 
5. On iPhone add to wallet 

On Phone

1. Visit https://www.passsource.com/pass/register.php?hashedSerialNumber=eNortjIysVJKtUyuMDR0TNFPTfUOSi_N1y_SN3QNtLVVsgZcMJqGCT8,&psRegisteredFlag=1&psMessage=&
2. Tap on 'add to wallet'
3. Standard passkit UI should show the item and allow you to add it to your wallet 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
