### PR TITLE
Don't require iOS 16 for Sync end-to-end tests build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         xcodebuild clean build \
         -target "DuckDuckGo" \
         -scheme "DuckDuckGo" \
-        -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4"
+        -destination "platform=iOS Simulator,name=iPhone 15"
         -skipPackagePluginValidation \
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild \
           -scheme "DuckDuckGo" \
-          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
+          -destination "platform=iOS Simulator,name=iPhone 15" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
         | tee xcodebuild.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild test \
           -scheme "AtbUITests" \
-          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
+          -destination "platform=iOS Simulator,name=iPhone 15" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
           | tee xcodebuild.log \
@@ -86,7 +86,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild test \
           -scheme "FingerprintingUITests" \
-          -destination "platform=iOS Simulator,name=iPhone 14,OS=16.4" \
+          -destination "platform=iOS Simulator,name=iPhone 15" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
           | xcbeautify --report junit --report-path . --junit-report-filename unittests.xml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild test \
           -scheme "DuckDuckGo" \
-          -destination "platform=iOS Simulator,name=iPhone 15,OS=17.2" \
+          -destination "platform=iOS Simulator,name=iPhone 15" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
           DDG_SLOW_COMPILE_CHECK_THRESHOLD=250 \
@@ -181,7 +181,7 @@ jobs:
 
         set -o pipefail && xcodebuild \
         -scheme "DuckDuckGo" \
-        -destination "platform=iOS Simulator,name=iPhone 14" \
+        -destination "platform=iOS Simulator,name=iPhone 15" \
         -derivedDataPath "DerivedData" \
         -configuration "Release" \
         -skipPackagePluginValidation \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
 
     name: Unit Tests
 
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     timeout-minutes: 30
 
     outputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
 
     name: Unit Tests
 
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     timeout-minutes: 30
 
     outputs:

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -1,7 +1,6 @@
 name: Sync-End-to-End tests
 
 on:
-  pull_request:
   schedule:
     - cron: '0 5 * * *' # run at 5 AM UTC
 

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -1,6 +1,7 @@
 name: Sync-End-to-End tests
 
 on:
+  pull_request:
   schedule:
     - cron: '0 5 * * *' # run at 5 AM UTC
 

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -55,7 +55,7 @@ jobs:
     
     - name: Upload logs when workflow failed
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() || cancelled()
       with:
         name: BuildLogs
         path: |

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         set -o pipefail && xcodebuild \
           -scheme "DuckDuckGo" \
-          -destination "platform=iOS Simulator,name=iPhone 14" \
+          -destination "platform=iOS Simulator,name=iPhone 15" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
         | tee xcodebuild.log

--- a/.maestro/shared/copy_recovery_code_from_settings.yaml
+++ b/.maestro/shared/copy_recovery_code_from_settings.yaml
@@ -6,8 +6,8 @@ appId: com.duckduckgo.mobile.ios
 - scroll
 - scroll
 - scroll
-- assertVisible: Debug Menu
-- tapOn: Debug Menu
+- assertVisible: All debug options
+- tapOn: All debug options
 - tapOn: Sync Info
 - tapOn: Paste and Copy Recovery Code
 - inputText: ${CODE}

--- a/.maestro/shared/set_internal_user_from_settings.yaml
+++ b/.maestro/shared/set_internal_user_from_settings.yaml
@@ -4,7 +4,7 @@ appId: com.duckduckgo.mobile.ios
 - scroll
 - scroll
 - scroll
-- assertVisible: Debug Menu
-- tapOn: Debug Menu
+- assertVisible: All debug options
+- tapOn: All debug options
 - tapOn: Internal User State
 - tapOn: Settings


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1206315757855486/f

**Description**:
After upgrading to Xcode 15, some workflows fail because they require iOS 16 simulator.
This change is removing that requirement.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
Verify that CI is green


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
