### PR TITLE
Update VPN active user check and debug options

### DIFF
--- a/DuckDuckGo/AppDelegate+Waitlists.swift
+++ b/DuckDuckGo/AppDelegate+Waitlists.swift
@@ -43,20 +43,21 @@ extension AppDelegate {
 
 #if NETWORK_PROTECTION
     private func checkNetworkProtectionWaitlist() {
-        if AppDependencyProvider.shared.featureFlagger.isFeatureOn(.networkProtectionWaitlistAccess) {
+        let accessController = NetworkProtectionAccessController()
+        if accessController.isPotentialOrCurrentWaitlistUser {
             DailyPixel.fire(pixel: .networkProtectionWaitlistUserActive)
         }
 
         VPNWaitlist.shared.fetchInviteCodeIfAvailable { [weak self] error in
             guard error == nil else {
 #if !DEBUG
-                // If the user already has an invite code but their auth token has gone missing, attempt to redeem it again.
-                let tokenStore = NetworkProtectionKeychainTokenStore()
-                let waitlistStorage = VPNWaitlist.shared.waitlistStorage
-                if error == .alreadyHasInviteCode,
-                   let inviteCode = waitlistStorage.getWaitlistInviteCode(),
-                   !tokenStore.isFeatureActivated {
-                    self?.fetchVPNWaitlistAuthToken(inviteCode: inviteCode)
+                if error == .alreadyHasInviteCode {
+                    // If the user already has an invite code but their auth token has gone missing, attempt to redeem it again.
+                    let tokenStore = NetworkProtectionKeychainTokenStore()
+                    let waitlistStorage = VPNWaitlist.shared.waitlistStorage
+                    if let inviteCode = waitlistStorage.getWaitlistInviteCode(), !tokenStore.isFeatureActivated {
+                        self?.fetchVPNWaitlistAuthToken(inviteCode: inviteCode)
+                    }
                 }
 #endif
                 return

--- a/DuckDuckGo/NetworkProtectionDebugViewController.swift
+++ b/DuckDuckGo/NetworkProtectionDebugViewController.swift
@@ -37,7 +37,7 @@ import NetworkProtection
 // swiftlint:disable:next type_body_length
 final class NetworkProtectionDebugViewController: UITableViewController {
     private let titles = [
-        Sections.keychain: "Keychain",
+        Sections.clearData: "Clear Data",
         Sections.debugFeature: "Debug Features",
         Sections.simulateFailure: "Simulate Failure",
         Sections.registrationKey: "Registration Key",
@@ -49,7 +49,7 @@ final class NetworkProtectionDebugViewController: UITableViewController {
     ]
 
     enum Sections: Int, CaseIterable {
-        case keychain
+        case clearData
         case debugFeature
         case simulateFailure
         case registrationKey
@@ -59,9 +59,10 @@ final class NetworkProtectionDebugViewController: UITableViewController {
         case vpnConfiguration
     }
 
-    enum KeychainRows: Int, CaseIterable {
+    enum ClearDataRows: Int, CaseIterable {
 
         case clearAuthToken
+        case clearAllVPNData
 
     }
 
@@ -162,10 +163,12 @@ final class NetworkProtectionDebugViewController: UITableViewController {
 
         switch Sections(rawValue: indexPath.section) {
 
-        case .keychain:
-            switch KeychainRows(rawValue: indexPath.row) {
+        case .clearData:
+            switch ClearDataRows(rawValue: indexPath.row) {
             case .clearAuthToken:
-                cell.textLabel?.text = "Clear auth token"
+                cell.textLabel?.text = "Clear Auth Token"
+            case .clearAllVPNData:
+                cell.textLabel?.text = "Reset VPN State Completely"
             case .none:
                 break
             }
@@ -200,7 +203,7 @@ final class NetworkProtectionDebugViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Sections(rawValue: section) {
-        case .keychain: return KeychainRows.allCases.count
+        case .clearData: return ClearDataRows.allCases.count
         case .debugFeature: return DebugFeatureRows.allCases.count
         case .simulateFailure: return SimulateFailureRows.allCases.count
         case .registrationKey: return RegistrationKeyRows.allCases.count
@@ -216,9 +219,10 @@ final class NetworkProtectionDebugViewController: UITableViewController {
     // swiftlint:disable:next cyclomatic_complexity
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch Sections(rawValue: indexPath.section) {
-        case .keychain:
-            switch KeychainRows(rawValue: indexPath.row) {
+        case .clearData:
+            switch ClearDataRows(rawValue: indexPath.row) {
             case .clearAuthToken: clearAuthToken()
+            case .clearAllVPNData: clearAllVPNData()
             default: break
             }
         case .debugFeature:
@@ -542,6 +546,12 @@ final class NetworkProtectionDebugViewController: UITableViewController {
     private func clearAuthToken() {
         try? tokenStore.deleteToken()
     }
+
+    private func clearAllVPNData() {
+        let accessController = NetworkProtectionAccessController()
+        accessController.revokeNetworkProtectionAccess()
+    }
+
 }
 
 

--- a/DuckDuckGoTests/NetworkProtectionAccessControllerTests.swift
+++ b/DuckDuckGoTests/NetworkProtectionAccessControllerTests.swift
@@ -117,6 +117,43 @@ final class NetworkProtectionAccessControllerTests: XCTestCase {
         XCTAssertEqual(controller.networkProtectionAccessType(), .waitlistInvited)
     }
 
+    func testWhenUserHasWaitlistAccess_ThenWaitlistUserCheckIsTrue() {
+        let controller = createMockAccessController(
+            isInternalUser: true,
+            featureActivated: true,
+            termsAccepted: true,
+            featureFlagsEnabled: true,
+            hasJoinedWaitlist: true,
+            hasBeenInvited: true
+        )
+
+        XCTAssertTrue(controller.isPotentialOrCurrentWaitlistUser)
+    }
+
+    func testWhenUserDoesNotHaveWaitlistAccess_ThenWaitlistUserCheckIsFalse() {
+        let controller = createMockAccessController(
+            featureActivated: false,
+            termsAccepted: false,
+            featureFlagsEnabled: false,
+            hasJoinedWaitlist: false,
+            hasBeenInvited: false
+        )
+
+        XCTAssertFalse(controller.isPotentialOrCurrentWaitlistUser)
+    }
+
+    func testWhenUserIsInternal_ThenWaitlistUserCheckIsFalse() {
+        let controller = createMockAccessController(
+            featureActivated: true,
+            termsAccepted: false,
+            featureFlagsEnabled: false,
+            hasJoinedWaitlist: false,
+            hasBeenInvited: false
+        )
+
+        XCTAssertFalse(controller.isPotentialOrCurrentWaitlistUser)
+    }
+
     // MARK: - Mock Creation
 
     private func createMockAccessController(
@@ -146,12 +183,14 @@ final class NetworkProtectionAccessControllerTests: XCTestCase {
         let mockTermsAndConditionsStore = MockNetworkProtectionTermsAndConditionsStore()
         mockTermsAndConditionsStore.networkProtectionWaitlistTermsAndConditionsAccepted = termsAccepted
         let mockFeatureFlagger = createFeatureFlagger(withSubfeatureEnabled: featureFlagsEnabled)
+        let internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
 
         return NetworkProtectionAccessController(
             networkProtectionActivation: mockActivation,
             networkProtectionWaitlistStorage: mockWaitlistStorage,
             networkProtectionTermsAndConditionsStore: mockTermsAndConditionsStore,
-            featureFlagger: mockFeatureFlagger
+            featureFlagger: mockFeatureFlagger,
+            internalUserDecider: internalUserDecider
         )
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206165514403612/f
Tech Design URL:
CC:

**Description**:

This PR updates the active user pixel check to accurately reflect the conditions under which you need to meet to be counted as a potential user. The old check was looking for the active flag only, which isn't accurate as it includes non-US users.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure that the waitlist active user pixel doesn't fire if you're outside the US
2. Make sure that the new "Clear All VPN Data" debug menu option completely disables NetP and removes all keychain data

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
