### PR TITLE
NetP: Fix list row colours

### DIFF
--- a/DuckDuckGo/NetworkProtectionInviteView.swift
+++ b/DuckDuckGo/NetworkProtectionInviteView.swift
@@ -55,7 +55,7 @@ struct NetworkProtectionInviteView: View {
             )
             .frame(height: 44)
             .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-            .background(Color.textFieldBackground)
+            .background(Color(designSystemColor: .surface))
             .cornerRadius(10)
             .disabled(model.shouldDisableTextField)
             Button(UserText.inviteDialogContinueButton) {
@@ -104,25 +104,25 @@ private struct NetworkProtectionInviteMessageView<Content>: View where Content: 
                     Text(messageData.title)
                         .daxTitle2()
                         .multilineTextAlignment(.center)
-                        .foregroundColor(.textPrimary)
+                        .foregroundColor(.init(designSystemColor: .textPrimary))
                     Text(messageData.message)
                         .daxBodyRegular()
                         .multilineTextAlignment(.center)
-                        .foregroundColor(.textSecondary)
+                        .foregroundColor(.init(designSystemColor: .textSecondary))
                         .padding(.bottom, 16)
                     interactiveContent()
                     Spacer()
                     Text(UserText.netPInviteOnlyMessage)
-                        .foregroundColor(.textSecondary)
+                        .foregroundColor(.init(designSystemColor: .textSecondary))
                         .daxFootnoteRegular()
                         .multilineTextAlignment(.center)
                 }
                 .padding(24)
                 .frame(minHeight: proxy.size.height)
-                .background(Color.viewBackground)
+                .background(Color(designSystemColor: .background))
             }
         }
-        .background(Color.viewBackground)
+        .background(Color(designSystemColor: .background))
     }
 }
 
@@ -137,14 +137,9 @@ extension AnyTransition {
     static var slideFromRight: AnyTransition {
         AnyTransition.asymmetric(
             insertion: .move(edge: .trailing),
-            removal: .move(edge: .leading))}
-}
-
-private extension Color {
-    static let textPrimary = Color(designSystemColor: .textPrimary)
-    static let textSecondary = Color(designSystemColor: .textSecondary)
-    static let textFieldBackground = Color(designSystemColor: .surface)
-    static let viewBackground = Color(designSystemColor: .background)
+            removal: .move(edge: .leading)
+        )
+    }
 }
 
 import NetworkProtection

--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -74,11 +74,11 @@ struct NetworkProtectionStatusView: View {
                 .disabled(statusModel.shouldDisableToggle)
                 .toggleStyle(SwitchToggleStyle(tint: .controlColor))
             }
-            .listRowBackground(Color.cellBackground)
         } header: {
             header()
         }
         .increaseHeaderProminence()
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 
     @ViewBuilder
@@ -131,6 +131,7 @@ struct NetworkProtectionStatusView: View {
         } header: {
             Text(UserText.netPStatusViewConnectionDetails).foregroundColor(.textSecondary)
         }
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 
     @ViewBuilder
@@ -147,6 +148,7 @@ struct NetworkProtectionStatusView: View {
         } footer: {
             inviteOnlyFooter()
         }
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 
     @ViewBuilder

--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -57,10 +57,10 @@ struct NetworkProtectionStatusView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(UserText.netPStatusViewTitle)
                         .daxBodyRegular()
-                        .foregroundColor(.textPrimary)
+                        .foregroundColor(.init(designSystemColor: .textPrimary))
                     Text(statusModel.statusMessage)
                         .daxFootnoteRegular()
-                        .foregroundColor(.textSecondary)
+                        .foregroundColor(.init(designSystemColor: .textSecondary))
                 }
 
                 Toggle("", isOn: Binding(
@@ -72,7 +72,7 @@ struct NetworkProtectionStatusView: View {
                     }
                 ))
                 .disabled(statusModel.shouldDisableToggle)
-                .toggleStyle(SwitchToggleStyle(tint: .controlColor))
+                .toggleStyle(SwitchToggleStyle(tint: .init(designSystemColor: .accent)))
             }
         } header: {
             header()
@@ -94,17 +94,17 @@ struct NetworkProtectionStatusView: View {
                 Text(statusModel.headerTitle)
                     .daxHeadline()
                     .multilineTextAlignment(.center)
-                    .foregroundColor(.textPrimary)
+                    .foregroundColor(.init(designSystemColor: .textPrimary))
                 Text(UserText.netPStatusHeaderMessage)
                     .daxFootnoteRegular()
                     .multilineTextAlignment(.center)
-                    .foregroundColor(.textSecondary)
+                    .foregroundColor(.init(designSystemColor: .textSecondary))
                     .padding(.bottom, 8)
             }
             .padding(.bottom, 4)
             // Pads beyond the default header inset
             .padding(.horizontal, -16)
-            .background(Color.viewBackground)
+            .background(Color(designSystemColor: .background))
             Spacer(minLength: 0)
         }
     }
