### PR TITLE
Add search retention pixel for NetP

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -203,7 +203,7 @@ public class Pixel {
                                                      headers: headers)
         let request = APIRequest(configuration: configuration, urlSession: .session(useMainThreadCallbackQueue: true))
         request.fetch { _, error in
-            os_log("Pixel fired %s %s", log: .generalLog, type: .debug, pixelName, "\(params)")
+            os_log("Pixel fired %{public}s %{public}s", log: .generalLog, type: .debug, pixelName, "\(params)")
             onComplete(error)
         }
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -35,6 +35,10 @@ import TrackerRadarKit
 import Networking
 import SecureStorage
 
+#if NETWORK_PROTECTION
+import NetworkProtection
+#endif
+
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 class TabViewController: UIViewController {
@@ -116,6 +120,12 @@ class TabViewController: UIViewController {
 
     private var trackersInfoWorkItem: DispatchWorkItem?
     
+#if NETWORK_PROTECTION
+    private let netPConnectionObserver = ConnectionStatusObserverThroughSession()
+    private var netPConnectionObserverCancellable: AnyCancellable?
+    private var netPConnectionStatus: ConnectionStatus = .default
+#endif
+
     // Required to know when to disable autofill, see SaveLoginViewModel for details
     // Stored in memory on TabViewController for privacy reasons
     private var domainSaveLoginPromptLastShownOn: String?
@@ -306,6 +316,10 @@ class TabViewController: UIViewController {
         if #available(iOS 16.4, *) {
             registerForInspectableWebViewNotifications()
         }
+
+#if NETWORK_PROTECTION
+        observeNetPConnectionStatusChanges()
+#endif
     }
 
     @available(iOS 16.4, *)
@@ -323,6 +337,12 @@ class TabViewController: UIViewController {
 #else
         webView.isInspectable = AppUserDefaults().inspectableWebViewEnabled
 #endif
+    }
+
+    private func observeNetPConnectionStatusChanges() {
+        netPConnectionObserverCancellable = netPConnectionObserver.publisher
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.netPConnectionStatus, onWeaklyHeld: self)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -1104,6 +1124,12 @@ extension TabViewController: WKNavigationDelegate {
         linkProtection.setMainFrameUrl(nil)
         referrerTrimming.onFinishNavigation()
         urlProvidedBasicAuthCredential = nil
+
+#if NETWORK_PROTECTION
+        if webView.url?.isDuckDuckGoSearch == true, case .connected = netPConnectionStatus {
+            DailyPixel.fireDailyAndCount(pixel: .networkProtectionEnabledOnSearch)
+        }
+#endif
     }
     
     func preparePreview(completion: @escaping (UIImage?) -> Void) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205948683470045/f

**Description**:

Adds VPN search retention pixel. This is triggered in `TabViewController.webView(_:didFinish:)`

**Steps to test this PR**:

Perform a search in different scenarios and see if pixel firing is triggered (`TabViewController#L1130`)

- First time VPN is installed
- On subsequent launches with VPN connected
- From different tabs
- When VPN is toggled
- etc

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
