### PR TITLE
Fix concurrent timestamp updates

### DIFF
--- a/DuckDuckGo/FavoritesDisplayModeSyncHandler.swift
+++ b/DuckDuckGo/FavoritesDisplayModeSyncHandler.swift
@@ -31,13 +31,18 @@ final class FavoritesDisplayModeSyncHandler: FavoritesDisplayModeSyncHandlerBase
     override func setValue(_ value: String?, shouldDetectOverride: Bool) throws {
         if let value, let displayMode = FavoritesDisplayMode(value) {
             appSettings.favoritesDisplayMode = displayMode
-            NotificationCenter.default.post(name: AppUserDefaults.Notifications.favoritesDisplayModeChange, object: nil)
+            NotificationCenter.default.post(name: AppUserDefaults.Notifications.favoritesDisplayModeChange, object: self)
         }
     }
 
     override var valueDidChangePublisher: AnyPublisher<Void, Never> {
         NotificationCenter.default
             .publisher(for: AppUserDefaults.Notifications.favoritesDisplayModeChange)
+            .filter({ [weak self] n in
+                guard let self else { return false }
+                guard let object = n.object as? AnyObject else { return true }
+                return object !== self
+            })
             .map { _ in }
             .eraseToAnyPublisher()
     }

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -135,7 +135,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsView> {
     private func setUpFavoritesDisplayModeSwitch(_ viewModel: SyncSettingsViewModel, _ appSettings: AppSettings) {
         viewModel.isUnifiedFavoritesEnabled = appSettings.favoritesDisplayMode.isDisplayUnified
 
-        viewModel.$isUnifiedFavoritesEnabled.dropFirst()
+        viewModel.$isUnifiedFavoritesEnabled.dropFirst().removeDuplicates()
             .sink { [weak self] isEnabled in
                 appSettings.favoritesDisplayMode = isEnabled ? .displayUnified(native: .mobile) : .displayNative(.mobile)
                 NotificationCenter.default.post(name: AppUserDefaults.Notifications.favoritesDisplayModeChange, object: self)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201493110486074/1206372583396814/f
Tech Design URL:
CC:

**Description**:

Make sure that direct updates from sync does not invoke the generic timestamp-bumping logic.

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the connect flow.
2. Ensure no pixel about local override is fired.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
