### PR TITLE
Add geoswitching usage pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -374,6 +374,11 @@ extension Pixel {
         case networkProtectionWaitlistNotificationShown
         case networkProtectionWaitlistNotificationLaunched
 
+        case networkProtectionGeoswitchingOpened
+        case networkProtectionGeoswitchingSetNearest
+        case networkProtectionGeoswitchingSetCustom
+        case networkProtectionGeoswitchingNoLocations
+
         // MARK: remote messaging pixels
 
         case remoteMessageShown
@@ -888,6 +893,11 @@ extension Pixel.Event {
         case .networkProtectionWaitlistTermsAccepted: return "m_netp_waitlist_terms_accepted"
         case .networkProtectionWaitlistNotificationShown: return "m_netp_waitlist_notification_shown"
         case .networkProtectionWaitlistNotificationLaunched: return "m_netp_waitlist_notification_launched"
+
+        case .networkProtectionGeoswitchingOpened: return "m_netp_imp_geoswitching"
+        case .networkProtectionGeoswitchingSetNearest: return "m_netp_ev_geoswitching_set_nearest"
+        case .networkProtectionGeoswitchingSetCustom: return "m_netp_ev_geoswitching_set_custom"
+        case .networkProtectionGeoswitchingNoLocations: return "m_netp_ev_geoswitching_no_locations"
 
         // MARK: remote messaging pixels
 

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9156,8 +9156,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 91.0.1;
+				kind = revision;
+				revision = ce85f6cf0584ab9865544600c5fc27f18e0724ae;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "822e284a50ebb42f0880ebcae87dc36e007f8c31",
-          "version": "91.0.1"
+          "revision": "ce85f6cf0584ab9865544600c5fc27f18e0724ae",
+          "version": null
         }
       },
       {

--- a/DuckDuckGo/NetworkProtectionConvenienceInitialisers.swift
+++ b/DuckDuckGo/NetworkProtectionConvenienceInitialisers.swift
@@ -83,7 +83,8 @@ extension NetworkProtectionLocationListCompositeRepository {
         let settings = VPNSettings(defaults: .networkProtectionGroupDefaults)
         self.init(
             environment: settings.selectedEnvironment,
-            tokenStore: NetworkProtectionKeychainTokenStore()
+            tokenStore: NetworkProtectionKeychainTokenStore(),
+            errorEvents: .networkProtectionAppDebugEvents
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206107031155633/f

**Description**:

Adds the Pixels described in the parent of the linked PR task to monitor Geoswitching during the Waitlist beta

**Steps to test this PR**:
1. Run the app in the debugger
2. Make sure you’re an internal user and you’ve used an invite code to access NetP
3. Go to Settings -> Network Protection -> VPN Settings -> VPN Location
4. **You should see the Pixel for opening Geoswitching in the debugger**
5. Select a location
6. ** You should see the Pixel for selecting custom int the debugger
7. Select Nearest
8. ** You should see the Pixel for selecting nearest in the debugger
9. There is also a pixel for if there is no list returned. Perhaps get creative with how you test that, but my guess is we won’t get many of these due to the fact they’ll be most likely to occur when offline. 

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
