### PR TITLE
Updates BSK

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9142,8 +9142,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 84.1.0;
+				kind = revision;
+				revision = 8233956d88a5ab6b14ab603ac6e907ec220c0df9;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9142,8 +9142,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 8233956d88a5ab6b14ab603ac6e907ec220c0df9;
+				kind = exactVersion;
+				version = 84.1.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "8233956d88a5ab6b14ab603ac6e907ec220c0df9",
-          "version": null
+          "revision": "b97c451037f7a24aef6389be8252df301d2294cd",
+          "version": "84.1.1"
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "641018cef1a3a13e9fdeb490b18639d1cb25569f",
-          "version": "84.1.0"
+          "revision": "8233956d88a5ab6b14ab603ac6e907ec220c0df9",
+          "version": null
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205973361141860/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/567
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1866

## Description:

Fixes some connectivity issues with NetP

## Testing

1. Make sure you reset NetP completely (keeping invite)
2. If you think there's a risk of cross contamination with the login item from other builds, try removing other builds of NetP and NetP privacy pro and restart your computer.
3. Run NetP a few times, make sure it never shows a "connected" alert twice for the same connect event.
4. Try to ensure it works reasonably well, and that you don't see a WireGuard.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
