### PR TITLE
new pixels for toolbars and share sheet 

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -214,13 +214,14 @@ extension Pixel {
     
     public static func fire(pixel: Pixel.Event,
                             error: Error?,
+                            includedParameters: [QueryParameters] = [.appVersion],
                             withAdditionalParameters params: [String: String] = [:],
                             onComplete: @escaping (Error?) -> Void = { _ in }) {
         var newParams = params
         if let error {
             newParams.appendErrorPixelParams(error: error)
         }
-        fire(pixel: pixel, withAdditionalParameters: newParams, includedParameters: [], onComplete: onComplete)
+        fire(pixel: pixel, withAdditionalParameters: newParams, includedParameters: includedParameters, onComplete: onComplete)
     }
 }
 

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -74,6 +74,9 @@ extension Pixel {
         case browsingMenuFireproof
         case browsingMenuAutofill
         
+        case addressBarShare
+        case addressBarSettings
+
         case tabBarBackPressed
         case tabBarForwardPressed
         case bookmarksButtonPressed
@@ -570,7 +573,10 @@ extension Pixel.Event {
         case .browsingMenuReportBrokenSite: return "mb_rb"
         case .browsingMenuFireproof: return "mb_f"
         case .browsingMenuAutofill: return "m_nav_autofill_menu_item_pressed"
-            
+
+        case .addressBarShare: return "m_addressbar_share"
+        case .addressBarSettings: return "m_addressbar_settings"
+
         case .tabBarBackPressed: return "mt_bk"
         case .tabBarForwardPressed: return "mt_fw"
         case .bookmarksButtonPressed: return "mt_bm"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -77,6 +77,16 @@ extension Pixel {
         case addressBarShare
         case addressBarSettings
 
+        case shareSheetResultSuccess
+        case shareSheetResultFail
+        case shareSheetActivityCopy
+        case shareSheetActivityAddBookmark
+        case shareSheetActivityAddFavorite
+        case shareSheetActivityFindInPage
+        case shareSheetActivityPrint
+        case shareSheetActivityAddToReadingList
+        case shareSheetActivityOther
+
         case tabBarBackPressed
         case tabBarForwardPressed
         case bookmarksButtonPressed
@@ -563,7 +573,6 @@ extension Pixel.Event {
         case .browsingMenuRemoveFromFavorites: return "mb_df"
         case .browsingMenuAddToFavoritesAddFavoriteFlow: return "mb_aff"
         case .browsingMenuToggleBrowsingMode: return "mb_dm"
-        case .browsingMenuShare: return "mb_sh"
         case .browsingMenuCopy: return "mb_cp"
         case .browsingMenuPrint: return "mb_pr"
         case .browsingMenuSettings: return "mb_st"
@@ -574,8 +583,19 @@ extension Pixel.Event {
         case .browsingMenuFireproof: return "mb_f"
         case .browsingMenuAutofill: return "m_nav_autofill_menu_item_pressed"
 
+        case .browsingMenuShare: return "m_browsingmenu_share"
+
         case .addressBarShare: return "m_addressbar_share"
         case .addressBarSettings: return "m_addressbar_settings"
+        case .shareSheetResultSuccess: return "m_sharesheet_result_success"
+        case .shareSheetResultFail: return "m_sharesheet_result_fail"
+        case .shareSheetActivityCopy: return "m_sharesheet_activity_copy"
+        case .shareSheetActivityAddBookmark: return "m_sharesheet_activity_addbookmark"
+        case .shareSheetActivityAddFavorite: return "m_sharesheet_activity_addfavorite"
+        case .shareSheetActivityFindInPage: return "m_sharesheet_activity_findinpage"
+        case .shareSheetActivityPrint: return "m_sharesheet_activity_print"
+        case .shareSheetActivityAddToReadingList: return "m_sharesheet_activity_addtoreadinglist"
+        case .shareSheetActivityOther: return "m_sharesheet_activity_other"
 
         case .tabBarBackPressed: return "mt_bk"
         case .tabBarForwardPressed: return "mt_fw"

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1457,7 +1457,7 @@ extension MainViewController: OmniBarDelegate {
     func onSharePressed() {
         hideSuggestionTray()
         guard let link = currentTab?.link else { return }
-        currentTab?.onShareAction(forLink: link, fromView: viewCoordinator.omniBar.shareButton, orginatedFromMenu: false)
+        currentTab?.onShareAction(forLink: link, fromView: viewCoordinator.omniBar.shareButton)
     }
     
     func onVoiceSearchPressed() {

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -446,7 +446,7 @@ class OmniBar: UIView {
     }
 
     @IBAction func onSettingsButtonPressed(_ sender: Any) {
-        Pixel.fire(.addressBarSettings)
+        Pixel.fire(pixel: .addressBarSettings)
         omniDelegate?.onSettingsPressed()
     }
     

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -446,6 +446,7 @@ class OmniBar: UIView {
     }
 
     @IBAction func onSettingsButtonPressed(_ sender: Any) {
+        Pixel.fire(.addressBarSettings)
         omniDelegate?.onSettingsPressed()
     }
     
@@ -474,6 +475,7 @@ class OmniBar: UIView {
     }
     
     @IBAction func onSharePressed(_ sender: Any) {
+        Pixel.fire(pixel: .addressBarShare)
         omniDelegate?.onSharePressed()
     }
     

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -42,7 +42,8 @@ extension TabViewController {
         entries.append(BrowsingMenuEntry.regular(name: UserText.actionShare, image: UIImage(named: "Share-24")!, action: { [weak self] in
             guard let self = self else { return }
             guard let menu = self.chromeDelegate?.omniBar.menuButton else { return }
-            self.onShareAction(forLink: self.link!, fromView: menu, orginatedFromMenu: true)
+            Pixel.fire(pixel: .browsingMenuShare)
+            self.onShareAction(forLink: self.link!, fromView: menu)
         }))
         
         entries.append(BrowsingMenuEntry.regular(name: UserText.actionCopy, image: UIImage(named: "Copy-24")!, action: { [weak self] in
@@ -302,10 +303,7 @@ extension TabViewController {
         }
     }
 
-    func onShareAction(forLink link: Link, fromView view: UIView, orginatedFromMenu: Bool) {
-        Pixel.fire(pixel: .browsingMenuShare,
-                   withAdditionalParameters: [PixelParameters.originatedFromMenu: orginatedFromMenu ? "1" : "0"])
-        
+    func onShareAction(forLink link: Link, fromView view: UIView) {
         shareLinkWithTemporaryDownload(temporaryDownloadForPreviewedFile, originalLink: link) { [weak self] link in
             guard let self = self else { return }
             var items: [Any] = [link, self.webView.viewPrintFormatter()]

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -311,10 +311,40 @@ extension TabViewController {
             if let webView = self.webView {
                 items.append(webView)
             }
-            self.presentShareSheet(withItems: items, fromView: view)
+
+            self.presentShareSheet(withItems: items, fromView: view) { [weak self] activityType, result, _, error in
+                if result {
+                    Pixel.fire(pixel: .shareSheetResultSuccess)
+                } else {
+                    Pixel.fire(pixel: .shareSheetResultFail, error: error)
+                }
+
+                if let activityType {
+                    self?.firePixelForActivityType(activityType)
+                }
+            }
         }
     }
     
+    private func firePixelForActivityType(_ activityType: UIActivity.ActivityType) {
+        switch activityType {
+        case .copyToPasteboard:
+            Pixel.fire(pixel: .shareSheetActivityCopy)
+        case .saveBookmarkInDuckDuckGo:
+            Pixel.fire(pixel: .shareSheetActivityAddBookmark)
+        case .saveFavoriteInDuckDuckGo:
+            Pixel.fire(pixel: .shareSheetActivityAddFavorite)
+        case .findInPage:
+            Pixel.fire(pixel: .shareSheetActivityFindInPage)
+        case .print:
+            Pixel.fire(pixel: .shareSheetActivityPrint)
+        case .addToReadingList:
+            Pixel.fire(pixel: .shareSheetActivityAddToReadingList)
+        default:
+            Pixel.fire(pixel: .shareSheetActivityOther)
+        }
+    }
+
     private func shareLinkWithTemporaryDownload(_ temporaryDownload: Download?,
                                                 originalLink: Link,
                                                 completion: @escaping(Link) -> Void) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1205953072928854/f
Tech Design URL:
CC:

**Description**:

New pixels for iOS toolbars project. 

Address Bar
* AddressBarSettingsPressed: New pixel m_addressbar_settings 
* AddressBarRefreshPressed: This is the m_r pixel and is only called from the address bar so already exists
* AddressBarShieldPressed: This is the mp pixel so already exists
* AddressBarSharePressed:  This was one pixel with a parameter, but I'm splitting into two new ones for clarity:
    * new pixel: m_addressbar_share from the address bar
    * new pixel: m_browsingmenu_share from the menu 
    * pixel removed: mb_sh has been removed 

Share Sheet
* Share result
    * New pixel m_sharesheet_result_success when success is true
    * New pixel m_sharesheet_result_fail  when success is false
* ShareSheetCopy: new pixel m_sharesheet_activity_copy
* ShareSheetAddBookmark: new pixel m_sharesheet_activity_addbookmark
* ShareSheetAddFavorite: new pixel m_sharesheet_activity_addfavorite
* ShareSheetFindinPage: new pixel m_sharesheet_activity_findinpage
* ShareSheetPrint: new pixel m_sharesheet_activity_print
* ShareSheetAddToReadingList: new pixel m_sharesheet_activity_addtoreadinglist

Also includes adding app version by default to the pixels as part of privacy triage: https://app.asana.com/0/69071770703008/1206042861558143/f

**Steps to test this PR**:
1. Try each of the above functionalities and ensure the appropriate pixel is fired.
2. Check that pixels have appVersion by default.
