### PR TITLE
add xcargs: -skipPackagePluginValidation arg to build_app

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,7 +77,8 @@ lane :adhoc do |options|
     export_method: "ad-hoc",
     scheme: "DuckDuckGo",
     export_options: "adhocExportOptions.plist",
-    derived_data_path: "DerivedData"
+    derived_data_path: "DerivedData",
+    xcargs: "-skipPackagePluginValidation"
   )
 
   if is_ci


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1206316210209892/f

**Description**:
- Fixes iOS ad-hoc fastlane build

**Steps to test this PR**:
1. Validate ad-hoc build workflow passes: https://github.com/duckduckgo/iOS/actions/runs/7488595638/job/20383410288