### PR TITLE
Autofill pixel parameter removed

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -126,8 +126,6 @@ public struct PixelParameters {
     public static let returnUserErrorCode = "error_code"
     public static let returnUserOldATB = "old_atb"
     public static let returnUserNewATB = "new_atb"
-
-    public static let autofillDefaultState = "default_state"
 }
 
 public struct PixelValues {

--- a/DuckDuckGo/AutofillLoginPromptViewController.swift
+++ b/DuckDuckGo/AutofillLoginPromptViewController.swift
@@ -69,11 +69,9 @@ class AutofillLoginPromptViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if trigger == AutofillUserScript.GetTriggerType.autoprompt {
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineAutopromptDisplayed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineAutopromptDisplayed)
         } else {
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualDisplayed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualDisplayed)
         }
     }
     
@@ -97,11 +95,9 @@ class AutofillLoginPromptViewController: UIViewController {
 extension AutofillLoginPromptViewController: UISheetPresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         if self.trigger == AutofillUserScript.GetTriggerType.autoprompt {
-            Pixel.fire(pixel: .autofillLoginsAutopromptDismissed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsAutopromptDismissed)
         } else {
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualDismissed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualDismissed)
         }
         completion?(nil, false)
     }
@@ -111,11 +107,9 @@ extension AutofillLoginPromptViewController: AutofillLoginPromptViewModelDelegat
     func autofillLoginPromptViewModel(_ viewModel: AutofillLoginPromptViewModel, didSelectAccount account: SecureVaultModels.WebsiteAccount) {
         
         if trigger == AutofillUserScript.GetTriggerType.autoprompt {
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineAutopromptConfirmed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineAutopromptConfirmed)
         } else {
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualConfirmed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualConfirmed)
         }
 
         if AppDependencyProvider.shared.autofillLoginSession.isValidSession {
@@ -169,11 +163,9 @@ extension AutofillLoginPromptViewController: AutofillLoginPromptViewModelDelegat
     func autofillLoginPromptViewModelDidCancel(_ viewModel: AutofillLoginPromptViewModel) {
         dismiss(animated: true) {
             if self.trigger == AutofillUserScript.GetTriggerType.autoprompt {
-                Pixel.fire(pixel: .autofillLoginsAutopromptDismissed,
-                           withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+                Pixel.fire(pixel: .autofillLoginsAutopromptDismissed)
             } else {
-                Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualDismissed,
-                           withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+                Pixel.fire(pixel: .autofillLoginsFillLoginInlineManualDismissed)
             }
             
             self.completion?(nil, false)

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -693,11 +693,9 @@ extension AutofillLoginSettingsListViewController: AutofillLoginDetailsViewContr
 extension AutofillLoginSettingsListViewController: EnableAutofillSettingsTableViewCellDelegate {
     func enableAutofillSettingsTableViewCell(_ cell: EnableAutofillSettingsTableViewCell, didChangeSettings value: Bool) {
         if value {
-            Pixel.fire(pixel: .autofillLoginsSettingsEnabled,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsSettingsEnabled)
         } else {
-            Pixel.fire(pixel: .autofillLoginsSettingsDisabled,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsSettingsDisabled)
         }
         
         viewModel.isAutofillEnabledInSettings = value

--- a/DuckDuckGo/AutofillSettingStatus.swift
+++ b/DuckDuckGo/AutofillSettingStatus.swift
@@ -30,8 +30,4 @@ struct AutofillSettingStatus {
         let canAuthenticate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
         return appSettings.autofillCredentialsEnabled && canAuthenticate
     }
-
-    static var defaultState: String {
-        return appSettings.autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary ? "on" : "off"
-    }
 }

--- a/DuckDuckGo/PasswordGenerationPromptViewController.swift
+++ b/DuckDuckGo/PasswordGenerationPromptViewController.swift
@@ -49,8 +49,7 @@ class PasswordGenerationPromptViewController: UIViewController {
 
         setupPasswordGenerationPromptView()
 
-        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDisplayed,
-                   withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDisplayed)
     }
 
     private func setupPasswordGenerationPromptView() {
@@ -68,8 +67,7 @@ class PasswordGenerationPromptViewController: UIViewController {
 
 extension PasswordGenerationPromptViewController: UISheetPresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-            Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed)
 
         self.completion?(false)
     }
@@ -77,8 +75,7 @@ extension PasswordGenerationPromptViewController: UISheetPresentationControllerD
 
 extension PasswordGenerationPromptViewController: PasswordGenerationPromptViewModelDelegate {
     func passwordGenerationPromptViewModelDidSelect(_ viewModel: PasswordGenerationPromptViewModel) {
-        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptConfirmed,
-                   withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptConfirmed)
 
         dismiss(animated: true) {
             self.completion?(true)
@@ -86,8 +83,7 @@ extension PasswordGenerationPromptViewController: PasswordGenerationPromptViewMo
     }
 
     func passwordGenerationPromptViewModelDidCancel(_ viewModel: PasswordGenerationPromptViewModel) {
-        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed,
-                   withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed)
 
         dismiss(animated: true) {
             self.completion?(false)

--- a/DuckDuckGo/SaveLoginViewController.swift
+++ b/DuckDuckGo/SaveLoginViewController.swift
@@ -72,11 +72,9 @@ class SaveLoginViewController: UIViewController {
         }
         switch viewModel.layoutType {
         case .newUser, .saveLogin:
-            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDismissed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDismissed)
         case .savePassword:
-            Pixel.fire(pixel: .autofillLoginsSavePasswordModalDismissed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsSavePasswordModalDismissed)
         case .updateUsername:
             Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDismissed)
         case .updatePassword:
@@ -98,11 +96,9 @@ class SaveLoginViewController: UIViewController {
         
         switch saveViewModel.layoutType {
         case .newUser, .saveLogin:
-            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDisplayed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsSaveLoginModalDisplayed)
         case .savePassword:
-            Pixel.fire(pixel: .autofillLoginsSavePasswordModalDisplayed,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsSavePasswordModalDisplayed)
         case .updateUsername:
             Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDisplayed)
         case .updatePassword:
@@ -116,11 +112,9 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
         switch viewModel.layoutType {
         case .saveLogin, .savePassword, .newUser:
             if viewModel.layoutType == .savePassword {
-                Pixel.fire(pixel: .autofillLoginsSavePasswordModalConfirmed,
-                           withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+                Pixel.fire(pixel: .autofillLoginsSavePasswordModalConfirmed)
             } else {
-                Pixel.fire(pixel: .autofillLoginsSaveLoginModalConfirmed,
-                           withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+                Pixel.fire(pixel: .autofillLoginsSaveLoginModalConfirmed)
             }
             delegate?.saveLoginViewController(self, didSaveCredentials: credentialManager.credentials)
         case .updatePassword, .updateUsername:
@@ -152,8 +146,7 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
         alertController.overrideUserInterfaceStyle()
 
         let disableAction = UIAlertAction(title: UserText.autofillKeepEnabledAlertDisableAction, style: .cancel) { _ in
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptAutofillDisabled,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptAutofillDisabled)
             if isSelfPresentingAlert {
                 self.delegate?.saveLoginViewControllerDidCancel(self)
             }
@@ -161,8 +154,7 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
         }
 
         let keepUsingAction = UIAlertAction(title: UserText.autofillKeepEnabledAlertKeepUsingAction, style: .default) { _ in
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptAutofillKept,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptAutofillKept)
             if isSelfPresentingAlert {
                 self.delegate?.saveLoginViewControllerDidCancel(self)
             }
@@ -176,8 +168,7 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
         if isAlreadyDismissed {
             delegate?.saveLoginViewController(self, didRequestPresentConfirmKeepUsingAlertController: alertController)
         } else {
-            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown,
-                       withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+            Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown)
             present(alertController, animated: true)
         }
     }

--- a/DuckDuckGo/SettingsViewController.swift
+++ b/DuckDuckGo/SettingsViewController.swift
@@ -387,8 +387,7 @@ class SettingsViewController: UITableViewController {
             syncDataProviders: syncDataProviders
         )
         autofillController.delegate = self
-        Pixel.fire(pixel: .autofillSettingsOpened,
-                   withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+        Pixel.fire(pixel: .autofillSettingsOpened)
         navigationController?.pushViewController(autofillController, animated: animated)
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2569,8 +2569,7 @@ extension TabViewController: SaveLoginViewControllerDelegate {
     
     func saveLoginViewController(_ viewController: SaveLoginViewController,
                                  didRequestPresentConfirmKeepUsingAlertController alertController: UIAlertController) {
-        Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown,
-                   withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+        Pixel.fire(pixel: .autofillLoginsFillLoginInlineDisablePromptShown)
         present(alertController, animated: true)
     }
 }

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -369,8 +369,7 @@ extension TabViewController {
     }
     
     private func onOpenAutofillLoginsAction() {
-        Pixel.fire(pixel: .browsingMenuAutofill,
-                   withAdditionalParameters: [PixelParameters.autofillDefaultState: AutofillSettingStatus.defaultState])
+        Pixel.fire(pixel: .browsingMenuAutofill)
         delegate?.tabDidRequestAutofillLogins(tab: self)
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1205278999335242/1205495150811779/f
Tech Design URL:
CC:

**Description**:
Removes the parameter which distinguishes between the default on or off state of the autofill setting now that new installs are set to enabled by default.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:

Run through the various Autofill actions to trigger the pixels from this list and confirm that they no longer have the `default_state` parameter. https://fill.dev/ is a useful site for testing

**Prompt to disable setting:**
To test this, start with a clean install and Autofill enabled. Visit 2 different websites that have a login option and attempt to login to each. For each Save Prompt choose "Not Now". After the 2rd "Not Now" you'll be presented with the alert that fires these pixels:
- [] `m_autofill_logins_save_disable-prompt_shown`
- [] `m_autofill_logins_save_disable-prompt_autofill-kept` (tapping `Keep Saving`)
- [] `m_autofill_logins_save_disable-prompt_autofill-disabled` (tapping `Disable`)

**Save login prompt:**
Visit https://fill.dev/form/login-simple and enter some credentials to trigger the prompt
- [] `m_autofill_logins_save_login_inline_displayed`
- [] `m_autofill_logins_save_login_inline_confirmed` (Tapping `Save Password`)
- [] `m_autofill_logins_save_login_inline_dismissed` (Tapped `X` at top right or swipe down)
- [] `m_autofill_logins_save_login_exclude_site_confirmed` (Tapping `Never Ask for This Site`)

**Save password prompt:**
(https://news.ycombinator.com/login is a useful site to test triggering the password only save prompt - in the login form enter only a password and tap login to trigger)
- [] `m_autofill_logins_save_password_inline_displayed`
- [] `m_autofill_logins_save_password_inline_confirmed`
- [] `m_autofill_logins_save_password_inline_dismissed`

**Fill login prompt:**
Visit https://fill.dev/form/login-simple and use credentials saved from `Save login prompt` step
- [] `m_autofill_logins_fill_login_inline_autoprompt_displayed` (autoprompt triggered when fill login prompt presents automatically)
- [] `m_autofill_logins_fill_login_inline_autoprompt_confirmed`
- [] `m_autofill_logins_fill_login_inline_manual_displayed` (manual pixels triggered when tapping the key icon)
- [] `m_autofill_logins_fill_login_inline_manual_confirmed`
- [] `m_autofill_logins_fill_login_inline_manual_dismissed`
- [] `m_autofill_logins_autoprompt_dismissed`

**Opening and toggling autofill logins setting:**
- [] `m_autofill_settings_opened` (Triggered by accessing Logins from Settings screen)
- [] `m_nav_autofill_menu_item_pressed` (Triggered by accessing Logins from browsing menu)
- [] `m_autofill_logins_settings_enabled`
- [] `m_autofill_logins_settings_disabled`

**Password generation prompts:**
Visit https://fill.dev/form/registration-email and tap the key icon in the password field
- [] `m_autofill_logins_password_generation_prompt_displayed`
- [] `m_autofill_logins_password_generation_prompt_confirmed`
- [] `m_autofill_logins_password_generation_prompt_dismissed`

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