@@ -129,7 +129,7 @@ struct NetworkProtectionStatusView: View {
                 )
             }
         } header: {
-            Text(UserText.netPStatusViewConnectionDetails).foregroundColor(.textSecondary)
+            Text(UserText.netPStatusViewConnectionDetails).foregroundColor(.init(designSystemColor: .textSecondary))
         }
         .listRowBackground(Color(designSystemColor: .surface))
     }
@@ -139,12 +139,12 @@ struct NetworkProtectionStatusView: View {
         Section {
             NavigationLink(UserText.netPVPNSettingsTitle, destination: NetworkProtectionVPNSettingsView())
                 .daxBodyRegular()
-                .foregroundColor(.textPrimary)
+                .foregroundColor(.init(designSystemColor: .textPrimary))
             NavigationLink(UserText.netPVPNNotificationsTitle, destination: NetworkProtectionVPNNotificationsView())
                 .daxBodyRegular()
-                .foregroundColor(.textPrimary)
+                .foregroundColor(.init(designSystemColor: .textPrimary))
         } header: {
-            Text(UserText.netPStatusViewSettingsSectionTitle).foregroundColor(.textSecondary)
+            Text(UserText.netPStatusViewSettingsSectionTitle).foregroundColor(.init(designSystemColor: .textSecondary))
         } footer: {
             inviteOnlyFooter()
         }
@@ -155,8 +155,8 @@ struct NetworkProtectionStatusView: View {
     private func inviteOnlyFooter() -> some View {
         // Needs to be inlined like this for the markdown parsing to work
         Text("\(UserText.netPInviteOnlyMessage) [\(UserText.netPStatusViewShareFeedback)](https://form.asana.com/?k=_wNLt6YcT5ILpQjDuW0Mxw&d=137249556945)")
-            .foregroundColor(.textSecondary)
-            .accentColor(Color.controlColor)
+            .foregroundColor(.init(designSystemColor: .textSecondary))
+            .accentColor(.init(designSystemColor: .accent))
             .daxFootnoteRegular()
             .padding(.top, 6)
     }
@@ -178,7 +178,7 @@ private struct NetworkProtectionErrorView: View {
                 .daxBodyRegular()
                 .foregroundColor(.primary)
         }
-        .listRowBackground(Color.cellBackground)
+        .listRowBackground(Color(designSystemColor: .accent))
     }
 }
 
@@ -192,22 +192,14 @@ private struct NetworkProtectionServerItemView: View {
             Image(imageID)
             Text(title)
                 .daxBodyRegular()
-                .foregroundColor(.textPrimary)
+                .foregroundColor(.init(designSystemColor: .textPrimary))
             Spacer(minLength: 2)
             Text(value)
                 .daxBodyRegular()
-                .foregroundColor(.textSecondary)
+                .foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color.cellBackground)
+        .listRowBackground(Color(designSystemColor: .surface))
     }
-}
-
-private extension Color {
-    static let textPrimary = Color(designSystemColor: .textPrimary)
-    static let textSecondary = Color(designSystemColor: .textSecondary)
-    static let cellBackground = Color(designSystemColor: .surface)
-    static let viewBackground = Color(designSystemColor: .background)
-    static let controlColor = Color(designSystemColor: .accent)
 }
 
 #endif

--- a/DuckDuckGo/NetworkProtectionVPNLocationView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNLocationView.swift
@@ -65,6 +65,7 @@ struct NetworkProtectionVPNLocationView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 
     @ViewBuilder
@@ -92,6 +93,7 @@ struct NetworkProtectionVPNLocationView: View {
                 .foregroundStyle(Color.textPrimary)
         }
         .animation(.default, value: model.state.isLoading)
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 }
 

