### PR TITLE
Sync Flow Error Handling

### DIFF
--- a/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -68,7 +68,6 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
 
     @MainActor
     func handleError(_ type: SyncError, error: Error) {
-        self.dismissPresentedViewController()
         let alertController = UIAlertController(
             title: type.title,
             message: type.description + "\n" + error.localizedDescription,
@@ -78,9 +77,9 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
         alertController.addAction(okAction)
 
         // Give time to the is syncing view to appear
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             self.dismissPresentedViewController { [weak self] in
-                self?.navigationController?.topViewController?.present(alertController, animated: true, completion: nil)
+                self?.present(alertController, animated: true, completion: nil)
             }
         }
     }

--- a/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -77,6 +77,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
         let okAction = UIAlertAction(title: UserText.syncPausedAlertOkButton, style: .default, handler: nil)
         alertController.addAction(okAction)
 
+        // Give time to the is syncing view to appear
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.dismissPresentedViewController { [weak self] in
                 self?.navigationController?.topViewController?.present(alertController, animated: true, completion: nil)

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -22,6 +22,7 @@ import Core
 import Combine
 import SyncUI
 import DDGSync
+import Common
 
 @MainActor
 class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
@@ -194,7 +195,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
                 mapDevices(devices)
             } catch {
                 // Not displaying error since there is the spinner and it is called every few seconds
-//                assertionFailure(error.localizedDescription)
+                os_log(error.localizedDescription, log: .syncLog, type: .error)
             }
         }
     }

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -171,10 +171,10 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
         }
     }
 
-    func dismissPresentedViewController() {
+    func dismissPresentedViewController(completion: (() -> Void)? = nil) {
         guard let presentedViewController = navigationController?.presentedViewController,
               !(presentedViewController is UIHostingController<SyncSettingsView>) else { return }
-        presentedViewController.dismiss(animated: true, completion: nil)
+        presentedViewController.dismiss(animated: true, completion: completion)
         endConnectMode()
     }
 
@@ -190,7 +190,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
                 let devices = try await syncService.fetchDevices()
                 mapDevices(devices)
             } catch {
-                handleError(error)
+                handleError(SyncError.unableToGetDevices, error: error)
             }
         }
     }
@@ -223,7 +223,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
             self.startPolling()
             return self.connector?.code
         } catch {
-            self.handleError(error)
+            self.handleError(SyncError.unableToSync, error: error)
             return nil
         }
     }
@@ -249,7 +249,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
                     return
                 }
             } catch {
-                handleError(error)
+                handleError(SyncError.unableToSync, error: error)
             }
         }
     }
@@ -292,7 +292,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
             }
 
         } catch {
-            handleError(error)
+            handleError(SyncError.unableToSync, error: error)
         }
         return false
     }

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -173,7 +173,10 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
 
     func dismissPresentedViewController(completion: (() -> Void)? = nil) {
         guard let presentedViewController = navigationController?.presentedViewController,
-              !(presentedViewController is UIHostingController<SyncSettingsView>) else { return }
+              !(presentedViewController is UIHostingController<SyncSettingsView>) else { 
+            completion?()
+            return
+        }
         presentedViewController.dismiss(animated: true, completion: completion)
         endConnectMode()
     }
