### PR TITLE
Always use black and white colors for the QR code

### DIFF
--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/Internal/QRCodeView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/Internal/QRCodeView.swift
@@ -22,23 +22,14 @@ import UIKit
 import SwiftUI
 
 struct QRCodeView: View {
-
-    enum Style {
-
-        case light, dark
-
-    }
-
     let context = CIContext()
 
     let string: String
     let size: CGFloat
-    let style: Style
 
-    init(string: String, size: CGFloat, style: Style = .light) {
+    init(string: String, size: CGFloat) {
         self.string = string
         self.size = size
-        self.style = style
     }
 
     var body: some View {
@@ -69,8 +60,8 @@ struct QRCodeView: View {
         }
 
         let colorParameters: [String: Any] = [
-            "inputColor0": CIColor(color: style == .light ? .white : .black),
-            "inputColor1": CIColor(color: style == .light ? .black : .white)
+            "inputColor0": CIColor(color: .black),
+            "inputColor1": CIColor(color: .white)
         ]
         let coloredImage = outputImage.applyingFilter("CIFalseColor", parameters: colorParameters)
 

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SaveRecoveryKeyView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SaveRecoveryKeyView.swift
@@ -41,7 +41,7 @@ public struct SaveRecoveryKeyView: View {
     func recoveryInfo() -> some View {
             VStack(spacing: 26) {
                 HStack(spacing: 16) {
-                    QRCodeView(string: model.key, size: 64, style: .dark)
+                    QRCodeView(string: model.key, size: 64)
 
                     Text(model.key)
                         .fontWeight(.light)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1205142491450702/f

**Description**:
This is to increase compatibility with Android devices.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Verify that the Sync QR codes are displayed properly in both dark and light modes.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
