### PR TITLE
Switch to FlyCI's M2 MacOS runners

### DIFF
--- a/.github/workflows/adhoc.yml
+++ b/.github/workflows/adhoc.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   make-adhoc:
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     name: Make ad-hoc build
 
     steps:

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   make-alpha:
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     name: Make TestFlight Alpha Build
     timeout-minutes: 30
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     timeout-minutes: 60
     permissions:
       actions: read

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   end-to-end-tests:
     name: End to end Tests
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
 
     steps:
     - name: Check out the code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   atb-ui-tests:
     name: ATB UI Tests
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     timeout-minutes: 30
 
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   fingerprinting-ui-tests:
     name: Fingerprinting UI Tests
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
 
     name: Unit Tests
 
-    runs-on: macos-13-xlarge
+    runs-on: flyci-macos-xlarge-latest-m2
     timeout-minutes: 30
 
     outputs:
@@ -128,7 +128,7 @@ jobs:
 
     name: Make Release Build
 
-    runs-on: macos-13-xlarge
+    runs-on: flyci-macos-xlarge-latest-m2
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   make-release:
     if: github.event.action == 0 || github.event.pull_request.merged == true # empty string returns 0; for case when workflow is triggered manually
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     name: Make App Store Connect Release
 
     steps:

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-for-sync-end-to-end-tests:
     name: Build for Sync End To End Tests
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     timeout-minutes: 30
 
     steps:
@@ -65,7 +65,7 @@ jobs:
   sync-end-to-end-tests:
     name: Sync End To End Tests
     needs: build-for-sync-end-to-end-tests
-    runs-on: macos-13
+    runs-on: flyci-macos-large-latest-m2
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
**Description**:

This PR updates the GitHub Actions workflows to use [FlyCI](https://flyci.net)'s macOS runners with M2 chips. This change is made to leverage the performance benefits and cost efficiency provided by FlyCI's infrastructure. The updates include changing the `runs-on` field from `macos-13` to either `flyci-macos-large-latest-m2` or `flyci-macos-xlarge-latest-m2` in various workflow files. This shift not only aligns with our ongoing efforts to optimize CI/CD processes but also offers a more tailored environment for our macOS-specific workflows.

The following workflow files and their respective jobs have been updated:
- `.github/workflows/adhoc.yml`: `make-adhoc`
- `.github/workflows/alpha.yml`: `make-alpha`
- `.github/workflows/codeql.yml`: `analyze`
- `.github/workflows/end-to-end.yml`: `end-to-end-tests`
- `.github/workflows/nightly.yml`: `atb-ui-tests` and `fingerprinting-ui-tests`
- `.github/workflows/pr.yml`: `Unit Tests` and `Make Release Build`
- `.github/workflows/release.yml`: `make-release`
- `.github/workflows/sync-end-to-end.yml`: `build-for-sync-end-to-end-tests` and `sync-end-to-end-tests`

| Processor | vCPU | RAM (GB) | Label | Price on FlyCI | Price on GitHub |
|-----------|------|----------|-------------------------------|----------------|-----------------|
| M1        | 4    | 7        | flyci-macos-large-latest-m1   | $0.06          | N/A             |
| M1        | 8    | 14       | flyci-macos-xlarge-latest-m1  | $0.12          | $0.16           |
| M2        | 4    | 7        | flyci-macos-large-latest-m2   | $0.08          | N/A             |
| M2        | 8    | 14       | flyci-macos-xlarge-latest-m2  | $0.16          | N/A             |

This change represents a strategic move to a more efficient and cost-effective CI infrastructure.