### PR TITLE
Prevents VPNSettings from reporting fake changes

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9224,8 +9224,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = a0398c48081cdec0d862f563359376dbf5be0ce6;
+				kind = exactVersion;
+				version = 99.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9224,8 +9224,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 98.0.1;
+				kind = revision;
+				revision = a0398c48081cdec0d862f563359376dbf5be0ce6;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "ea133abe237b6cb57a4237e0373318a40c10afc2",
-        "version" : "98.0.1"
+        "revision" : "a0398c48081cdec0d862f563359376dbf5be0ce6"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "a0398c48081cdec0d862f563359376dbf5be0ce6"
+        "revision" : "2dc2db96016b86cbb3a300e102bb68f03e953f4a",
+        "version" : "99.0.1"
       }
     },
     {

--- a/DuckDuckGo/ConfigurationDebugViewController.swift
+++ b/DuckDuckGo/ConfigurationDebugViewController.swift
@@ -169,7 +169,6 @@ class ConfigurationDebugViewController: UITableViewController {
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch Sections(rawValue: indexPath.section) {
         case .refreshInformation:

--- a/LocalPackages/DuckUI/Package.swift
+++ b/LocalPackages/DuckUI/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             targets: ["DuckUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../DuckUI"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [

--- a/LocalPackages/Waitlist/Package.swift
+++ b/LocalPackages/Waitlist/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Waitlist", "WaitlistMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "99.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206212872939261/f

macOS PR: https://github.com/duckduckgo/macos-browser/pull/2004
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/614

## Description

Makes some changes to VPNSettings so that it won't publish fake settings updates.

## Testing

1. Run the app
2. Connect NetP and make sure everything works fine.
3. Ensure changing location works.
4. Ensure "Exclude local networks" works.  You may need an app to do a traceroute.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
