### PR TITLE
Remove the reconnect/disconnect logic from the connection tester

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9165,8 +9165,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 94.0.0;
+				kind = revision;
+				revision = 4ac7b80839ddccd462dc356382159e7a474d489a;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9165,8 +9165,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 4ac7b80839ddccd462dc356382159e7a474d489a;
+				kind = exactVersion;
+				version = 94.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "e4f4ae624174c1398d345cfc387db38f8f69986d",
-          "version": "94.0.0"
+          "revision": "4ac7b80839ddccd462dc356382159e7a474d489a",
+          "version": null
         }
       },
       {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DuckDuckGo/BrowserServicesKit",
         "state": {
           "branch": null,
-          "revision": "4ac7b80839ddccd462dc356382159e7a474d489a",
-          "version": null
+          "revision": "7b0910360d6f700ca9bea5e5374c8e2c9a2da899",
+          "version": "94.0.1"
         }
       },
       {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206173513538619/f

macOS PR: https://github.com/duckduckgo/macos-browser/pull/1970
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/601

## Description

Removes the logic that would reconnect / disconnect NetP in case of trouble.

## Testing

It's not as easy to test in macOS... try connecting NetP, then disconnecting your wifi... swapping to cellular... entering Airplane mode.  See that NetP stays connected and works fine.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
