### PR TITLE
Updates BSK

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9156,8 +9156,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 6173444ae81216f0ca1f6c9b997365e596db4b63;
+				branch = "diego/fix-vpn-dns-routing";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9156,8 +9156,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 91.0.2;
+				kind = revision;
+				revision = 6173444ae81216f0ca1f6c9b997365e596db4b63;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9156,8 +9156,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "diego/fix-vpn-dns-routing";
-				kind = branch;
+				kind = exactVersion;
+				version = 92.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "c871e62fd8d07f9e3136948614003fbe7e582963",
-          "version": "91.0.2"
+          "revision": "6173444ae81216f0ca1f6c9b997365e596db4b63",
+          "version": null
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": null,
-          "revision": "6173444ae81216f0ca1f6c9b997365e596db4b63",
+          "branch": "diego/fix-vpn-dns-routing",
+          "revision": "8950aacee05c50792b35bd869836ed31908c1c82",
           "version": null
         }
       },

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "BrowserServicesKit",
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
-          "branch": "diego/fix-vpn-dns-routing",
-          "revision": "8950aacee05c50792b35bd869836ed31908c1c82",
-          "version": null
+          "branch": null,
+          "revision": "fe577c508ad4ea163075ac8fab20673d0a7565f6",
+          "version": "92.0.1"
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206114617364817/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/594
macOS PR: https://github.com/duckduckgo/macos-browser/pull/1934

## Description

We no longer exclude 10.0.0.0/8 from the VPN since it was causing our DNS to be excluded as well.

## Testing:

1. Connect the VPN
2. Make sure it works
3. Download a traceroute app for iOS and make sure the route for 10.11.12.1 goes through our tunnel.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
