### PR TITLE
removed unarchiveTopLevelObjectWithData deprecation

### DIFF
--- a/DuckDuckGo/TabsModelPersistenceExtension.swift
+++ b/DuckDuckGo/TabsModelPersistenceExtension.swift
@@ -18,6 +18,8 @@
 //
 
 import Foundation
+import Core
+import Common
 
 extension TabsModel {
 
@@ -26,8 +28,21 @@ extension TabsModel {
     }
 
     public static func get() -> TabsModel? {
-        guard let data = UserDefaults.app.object(forKey: Constants.key) as? Data else { return nil }
-        return try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? TabsModel
+        guard let data = UserDefaults.app.object(forKey: Constants.key) as? Data else {
+            return nil
+        }
+        var tabsModel: TabsModel?
+        do {
+            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+            unarchiver.requiresSecureCoding = false
+            tabsModel = unarchiver.decodeObject(of: self, forKey: NSKeyedArchiveRootObjectKey)
+            if let error = unarchiver.error {
+                throw error
+            }
+        } catch {
+            os_log("Something went wrong unarchiving TabsModel %@", log: .generalLog, type: .error, error.localizedDescription)
+        }
+        return tabsModel
     }
 
     public static func clear() {
@@ -35,8 +50,12 @@ extension TabsModel {
     }
 
     func save() {
-        guard let data = try? NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false) else { return }
-        UserDefaults.app.set(data, forKey: Constants.key)
+        var data: Data
+        do {
+            data = try NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
+            UserDefaults.app.set(data, forKey: Constants.key)
+        } catch {
+            os_log("Something went wrong archiving TabsModel %@", log: .generalLog, type: .error, error.localizedDescription)
+        }
     }
-    
 }

--- a/DuckDuckGo/TabsModelPersistenceExtension.swift
+++ b/DuckDuckGo/TabsModelPersistenceExtension.swift
@@ -50,9 +50,8 @@ extension TabsModel {
     }
 
     func save() {
-        var data: Data
         do {
-            data = try NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
+            let data = try NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
             UserDefaults.app.set(data, forKey: Constants.key)
         } catch {
             os_log("Something went wrong archiving TabsModel %@", log: .generalLog, type: .error, error.localizedDescription)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1205990984763603/f

**Description**:

I replaced the deprecated (iOS 12) API `unarchiveTopLevelObjectWithData` maintaining the use of non-secure coding in order to achieve backward compatibility with the already saved Tabs.

All functions that can throw errors are now correctly handled and in case of error a log is added.

**Steps to test this PR**:
1. Install the current app and save tabs
2. Update the new app version and check if the tabs are still there.

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17