### PR TITLE
Fix spacing between buttons

### DIFF
--- a/DuckDuckGo/VPNWaitlistView.swift
+++ b/DuckDuckGo/VPNWaitlistView.swift
@@ -87,7 +87,7 @@ struct VPNWaitlistSignUpView: View {
                         action(.custom(.openNetworkProtectionInviteCodeScreen))
                     })
                         .buttonStyle(RoundedButtonStyle(enabled: true, style: .bordered))
-                        .padding(.top, 16)
+                        .padding(.top, 8)
 
                     if requestInFlight {
                         HStack {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206111074849454/f

**Description:**

Yet another spacing tweak. I didn’t measure it properly the first time, but this time it’s definitely correct (Design approved).

**Steps to test this PR:**

Check that the buttons on the NetP Waitlist landing page are 16px apart.