@@ -190,7 +193,8 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
                 let devices = try await syncService.fetchDevices()
                 mapDevices(devices)
             } catch {
-                handleError(SyncError.unableToGetDevices, error: error)
+                // Not displaying error since there is the spinner and it is called every few seconds
+//                assertionFailure(error.localizedDescription)
             }
         }
     }

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -174,7 +174,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
 
     func dismissPresentedViewController(completion: (() -> Void)? = nil) {
         guard let presentedViewController = navigationController?.presentedViewController,
-              !(presentedViewController is UIHostingController<SyncSettingsView>) else { 
+              !(presentedViewController is UIHostingController<SyncSettingsView>) else {
             completion?()
             return
         }

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -860,6 +860,13 @@ But if you *do* want a peek under the hood, you can find more information about 
     static let syncCredentialsPausedAlertDescription = NSLocalizedString("alert.sync-credentials-paused-description", value: "You have exceeded the passwords sync limit. Try deleting some passwords. Until this is resolved your passwords will not be backed up.", comment: "Description for alert shown when sync credentials paused for too many items")
     public static let syncPausedAlertOkButton = NSLocalizedString("alert.sync-paused-alert-ok-button", value: "OK", comment: "Confirmation button in alert")
     public static let syncPausedAlertLearnMoreButton = NSLocalizedString("alert.sync-paused-alert-learn-more-button", value: "Learn More", comment: "Learn more button in alert")
+    public static let syncErrorAlertTitle = NSLocalizedString("alert.sync-error", value: "Sync Error", comment: "Title for sync error alert")
+    public static let unableToSyncDescription = NSLocalizedString("alert.unable-to-sync-description", value: "Unable to sync.", comment: "Description for unable to sync error")
+    public static let unableToGetDevicesDescription = NSLocalizedString("alert.unable-to-get-devices-description", value: "Unable to retrieve the list of connected devices.", comment: "Description for unable to get devices error")
+    public static let unableToUpdateDeviceNameDescription = NSLocalizedString("alert.unable-to-update-device-name-description", value: "Unable to update the name of the device.", comment: "Description for unable to update device name error")
+    public static let unableToTurnSyncOffDescription = NSLocalizedString("alert.unable-to-turn-sync-off-description", value: "Unable to turn sync off.", comment: "Description for unable to turn sync off error")
+    public static let unableToDeleteDataDescription = NSLocalizedString("alert.unable-to-delete-data-description", value: "Unable to delete data on the server.", comment: "Description for unable to delete data error")
+    public static let unableToRemoveDeviceDescription = NSLocalizedString("alert.unable-to-remove-device-description", value: "Unable to remove the specified device from the synchronized devices.", comment: "Description for unable to remove device error")
 
     static let preemptiveCrashTitle = NSLocalizedString("error.preemptive-crash.title", value: "App issue detected", comment: "Alert title")
     static let preemptiveCrashBody = NSLocalizedString("error.preemptive-crash.body", value: "Looks like there's an issue with the app and it needs to close. Please reopen to continue.", comment: "Alert message")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -139,6 +139,9 @@
 /* Title for alert shown when sync credentials paused for too many items */
 "alert.sync-credentials-paused-title" = "Passwords Sync is Paused";
 
+/* Title for sync error alert */
+"alert.sync-error" = "Sync Error";
+
 /* Learn more button in alert */
 "alert.sync-paused-alert-learn-more-button" = "Learn More";
 
@@ -159,6 +162,24 @@
 
 /* Save Favorite action */
 "alert.title.save.favorite" = "Save Favorite";
+
+/* Description for unable to delete data error */
+"alert.unable-to-delete-data-description" = "Unable to delete data on the server.";
+
+/* Description for unable to get devices error */
+"alert.unable-to-get-devices-description" = "Unable to retrieve the list of connected devices.";
+
+/* Description for unable to remove device error */
+"alert.unable-to-remove-device-description" = "Unable to remove the specified device from the synchronized devices.";
+
+/* Description for unable to sync error */
+"alert.unable-to-sync-description" = "Unable to sync.";
+
+/* Description for unable to turn sync off error */
+"alert.unable-to-turn-sync-off-description" = "Unable to turn sync off.";
+
+/* Description for unable to update device name error */
+"alert.unable-to-update-device-name-description" = "Unable to update the name of the device.";
 
 /* Shown on authentication screen */
 "app.authentication.unlock" = "Unlock DuckDuckGo.";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206157806473027/f

**Description**: Add alerts for errors during sync set up flow

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Turn wi fi off 
2. Click on "sync to another device" and check an error alert is shown and modal is dismissed
3. Click on “sync and back up this device” then on “turn on sync & back up”  and check an error alert is shown and modal is dismissed
4. Turn wi fi on
5. Click on “sync and back up this device”, then on “turn on sync & back up”, 
6. copy the recovery code, then turn sync off
7. Turn wifi off
8. Click on “Recover sync Data” then on “Get started” then on enter text code manually and paste the code check an error alert is shown and modal is dismissed
9. Turn wifi on log in with the code and once logged in remove the data
10. Go again through the recovery flow and check an error alert is shown and modal is dismissed
11. On wifi off try to turn off and remove the account and check error is displayed.

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
