### PR TITLE
Fix spacing between Waitlist buttons

### DIFF
--- a/DuckDuckGo/VPNWaitlistView.swift
+++ b/DuckDuckGo/VPNWaitlistView.swift
@@ -87,7 +87,7 @@ struct VPNWaitlistSignUpView: View {
                         action(.custom(.openNetworkProtectionInviteCodeScreen))
                     })
                         .buttonStyle(RoundedButtonStyle(enabled: true, style: .bordered))
-                        .padding(.top, 16)
+                        .padding(.top, 8)
 
                     if requestInFlight {
                         HStack {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206111074849454/f

**Description**:

Yet another spacing tweak. I didn’t measure it properly the first time, but this time it’s definitely correct (Design approved).

**Steps to test this PR**:
1. Check that the buttons on the NetP Waitlist landing page are 16px apart.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
