### PR TITLE
Suspend Sync when updating device name

### DIFF
--- a/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -41,12 +41,14 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     func updateDeviceName(_ name: String) {
         Task { @MainActor in
             rootView.model.devices = []
+            syncService.scheduler.cancelSyncAndSuspendSyncQueue()
             do {
                 let devices = try await syncService.updateDeviceName(name)
                 mapDevices(devices)
             } catch {
                 handleError(SyncError.unableToUpdateDeviceName, error: error)
             }
+            syncService.scheduler.resumeSyncQueue()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1206304176229205/f

**Description**:
This is to prevent data sync requests being sent with an outdated authorization token.

**Steps to test this PR**:
1. Enable Sync (best to test on production).
2. Change device name a few times.
3. Verify that you're not logged out while updating device name.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
