### PR TITLE
NetP: Reenable loading toggle after 2 sec delay

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -24,7 +24,7 @@ import NetworkProtection
 
 @available(iOS 15, *)
 struct NetworkProtectionStatusView: View {
-    @ObservedObject public var statusModel: NetworkProtectionStatusViewModel
+    @StateObject public var statusModel: NetworkProtectionStatusViewModel
 
     var body: some View {
         List {

--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -192,7 +192,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     @MainActor
     func didToggleNetP(to enabled: Bool) async {
         shouldDisableToggle = true
-        // isNetPEnabled = enabled
+        
         // This is to prevent weird looking animations on navigating to the screen.
         // It makes sense as animations should mostly only happen when a user has interacted.
         animationsOn = true

--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -154,7 +154,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
             .assign(to: \.shouldDisableToggle, onWeaklyHeld: self)
             .store(in: &cancellables)
 
-        // Set up a delayed publisher to fire just once that disabled the toggle
+        // Set up a delayed publisher to fire just once that reenables the toggle
         // Each event cancels the previous delayed publisher
         isLoadingPublisher
             .filter { $0 }

--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -37,6 +37,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     private let serverInfoObserver: ConnectionServerInfoObserver
     private let errorObserver: ConnectionErrorObserver
     private var cancellables: Set<AnyCancellable> = []
+    private var delayedToggleReenableCancellable: Cancellable?
 
     // MARK: Error
 
@@ -146,10 +147,23 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     }
 
     private func setUpDisableTogglePublisher() {
-        statusObserver.publisher
-            .map { $0.isLoading }
+        let isLoadingPublisher = statusObserver.publisher.map { $0.isLoading }
+
+        isLoadingPublisher
             .receive(on: DispatchQueue.main)
             .assign(to: \.shouldDisableToggle, onWeaklyHeld: self)
+            .store(in: &cancellables)
+
+        // Set up a delayed publisher to fire just once that disabled the toggle
+        // Each event cancels the previous delayed publisher
+        isLoadingPublisher
+            .filter { $0 }
+            .map {
+                Just(!$0)
+                    .delay(for: 2.0, scheduler: DispatchQueue.main)
+                    .assign(to: \.shouldDisableToggle, onWeaklyHeld: self)
+            }
+            .assign(to: \.delayedToggleReenableCancellable, onWeaklyHeld: self)
             .store(in: &cancellables)
     }
 
@@ -177,6 +191,8 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
 
     @MainActor
     func didToggleNetP(to enabled: Bool) async {
+        shouldDisableToggle = true
+        // isNetPEnabled = enabled
         // This is to prevent weird looking animations on navigating to the screen.
         // It makes sense as animations should mostly only happen when a user has interacted.
         animationsOn = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/276630244458377/1206281658466442/f

**Description**:

During internal testing of the VPN on iOS, we had some reports that people were being stuck in the connecting state (presumably because Connect on Demand is trying to reconnect but there’s a problem connecting). I’ve seen this issue with a few other VPN apps, however they all allow you to cancel the connection and retry which often fixes the issue. We, however, disable the toggle when we’re in this state and, when the user tries to disconnect from the settings, they need to know to first switch of Connect on Demand which is really not obvious.

This allows users to cancel the VPN connection while stuck in the connecting state by reenabling the toggle 2 seconds after loading starts to allow the user to cancel the connection but not spam the toggle.

Please see the comments threat of the above linked task for context on the solution

**Steps to test this PR**:
1. Make sure you have access to NetP.
2. Make sure NetP is disabled
3. Simulate a poor network connection by using the Network Link Conditioner (iOS Settings -> Developer -> Network Link…)
4. Enable NetP
5. **After 2 seconds the toggle should become enabled despite the status displaying _Connecting..._**
6. Disable the toggle
7. **The connection attempt should be cancelled**

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