--- a/DuckDuckGo/NetworkProtectionVPNLocationView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNLocationView.swift
@@ -52,16 +52,16 @@ struct NetworkProtectionVPNLocationView: View {
                     }
                 }, label: {
                     Text(UserText.netPPreferredLocationNearest)
-                        .foregroundStyle(Color.textPrimary)
+                        .foregroundStyle(Color(designSystemColor: .textPrimary))
                         .daxBodyRegular()
                 }
             )
         } header: {
             Text(UserText.netPVPNLocationRecommendedSectionTitle)
-                .foregroundStyle(Color.textPrimary)
+                .foregroundStyle(Color(designSystemColor: .textPrimary))
         } footer: {
             Text(UserText.netPVPNLocationRecommendedSectionFooter)
-                .foregroundStyle(Color.textSecondary)
+                .foregroundStyle(Color(designSystemColor: .textSecondary))
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
@@ -90,7 +90,7 @@ struct NetworkProtectionVPNLocationView: View {
             }
         } header: {
             Text(UserText.netPVPNLocationAllCountriesSectionTitle)
-                .foregroundStyle(Color.textPrimary)
+                .foregroundStyle(Color(designSystemColor: .textPrimary))
         }
         .animation(.default, value: model.state.isLoading)
         .listRowBackground(Color(designSystemColor: .surface))
@@ -118,11 +118,11 @@ private struct CountryItem: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(itemModel.title)
                         .daxBodyRegular()
-                        .foregroundStyle(Color.textPrimary)
+                        .foregroundStyle(Color(designSystemColor: .textPrimary))
                     if let subtitle = itemModel.subtitle {
                         Text(subtitle)
                             .daxFootnoteRegular()
-                            .foregroundStyle(Color.textSecondary)
+                            .foregroundStyle(Color(designSystemColor: .textSecondary))
                     }
                 }
                 if itemModel.shouldShowPicker {
@@ -136,7 +136,8 @@ private struct CountryItem: View {
                     } label: {
                         Image(systemName: "ellipsis.circle")
                             .resizable()
-                            .frame(width: 22, height: 22).tint(.textSecondary)
+                            .frame(width: 22, height: 22)
+                            .tint(.init(designSystemColor: .textSecondary))
                     }
                 }
             }
@@ -156,7 +157,7 @@ private struct ChecklistItem<Content>: View where Content: View {
             label: {
                 HStack(spacing: 12) {
                     Image(systemName: "checkmark")
-                        .tint(.controlColor)
+                        .tint(.init(designSystemColor: .accent))
                         .if(!isSelected) {
                             $0.hidden()
                         }
@@ -186,18 +187,12 @@ private struct MenuItem: View {
                         .if(!isSelected) {
                             $0.hidden()
                         }
-                        .tint(.textPrimary)
+                        .tint(Color(designSystemColor: .textPrimary))
                 }
             }
         )
         .tint(Color(designSystemColor: .textPrimary))
     }
-}
-
-private extension Color {
-    static let textPrimary = Color(designSystemColor: .textPrimary)
-    static let textSecondary = Color(designSystemColor: .textSecondary)
-    static let controlColor = Color(designSystemColor: .accent)
 }
 
 #endif

--- a/DuckDuckGo/NetworkProtectionVPNNotificationsView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNNotificationsView.swift
@@ -54,10 +54,10 @@ struct NetworkProtectionVPNNotificationsView: View {
             Button(UserText.netPTurnOnNotificationsButtonTitle) {
                 model.turnOnNotifications()
             }
-            .foregroundColor(.controlColor)
+            .foregroundColor(.init(designSystemColor: .accent))
         } footer: {
             Text(UserText.netPTurnOnNotificationsSectionFooter)
-                .foregroundColor(.textSecondary)
+                .foregroundColor(.init(designSystemColor: .textSecondary))
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
@@ -67,26 +67,22 @@ struct NetworkProtectionVPNNotificationsView: View {
     @ViewBuilder
     private var authorizedView: some View {
         Section {
-            Toggle(UserText.netPVPNAlertsToggleTitle, isOn: Binding(
-                get: { model.alertsEnabled },
-                set: model.didToggleAlerts(to:)
-            ))
-            .toggleStyle(SwitchToggleStyle(tint: .controlColor))
+            Toggle(
+                UserText.netPVPNAlertsToggleTitle,
+                isOn: Binding(
+                    get: { model.alertsEnabled },
+                    set: model.didToggleAlerts(to:)
+                )
+            )
+            .toggleStyle(SwitchToggleStyle(tint: .init(designSystemColor: .accent)))
         } footer: {
             Text(UserText.netPVPNAlertsToggleSectionFooter)
-                .foregroundColor(.textSecondary)
+                .foregroundColor(.init(designSystemColor: .textSecondary))
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
         .listRowBackground(Color(designSystemColor: .surface))
     }
-}
-
-private extension Color {
-    static let textPrimary = Color(designSystemColor: .textPrimary)
-    static let textSecondary = Color(designSystemColor: .textSecondary)
-    static let cellBackground = Color(designSystemColor: .surface)
-    static let controlColor = Color(designSystemColor: .accent)
 }
 
 #endif

--- a/DuckDuckGo/NetworkProtectionVPNNotificationsView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNNotificationsView.swift
@@ -61,6 +61,7 @@ struct NetworkProtectionVPNNotificationsView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 
     @ViewBuilder
@@ -77,6 +78,7 @@ struct NetworkProtectionVPNNotificationsView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 }
 

--- a/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
@@ -41,10 +41,10 @@ struct NetworkProtectionVPNSettingsView: View {
                             VStack(alignment: .leading) {
                                 Text(UserText.netPPreferredLocationSettingTitle)
                                     .daxBodyRegular()
-                                    .foregroundColor(.textPrimary)
+                                    .foregroundColor(.init(designSystemColor: .textPrimary))
                                 Text(viewModel.preferredLocation.title)
                                     .daxFootnoteRegular()
-                                    .foregroundColor(.textSecondary)
+                                    .foregroundColor(.init(designSystemColor: .textSecondary))
                             }
                         }
                     }
