### PR TITLE
Update more workflows to use XL runners

### DIFF
--- a/.github/workflows/adhoc.yml
+++ b/.github/workflows/adhoc.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   make-adhoc:
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     name: Make ad-hoc build
 
     steps:

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   make-alpha:
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     name: Make TestFlight Alpha Build
     timeout-minutes: 30
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   atb-ui-tests:
     name: ATB UI Tests
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     timeout-minutes: 30
 
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   fingerprinting-ui-tests:
     name: Fingerprinting UI Tests
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   make-release:
     if: github.event.action == 0 || github.event.pull_request.merged == true # empty string returns 0; for case when workflow is triggered manually
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     name: Make App Store Connect Release
 
     steps:


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1206350423061609/f

**Description**:
Intel Mac runners are known for having timeout issues related to SwiftLint Package Plugin.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
