### PR TITLE
Add Checkmark icon to pickers

### DIFF
--- a/DuckDuckGo/SettingsCell.swift
+++ b/DuckDuckGo/SettingsCell.swift
@@ -207,6 +207,7 @@ struct SettingsPickerCellView<T: CaseIterable & Hashable & CustomStringConvertib
                     Image(systemName: "chevron.up.chevron.down")
                         .font(Font.system(.footnote).weight(.bold))
                         .foregroundColor(Color(UIColor.tertiaryLabel))
+                        .padding(.trailing, -2)
                 }
             }
         }
@@ -222,8 +223,6 @@ struct SettingsPickerCellView<T: CaseIterable & Hashable & CustomStringConvertib
                         Image(systemName: "checkmark")
                     }
                     Text(option)
-                        .daxBodyRegular()
-                        .foregroundColor(Color(designSystemColor: .textSecondary))
                 }
             }
         }

--- a/DuckDuckGo/SettingsCell.swift
+++ b/DuckDuckGo/SettingsCell.swift
@@ -193,8 +193,11 @@ struct SettingsPickerCellView<T: CaseIterable & Hashable & CustomStringConvertib
             Spacer()
             Menu {
                 ForEach(options, id: \.self) { option in
-                    getButtonWithAction(action: { self.selectedOption = option },
-                                        option: option.description)
+                    Group {
+                        getButtonWithAction(action: { self.selectedOption = option },
+                                            option: option.description,
+                                            selected: option == selectedOption)
+                    }
                 }
             } label: {
                 HStack {
@@ -209,11 +212,20 @@ struct SettingsPickerCellView<T: CaseIterable & Hashable & CustomStringConvertib
         }
     }
     
-    private func getButtonWithAction(action: @escaping () -> Void, option: String) -> some View {
-        return Button(action: action) {
-            Text(option)
-                .daxBodyRegular()
-                .foregroundColor(Color(designSystemColor: .textSecondary))
+    private func getButtonWithAction(action: @escaping () -> Void,
+                                     option: String,
+                                     selected: Bool) -> some View {
+        return Group {
+            Button(action: action) {
+                HStack {
+                    if selected {
+                        Image(systemName: "checkmark")
+                    }
+                    Text(option)
+                        .daxBodyRegular()
+                        .foregroundColor(Color(designSystemColor: .textSecondary))
+                }
+            }
         }
     }
 }

--- a/DuckDuckGo/SettingsHostingController.swift
+++ b/DuckDuckGo/SettingsHostingController.swift
@@ -64,3 +64,22 @@ class SettingsHostingController: UIHostingController<AnyView> {
         navigationController?.present(vc, animated: true)
     }
 }
+
+extension SettingsHostingController: Themable {
+    
+    func decorate(with theme: Theme) {
+        // Apply Theme
+        navigationController?.navigationBar.barTintColor = theme.barBackgroundColor
+        navigationController?.navigationBar.tintColor = theme.navigationBarTintColor
+
+        if #available(iOS 15.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.shadowColor = .clear
+            appearance.backgroundColor = theme.backgroundColor
+
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        }
+    }
+    
+}

