### PR TITLE
Update BSK with autofill 10.0.3

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9897,8 +9897,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = f72fcfb0f2570d86ccc4324266b7d423734c1f10;
+				kind = exactVersion;
+				version = 101.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9897,8 +9897,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 101.0.0;
+				kind = revision;
+				revision = f72fcfb0f2570d86ccc4324266b7d423734c1f10;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "71f65c35de0ae291a1b012ff17c91b9dcd6618fb",
-        "version" : "101.0.0"
+        "revision" : "c5ffbf442caa77d7fe4213748b65cd973c0acdfd",
+        "version" : "101.0.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "5597bc17709c8acf454ecaad4f4082007986242a",
-        "version" : "10.0.2"
+        "revision" : "b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
+        "version" : "10.0.3"
       }
     },
     {

--- a/LocalPackages/DuckUI/Package.swift
+++ b/LocalPackages/DuckUI/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             targets: ["DuckUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../DuckUI"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [

--- a/LocalPackages/Waitlist/Package.swift
+++ b/LocalPackages/Waitlist/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Waitlist", "WaitlistMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "101.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206327382038432/1206327382038432
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/623

## Description
Updates Autofill to version [10.0.3](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/10.0.3).

### Autofill 10.0.3 release notes
## What's Changed
* Use the default branch when checking out repos by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/444
* Password update flows by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/453
* Bump @types/jest from 29.5.5 to 29.5.11 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/439
* Update password-related json files (2023-12-21) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/454
* Move test forms out of src by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/457
* Move integration tests around by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/455
* Fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/467
* Update password-related json files (2024-01-11) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/466


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/10.0.2...10.0.3

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).