### PR TITLE
Fix: "SwiftLintPlugin" must be enabled before it can be used

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -168,7 +168,8 @@ private_lane :build_release do |options|
     export_method: "app-store",
     scheme: "DuckDuckGo",
     export_options: "appStoreExportOptions.plist",
-    derived_data_path: "DerivedData"
+    derived_data_path: "DerivedData",
+    xcargs: "-skipPackagePluginValidation"
   )
 end
 


### PR DESCRIPTION
**Description**:

When making the App Store release build for 7.102.0, the GH workflow [stops](https://github.com/duckduckgo/iOS/actions/runs/7254427371/job/19763123115) with this error: `“SwiftLintPlugin” must be enabled before it can be used`.

This PR adds the `-skipPackagePluginValidation` flag to `xcodebuild` to [resolve the issue](https://github.com/duckduckgo/iOS/actions/runs/7254662452/job/19763796978).

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