@@ -62,10 +62,10 @@ struct NetworkProtectionVPNSettingsView: View {
                 Section {
                     HStack(spacing: 16) {
                         Image("Info-Solid-24")
-                            .foregroundColor(.icon)
+                            .foregroundColor(.init(designSystemColor: .icons).opacity(0.3))
                         Text(UserText.netPSecureDNSSettingFooter)
                             .daxFootnoteRegular()
-                            .foregroundColor(.textSecondary)
+                            .foregroundColor(.init(designSystemColor: .textSecondary))
                     }
                 }
                 .listRowBackground(Color(designSystemColor: .surface))
@@ -82,29 +82,22 @@ struct NetworkProtectionVPNSettingsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(text)
                         .daxBodyRegular()
-                        .foregroundColor(.textPrimary)
+                        .foregroundColor(.init(designSystemColor: .textPrimary))
                         .layoutPriority(1)
                 }
 
                 toggle()
-                    .toggleStyle(SwitchToggleStyle(tint: .controlColor))
+                    .toggleStyle(SwitchToggleStyle(tint: .init(designSystemColor: .accent)))
             }
         } footer: {
             Text(footerText)
-                .foregroundColor(.textSecondary)
-                .accentColor(Color.controlColor)
+                .foregroundColor(.init(designSystemColor: .textSecondary))
+                .accentColor(Color(designSystemColor: .accent))
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
         .listRowBackground(Color(designSystemColor: .surface))
     }
-}
-
-private extension Color {
-    static let textPrimary = Color(designSystemColor: .textPrimary)
-    static let textSecondary = Color(designSystemColor: .textSecondary)
-    static let controlColor = Color(designSystemColor: .accent)
-    static let icon = Color(designSystemColor: .icons).opacity(0.3)
 }
 
 #endif

--- a/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
+++ b/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
@@ -49,6 +49,7 @@ struct NetworkProtectionVPNSettingsView: View {
                         }
                     }
                 }
+                .listRowBackground(Color(designSystemColor: .surface))
                 toggleSection(
                     text: UserText.netPExcludeLocalNetworksSettingTitle,
                     footerText: UserText.netPExcludeLocalNetworksSettingFooter
@@ -67,6 +68,7 @@ struct NetworkProtectionVPNSettingsView: View {
                             .foregroundColor(.textSecondary)
                     }
                 }
+                .listRowBackground(Color(designSystemColor: .surface))
             }
         }
         .applyInsetGroupedListStyle()
@@ -87,7 +89,6 @@ struct NetworkProtectionVPNSettingsView: View {
                 toggle()
                     .toggleStyle(SwitchToggleStyle(tint: .controlColor))
             }
-            .listRowBackground(Color.cellBackground)
         } footer: {
             Text(footerText)
                 .foregroundColor(.textSecondary)
@@ -95,13 +96,13 @@ struct NetworkProtectionVPNSettingsView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
+        .listRowBackground(Color(designSystemColor: .surface))
     }
 }
 
 private extension Color {
     static let textPrimary = Color(designSystemColor: .textPrimary)
     static let textSecondary = Color(designSystemColor: .textSecondary)
-    static let cellBackground = Color(designSystemColor: .surface)
     static let controlColor = Color(designSystemColor: .accent)
     static let icon = Color(designSystemColor: .icons).opacity(0.3)
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206077611337618/f

**Description**:

We noticed some incorrect surface colours on some of the NetP views. This fixes that and also just uses the design system helpers directly to avoid the unnecessary indirection.

**Steps to test this PR**:
Step through NetP Invite + Status + Settings + Location + Notifications screens in light and dark mode and check it all looks right. Compare against other parts of the app to reference whether the colours are correct if you need to

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
