### PR TITLE
Hide bottom URL bar when find in page is active

### DIFF
--- a/DuckDuckGo/MainView.swift
+++ b/DuckDuckGo/MainView.swift
@@ -392,6 +392,29 @@ class MainViewCoordinator {
         addressBarPosition = position
     }
 
+    func hideNavigationWithForBottomPosition() {
+        guard addressBarPosition == .bottom else {
+            return
+        }
+
+        // Hiding the container won't suffice as it still defines the contentContainer.bottomY through constraints
+        navigationBarContainer.isHidden = true
+
+        constraints.contentContainerBottomToNavigationBarContainerTop.isActive = false
+        constraints.contentContainerBottomToToolbarTop.isActive = true
+    }
+
+    func showNavigationBarWithBottomPosition() {
+        guard addressBarPosition.isBottom else {
+            return
+        }
+
+        constraints.contentContainerBottomToToolbarTop.isActive = false
+        constraints.contentContainerBottomToNavigationBarContainerTop.isActive = true
+
+        navigationBarContainer.isHidden = false
+    }
+
     func setAddressBarTopActive(_ active: Bool) {
         constraints.contentContainerBottomToToolbarTop.isActive = active
         constraints.navigationBarContainerTop.isActive = active

--- a/DuckDuckGo/MainView.swift
+++ b/DuckDuckGo/MainView.swift
@@ -393,7 +393,7 @@ class MainViewCoordinator {
     }
 
     func hideNavigationWithForBottomPosition() {
-        guard addressBarPosition == .bottom else {
+        guard addressBarPosition.isBottom else {
             return
         }
 

--- a/DuckDuckGo/MainView.swift
+++ b/DuckDuckGo/MainView.swift
@@ -392,7 +392,7 @@ class MainViewCoordinator {
         addressBarPosition = position
     }
 
-    func hideNavigationWithForBottomPosition() {
+    func hideNavigationBarWithBottomPosition() {
         guard addressBarPosition.isBottom else {
             return
         }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1273,8 +1273,9 @@ extension MainViewController: FindInPageViewDelegate {
     func done(findInPageView: FindInPageView) {
         currentTab?.findInPage = nil
         viewCoordinator.toolbar.accessibilityElementsHidden = false
+
+        viewCoordinator.showNavigationBarWithBottomPosition()
     }
-    
 }
 
 extension MainViewController: BrowserChromeDelegate {
@@ -1801,6 +1802,8 @@ extension MainViewController: TabDelegate {
     func tabDidRequestFindInPage(tab: TabViewController) {
         updateFindInPage()
         _ = findInPageView?.becomeFirstResponder()
+
+        viewCoordinator.hideNavigationWithForBottomPosition()
     }
 
     func closeFindInPage(tab: TabViewController) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1803,7 +1803,7 @@ extension MainViewController: TabDelegate {
         updateFindInPage()
         _ = findInPageView?.becomeFirstResponder()
 
-        viewCoordinator.hideNavigationWithForBottomPosition()
+        viewCoordinator.hideNavigationBarWithBottomPosition()
     }
 
     func closeFindInPage(tab: TabViewController) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1205827538125539/f

**Description**:

Hides the bottom address bar while find in page is active.

**Steps to test this PR**:

On iPhone:
1. Go to any valid address.
2. Activate Find in page.
3. Check if address bar is not visible and there are no gaps between content and bottom bar.
4. Deactivate Find in page.
5. Check if address bar shows above keyboard while editing.

**Orientation Testing**:
* [ ] Portrait
* [ ] Landscape
