### PR TITLE
Remove disabled switches from VPN Settings screen

### DIFF
--- a/DuckDuckGo/NetworkProtectionVPNLocationView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNLocationView.swift
@@ -134,7 +134,7 @@ private struct CountryItem: View {
                     } label: {
                         Image(systemName: "ellipsis.circle")
                             .resizable()
-                            .frame(width: 22, height: 22)
+                            .frame(width: 22, height: 22).tint(.textSecondary)
                     }
                 }
             }
@@ -184,6 +184,7 @@ private struct MenuItem: View {
                         .if(!isSelected) {
                             $0.hidden()
                         }
+                        .tint(.textPrimary)
                 }
             }
         )

--- a/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
@@ -27,52 +27,30 @@ struct NetworkProtectionVPNSettingsView: View {
     @StateObject var viewModel = NetworkProtectionVPNSettingsViewModel()
 
     var body: some View {
-        List {
-            NavigationLink(destination: NetworkProtectionVPNLocationView()) {
-                HStack {
-                    Text(UserText.netPPreferredLocationSettingTitle).daxBodyRegular().foregroundColor(.textPrimary)
-                    Spacer()
-                    Text(viewModel.preferredLocation).daxBodyRegular().foregroundColor(.textSecondary)
+        VStack {
+            List {
+                Section {
+                    NavigationLink(destination: NetworkProtectionVPNLocationView()) {
+                        HStack {
+                            Text(UserText.netPPreferredLocationSettingTitle).daxBodyRegular().foregroundColor(.textPrimary)
+                            Spacer()
+                            Text(viewModel.preferredLocation).daxBodyRegular().foregroundColor(.textSecondary)
+                        }
+                    }
+                }
+                Section {
+                    HStack(spacing: 16) {
+                        Image("Info-Solid-24")
+                            .foregroundColor(.icon)
+                        Text(UserText.netPSecureDNSSettingFooter)
+                            .daxFootnoteRegular()
+                            .foregroundColor(.textSecondary)
+                    }
                 }
             }
-            toggleSection(
-                text: UserText.netPAlwaysOnSettingTitle,
-                footerText: UserText.netPAlwaysOnSettingFooter
-            )
-            toggleSection(
-                text: UserText.netPSecureDNSSettingTitle,
-                footerText: UserText.netPSecureDNSSettingFooter
-            )
         }
         .applyInsetGroupedListStyle()
         .navigationTitle(UserText.netPVPNSettingsTitle)
-    }
-
-    @ViewBuilder
-    func toggleSection(text: String, footerText: String) -> some View {
-        Section {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(text)
-                        .font(.system(size: 16))
-                        .foregroundColor(.textPrimary.opacity(0.4))
-                        .font(.system(size: 13))
-                        .foregroundColor(.textSecondary.opacity(0.4))
-                }
-
-                // These toggles are permanantly disabled as the features are permanantly enabled. Product decision.
-                Toggle("", isOn: .constant(true))
-                    .disabled(true)
-                    .toggleStyle(SwitchToggleStyle(tint: .controlColor))
-            }
-            .listRowBackground(Color.cellBackground)
-        } footer: {
-            Text(footerText)
-                .foregroundColor(.textSecondary)
-                .accentColor(Color.controlColor)
-                .font(.system(size: 13))
-                .padding(.top, 6)
-        }
     }
 }
 
@@ -81,6 +59,7 @@ private extension Color {
     static let textSecondary = Color(designSystemColor: .textSecondary)
     static let cellBackground = Color(designSystemColor: .surface)
     static let controlColor = Color(designSystemColor: .accent)
+    static let icon = Color(designSystemColor: .icons).opacity(0.3)
 }
 
 #endif

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -660,9 +660,6 @@ In addition to the details entered into this form, your app issue report will co
         let message = NSLocalizedString("network.protection.vpn.location.country.item.formatted.cities.count", value: "%d cities", comment: "Subtitle of countries item when there are multiple cities, example : ")
         return message.format(arguments: count)
     }
-    static let netPAlwaysOnSettingTitle = NSLocalizedString("network.protection.vpn.always.on.setting.title", value: "Always On", comment: "Title for the Always on VPN setting item.")
-    static let netPAlwaysOnSettingFooter = NSLocalizedString("network.protection.vpn.always.on.setting.footer", value: "Automatically restore a VPN connection after interruption.", comment: "Footer text for the Always on VPN setting item.")
-    static let netPSecureDNSSettingTitle = NSLocalizedString("network.protection.vpn.secure.dns.setting.title", value: "Secure DNS", comment: "Title for the Always on VPN setting item.")
     static let netPSecureDNSSettingFooter = NSLocalizedString("network.protection.vpn.secure.dns.setting.footer", value: "Network Protection prevents DNS leaks to your Internet Service Provider by routing DNS queries though the VPN tunnel to our own resolver.", comment: "Footer text for the Always on VPN setting item.")
     static let netPTurnOnNotificationsButtonTitle = NSLocalizedString("network.protection.turn.on.notifications.button.title", value: "Turn on Notifications", comment: "Title for the button to link to the iOS app settings and enable notifications app-wide.")
     static let netPTurnOnNotificationsSectionFooter = NSLocalizedString("network.protection.turn.on.notifications.section.footer", value: "Allow DuckDuckGo to notify you if your connection drops or VPN status changes.", comment: "Footer text under the button to link to the iOS app settings and enable notifications app-wide.")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1609,12 +1609,6 @@ https://duckduckgo.com/mac";
 /* Title for the toggle for VPN alerts. */
 "network.protection.vpn.alerts.toggle.title" = "VPN Alerts";
 
-/* Footer text for the Always on VPN setting item. */
-"network.protection.vpn.always.on.setting.footer" = "Automatically restore a VPN connection after interruption.";
-
-/* Title for the Always on VPN setting item. */
-"network.protection.vpn.always.on.setting.title" = "Always On";
-
 /* Title for the VPN Location screen's All Countries section. */
 "network.protection.vpn.location.all.countries.section.title" = "All Countries";
 
@@ -1644,9 +1638,6 @@ https://duckduckgo.com/mac";
 
 /* Footer text for the Always on VPN setting item. */
 "network.protection.vpn.secure.dns.setting.footer" = "Network Protection prevents DNS leaks to your Internet Service Provider by routing DNS queries though the VPN tunnel to our own resolver.";
-
-/* Title for the Always on VPN setting item. */
-"network.protection.vpn.secure.dns.setting.title" = "Secure DNS";
 
 /* Title for the VPN Settings screen. */
 "network.protection.vpn.settings.title" = "VPN Settings";


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206048223525575/f

**Description**:

Removes the disabled switches that communicate when settings cannot be disabled.
These Secure DNS setting should remain visible in the VPN Settings where is is currently.
Also just remove Always On altogether.
 
Designs linked below

**Steps to test this PR**:
1. Ensure you’ve enabled the Network Protection feature
2. Go to Settings -> Network Protection -> VPN Settings
3. **Check that the UI matches [the Designs](https://www.figma.com/file/d7d8ZGkWD0W5ExhBI0tESv/O-N---VPN-Settings-Templates?type=design&node-id=2224-4088&mode=design&t=OIODsjVBi0bBqInm-0) (Option 2)**

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