--- a/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/DuckDuckGo/bg.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Интернет може да бъде и доста опасно място.\n\nНе се притеснявайте! Поверителното търсене и сърфиране е много по-лесно, отколкото си мислите.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Деактивирано";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Добре дошли в\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo за Mac притежава необходимата скорост, както и очакваните от Вас функции за сърфиране, и предлага най-добрите в този клас елементи за защита.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Включете се в списъка с чакащи и ще Ви уведомим, когато дойде Вашият ред.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Включени сте в списъка с чакащи!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Любими";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Относно DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "За нас";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo е независима компания, основана през 2008 г., за защита на личните данни в интернет за всеки, на когото му е омръзнало да бъде проследяван онлайн и иска лесно решение на проблема. Ние сме доказателство, че можете да получите реална и безкомпромисна защита на личните данни онлайн.\n\nБраузърът DuckDuckGo притежава функциите, които очаквате от един основен браузър, като отметки, раздели, пароли и много други, както и [редица мощни защити на поверителността](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), които не се предлагат в повечето популярни браузъри по подразбиране. Този уникален и комплексен набор от защити на поверителността предлага сигурност при онлайн дейностите – търсене, сърфиране, изпращане на имейли и др.\n\nЗа да работят, нашите защити на поверителността не изискват да имате технически познания или да се извършвате сложни настройки. Необходимо е да използвате браузъра DuckDuckGo на всички Ваши устройства и ще получите поверителност по подразбиране.\n\nНо ако *наистина* искате да надникнете зад кулисите, и да разберете как работят защитите на поверителността на DuckDuckGo, можете да намерите повече информация на нашите [страници за помощ](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Добавяне на приложението към панела";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Добавяне на приспособлението към началния екран";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Позиция на адресната лента";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Външен Вид";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Отваряне на връзките в свързаните приложения";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Деактивирайте, за да предотвратите автоматично отваряне на връзки в други инсталирани приложения.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Показване на предложенията за автоматично довършване";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Заключване на приложение";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Ако сте задали пръстов отпечатък, лицево разпознаване или системна парола, ще бъдете приканени да отключите приложението при отваряне.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Автоматично изчистване на данните";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Управление на прозорци за бисквитки";
+
+/* Settings title for the customize section */
+"settings.customize" = "Персонализиране";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Задаване като браузър по подразбиране";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Защита на имейл";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Блокирайте имейл тракерите и скрийте своя адрес";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Споделяне на отзив";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Анимация на огнения бутон";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Огнеустойчиви сайтове";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Глобален контрол на поверителността (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Икона на приложението";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Клавиатура";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Още от DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Прегледи с продължително натискане";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Поверителност";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Синхронизиране и архивиране";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Размер на текста";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Тема";
+
+/* Title for the Settings View */
+"settings.title" = "Настройки";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Незащитени сайтове";
+
+/* Settings cell for Version */
+"settings.version" = "Версия";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Поверително гласово търсене";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Изпращане на доклад";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Разрешете достъп до микрофона в настройките на системата iOS, за да може DuckDuckGo да използва гласовите функции.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "ОК";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Изисква се достъп до микрофона";

--- a/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/DuckDuckGo/cs.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet může být trochu strašidelný.\n\nNebojte se! Anonymní vyhledávání a procházení je jednodušší, než si myslíte.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Zakázáno";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Vítejte na\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo pro Mac má rychlost, kterou potřebuješ, funkce prohlížeče, které očekáváš, a obsahuje naše nejlepší nástroje na ochranu soukromí.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Zapiš se na čekací listinu a my tě upozorníme, až budeš na řadě.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Jsi v pořadníku!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Oblíbené";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "O DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "O společnosti";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo je nezávislá společnost založená v roce 2008, která se zabývá ochranou soukromí pro všechny, kdo už mají dost sledování na internetu a chtějí snadné řešení. Jsme důkazem, že skutečná ochrana soukromí na internetu nemusí mít kompromisy.\n\nProhlížeč DuckDuckGo má všechno, co od prohlížeče očekáváš, jako jsou záložky, karty, hesla a další funkce. A k tomu má víc než [desítku účinných funkcí na ochranu soukromí](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), které většina oblíbených prohlížečů ve výchozím nastavení nenabízí. Tahle jedinečná komplexní sada na ochranu soukromí pomáhá chránit tvoje aktivity na internetu, ať už zrovna něco vyhledáváš, jen tak surfuješ, nebo posíláš e-maily.\n\nAby naše ochrana soukromí fungovala, nemusíš znát technické detaily ani řešit žádná složitá nastavení. Stačí přejít na prohlížeč DuckDuckGo ve všech zařízeních a dostaneš soukromí pro všechny své aktivity.\n\nJestli chceš nahlédnout pod pokličku, víc informací o tom, jak ochrana soukromí DuckDuckGo funguje, najdeš v naší [nápovědě](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Přidat aplikaci do docku";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Přidat widget na domovskou obrazovku";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Pozice adresního řádku";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Vzhled";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Otevřít odkazy v přidružených aplikacích";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Zakažte, chcete-li zabránit automatickému otevírání odkazů v jiných nainstalovaných aplikacích.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Zobrazit návrhy automatického doplňování";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Zámek aplikace";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Pokud je nastaveno Touch ID, Face ID nebo přístupový kód k systému, budete při otevírání požádáni o odemknutí aplikace.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Automaticky vymazat data";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Správa vyskakovacích oken ohledně cookies";
+
+/* Settings title for the customize section */
+"settings.customize" = "Přizpůsobit";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Nastavit jako výchozí prohlížeč";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Ochrana e-mailu";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokování trackerů v e-mailu a skrytí adresy";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Podělte se o zpětnou vazbu";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animace tlačítka pro mazání";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Stránky s ochranou";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Globální kontrola ochrany osobních údajů (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Ikona aplikace";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Klávesnice";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Další od DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Náhledy dlouhého stisknutí";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Soukromí";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synchronizace a zálohování";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Velikost textu";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Téma";
+
+/* Title for the Settings View */
+"settings.title" = "Nastavení";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Nechráněné stránky";
+
+/* Settings cell for Version */
+"settings.version" = "Verze";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Soukromé hlasové vyhledávání";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Odešlete zprávu";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Pro používání hlasových funkcí DuckDuckGo je potřeba v Nastaveních iOS povolit přístup k mikrofonu.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "DOBŘE";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Je nutný přístup k mikrofonu";

--- a/DuckDuckGo/da.lproj/Localizable.strings
+++ b/DuckDuckGo/da.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internettet kan være ret uhyggeligt.\n\nBare rolig! Det er lettere at søge og browse privat, end du tror.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Deaktiveret";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Velkommen til\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo til Mac har den hastighed, du har brug for, de browserfunktioner, du forventer, og leveres spækket med vores bedste privatlivsartikler i klassen.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Tilmeld dig ventelisten – vi giver dig besked, når det er din tur.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Du er på listen!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoritter";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Om DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Omkring";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo er en uafhængig virksomhed, grundlagt i 2008, der beskytter privatlivet på internettet for alle, der er trætte af at blive sporet online og ønsker en nem løsning. Vi er bevis på, at du kan få ægte beskyttelse af privatlivet online uden at gå på kompromis.\n\nDuckDuckGo-browseren kommer med de funktioner, du forventer af en standardbrowser, som bogmærker, faner, adgangskoder og meget mere, plus over [et dusin kraftfulde beskyttelser af privatlivet](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), som ikke tilbydes i de fleste populære browsere som standard. Dette unikke og omfattende sæt af beskyttelsesfunktioner hjælper med at beskytte dine onlineaktiviteter, fra søgning til browsing, e-mailing og meget mere.\n\nVores beskyttelse af privatlivet fungerer, uden at du behøver at vide noget om de tekniske detaljer eller håndtere komplicerede indstillinger. Det eneste, du skal gøre, er at skifte din browser til DuckDuckGo på alle dine enheder, så får du privatliv som standard.\n\nMen hvis du gerne vil have et kig under motorhjelmen, kan du finde flere oplysninger om, hvordan DuckDuckGos beskyttelse af privatlivet fungerer, på vores [hjælpesider](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Føj appen til din dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Tilføj widget til startskærmen";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Placering af adresselinje";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "udseende";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Åbn links i tilknyttede apps";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Deaktiver for at forhindre, at links automatisk åbnes i andre installerede apps.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Vis forslag til Autoudfyld";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Applikationslås";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Hvis Touch ID, Face ID eller en systemadgangskode er indstillet, bliver du bedt om at låse appen op, når du åbner.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Ryd data automatisk";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Administrer cookie pop op-vinduer";
+
+/* Settings title for the customize section */
+"settings.customize" = "Tilpas";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Angiv som standardbrowser";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-mailbeskyttelse";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Bloker e-mailtrackere, og skjul din adresse";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Del feedback";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Ildknap-animation";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Brandsikre websteder";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "App-ikon";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tastatur";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Mere fra DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Eksempler med lang tryk";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privatliv";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synkronisering og sikkerhedskopiering";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Tekststørrelse";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Indstillinger";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Ubeskyttede websteder";
+
+/* Settings cell for Version */
+"settings.version" = "Version";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privat stemmesøgning";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Indsend rapport";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Tillad mikrofonadgang i iOS-systemindstillinger for DuckDuckGo for at bruge stemmefunktioner.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "Okay";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofonadgang påkrævet";

--- a/DuckDuckGo/de.lproj/Localizable.strings
+++ b/DuckDuckGo/de.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Das Internet kann ein bisschen gruselig sein.\n\nKeine Sorge! Privat zu suchen und zu browsen ist einfacher als du denkst.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Deaktiviert";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Willkommen bei\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo für Mac hat die Geschwindigkeit, die du brauchst, die Browserfunktionen, die du erwartest, und ist vollgepackt mit unseren grundlegenden Funktionen für den Datenschutz.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Trage dich in die Warteliste ein, und wir benachrichtigen dich, wenn du an der Reihe bist.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Du stehst auf der Liste!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoriten";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Über DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Über";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo ist die unabhängige Firma für Internet-Datenschutz, die 2008 für alle gegründet wurde, die es leid sind, online getrackt zu werden, und eine einfache Lösung suchen. Wir sind der Beweis, dass du echten Online-Datenschutz ohne Kompromisse erhalten kannst.\n\nDer DuckDuckGo-Browser bietet die Funktionen, die von einem alltagstauglichen Browser erwartet werden, wie Lesezeichen, Tabs, Passwörter und mehr, sowie über [ein Dutzend leistungsstarke Datenschutzmaßnahmen](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), die in den meisten gängigen Browsern nicht standardmäßig angeboten werden. Dieser einzigartige, umfassende Datenschutz hilft dir, deine Online-Aktivitäten zu schützen – von der Suche über das Browsen bis hin zu E-Mails und vielem mehr.\n\nUnser Datenschutz funktioniert, ohne dass du etwas über die technischen Details wissen oder dich mit komplizierten Einstellungen auseinandersetzen musst. Du musst lediglich den Browser auf allen deinen Geräten auf DuckDuckGo umstellen und schon erhältst du echte Privatsphäre als Standard.\n\nWenn du jedoch einen Blick unter die Haube werfen möchtest, findest du auf unseren [Hilfeseiten](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/) weitere Informationen darüber, wie der Datenschutz bei DuckDuckGo funktioniert.";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "App zum Dock hinzufügen";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Widget zum Startbildschirm hinzufügen";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Position der Adressleiste";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Aussehen";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Links in den dazugehörigen Apps öffnen";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Aktivieren, damit sich Links nicht automatisch in anderen installierten Apps öffnen.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Vorschläge für die Autovervollständigung";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Anwendungssperre";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Wenn Touch ID, Face ID oder ein Systempasswort eingestellt sind, wirst du aufgefordert, die App beim Öffnen zu entsperren.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Daten automatisch löschen";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Cookie-Pop-ups verwalten";
+
+/* Settings title for the customize section */
+"settings.customize" = "Anpassen";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Als Standard-Browser festlegen";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-Mail-Schutz";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "E-Mail-Tracker blockieren und deine Adresse verbergen";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Feedback teilen";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animation der Schaltfläche „Feuer“";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Feuerfeste Seiten";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "App-Symbol";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tastatur";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Mehr von DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Vorschau durch langes Tippen";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privatsphäre";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synchronisieren und sichern";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Textgröße";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Design";
+
+/* Title for the Settings View */
+"settings.title" = "Einstellungen";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Ungeschützte Websites";
+
+/* Settings cell for Version */
+"settings.version" = "Version";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Private Sprachsuche";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Bericht senden";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Bitte erlaube den Mikrofonzugriff in den iOS-Systemeinstellungen, damit DuckDuckGo Sprachfunktionen nutzen kann.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofonzugriff erforderlich";

--- a/DuckDuckGo/el.lproj/Localizable.strings
+++ b/DuckDuckGo/el.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Το Διαδίκτυο μπορεί να είναι κάπως ανατριχιαστικό.\n\nΜην ανησυχείτε! Το να πραγματοποιείτε αναζήτηση και περιήγηση ιδιωτικά είναι πιο εύκολο απ' όσο νομίζετε.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Απενεργοποιήθηκε";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Καλώς ορίσατε στο\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "Το DuckDuckGo για Mac έχει την ταχύτητα που χρειάζεστε, τις λειτουργίες περιήγησης που αναμένετε και περιλαμβάνει τις καλύτερες δυνατότητες απορρήτου στην κατηγορία μας.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Εγγραφείτε στη λίστα αναμονής και θα σας ειδοποιήσουμε όταν έρθει η σειρά σας.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Βρίσκεστε στη λίστα!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Αγαπημένα";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Σχετικά με το DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Σχετικά";
+
 /* about page */
 "settings.about.text" = "Το DuckDuckGo αποτελεί την ανεξάρτητη εταιρεία προστασίας προσωπικών δεδομένων στο διαδίκτυο που ιδρύθηκε το 2008 για όσους έχουν βαρεθεί να παρακολουθούνται στο διαδίκτυο και επιθυμούν μια εύκολη λύση. Αποτελούμε τρανή απόδειξη ότι μπορείτε να αποκτήσετε πραγματική προστασία του απορρήτου σας στο διαδίκτυο χωρίς συμβιβασμούς.\n\nο πρόγραμμα περιήγησης DuckDuckGo διαθέτει τις λειτουργίες που περιμένετε από ένα πρόγραμμα περιήγησης, όπως σελιδοδείκτες, καρτέλες, κωδικούς πρόσβασης και πολλά άλλα, καθώς και πάνω από [δώδεκα ισχυρές λειτουργίες προστασίες απορρήτου](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) που δεν προσφέρονται από τα περισσότερα δημοφιλή προγράμματα περιήγησης βάσει προεπιλογής. Αυτό το μοναδικά ολοκληρωμένο σύνολο προστασίας του απορρήτου συμβάλλει στην προστασία των διαδικτυακών δραστηριοτήτων σας, από αναζήτηση έως περιήγηση, αποστολή email και πολλά άλλα.\n\nΗ προστασία απορρήτου μας λειτουργεί χωρίς να χρειάζεται να γνωρίζετε τις τεχνικές λεπτομέρειες ή να ασχολείστε με περίπλοκες ρυθμίσεις. Το μόνο που έχετε να κάνετε είναι να αλλάξετε το πρόγραμμα περιήγησής σας σε DuckDuckGo σε όλες τις συσκευές σας και θα έχετε ιδιωτικότητα βάσει προεπιλογής.\n\nΑλλά αν *θέλετε* να ρίξετε μια αναλυτική ματιά, μπορείτε να βρείτε περισσότερες πληροφορίες σχετικά με το πώς λειτουργούν οι προστασίες απορρήτου του DuckDuckGo στις [σελίδες της ενότητας Βοήθεια](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Προσθήκη εφαρμογής στο Dock σας";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Προσθήκη μικροεφαρμογής στην Αρχική οθόνη";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Θέση γραμμής διευθύνσεων";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Εμφάνιση";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Ανοίξτε τους συνδέσμους στις σχετικές εφαρμογές";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Απενεργοποιήστε για να αποτρέψετε το αυτόματο άνοιγμα συνδέσμων σε άλλες εγκατεστημένες εφαρμογές.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Εμφάνιση προτάσεων αυτόματης συμπλήρωσης";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Κλείδωμα εφαρμογής";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Εάν έχει οριστεί Touch ID, Face ID ή κωδικός πρόσβασης συστήματος, θα σας ζητηθεί να ξεκλειδώσετε την εφαρμογή κατά το άνοιγμά της.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Αυτόματη απαλοιφή δεδομένων";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Διαχείριση αναδυόμενων παραθύρων cookies";
+
+/* Settings title for the customize section */
+"settings.customize" = "Προσαρμογή";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Ορισμός ως προεπιλεγμένο πρόγραμμα περιήγησης";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Προστασία email";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Κοινοποίηση σχολίου";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Κινούμενο κουμπί φωτιάς";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Ασφαλείς ιστότοποι";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Παγκόσμιος έλεγχος απορρήτου (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Εικονίδιο Εφαρμογής";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Πληκτρολόγιο";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Περισσότερα από το DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Προεπισκοπήσεις με παρατεταμένο πάτημα";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Ιδιωτικότητα";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Συγχρονισμός και δημιουργία αντιγράφων ασφαλείας";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Μέγεθος κειμένου";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Θέμα";
+
+/* Title for the Settings View */
+"settings.title" = "Ρυθμίσεις";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Μη προστατευόμενοι ιστότοποι";
+
+/* Settings cell for Version */
+"settings.version" = "Έκδοση";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Ιδιωτική φωνητική αναζήτηση";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Υποβολή αναφοράς";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Επιτρέψτε πρόσβαση στο Μικρόφωνο από τις Ρυθμίσεις συστήματος iOS για να κάνει το DuckDuckGo χρήση των φωνητικών λειτουργιών.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "Εντάξει";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Απαιτείται πρόσβαση στο μικρόφωνο";

--- a/DuckDuckGo/es.lproj/Localizable.strings
+++ b/DuckDuckGo/es.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet puede ser un lugar horrible.\n\nNo te preocupes. Buscar y navegar de forma privada es más fácil de lo que piensas.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Desactivado";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "¡Bienvenido a\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo para Mac tiene la velocidad que necesitas, las funciones de navegación que esperas y viene repleta de nuestros mejores Privacy Essentials.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Únete a la lista de espera y te avisaremos cuando sea tu turno.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "¡Estás en la lista!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoritos";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Acerca de DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Acerca de";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo es la empresa de privacidad en internet independiente fundada en 2008 para quienes estén cansados de ser rastreados en línea y quieran una solución sencilla. Somos la prueba de que es posible obtener protección de privacidad real en línea sin concesiones.\n\nEl navegador DuckDuckGo incluye las funciones que esperas de un navegador de referencia, como marcadores, pestañas, contraseñas y más, así como más de [una docena de potentes funciones de protección de privacidad](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) no se ofrece en la mayoría de los navegadores populares de forma predeterminada. Este conjunto completo de funciones de protección de privacidad ayuda a proteger tu actividad en línea, desde la búsqueda hasta la navegación, el correo electrónico y mucho más.\n\nNuestra protección de privacidad funciona sin necesidad de conocimientos técnicos y sin tener que lidiar con configuraciones complicadas. Lo único que tienes que hacer es cambiar el navegador a DuckDuckGo en todos tus dispositivos y obtener privacidad de forma predeterminada.\n\nSin embargo, si quieres conocer los entresijos, puedes encontrar más información sobre cómo funcionan las protecciones de privacidad de DuckDuckGo en nuestras [páginas de ayuda](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Añadir una aplicación a tu Dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Añadir widget a la pantalla de inicio";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Posición de la barra de direcciones";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Apariencia";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Abrir enlaces en aplicaciones asociadas";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Desactivar para evitar que los enlaces se abran automáticamente en otras aplicaciones instaladas.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Sugerencias de autocompletado";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Bloqueo de aplicación";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Si se establece Touch ID, Face ID o una contraseña del sistema, deberás desbloquear la aplicación al abrirla.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Borrar datos automáticamente";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Administrar ventanas emergentes de cookies";
+
+/* Settings title for the customize section */
+"settings.customize" = "Personalizar";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Definir como navegador predeterminado";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Protección del correo electrónico";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Bloquea los rastreadores de correo electrónico y oculta tu dirección";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Compartir opiniones";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animación del botón Fuego";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Sitios web a prueba de fuego";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Control Global de Privacidad (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Icono de la aplicación";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Teclado";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Más sobre DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Vistas previas con pulsación larga";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privacidad";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sincronización y copia de seguridad";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Tamaño del texto";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Ajustes";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Sitios no protegidos";
+
+/* Settings cell for Version */
+"settings.version" = "Versión";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Búsqueda privada por voz";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Enviar informe";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Permite el acceso al micrófono en la configuración del sistema de iOS para que DuckDuckGo use las funciones de voz.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "De acuerdo";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Se requiere acceso al micrófono";

--- a/DuckDuckGo/et.lproj/Localizable.strings
+++ b/DuckDuckGo/et.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet võib olla üsna jube.\n\nÄra muretse! Privaatselt otsimine ja sirvimine on lihtsam kui arvad.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Keelatud";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Tere tulemast\nDuckDuckGo kasutajaks!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo for Mac on just nii kiire, kui vajad, oodatud sirvimisfunktsioonidega ja tulvil meie oma klassi parimaid privaatsuselemente.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Liitu ootenimekirjaga ja me anname teada, kui on sinu kord.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Oled ootenimekirjas!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Lemmikud";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "DuckDuckGo'st";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Teave";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo on 2008. aastal asutatud sõltumatu internetiprivaatsuse ettevõte igaühele, kellel on kõrini varjatud jälgimisest internetis ja kes soovib lihtsat lahendust selle vältimiseks. Me oleme tõestuseks, et internetis on võimalik saada tõelist privaatsuskaitset ilma kompromisse tegemata.\n\nDuckDuckGo brauseril on kõik funktsioonid, mida sa brauserilt ootad, nagu järjehoidjad, vahekaardid, paroolid ja palju muud, lisaks sellele aga ka üle [tosina võimsa privaatsuskaitse funktsiooni](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), mida enamik populaarsemaid brausereid vaikimisi ei paku. See ainulaadselt terviklik privaatsuskaitse aitab kaitsta sinu tegevust internetis alates otsingutest kuni sirvimiseni, meilide saatmiseni ja palju muuni.\n\nMeie privaatsuskaitse toimib ilma, et peaksid teadma midagi tehnilistest nüanssidest või tegelema keeruliste seadistustega. Ainus, mis sa pead tegema, on vahetada oma brauser kõigis seadmetes DuckDuckGo vastu – ja vaikeprivaatsus ongi tagatud.\n\nKui aga *soovid* piiluda kapoti alla, leiate lisateavet DuckDuckGo privaatsuskaitse tööpõhimõtete kohta meie [abilehtedelt](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Lisa rakendus oma dokki";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Lisa vidin avakuvale";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Aadressiriba asukoht";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Välimus";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Ava lingid seotud rakendustes";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Keela, et takistada linkide automaatset avanemist teistes installitud rakendustes.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Automaatselt täidetavad ettepanekud";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Rakenduse lukk";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Kui on määratud Touch ID, Face ID või süsteemi pääsukood, palutakse avamisel rakendus avada.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Kustuta andmed automaatselt";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Halda küpsiste hüpikaknaid";
+
+/* Settings title for the customize section */
+"settings.customize" = "Kohanda";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Määrake vaikebrauseriks";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-posti kaitse";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokeeri meilijälgurid ja peida oma aadress";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Jaga tagasisidet";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Tulenupu animatsioon";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Tulekindlad veebisaidid";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Üleilmne privaatsuskontroll (Global Privacy Control (GPC))";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Rakenduse ikoon";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Klaviatuur";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Veel DuckDuckGo'lt";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Pika vajutusega eelvaated";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privaatsus";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sünkroonimine ja varundamine";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Teksti suurus";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Teema";
+
+/* Title for the Settings View */
+"settings.title" = "Seaded";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Kaitseta saidid";
+
+/* Settings cell for Version */
+"settings.version" = "Versioon";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privaatne häälotsing";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Saada aruanne";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Häälfunktsioonide kasutamiseks lubage DuckDuckGo jaoks juurdepääs mikrofonile iOS-i süsteemiseadetes.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Vajalik juurdepääs mikrofonile";

--- a/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/DuckDuckGo/fi.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet voi olla pelottava paikka.\n\nMutta ei hätää! Yksityinen haku ja selaaminen on helpompaa kuin luulet.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Pois käytöstä";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Tervetuloa\nDuckDuckGo-sovellukseen!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "Macin DuckDuckGo tarjoaa kaipaamasi nopeuden, odottamasi selaintoiminnot ja luokkansa parhaat tietosuojaominaisuudet.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Tule odotuslistalle, niin ilmoitamme milloin on sinun vuorosi.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Olet odotuslistalla!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Suosikit";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Tietoa DuckDuckGo:sta";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Tietoja";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo on vuonna 2008 perustettu riippumaton internetissä tietosuojaa tarjoava yritys niille, jotka ovat kyllästyneet siihen, että heitä seurataan netissä, ja haluavat yksinkertaisen ratkaisun. Olemme todiste siitä, että voit saada todellista tietosuojaa verkossa ilman kompromisseja.\n\nDuckDuckGo-selaimessa on kaikki parhaiden selainten ominaisuudet, kuten kirjanmerkit, välilehdet, salasanat ja paljon muuta, sekä yli [kymmenkunta tehokasta tietosuojausta](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) ei tarjolla oletuksena suosituimmissa selaimissa. Tämä ainutlaatuisen kattava tietosuoja auttaa turvaamaan haut, selaamisen, sähköpostin lähettämiseen ja muun toimintasi verkossa.\n\nTietosuojamme toimivat, vaikka et tietäisi mitään teknisistä yksityiskohdista tai osaisi käsitellä monimutkaisia asetuksia. Sinun tarvitsee vain vaihtaa selaimesi DuckDuckGohon kaikilla laitteillasi, ja saat tietosuojan oletuksena.\n\nJos kuitenkin haluat kurkistaa konepellin alle, lisätietoja DuckDuckGon tietosuojan toiminnasta on [ohjesivuillamme](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Lisää sovellus telakkaasi";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Lisää widget aloitusnäyttöön";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Osoitepalkin sijainti";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Ulkoasu";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Avaa linkit liittyvissä sovelluksissa";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Ota pois käytöstä estääksesi linkkejä avautumasta automaattisesti muissa asennetuissa sovelluksissa.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Näytä automaattisen täydennyksen ehdotukset";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Sovelluksen lukitus";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Jos käytössä on Touch ID, Face ID tai järjestelmän salasana, sinua pyydetään poistamaan lukitus, kun avaat sovelluksen.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Tyhjennä tiedot automaattisesti";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Evästeiden hallinnan ponnahdusikkunat";
+
+/* Settings title for the customize section */
+"settings.customize" = "Mukauta";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Aseta oletusselaimeksi";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Sähköpostisuojaus";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Estä sähköpostiseuraajat ja piilota osoitteesi";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Jaa palaute";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Liekki-painikkeen animaatio";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Tee sivustoista palonkestäviä";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Sovelluskuvake";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Näppäimistö";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Lisää DuckDuckGolta";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Esikatselu pitkällä painalluksella";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Tietosuoja";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synkronoi ja varmuuskopioi";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Tekstin koko";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Teema";
+
+/* Title for the Settings View */
+"settings.title" = "Asetukset";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Suojaamattomat sivustot";
+
+/* Settings cell for Version */
+"settings.version" = "Versio";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Yksityinen äänihaku";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Lähetä raportti";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Salli mikrofonin käyttö DuckDuckGolle iOS-järjestelmäasetuksissa, jotta voit käyttää ääniominaisuuksia.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofonin käyttöoikeus vaaditaan";

--- a/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/DuckDuckGo/fr.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet peut être intrusif.\n\nMais ne vous inquiétez pas ! Rechercher et naviguer de manière confidentielle est plus facile que vous ne le pensez.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Désactivé";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Bienvenue sur\nDuckDuckGo !";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo pour Mac répond à vos besoins de rapidité et de fonctionnalités de navigation, et dispose des meilleurs outils de leur catégorie pour protéger votre vie privée.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Inscrivez-vous sur la liste d'attente et nous vous informerons quand viendra votre tour.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Vous êtes sur liste d'attente !";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoris";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "À propos de DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "À propos";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo est une société indépendante de confidentialité sur internet fondée en 2008, destinée à tous ceux qui en ont assez d'être suivis en ligne et qui veulent une solution simple. Nous sommes la preuve que vous pouvez bénéficier d'une véritable protection de la confidentialité en ligne, sans avoir à faire de compromis.\n\nLe navigateur DuckDuckGo est doté des fonctionnalités que vous attendez d'un navigateur de référence, comme les signets, les onglets et les mots de passe, entre autres, auxquels s'ajoutent plus d'[une douzaine de protections puissantes de la confidentialité](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) que la plupart des navigateurs populaires ne proposent pas par défaut. Cet ensemble unique et complet de protections de la confidentialité permet de préserver vos activités en ligne, de la recherche à la navigation, en passant par l'envoi d'e-mails, etc.\n\nInutile de s'y connaître en détails techniques ou de gérer des paramètres complexes pour faire fonctionner nos protections de la confidentialité. Il vous suffit d'opter pour le navigateur DuckDuckGo sur tous vos appareils afin de pouvoir bénéficier de la confidentialité par défaut.\n\nMais si vous voulez vous faire une idée, vous trouverez plus d'informations sur le fonctionnement des protections de la confidentialité DuckDuckGo sur nos [pages d'aide](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Ajouter l'application à votre Dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Ajouter le widget à l'écran d'accueil";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Position de la barre d'adresse";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Apparence";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Ouvrir les liens dans les applications associées";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Désactiver pour empêcher l'ouverture automatique des liens dans d'autres applications installées.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Afficher les suggestions de saisie semi-automatique";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Verrouillage de l'application";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Si Touch ID, Face ID ou un code d'accès au système est mis en place, il vous sera demandé de déverrouiller l'application lors de l'ouverture.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Effacer automatiquement les données";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Gérer les fenêtres contextuelles (cookies)";
+
+/* Settings title for the customize section */
+"settings.customize" = "Personnaliser";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Définir comme navigateur par défaut";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Protection des e-mails";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Bloquez les traqueurs d'e-mails et masquez votre adresse";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Partagez vos commentaires";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animation du bouton en forme de flamme";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Sites coupe-feu";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Icône de l'appli";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Clavier";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Plus de la part de DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Aperçus obtenus en appuyant longuement";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Confidentialité";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synchronisation et sauvegarde";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Taille du texte";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Thème";
+
+/* Title for the Settings View */
+"settings.title" = "Paramètres";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Sites non protégés";
+
+/* Settings cell for Version */
+"settings.version" = "Version";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Recherche vocale privée";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Envoyer le rapport";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Veuillez autoriser l'accès au microphone dans les réglages système iOS pour que DuckDuckGo puisse utiliser les fonctionnalités vocales.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Accès au microphone requis";

--- a/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/DuckDuckGo/hr.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet može biti pomalo neugodan.\n\nNe brini! Privatno pretraživanje i pregledavanje lakše je nego što misliš.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Onemogućeno";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Dobro došao/la u\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "Aplikacija DuckDuckGo za Mac pruža ti potrebnu brzinu i značajke pretraživanja kakve očekuješ, a isporučuje se s našim najboljim alatima za privatnost u svojoj klasi - privacy essentials.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Pridruži se listi čekanja, a mi ćemo te obavijestiti kada dođeš na red.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Na popisu ste!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Omiljeno";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "O DuckDuckGou";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "O nama";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo neovisna je tvrtka za privatnost na internetu osnovana 2008. godine. Namijenjena je svakome tko je umoran od toga da ga prate na internetu i želi jednostavno rješenje za to. Mi smo dokaz da je prava zaštita privatnosti na internetu moguća bez kompromisa.\n\nPreglednik DuckDuckGo dolazi sa značajkama koje očekujete od preglednika, kao što su oznake, kartice, lozinke i još mnogo toga, plus više od [desetak moćnih zaštita privatnosti](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) nije ponuđeno u većini popularnih preglednika prema zadanim postavkama. Ovaj jedinstveno sveobuhvatan skup zaštita privatnosti pomaže u zaštiti tvojih mrežnih aktivnosti, od pretraživanja do pregledavanja, slanja e-pošte i još mnogo toga.\n\nNaša zaštita privatnosti funkcionira bez potrebe da znamo bilo što o tehničkim detaljima ili da se bavimo kompliciranim postavkama. Sve što trebaš učiniti jest prebaciti svoj preglednik na DuckDuckGo na svim svojim uređajima i prema zadanim postavkama dobivaš našu zaštitu privatnosti.\n\nAli ako *želite* zaviriti \"ispod haube\", više o tome kako DuckDuckGo zaštita privatnosti funkcionira možeš pronaći na našim [stranicama pomoći](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Dodajte aplikaciju na Dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Dodajte widget na početni zaslon";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Položaj adresne trake";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Izgled";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Otvori veze u povezanim aplikacijama";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Onemogući da spriječiš automatsko otvaranje poveznica u drugim instaliranim aplikacijama.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Prikaži prijedloge za automatsko ispunjavanje";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Zaključavanje aplikacije";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Ako su postavljeni Touch ID, Face ID ili pristupni kôd sustava, od tebe će se tražiti da otključaš aplikaciju prilikom otvaranja.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Automatsko brisanje podataka";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Upravljanje skočnim prozorima kolačića";
+
+/* Settings title for the customize section */
+"settings.customize" = "Prilagodba";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Postavi kao zadani preglednik";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Zaštita e-pošte";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokiraj programe za praćenje e-pošte i sakrij svoju adresu";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Podijeli povratne informacije";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animacija gumba Vatre";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Zaštićena web-mjesta";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Globalna kontrola privatnosti (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Ikona aplikacije";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tipkovnica";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Više od DuckDuckGoa";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Pretpregledi na dugi pritisak";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Zaštita privatnosti";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sinkronizacija i sigurnosno kopiranje";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Veličina teksta";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Postavke";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Nezaštićena web-mjesta";
+
+/* Settings cell for Version */
+"settings.version" = "Verzija";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privatno glasovno pretraživanje";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Pošalji izvješće";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Dopustite pristup mikrofonu u postavkama sustava iOS kako bi DuckDuckGo mogao koristiti glasovne funkcije.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "U redu";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Potreban je pristup mikrofonu";

--- a/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/DuckDuckGo/hu.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Az internet meglehetősen undok hely lehet.\n\nNe aggódj! A bizalmas keresés és böngészés egyszerűbb, mint hinnéd.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Letiltva";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Üdvözlünk a\nDuckDuckGo-ban!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "A DuckDuckGo Mac verziója gyors, böngészési funkciókban gazdag, és kategóriája legjobb adatvédelmi megoldásait kínálja.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Iratkozz fel a várólistára, és értesítést kapsz, ha rád kerül a sor.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Felkerültél a listára!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Kedvencek";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "A DuckDuckGóról";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Rólunk";
+
 /* about page */
 "settings.about.text" = "A 2008-ban alapított független internetes adatvédelmi cég, a DuckDuckGo egyszerű megoldást kínál azoknak, akiknek elegük van abból, hogy állandóan nyomon követik őket az interneten. Mi vagyunk annak a bizonyítéka, hogy kompromisszumok nélkül is lehet valódi online adatvédelmet biztosítani.\n\nA DuckDuckGo böngésző rendelkezik a böngészőktől elvárt funkciókkal, mint például könyvjelzők, lapok, jelszavak és egyéb funkciók, valamint több mint [egy tucat olyan hatékony adatvédelmi megoldással](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), amelyet a legtöbb népszerű böngésző nem kínál alapértelmezés szerint. Ezek az egyedülállóan átfogó adatvédelmi megoldások segítenek megvédeni online tevékenységeid, legyen szó keresésről, böngészésről, e-mailezésről vagy sok minden másról.\n\nAdatvédelmi megoldásaink anélkül működnek, hogy bármit is tudnod kellene a technikai részletekről vagy bonyolult beállításokkal kellene foglalkoznod. Mindössze annyit kell tenned, hogy minden eszközödön a DuckDuckGo böngészőre váltasz, és máris igénybe veheted az alapértelmezés szerinti adatvédelmet.\n\nHa azonban *igazán* szeretnél bepillantani a motorháztető alá is, a [súgóoldalainkon](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/) további információkat találhatsz a DuckDuckGo adatvédelmi megoldásainak működéséről.";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Alkalmazás hozzáadása a dokkodhoz";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Minialkalmazás hozzáadása a kezdőképernyőhöz";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Címsor elhelyezkedése";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Megjelenés";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Hivatkozások megnyitása társított alkalmazásokban";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Letiltásával megakadályozhatod, hogy a hivatkozások automatikusan megnyíljanak más telepített alkalmazásokban.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Automatikus kiegészítési javaslatok megjelenítése";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Alkalmazás zárolás";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Ha be van állítva ujjlenyomat- vagy arcfelismerés, illetve rendszerjelszó, megnyitásakor fel kell oldanod az alkalmazást.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Adatok automatikus törlése";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Felugró sütiablakok kezelése";
+
+/* Settings title for the customize section */
+"settings.customize" = "Testreszabás";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Beállítás alapértelmezett böngészőként";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-mail védelem";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "E-mail nyomkövetők letiltása, és a cím elrejtése";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Visszajelzés megosztása";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Tűz gomb animáció";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Tűzálló weboldalak";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Nemzetközi adatvédelmi szabályozás (Global Privacy Control, GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Alkalmazásikon";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Billentyűzet";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Továbbiak a DuckDuckGo-tól";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Hosszú lenyomásos előnézetek";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Adatvédelem";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Szinkronizálás és biztonsági mentés";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Szövegméret";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Kinézet";
+
+/* Title for the Settings View */
+"settings.title" = "Beállítások";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Védelem nélküli weboldalak";
+
+/* Settings cell for Version */
+"settings.version" = "Változat";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privát beszédhangalapú keresés";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Jelentés beküldése";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "A beszédhangfunkciók használatához az iOS rendszerbeállításaiban engedélyezd a DuckDuckGo számára a Mikrofon-hozzáférést.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofon-hozzáférés szükséges";

--- a/DuckDuckGo/it.lproj/Localizable.strings
+++ b/DuckDuckGo/it.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet può essere un po' inquietante.\n\nNon preoccuparti! Effettuare ricerche e navigare in modo privato è più facile di quanto pensi.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Disattivato";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "DuckDuckGo\nti dà il benvenuto!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo per Mac ti offre la velocità di cui hai bisogno, le funzioni di navigazione che desideri e i migliori strumenti per la privacy.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Iscriviti alla lista d'attesa e ti avviseremo quando sarà il tuo turno.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Sei in lista d'attesa.";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Preferiti";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Info su DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Informazioni";
+
 /* about page */
 "settings.about.text" = "Fondata nel 2008, DuckDuckGo è un'azienda indipendente che tutela la privacy online per tutti coloro che sono stanchi di essere tracciati online e vogliono una soluzione semplice. Siamo la dimostrazione che si può garantire una vera protezione della privacy online senza compromessi.\n\nIl browser DuckDuckGo è ricco di funzioni essenziali come i segnalibri, le schede, le password e molto altro ancora, [oltre a numerose e potenti protezioni della privacy](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) che normalmente non vengono offerte dai browser più comuni. Stiamo parlando di uno straordinario set completo per la protezione della privacy, che aiuta a proteggere le attività online, dalla ricerca alla navigazione, alle e-mail e molto altro ancora.\n\nCon le nostre protezioni della privacy non è necessario conoscere particolari tecnici o dover affrontare configurazioni complesse. È sufficiente scegliere il browser DuckDuckGo su tutti i dispositivi personali per avere automaticamente garantita la privacy.\n\nPer saperne di più su come funzionano le protezioni della privacy di DuckDuckGo, è possibile consultare le nostre [pagine di aiuto](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Aggiungi app al tuo dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Aggiungi widget alla schermata iniziale";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Posizione Barra degli indirizzi";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Aspetto";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Apri i collegamenti nelle loro app associate";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Disattiva per impedire che i collegamenti si aprano automaticamente in altre app installate.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Mostra suggerimenti di completamento automatico";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Blocco applicazione";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Se hai impostato Touch ID, Face ID o un codice di accesso al sistema, ti verrà richiesto di sbloccare l'app all'apertura.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Cancellazione automatica dei dati";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Gestione popup dei cookie";
+
+/* Settings title for the customize section */
+"settings.customize" = "Personalizza";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Imposta come browser predefinito";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Protezione email";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blocca i sistemi di tracciamento delle email e nascondi il tuo indirizzo";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Condividi feedback";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animazione pulsante fuoco";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Siti protetti";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Icona dell'app";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tastiera";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Ulteriori informazioni su DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Anteprime con pressione prolungata";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privacy";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sincronizzazione e backup";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Dimensione testo";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Impostazioni";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Siti non protetti";
+
+/* Settings cell for Version */
+"settings.version" = "Versione";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Ricerca vocale privata";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Invia segnalazione";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Consenti l'accesso al microfono nelle impostazioni di sistema di iOS, in modo che DuckDuckGo possa utilizzare le funzioni vocali.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Accesso al microfono obbligatorio";

--- a/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/DuckDuckGo/lt.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internetas gali būti bauginantis.\n\nNesijaudink! Ieškoti ir naršyti privačiai yra lengviau, nei manai.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Išjungta";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Sveiki atvykę į\n„DuckDuckGo“!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "„Mac“ skirta „DuckDuckGo“ pasižymi jums reikiama sparta, naršymo funkcijomis ir aukščiausios klasės privatumo įrankiais.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Prisijunkite prie laukiančiųjų sąrašo ir mes jums pranešime, kai ateis jūsų eilė.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Esate sąraše!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Mėgstami";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Apie DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Apie";
+
 /* about page */
 "settings.about.text" = "„DuckDuckGo“ yra nepriklausoma interneto privatumo bendrovė, įkurta 2008 metais ir skirta visiems, kurie pavargo nuo sekimo internete ir nori lengvo sprendimo. Esame įrodymas, kad galite gauti tikrą privatumo apsaugą internete be kompromisų.\n\n„DuckDuckGo“ naršyklėje yra funkcijos, kurių tikitės iš pagrindinės naršyklės, pvz., žymės, skirtukai, slaptažodžiai ir dar daugiau, taip pat [keliolika galingų privatumo apsaugos priemonių](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) pagal numatytuosius nustatymus nėra siūlomas daugelyje populiarių naršyklių. Šis unikalus išsamus privatumo apsaugos rinkinys padeda apsaugoti jūsų veiklą internete – nuo paieškos iki naršymo, el. pašto ir kt.\n\nMūsų privatumo apsaugos priemonės veikia nereikalaudamos nieko žinoti apie technines detales ar naudotis sudėtingais nustatymais. Tereikia visuose įrenginiuose perjungti naršyklę į „DuckDuckGo“ ir privatumas bus užtikrintas pagal numatytuosius nustatymus.\n\nTačiau jei norite žvilgtelėti po gaubtu, daugiau informacijos apie tai, kaip veikia „DuckDuckGo“ privatumo apsauga, galite rasti mūsų [pagalbos puslapiuose] (ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Įtraukti programėlę į stotelę";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Įtraukti valdiklį į pagrindinį ekraną";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Adreso juostos padėtis";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Išvaizda";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Atidaryti nuorodas susijusiose programose";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Išjungti, kad nuorodos automatiškai neatsidarytų kitose įdiegtose programose.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Rodyti automatinio užbaigimo pasiūlymus";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Programos užraktas";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Jei nustatytas „Touch ID“, „Face ID“ arba sistemos slaptažodis, prieš atidarydami būsite paprašyti atrakinti programą.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Automatiškai valyti duomenis";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Valdyti slapukų iššokančiuosius langus";
+
+/* Settings title for the customize section */
+"settings.customize" = "Tinkinti";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Nustatyti kaip numatytąją naršyklę";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "El. pašto apsauga";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokuokite el. laiškų sekimo priemones ir paslėpkite savo adresą";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Bendrinti atsiliepimą";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Mygtuko „Fire“ animacija";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Apsaugoti svetaines";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Visuotinė privatumo kontrolė (VPK)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Programėlės piktograma";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Klaviatūra";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Daugiau iš „DuckDuckGo“";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Peržiūros ilgai spaudžiant";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privatumas";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sinchronizuoti ir kurti atsarginę kopiją";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Teksto dydis";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Nustatymai";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Neapsaugotos svetainės";
+
+/* Settings cell for Version */
+"settings.version" = "Versija";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privati paieška balsu";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Pateikti ataskaitą";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Patvirtinkite prieigą prie mikrofono „iOS“ sistemos nustatymuose, kad galėtumėte naudotis „DuckDuckGo“ balsu valdomomis funkcijomis.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "GERAI";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Būtina prieiga prie mikrofono";

--- a/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/DuckDuckGo/lv.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internets var būt diezgan “mežonīgs”.\n\nBet neuztraucies! Meklēt un pārlūkot privātā režīmā ir vieglāk, nekā tu domā.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Atspējota";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Laipni lūdzam\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo Mac datoram sniedz nepieciešamo ātrumu, ierastās pārlūkošanas funkcijas un savā klasē labākās privātuma pamatfunkcijas.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Pievienojies gaidīšanas sarakstam, un mēs paziņosim, kad pienāks tava kārta.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Tu esi sarakstā!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Izlase";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Par DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Par";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo ir neatkarīgs 2008. gadā dibināts interneta privātuma uzņēmums ikvienam, kam ir apnikusi izsekošana tiešsaistē un kas vēlas vienkāršu risinājumu. Mēs esam pierādījums tam, ka tiešsaistē var iegūt reālu privātuma aizsardzību bez kompromisiem.\n\nDuckDuckGo pārlūks sniedz visas iespējas, ko gaidi no pārlūkprogrammas, piemēram, grāmatzīmes, cilnes, paroles un citas, kā arī vairāk nekā [duci spēcīgu privātuma aizsardzības funkciju](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) pēc noklusējuma netiek piedāvāts lielākajā daļā populārāko pārlūkprogrammu. Šis unikāli visaptverošais privātuma aizsardzības komplekts palīdz aizsargāt tavas darbības tiešsaistē, sākot no meklēšanas līdz pārlūkošanai, e-pasta sūtīšanai u.c.\n\nMūsu privātuma aizsardzība darbojas vienmēr – tev nav jāpārzina sarežģīti tehniskie aspekti vai iestatījumi. Tev vienkārši jālieto DuckDuckGo pārlūks visās savās ierīcēs, un privātums būs tavs standarta risinājums.\n\nBet, ja vēlies paskatīties, kas lācītim vēderā, vairāk informācijas par to, kā darbojas DuckDuckGo privātuma aizsardzība, vari atrast mūsu [palīdzības lapās](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Pievienot lietotni dokam";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Pievienot logrīku sākuma ekrānam";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Adreses joslas pozīcija";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Parādas";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Atvērt saites saistītajās lietotnēs";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Atspējo, lai novērstu saišu automātisku atvēršanu citās instalētajās lietotnēs.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Automātiski pabeigt ieteikumus";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Lietojumprogrammas bloķēšana";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Ja ir iestatīts Touch ID, Face ID vai sistēmas piekļuves kods, atverot lietotni, tev tā būs jāatbloķē.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Automātiski notīrīt datus";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Pārvaldīt sīkfailu uznirstošos logus";
+
+/* Settings title for the customize section */
+"settings.customize" = "Pielāgošana";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Iestatīt kā noklusējuma pārlūku";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-pasta aizsardzība";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Bloķē e-pasta izsekotājus un paslēp savu adresi";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Kopīgot atsauksmi";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Uguns pogas animācija";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Ugunsdrošas vietnes";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Globālā privātuma kontrole (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Lietotnes ikona";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tastatūra";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Vairāk no DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Ilgas nospiešanas rezultātu priekšskatījumi";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privātums";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sinhronizācija un dublēšana";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Burtu izmērs";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Motīvs";
+
+/* Title for the Settings View */
+"settings.title" = "Iestatījumi";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Neaizsargātas vietnes";
+
+/* Settings cell for Version */
+"settings.version" = "Versija";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privātā balss meklēšana";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Iesniegt ziņojumu";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Lūdzu, atļauj piekļuvi mikrofonam iOS sistēmas iestatījumos, lai DuckDuckGo varētu izmantot balss funkcijas.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "Labi";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Nepieciešama piekļuve mikrofonam";

--- a/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/DuckDuckGo/nb.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internettet kan være ganske skummelt.\n\nMen ikke vær redd! Det er enklere enn du tror å søke og surfe privat.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Deaktivert";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Velkommen til\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo for Mac har hastigheten du trenger, nettleserfunksjonene du forventer, og er stappfull av våre førsteklasses personvernfunksjoner.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Sett deg på ventelisten, så varsler vi deg når det er din tur.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Du står på listen!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoritter";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Om DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Om";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo er et uavhengig personvernselskap som ble grunnlagt i 2008, for alle som er lei av å bli sporet på nettet og vil ha en enkel løsning. Vi er beviset på at ekte personvern er mulig på nettet uten å fire på kravene.\n\nDuckDuckGo-nettleseren har funksjoner du kan forvente i en vanlig nettleser, som bokmerker, faner, passord med mer, pluss over [en rekke kraftige personvernfunksjoner](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) ikke tilbys i de fleste populære nettlesere som standard. Disse usedvanlig omfattende personvernfunksjonene bidrar til å beskytte nettaktivitetene dine, fra søk til surfing, e-poster med mer.\n\nPersonvernfunksjonene fungerer uten at du behøver å kunne noe om de tekniske detaljene eller forholde deg til kompliserte innstillinger. Det eneste du behøver å gjøre, er å bytte nettleser til DuckDuckGo på alle enhetene dine, så får du personvern som standard.\n\nMen hvis du *vil* ta en titt under panseret, kan du finne mer informasjon om hvordan DuckDuckGos personvern fungerer på våre [hjelpesider](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Legg til appen i docken";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Legg til widgeten på startskjermen";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Plassering av adressefelt";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Utseende";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Åpne lenker i tilknyttede apper";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Deaktiver for å forhindre at lenker automatisk åpnes i andre installerte apper.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Vis forslag fra autofullføring";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Applås";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Hvis du har touch-ID, face-ID eller systempassord, blir du bedt om å låse opp appen når du åpner den.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Slett data automatisk";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Administrer vinduer om informasjonskapsler";
+
+/* Settings title for the customize section */
+"settings.customize" = "Tilpass";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Gjør til standardnettleser";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-postbeskyttelse";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokker e-postsporere og skjul adressen din";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Del tilbakemelding";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animasjon for brannknappen";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Brannsikre nettsteder";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Appikon";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tastatur";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Mer fra DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Forhåndsvisning ved å trykke og holde";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Personvern";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synkronisering og sikkerhetskopiering";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Tekststørrelse";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Utseende";
+
+/* Title for the Settings View */
+"settings.title" = "Innstillinger";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Ubeskyttede nettsteder";
+
+/* Settings cell for Version */
+"settings.version" = "Versjon";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privat talesøk";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Send inn rapport";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "For å bruke talefunksjoner må du gi DuckDuckGo mikrofontilgang i systeminnstillingene i iOS.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofontilgang kreves";

--- a/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/DuckDuckGo/nl.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet kan best eng zijn.\n\nMaak je geen zorgen! Privé zoeken en browsen is eenvoudiger dan je denkt.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Uitgeschakeld";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Welkom bij\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo voor Mac heeft de snelheid die je nodig hebt en de browsefuncties die je verwacht, en zit boordevol met onze allerbeste privacy essentials.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Schrijf je in op de wachtlijst, dan laten wij je weten wanneer je Network Protection kan testen.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Je staat op de lijst!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favorieten";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Over DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Over";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo is het onafhankelijke internetprivacybedrijf, opgericht in 2008, voor iedereen die het beu is om online gevolgd te worden en daar een eenvoudige oplossing voor wil. Wij zijn het bewijs dat je privacy op internet écht beschermd kan worden zonder compromissen.\n\nDe DuckDuckGo-browser wordt geleverd met de functies die je van een webbrowser verwacht, zoals bladwijzers, tabbladen, wachtwoorden en meer, plus meer dan [een dozijn krachtige tools om je privacy te beschermen](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) die niet standaard worden aangeboden in de meeste populaire browsers. Deze unieke, uitgebreide privacybescherming helpt je online activiteiten te beschermen – of je nu zoekt, surft of mailt.\n\nJe hoeft niets te weten over de technische details of ingewikkelde instellingen om te profiteren van onze privacybescherming. Je hoeft alleen maar DuckDuckGo op al je apparaten te installeren en geniet dan standaard van privacy.\n\nMaar als je *een kijkje onder de motorkap* wilt, vind je meer informatie over de privacybescherming van DuckDuckGo op onze [hulppagina's](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "App toevoegen aan je dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Widget toevoegen aan startscherm";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Positie van adresbalk";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Uiterlijk";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Links openen in bijbehorende apps";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Uitschakelen om te voorkomen dat links automatisch geopend worden in andere geïnstalleerde apps.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Suggesties voor automatisch aanvullen weergeven";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "App-vergrendeling";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Als je Touch ID, Face ID of een systeemwachtwoord hebt ingesteld, word je gevraagd om de app te ontgrendelen als je deze opent.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Gegevens automatisch wissen";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Cookiepop-ups beheren";
+
+/* Settings title for the customize section */
+"settings.customize" = "Aanpassen";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Instellen als standaardbrowser";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-mailbescherming";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokkeer e-mailtrackers en verberg je adres";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Feedback delen";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animatie vuurknop";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Brandveilige websites";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "App-pictogram";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Toetsenbord";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Meer over DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Voorbeeldweergave bij lang indrukken";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privacy";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synchronisatie en back-up";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Lettergrootte";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Thema";
+
+/* Title for the Settings View */
+"settings.title" = "Instellingen";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Onbeschermde sites";
+
+/* Settings cell for Version */
+"settings.version" = "Versie";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Private spraakzoekopdracht";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Rapport versturen";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Sta microfoontoegang toe in de iOS-systeeminstellingen zodat DuckDuckGo spraakfuncties kan gebruiken.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Toegang tot microfoon vereist";

--- a/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/DuckDuckGo/pl.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet może być trochę nieprzyjemny.\n\nBez obaw! Prywatne wyszukiwanie i przeglądanie jest łatwiejsze niż myślisz.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Wyłączone";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Witamy\nw DuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "Aplikacja DuckDuckGo dla komputerów Mac zapewnia szybkość, której potrzebujesz, i niezbędne funkcje przeglądania. Ponadto jest wyposażona w najlepsze w swojej klasie narzędzia do ochrony prywatności.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Dołącz do listy oczekujących, aby otrzymać powiadomienie, gdy nadejdzie Twoja kolej.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Jesteś na liście!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Ulubione";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "O DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Informacje";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo to założona w 2008 roku niezależna firma zajmująca się prywatnością w Internecie dla osób, które mają dosyć śledzenia online i poszukują łatwego w obsłudze rozwiązania. Jesteśmy dowodem na to, że możesz uzyskać prawdziwą ochronę prywatności online bez kompromisów.\n\nPrzeglądarka DuckDuckGo jest wyposażona w funkcje, których potrzebujesz, takie jak zakładki, karty, hasła i inne, a także [kilkanaście zaawansowanych mechanizmów ochrony prywatności](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), które nie są domyślnie oferowane w większości popularnych przeglądarek. Ten wyjątkowo zaawansowany zestaw mechanizmów ochrony prywatności pomaga chronić działania w Internecie, od wyszukiwania po przeglądanie, obsługę wiadomości e-mail i nie tylko.\n\nDo korzystania z mechanizmów ochrony prywatności nie jest wymagana znajomość szczegółów technicznych ani skomplikowane ustawienia. Aby uzyskać ochronę prywatności, wystarczy ustawić na wszystkich urządzeniach domyślną przeglądarkę DuckDuckGo.\n\nJeśli interesują Cię szczegóły techniczne, więcej informacji o działaniu mechanizmów ochrony prywatności DuckDuckGo można znaleźć na [stronach pomocy](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Dodaj aplikację do Docka";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Dodaj widżet do ekranu głównego";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Pozycja paska adresu";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Wygląd";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Otwieraj łącza w powiązanych aplikacjach";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Wyłącz, aby uniemożliwić automatyczne otwieranie łączy w innych zainstalowanych aplikacjach.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Pokaż sugestie autouzupełniania";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Blokada aplikacji";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Jeśli ustawiono Touch ID, Face ID lub hasło systemowe, pojawi się prośba o odblokowanie aplikacji podczas otwierania.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Automatyczne czyszczenie danych";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Zarządzaj okienkami z prośbą o zgodę";
+
+/* Settings title for the customize section */
+"settings.customize" = "Spersonalizuj";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Ustaw jako domyślną przeglądarkę";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Ochrona poczty e-mail";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Zablokuj skrypty śledzące pocztę e-mail i ukryj swój adres";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Podziel się opinią";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animacja przycisku ognia";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Bezpieczne witryny internetowe";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Globalna Kontrola Prywatności (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Ikona aplikacji";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Klawiatura";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Więcej możliwości DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Podglądy po dłuższym przyciśnięciu";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Prywatność";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synchronizacja i kopia zapasowa";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Rozmiar tekstu";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Motyw";
+
+/* Title for the Settings View */
+"settings.title" = "Ustawienia";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Niezabezpieczone witryny";
+
+/* Settings cell for Version */
+"settings.version" = "Wersja";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Prywatne wyszukiwanie głosowe";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Prześlij raport";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Aby korzystać z funkcji głosowych, zezwól na dostęp DuckDuckGo do mikrofonu w ustawieniach systemu iOS.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Wymagany dostęp do mikrofonu";

--- a/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/DuckDuckGo/pt.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "A Internet pode ser um pouco assustadora.\n\nMas não se preocupe! Pesquisar e navegar em privado é mais fácil do que pensa.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Desativado";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Damos-lhe as boas-vindas ao\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "O DuckDuckGo para Mac tem a velocidade de que necessita, as funcionalidades de navegação que espera e os nossos Privacy Essentials líderes no setor.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Entra na lista de espera. Avisamos-te quando for a tua vez.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Está na lista!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoritos";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Sobre o DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Acerca de";
+
 /* about page */
 "settings.about.text" = "A DuckDuckGo é a empresa independente de privacidade na Internet fundada em 2008 para quem está cansado de ser rastreado online e quer uma solução simples. Somos a prova de que podes proteger a tua privacidade online sem compromissos.\n\nO navegador DuckDuckGo vem com as funcionalidades que esperas num navegador de referência, como marcadores, separadores, palavras-passe, entre outras, além de mais de [uma dúzia de proteções de privacidade poderosas](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) que os navegadores mais populares não oferecem por predefinição. Este conjunto especialmente abrangente de proteções de privacidade ajuda a proteger as tuas atividades online, desde a pesquisa à navegação, e-mails, entre outras.\n\nPara utilizares as nossas proteções de privacidade, não tens de saber nada sobre os detalhes técnicos nem lidar com definições complicadas. Tudo o que tens de fazer é mudar o teu navegador para o DuckDuckGo em todos os teus dispositivos e desfrutar de privacidade como predefinição.\n\nMas *se* quiseres espreitar os bastidores, podes consultar mais informações sobre como funcionam as proteções de privacidade do DuckDuckGo nas nossas [páginas de ajuda](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Adicionar aplicação à sua dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Adicionar widget ao ecrã inicial";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Posição da barra de endereços";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Aparência";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Abrir links nas aplicações associadas";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Desative para prevenir que ligações sejam abertas automaticamente noutras aplicações instaladas.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Mostrar sugestões de preenchimento automático";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Bloqueio de aplicações";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Se o Touch ID, Face ID ou um código de acesso estiverem definidos, ser-lhe-á pedido o desbloqueio da aplicação ao abrir.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Limpar os dados automaticamente";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Gerir pop-ups de cookies";
+
+/* Settings title for the customize section */
+"settings.customize" = "Personalizar";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Definir como navegador padrão";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Proteção de e-mail";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Bloqueie rastreadores de e-mail e oculte o seu endereço.";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Partilhar comentários";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animação do Botão de Fogo";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Sites com barreira de segurança";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Controlo Global de Privacidade (CGP)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Ícone da aplicação";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Teclado";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Mais de DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Pré-visualizações ao premir prolongadamente";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Privacidade";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sincronização e cópia de segurança";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Tamanho do texto";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Definições";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Sites desprotegidos";
+
+/* Settings cell for Version */
+"settings.version" = "Versão";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Pesquisa por voz privada";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Submeter relatório";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Permita o acesso ao microfone nas definições do sistema iOS para que o DuckDuckGo use as funcionalidades de voz.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "É necessário o acesso ao microfone";

--- a/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/DuckDuckGo/ro.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internetul poate fi cam terifiant.\n\nNu te îngrijora! Căutarea și navigarea în mod confidențial sunt mai ușoare decât crezi.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Dezactivat";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Bine ai venit la\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo pentru Mac are viteza de care ai nevoie, funcționalitățile de răsfoire pe care ți le dorești și este prevăzută cu cele mai bune caracteristici de bază în privința confidențialității din domeniu.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Alătură-te listei de așteptare și te vom anunța când îți vine rândul.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Ești pe listă!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Preferințe";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Despre DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Despre";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo este o companie independentă înființată în 2008, care oferă confidențialitate pe internet tuturor celor care s-au săturat să fie urmăriți online și își doresc o soluție simplă. Suntem dovada că protecția confidențialității online fără compromisuri este reală.\n\nBrowserul DuckDuckGo oferă funcțiile pe care le aștepți de la browserul predilect, cum ar fi marcajele, filele, parolele și multe altele, plus peste [o duzină de instrumente puternice de protecție a confidențialității](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) care nu sunt oferite implicit de majoritatea browserelor populare. Acest set unic și cuprinzător de măsuri de protecție a confidențialității te ajută să îți protejezi activitățile online, de la căutări la navigare, e-mailuri și multe altele.\n\nMăsurile noastre robuste de protecție a confidențialității funcționează fără a necesita cunoștințe tehnice din partea ta și fără a fi nevoie să faci setări complicate. Tot ce trebuie să faci este să folosești browserul DuckDuckGo pe toate dispozitivele și vei beneficia implicit de confidențialitate.\n\nDar dacă *chiar dorești* să consulți detaliile mai tehnice, poți găsi mai multe informații despre modul în care funcționează instrumentele DuckDuckGo de protecție a confidențialității în [paginile noastre de asistență](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Adaugă aplicația la secțiunea ta fixă";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Adaugă un widget la ecranul de întâmpinare";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Poziția barei de adrese";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Aspect";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Deschide linkuri în aplicațiile asociate";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Dezactivează pentru a preveni deschiderea automată a linkurilor în alte aplicații instalate.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Afișează sugestiile de completare automată";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Blocarea aplicației";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Dacă este setat Touch ID, Face ID sau o parolă de sistem, ți se va solicita să deblochezi aplicația la deschidere.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Șterge automat datele";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Gestionare pop-up-uri pentru module cookie";
+
+/* Settings title for the customize section */
+"settings.customize" = "Personalizare";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Setare ca browser implicit";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Protecția comunicațiilor prin e-mail";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blochează tehnologiile de urmărire prin e-mail și ascunde-ți adresa";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Partajează feedback";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animație buton Foc";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Site-uri cu ștergerea activității și istoricului din browser la ieșire";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Pictograma aplicației";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tastatură";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Mai multe de la DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Previzualizări prin apăsare lungă";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Confidențialitate";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sincronizare și copiere de rezervă";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Dimensiune text";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Temă";
+
+/* Title for the Settings View */
+"settings.title" = "Setări";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Site-uri neprotejate";
+
+/* Settings cell for Version */
+"settings.version" = "Versiune";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Căutare vocală privată";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Trimite raportul";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Permite accesul la microfon din setările sistemului de operare iOS, pentru ca DuckDuckGo să folosească funcționalitățile vocale.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Este necesar accesul la microfon";

--- a/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/DuckDuckGo/ru.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Интернет набит трекерами.\n\nНо выход есть! Пользоваться сетью без слежки проще, чем вы думали.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Отключено";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Добро пожаловать в\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "Приложение DuckDuckGo для Mac — это высокая скорость, функциональность и беспрецедентная конфиденциальность.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Записывайтесь в очередь, и мы будем держать вас в курсе.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Вы в списке!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Избранное";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Несколько слов о DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "О нас";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo — независимая компания, которая c 2008 года предоставляет услуги защиты личных данных в интернете. Мы предлагаем простое решение для тех, кому надоело отслеживание онлайн. Своим примером DuckDuckGo показывает, что защита конфиденциальности в Сети не требует компромиссов.\n\nВ универсальном браузере DuckDuckGo вы найдете все те же привычные функции — вкладки, закладки, пароли, — а также более [десятка мощных средств защиты личной информации](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/), которых нет в стандартных пакетах других популярных веб-обозревателей. Наш всесторонний набор инструментов скроет от посторонних глаз всю вашу онлайн-активность, включая поиск, просмотр сайтов и чтение почты.\n\nСервисы DuckDuckGo не требуют особых технических познаний или работы со сложными настройками. Достаточно сменить свой браузер на DuckDuckGo на всех устройствах, и конфиденциальность онлайн станет вашим спутником по умолчанию.\n\nЕсли же вас интересует наша «кухня», вы можете почитать о том, как устроены инструменты защиты DuckDuckGo, на [страницах нашего справочного центра](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Добавьте приложение на док-панель";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Добавьте виджет на домашний экран";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Положение адресной строки";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Внешний вид";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Открывать ссылки в связанных приложениях";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Отключение этой функции не позволит ссылкам автоматически открываться в других приложениях.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Показать предложения автозаполнения";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Блокировка";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Если система защищена технологией Touch ID или Face ID либо кодом доступа, при запуске вам придется разблокировать приложение.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Автоудаление данных";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Управление окнами выбора куки-файлов";
+
+/* Settings title for the customize section */
+"settings.customize" = "Собственная настройка";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Сделать браузером по умолчанию";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Защита электронной почты";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Блокировка почтовых трекеров и скрытие адреса";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Оставьте нам отзыв";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Aнимация кнопки «Огонь»";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Огнеупорные сайты";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Глобальный контроль конфиденциальности (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Значок приложения";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Клавиатура";
+
+/* Settings title for the 'More' section */
+"settings.more" = "DuckDuckGo также предлагает...";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Предпросмотр долгим нажатием";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Настройки конфиденциальности";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Синхронизация и резервное копирование";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Размер текста";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Тема";
+
+/* Title for the Settings View */
+"settings.title" = "Настройки";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Незащищенные сайты";
+
+/* Settings cell for Version */
+"settings.version" = "Версия";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Конфиденциальный голосовой поиск";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Отправить жалобу";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Чтобы пользоваться голосовыми функциями, откройте DuckDuckGo доступ к микрофону в системных настройках iOS.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "Хорошо";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Требуется доступ к микрофону";

--- a/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/DuckDuckGo/sk.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet môže byť dosť nevyspytateľný.\n\nNemajte žiadne obavy! Súkromné vyhľadávanie a prehliadanie je jednoduchšie, ako si myslíte.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Zakázané";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Vitajte v\nprehliadači DuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo pre Mac má rýchlosť, ktorú potrebujete, funkcie prehliadania, ktoré očakávate, a obsahuje naše prvotriedne privacy essentials.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Pridajte sa na zoznam čakateľov a my vás upozorníme, keď na vás príde rad.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Ste na zozname čakateľov!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Obľúbené položky";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "O službe DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "O nás";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo je nezávislá spoločnosť na ochranu súkromia na internete, ktorá bola založená v roku 2008 pre všetkých, ktorých už nebaví sledovanie na internete a chcú jednoduché riešenie. Sme dôkazom, že skutočnú online ochranu súkromia môžete získať bez kompromisov.\n\nPrehliadač DuckDuckGo je vybavený funkciami, ktoré od prehliadača očakávate, ako sú napríklad záložky, karty, heslá a ďalšie funkcie. Navyše obsahuje viac ako [tucet účinných ochranných opatrení na ochranu súkromia](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) sa vo väčšine populárnych prehliadačov štandardne neponúka. Tento jedinečne komplexný súbor ochrany súkromia pomáha chrániť vaše online aktivity od vyhľadávania po prehliadanie, posielanie e-mailov a ďalšie.\n\nNaša ochrana súkromia funguje bez toho, aby ste museli poznať technické detaily alebo riešiť zložité nastavenia. Stačí prepnúť prehliadač na DuckDuckGo vo všetkých zariadeniach a získate predvolené súkromie.\n\nAk však chcete nahliadnuť pod pokrievku, viac informácií o tom, ako funguje ochrana súkromia DuckDuckGo, nájdete na našich [stránkach pomoci](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Pridať aplikáciu do Docku";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Pridať miniaplikáciu na domovskú obrazovku";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Poloha riadku s adresou";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Vzhľad";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Otvárať odkazy v pridružených aplikáciách";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Zakážte a zabráňte tak automatickému otváraniu odkazov v iných nainštalovaných aplikáciách.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Zobraziť návrhy automatického dopĺňania";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Zámok aplikácie";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Ak je nastavená funkcia Touch ID, Face ID alebo systémový prístupový kód, pri otvorení aplikácie sa zobrazí výzva na odomknutie aplikácie.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Automaticky vymazať údaje";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Správa kontextových okien súborov cookie";
+
+/* Settings title for the customize section */
+"settings.customize" = "Prispôsobiť";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Nastaviť ako predvolený prehliadač";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Ochrana e-mailu";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Zablokujte nástroje na sledovanie e‑mailov a skryte vašu adresu";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Zdieľať spätnú väzbu";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animácia tlačidla ohňa";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Zabezpečené stránky";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Globálna kontrola súkromia (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Ikona aplikácie";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Klávesnica";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Viac od DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Náhľady po dlhodobom stlačení";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Súkromie";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synchronizácia a zálohovanie";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Veľkosť textu";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Motív";
+
+/* Title for the Settings View */
+"settings.title" = "Nastavenia";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Nezabezpečené webové stránky";
+
+/* Settings cell for Version */
+"settings.version" = "Verzia";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Súkromné hlasové vyhľadávanie";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Odoslať správu";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Ak chcete používať hlasové funkcie, povoľte pre DuckDuckGo prístup k mikrofónu v nastaveniach systému iOS.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Vyžaduje sa prístup k mikrofónu";

--- a/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/DuckDuckGo/sl.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet je lahko grozljiv.\n\nNe skrbi! Iskanje in brskanje na zaseben način je lažje, kot si misliš.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Onemogočeno";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Dobrodošli v aplikaciji\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo za računalnike Mac zagotavlja hitrost, ki jo potrebujete, in funkcije brskanja, ki jih pričakujete, ter je opremljen z našimi ključnimi funkcijami zasebnosti, ki so najboljše v tem razredu.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Pridružite se čakalni listi in obvestili vas bomo, ko boste na vrsti.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Na seznamu ste!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Priljubljeni";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "O DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Več o";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo je neodvisno podjetje za zasebnost v internetu, ustanovljeno leta 2008, in je namenjeno vsem, ki so naveličani sledenja v spletu in si želijo preproste rešitve. Dokazujemo, da je v spletu mogoče zagotoviti pravo zaščito zasebnosti brez sklepanja kompromisov.\n\nBrskalnik DuckDuckGo ima funkcije, ki jih pričakujete od priljubljenega brskalnika, kot so zaznamki, zavihki, gesla in drugo, ter več kot [ducat učinkovitih zaščit zasebnosti](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) ki v večini priljubljenih brskalnikov niso na voljo privzeto. Ta edinstveni celovit sklop zaščite zasebnosti pomaga zaščititi vaše spletne dejavnosti, od iskanja do brskanja, pošiljanja e-pošte in še več.\n\nNaša zaščita zasebnosti deluje, ne da bi se vam bilo treba spoznati na tehnične podrobnosti ali se ukvarjati z zapletenimi nastavitvami. Vse, kar morate storiti, je, da brskalnik preklopite na DuckDuckGo v vseh napravah in zasebnost bo privzeta.\n\nČe pa želite pogledati v mehanizem delovanja, lahko več informacij o delovanju zaščite zasebnosti DuckDuckGo najdete na naših [straneh s pomočjo](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Dodajte aplikacijo na svoj domači zaslon";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Dodajte pripomoček na domači zaslon";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Položaj naslovne vrstice";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Izgled";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Odpri povezave v povezanih aplikacijah";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Onemogoči, da preprečiš samodejno odpiranje povezav v drugih nameščenih aplikacijah.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Pokaži predloge za samodokončanje";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Zaklepanje aplikacije";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Če nastavite prepoznavanje z dotikom, prepoznavanje z obrazom ali sistemsko geslo, boste ob odpiranju morali odkleniti aplikacijo.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Samodejno počisti podatke";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Upravljanje pojavnih oken za piškotke";
+
+/* Settings title for the customize section */
+"settings.customize" = "Prilagodi";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Nastavite za privzeti brskalnik";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "Zaščita e-pošte";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blokirajte sledilnike e-pošte in skrijte svoj naslov";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Deli povratne informacije";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animacija za gumb ogenj";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Spletne strani s požarno zaščito";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Globalni nadzor zasebnosti (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Ikona aplikacije";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tipkovnica";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Več od iskalnika DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Pregledi z dolgim pritiskom";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Zasebnost";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Sinhronizacija in varnostno kopiranje";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Velikost besedila";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Nastavitve";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Nezaščitene strani";
+
+/* Settings cell for Version */
+"settings.version" = "Različica";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Zasebno glasovno iskanje";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Pošlji poročilo";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Dovolite dostop do mikrofona v nastavitvah sistema iOS, da boste lahko v brskalniku DuckDuckGo uporabljali glasovne funkcije.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "V REDU";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Potreben je dostop do mikrofona";

--- a/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/DuckDuckGo/sv.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "Internet kan vara lite läskigt.\n\nOroa dig inte! Att söka och surfa privat är lättare än du tror.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Inaktiverad";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "Välkommen till\nDuckDuckGo!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "DuckDuckGo för Mac har hastigheten du behöver, webbläsarfunktionerna du förväntar dig och våra många förstklassiga integritetsfunktioner.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Skriv upp dig på väntelistan så meddelar vi dig när det är din tur.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Du står på listan!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoriter";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "Om DuckDuckGo";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Om";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo är det oberoende integritetsskyddsföretaget som grundades 2008 för alla som är trötta på att bli spårade online och vill ha en enkel lösning. Vi är beviset på att man kan få riktigt integritetsskydd på nätet utan att kompromissa.\n\nDuckDuckGo-webbläsaren har de funktioner du förväntar dig av en vanlig webbläsare, som bokmärken, flikar, lösenord och mer, plus över [ett dussin kraftfulla integritetsskydd](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) som inte ingår som standard i de flesta populära webbläsare. Den här omfattande uppsättningen av integritetsskydd hjälper dig att skydda dina onlineaktiviteter, från sökning och surfning till e-post och mycket mer.\n\nVårt integritetsskydd fungerar utan att du behöver känna till de tekniska detaljerna eller ta itu med komplicerade inställningar. Det enda du behöver göra är att byta webbläsare till DuckDuckGo på alla dina enheter för att få integritet som standard.\n\nMen om du * verkligen* vill ta en titt under huven hittar du mer information om hur DuckDuckGos integritetsskydd fungerar på våra [hjälpsidor](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/).";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Lägg till app i din Dock";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Lägg till widget på startsidan";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Adressfältsläge";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Utseende";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Öppna länkar i associerade appar";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Inaktivera för att förhindra att länkar automatiskt öppnas i andra installerade appar.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Visa Autoslutför förslag";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "App-lås";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Om Touch ID, Face ID eller ett systemlösenord har konfigurerats ombes du låsa upp appen när du öppnar.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Rensa data automatiskt";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Hantera popup-fönster för cookies";
+
+/* Settings title for the customize section */
+"settings.customize" = "Anpassa";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Ställ in som standardwebbläsare";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-postskydd";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "Blockera e-postspårare och dölj din adress";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Berätta vad du tycker";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Animation för brännarknapp";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Brandsäkra webbplatser";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Global Privacy Control (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "App-ikon";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Tangentbord";
+
+/* Settings title for the 'More' section */
+"settings.more" = "Mer från DuckDuckGo";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Förhandsvisning vid nedhållning";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Sekretess";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Synkronisering och säkerhetskopiering";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Textstorlek";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Inställningar";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Oskyddade webbplatser";
+
+/* Settings cell for Version */
+"settings.version" = "Version";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Privat röstsökning";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Skicka in rapport";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "För att DuckDuckGo ska kunna använda röstfunktionerna måste du tillåta åtkomst till mikrofonen i systeminställningarna för iOS.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "OK";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofonåtkomst krävs";

--- a/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/DuckDuckGo/tr.lproj/Localizable.strings
@@ -898,6 +898,9 @@
 /* No comment provided by engineer. */
 "dax.onboarding.message" = "İnternet bazen ürkütücü olabilir.\n\nEndişelenmeyin! İnternette kimsenin göremeyeceği şekilde arama yapmak ve gezinmek sandığınızdan çok daha kolay.";
 
+/* No comment provided by engineer. */
+"Debug" = "Debug";
+
 /* GPC Setting state */
 "donotsell.disabled" = "Devre Dışı";
 
@@ -1372,6 +1375,9 @@
 /* Please preserve newline character */
 "launchscreenWelcomeMessage" = "DuckDuckGo'ya\nHoş Geldiniz!";
 
+/* No comment provided by engineer. */
+"LOREM IPSUM" = "LOREM IPSUM";
+
 /* Summary text for the macOS browser waitlist */
 "mac-browser.waitlist.summary" = "Mac için DuckDuckGo, ihtiyacınız olan hız ve beklediğiniz tarama özelliklerinin yanı sıra sınıfındaki en iyi gizlilik özelliklerini (Privacy Essentials) sunuyor.";
 
@@ -1488,6 +1494,9 @@
 
 /* Second subtitle for Network Protection join waitlist screen */
 "network-protection.waitlist.join.subtitle.2" = "Bekleme listesine katılın. Sıra size geldiğinde sizi bilgilendireceğiz.";
+
+/* Title for Network Protection join waitlist screen */
+"network-protection.waitlist.join.title" = "Network Protection Early Access";
 
 /* Title for Network Protection joined waitlist screen */
 "network-protection.waitlist.joined.title" = "Listedesiniz!";
@@ -1762,8 +1771,107 @@
 /* No comment provided by engineer. */
 "section.title.favorites" = "Favoriler";
 
+/* Settings cell for About DDG */
+"settings.about.ddg" = "DuckDuckGo Hakkında";
+
+/* Settings section title for About DuckDuckGo */
+"settings.about.section" = "Hakkında";
+
 /* about page */
 "settings.about.text" = "DuckDuckGo, çevrim içi takip edilmeyi hiç istemeyen ve pratik bir çözüm arayan herkese hizmet veren, 2008 yılında kurulmuş bağımsız bir İnternet gizlilik şirketidir. Biz, çevrim içi ortamda ödün vermeden gerçek gizlilik koruması elde edebileceğinizin kanıtıyız.\n\nDuckDuckGo tarayıcı; yer imleri, sekmeler, parolalar ve daha fazlası gibi en çok kullandığınız tarayıcıdan beklediğiniz ama çoğu popüler tarayıcıda varsayılan olarak bulunmayan özelliklerin yanı sıra [sayısı ondan fazla güçlü gizlilik koruması](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections/) ile birlikte gelir. Son derece kapsamlı olan bu gizlilik koruma seti; aramadan gezinmeye, e-posta göndermeye ve daha fazlasına kadar çevrim içi etkinliklerinizde koruma sağlamaya yardımcı olur.\n\nGizlilik korumalarımız, teknik ayrıntılar hakkında hiçbir şey bilmenize veya karmaşık ayarlarla uğraşmanıza gerek kalmadan çalışır. Tüm cihazlarınızda tarayıcı olarak DuckDuckGo'yu kullanarak aradığınız gizliliği sağlayabilirsiniz.\n\nAncak ayrıntılara bir göz atmak *istiyorsanız*, DuckDuckGo gizlilik korumalarının nasıl çalıştığı hakkında daha fazla bilgiyi [yardım sayfalarımızda](ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/) bulabilirsiniz.";
+
+/* Settings screen cell text for adding the app to the dock */
+"settings.add.to.dock" = "Uygulamayı Dock'a Ekle";
+
+/* Settings screen cell text for add widget to the home screen */
+"settings.add.widget" = "Widget'ı Ana Ekrana Ekle";
+
+/* Settings screen cell text for addess bar position */
+"settings.address.bar" = "Adres Çubuğu Konumu";
+
+/* Settings screen appearance section title */
+"settings.appearance" = "Görünüm";
+
+/* Settings screen cell for opening links in associated apps */
+"settings.associated.apps" = "Bağlantıları İlişkili Uygulamalarda Aç";
+
+/* Description for associated apps description */
+"settings.associated.apps.description" = "Bağlantıların yüklenmiş olan diğer uygulamalarda otomatik olarak açılmasını önlemek için devre dışı bırakın.";
+
+/* Settings screen cell for autocomplete */
+"settings.autocomplete" = "Otomatik Tamamlama Önerileri";
+
+/* Settings screen cell text for Application Lock */
+"settings.autolock" = "Uygulama Kilidi";
+
+/* Section footer Autolock description */
+"settings.autolock.description" = "Touch ID, Face ID veya sistem parolası belirlenmişse uygulamayı açarken kilidini açmanız istenir.";
+
+/* Settings screen cell text for Automatically Clearing Data */
+"settings.clear.data" = "Verileri Otomatik Olarak Temizle";
+
+/* Settings screen cell text for Cookie popups */
+"settings.cookie.popups" = "Çerez Açılır Pencerelerini Yönetin";
+
+/* Settings title for the customize section */
+"settings.customize" = "Özelleştir";
+
+/* Settings screen cell text for setting the app as default browser */
+"settings.default.browser" = "Varsayılan Tarayıcı olarak ayarla";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection" = "E-posta Koruması";
+
+/* Settings cell for Email Protection */
+"settings.emailProtection.description" = "E-posta izleyicileri engelleyin ve adresinizi gizleyin";
+
+/* Settings cell for Feedback */
+"settings.feedback" = "Geri Bildirim Paylaş";
+
+/* Settings screen cell text for fire button animation */
+"settings.firebutton" = "Yangın Düğmesi Animasyonu";
+
+/* Settings screen cell text for Fireproof Sites */
+"settings.fireproof.sites" = "Korumalı Siteler";
+
+/* Settings screen cell text for GPC */
+"settings.gpc" = "Küresel Gizlilik Kontrolü (GPC)";
+
+/* Settings screen cell text for app icon selection */
+"settings.icon" = "Uygulama Simgesi";
+
+/* Settings screen cell for Keyboard */
+"settings.keyboard" = "Klavye";
+
+/* Settings title for the 'More' section */
+"settings.more" = "DuckDuckGo'dan daha fazlası";
+
+/* Settings screen cell for long press previews */
+"settings.previews" = "Uzun Basma Önizlemeleri";
+
+/* Settings title for the privacy section */
+"settings.privacy" = "Gizlilik";
+
+/* Settings screen cell text for sync and backup */
+"settings.sync" = "Senkronizasyon ve Yedekleme";
+
+/* Settings screen cell text for text size */
+"settings.text.size" = "Metin Boyutu";
+
+/* Settings screen cell text for theme */
+"settings.theme" = "Tema";
+
+/* Title for the Settings View */
+"settings.title" = "Ayarlar";
+
+/* Settings screen cell text for Unprotected Sites */
+"settings.unprotected.sites" = "Korumasız Siteler";
+
+/* Settings cell for Version */
+"settings.version" = "Versiyon";
+
+/* Settings screen cell for voice search */
+"settings.voice.search" = "Özel Sesli Arama";
 
 /* Report a Broken Site screen confirmation button */
 "siteFeedback.buttonText" = "Rapor Gönder";
@@ -1857,6 +1965,9 @@
 
 /* Message for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.message" = "Ses özelliklerini kullanmak istiyorsanız iOS Sistem Ayarları'ndan DuckDuckGo için Mikrofon erişimine izin verin.";
+
+/* OK button alert warning the user about missing microphone permission */
+"voiceSearch.alert.no-permission.ok" = "Tamam";
 
 /* Title for alert warning the user about missing microphone permission */
 "voiceSearch.alert.no-permission.title" = "Mikrofon Erişimi Gerekli";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206327436431895/f

**Description**:
- Adds a checkmark icon to the picker options in settings (based on design feedback)
- Fixes missing translations

<img width="546" alt="Screenshot 2024-01-12 at 7 17 48 PM" src="https://github.com/duckduckgo/iOS/assets/1156669/ac0a2dfe-a436-4bee-9841-8e55a9f9b922">

**Steps to test this PR**:
1. Go to Settings
2. Tap any option that displays a picker (Theme, Fire Button Animation or Address bar Position)
3. Observe there's a checkmark icon in the selected option
4. Test with iOS 15.x and observe menus for the above options work
5. Change device language 
6. Check settings main view is properly translated

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
