### PR TITLE
Show dev environment indicator in Sync Settings

### DIFF
--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -56,7 +56,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
 
-        let viewModel = SyncSettingsViewModel()
+        let viewModel = SyncSettingsViewModel(isOnDevEnvironment: syncService.serverEnvironment == .development)
 
         super.init(rootView: SyncSettingsView(model: viewModel))
 

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -56,7 +56,13 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
 
-        let viewModel = SyncSettingsViewModel(isOnDevEnvironment: syncService.serverEnvironment == .development)
+        let viewModel = SyncSettingsViewModel(
+            isOnDevEnvironment: { syncService.serverEnvironment == .development },
+            switchToProdEnvironment: {
+                syncService.updateServerEnvironment(.production)
+                UserDefaults.standard.set(ServerEnvironment.production.description, forKey: UserDefaultsWrapper<String>.Key.syncEnvironment.rawValue)
+            }
+        )
 
         super.init(rootView: SyncSettingsView(model: viewModel))
 

--- a/DuckDuckGoTests/SyncManagementViewModelTests.swift
+++ b/DuckDuckGoTests/SyncManagementViewModelTests.swift
@@ -26,7 +26,7 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
     fileprivate var monitor = Monitor<SyncManagementViewModelDelegate>()
 
     lazy var model: SyncSettingsViewModel = {
-        let model = SyncSettingsViewModel()
+        let model = SyncSettingsViewModel(isOnDevEnvironment: { false }, switchToProdEnvironment: {})
         model.delegate = self
         return model
     }()

--- a/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
@@ -85,10 +85,15 @@ public class SyncSettingsViewModel: ObservableObject {
     @Published var recoveryCode = ""
 
     public weak var delegate: SyncManagementViewModelDelegate?
-    let isOnDevEnvironment: Bool
+    private(set) var isOnDevEnvironment: Bool
+    private(set) var switchToProdEnvironment: () -> Void = {}
 
-    public init(isOnDevEnvironment: Bool) {
-        self.isOnDevEnvironment = isOnDevEnvironment
+    public init(isOnDevEnvironment: @escaping () -> Bool, switchToProdEnvironment: @escaping () -> Void) {
+        self.isOnDevEnvironment = isOnDevEnvironment()
+        self.switchToProdEnvironment = { [weak self] in
+            switchToProdEnvironment()
+            self?.isOnDevEnvironment = isOnDevEnvironment()
+        }
     }
 
     func disableSync() {

--- a/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
@@ -85,8 +85,11 @@ public class SyncSettingsViewModel: ObservableObject {
     @Published var recoveryCode = ""
 
     public weak var delegate: SyncManagementViewModelDelegate?
+    let isOnDevEnvironment: Bool
 
-    public init() { }
+    public init(isOnDevEnvironment: Bool) {
+        self.isOnDevEnvironment = isOnDevEnvironment
+    }
 
     func disableSync() {
         isBusy = true

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -368,9 +368,9 @@ extension SyncSettingsView {
             })
             .alert(isPresented: $isEnvironmentSwitcherInstructionsVisible) {
                 Alert(
-                    title: Text("Sync Development environment is in use"),
-                    message: Text("Go to Debug Menu -> Sync Info to switch to Production environment."),
-                    dismissButton: .default(Text("OK"))
+                    title: Text("You're using Sync Development environment"),
+                    primaryButton: .default(Text("Keep Development")),
+                    secondaryButton: .destructive(Text("Switch to Production"), action: model.switchToProdEnvironment)
                 )
             }
         } else {

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -27,6 +27,7 @@ public struct SyncSettingsView: View {
     let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
     @State var isSyncWithSetUpSheetVisible = false
     @State var isRecoverSyncedDataSheetVisible = false
+    @State var isEnvironmentSwitcherInstructionsVisible = false
 
     public init(model: SyncSettingsViewModel) {
         self.model = model
@@ -121,6 +122,8 @@ extension SyncSettingsView {
                 }
                 Spacer()
             }
+        } header: {
+            devEnvironmentIndicator()
         } footer: {
             HStack {
                 Spacer()
@@ -265,6 +268,7 @@ extension SyncSettingsView {
                     .fill(.green)
                     .frame(width: 8)
                     .padding(.bottom, 1)
+                devEnvironmentIndicator()
             }
         } footer: {
             Text(UserText.turnSyncOffSectionFooter)
@@ -341,6 +345,36 @@ extension SyncSettingsView {
                     model.manageLogins()
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    func devEnvironmentIndicator() -> some View {
+        if model.isOnDevEnvironment {
+            Button(action: {
+                isEnvironmentSwitcherInstructionsVisible.toggle()
+            }, label: {
+                if #available(iOS 15.0, *) {
+                    Text("Dev environment")
+                        .daxFootnoteRegular()
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 2)
+                        .foregroundColor(.white)
+                        .background(Color.red40)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                } else {
+                    Text("Dev environment")
+                }
+            })
+            .alert(isPresented: $isEnvironmentSwitcherInstructionsVisible) {
+                Alert(
+                    title: Text("Sync Development environment is in use"),
+                    message: Text("Go to Debug Menu -> Sync Info to switch to Production environment."),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+        } else {
+            EmptyView()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1206158416073061/f

**Description**:
When dev environment is active, a small pill button indicating this is shown on top of Sync Settings view.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the app in Xcode and go to Debug Menu -> Sync Info. Enable Dev environment.
2. Go to Sync Settings. Verify that Dev environment view on the top is shown.
3. Enable Sync. Verify that Dev environment view on the top is shown.
4. Tap the view, verify that it shows an alert with instructions.
5. Go back to Debug Menu and Switch to Production environment.
6. Go to Sync Settings. Verify that Dev environment view is not present.
7. Enable Sync. Verify that Dev environment view is not present. Verify that tapping the area where it's present on Dev environment doesn't cause an alert to show up.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
