### PR TITLE
Add last active and hardware model parameters to surveys

### DIFF
--- a/DuckDuckGo/VPNWaitlistActivationDateStore.swift
+++ b/DuckDuckGo/VPNWaitlistActivationDateStore.swift
@@ -27,12 +27,16 @@ protocol VPNWaitlistActivationDateStore {
     func setActivationDateIfNecessary()
     func daysSinceActivation() -> Int?
 
+    func updateLastActiveDate()
+    func daysSinceLastActive() -> Int?
+
 }
 
 struct DefaultVPNWaitlistActivationDateStore: VPNWaitlistActivationDateStore {
 
     private enum Constants {
         static let networkProtectionActivationDateKey = "com.duckduckgo.network-protection.activation-date"
+        static let networkProtectionLastActiveDateKey = "com.duckduckgo.network-protection.last-active-date"
     }
 
     private let userDefaults: UserDefaults
@@ -51,6 +55,21 @@ struct DefaultVPNWaitlistActivationDateStore: VPNWaitlistActivationDateStore {
 
     func daysSinceActivation() -> Int? {
         let timestamp = userDefaults.double(forKey: Constants.networkProtectionActivationDateKey)
+
+        if timestamp == 0 {
+            return nil
+        }
+
+        let activationDate = Date(timeIntervalSinceReferenceDate: timestamp)
+        return daysSince(date: activationDate)
+    }
+
+    func updateLastActiveDate() {
+        userDefaults.set(Date().timeIntervalSinceReferenceDate, forKey: Constants.networkProtectionLastActiveDateKey)
+    }
+
+    func daysSinceLastActive() -> Int? {
+        let timestamp = userDefaults.double(forKey: Constants.networkProtectionLastActiveDateKey)
 
         if timestamp == 0 {
             return nil

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -230,6 +230,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
         connectionStatusPublisher.sink { [weak self] status in
             if case .connected = status {
                 self?.activationDateStore.setActivationDateIfNecessary()
+                self?.activationDateStore.updateLastActiveDate()
             }
         }
         .store(in: &cancellables)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206137264954188/f
Tech Design URL:
CC:

**Description**:

This PR adds last active date and hardware model 

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run NetP at least once to make sure the new timestamp gets set
1. Rather than jump through the hoops of setting up a remote message, just hardcode a URL to add these params and check that the result looks good. Something like the following is fine:

```
let url = URL(string: "https://duckduckgo.com/")!
let builder = DefaultSurveyURLBuilder()
let result = builder.addSurveyParameters(to: url)
print(result)
```

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
