### PR TITLE
revert using content insets to fix page position problem

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -156,7 +156,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "a6b7ba151d9dc6684484f3785293875ec01cc1ff",
         "version" : "1.2.2"

--- a/DuckDuckGo/MainView.swift
+++ b/DuckDuckGo/MainView.swift
@@ -54,7 +54,6 @@ class MainViewFactory {
 extension MainViewFactory {
 
     private func createViews() {
-        createWebViewContainer()
         createLogoBackground()
         createContentContainer()
         createSuggestionTrayContainer()
@@ -66,12 +65,6 @@ extension MainViewFactory {
         createToolbar()
     }
     
-    final class WebViewContainerView: UIView { }
-    private func createWebViewContainer() {
-        coordinator.webViewContainer = WebViewContainerView()
-        superview.addSubview(coordinator.webViewContainer)
-    }
-
     private func createProgressView() {
         coordinator.progress = ProgressView()
         superview.addSubview(coordinator.progress)
@@ -163,7 +156,6 @@ extension MainViewFactory {
 extension MainViewFactory {
 
     private func constrainViews() {
-        constrainWebViewContainer()
         constrainLogoBackground()
         constrainContentContainer()
         constrainSuggestionTrayContainer()
@@ -173,16 +165,6 @@ extension MainViewFactory {
         constrainNavigationBarContainer()
         constrainProgress()
         constrainToolbar()
-    }
-    
-    private func constrainWebViewContainer() {
-        let webViewContainer = coordinator.webViewContainer!
-        NSLayoutConstraint.activate([
-            webViewContainer.constrainView(superview, by: .width),
-            webViewContainer.constrainView(superview, by: .height),
-            webViewContainer.constrainView(superview, by: .centerX),
-            webViewContainer.constrainView(superview, by: .centerY),
-        ])
     }
 
     private func constrainProgress() {
@@ -351,7 +333,6 @@ class MainViewCoordinator {
     var toolbarFireButton: UIBarButtonItem!
     var toolbarForwardButton: UIBarButtonItem!
     var toolbarTabSwitcherButton: UIBarButtonItem!
-    var webViewContainer: UIView!
 
     let constraints = Constraints()
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -644,7 +644,7 @@ class MainViewController: UIViewController {
             guard let tab = tabManager.current(createIfNeeded: true) else {
                 fatalError("Unable to create tab")
             }
-            addToWebViewContainer(tab: tab)
+            attachTab(tab: tab)
             refreshControls()
         } else {
             attachHomeScreen()
@@ -853,7 +853,7 @@ class MainViewController: UIViewController {
     private func addTab(url: URL?, inheritedAttribution: AdClickAttributionLogic.State?) {
         let tab = tabManager.add(url: url, inheritedAttribution: inheritedAttribution)
         dismissOmniBar()
-        addToWebViewContainer(tab: tab)
+        attachTab(tab: tab)
     }
 
     func select(tabAt index: Int) {
@@ -867,7 +867,7 @@ class MainViewController: UIViewController {
         if tab.link == nil {
             attachHomeScreen()
         } else {
-            addToWebViewContainer(tab: tab)
+            attachTab(tab: tab)
             refreshControls()
         }
         tabsBarController?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
@@ -876,21 +876,15 @@ class MainViewController: UIViewController {
         }
     }
 
-    private func addToWebViewContainer(tab: TabViewController) {
+    private func attachTab(tab: TabViewController) {
         removeHomeScreen()
         updateFindInPage()
         currentTab?.progressWorker.progressBar = nil
         currentTab?.chromeDelegate = nil
-        currentTab?.webView.scrollView.contentInsetAdjustmentBehavior = .never
-        
-        addChild(tab)
-        viewCoordinator.webViewContainer.subviews.forEach { $0.removeFromSuperview() }
-        viewCoordinator.webViewContainer.addSubview(tab.view)
-        tab.view.frame = self.viewCoordinator.webViewContainer.bounds
-        tab.didMove(toParent: self)
-        
+            
+        addToContentContainer(controller: tab)
+
         viewCoordinator.logoContainer.isHidden = true
-        viewCoordinator.contentContainer.isHidden = true
         
         tab.progressWorker.progressBar = viewCoordinator.progress
         chromeManager.attach(to: tab.webView.scrollView)
@@ -1365,7 +1359,8 @@ extension MainViewController: BrowserChromeDelegate {
                 + keyboardHeight
         }
         
-        webView.scrollView.contentInset = .init(top: top, left: 0, bottom: bottom, right: 0)
+        // webView.scrollView.contentInset = .init(top: top, left: 0, bottom: bottom, right: 0)
+        // webView.invalidateIntrinsicContentSize()
     }
     
     func setNavigationBarHidden(_ hidden: Bool) {
@@ -1733,7 +1728,7 @@ extension MainViewController: TabDelegate {
             guard self.tabManager.model.tabs.contains(newTab.tabModel) else { return }
 
             self.dismissOmniBar()
-            self.addToWebViewContainer(tab: newTab)
+            self.attachTab(tab: newTab)
             self.refreshOmniBar()
         }
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -432,7 +432,6 @@ class MainViewController: UIViewController {
     @objc func onAddressBarPositionChanged() {
         viewCoordinator.moveAddressBarToPosition(appSettings.currentAddressBarPosition)
         refreshViewsBasedOnAddressBarPosition(appSettings.currentAddressBarPosition)
-        refreshWebViewContentInsets()
     }
 
     func refreshViewsBasedOnAddressBarPosition(_ position: AddressBarPosition) {
@@ -479,7 +478,6 @@ class MainViewController: UIViewController {
 
         findInPageBottomLayoutConstraint.constant = height
         keyboardHeight = height
-        refreshWebViewContentInsets()
 
         if let suggestionsTray = suggestionTrayController {
             let suggestionsFrameInView = suggestionsTray.view.convert(suggestionsTray.contentFrame, to: view)
@@ -1332,35 +1330,10 @@ extension MainViewController: BrowserChromeDelegate {
         }
            
         if animated {
-            UIView.animate(withDuration: ChromeAnimationConstants.duration, animations: updateBlock) { _ in
-                self.refreshWebViewContentInsets()
-            }
+            UIView.animate(withDuration: ChromeAnimationConstants.duration, animations: updateBlock)
         } else {
             updateBlock()
-            self.refreshWebViewContentInsets()
         }
-    }
-
-    func refreshWebViewContentInsets() {
-        guard let webView = currentTab?.webView else { return }
-
-        let top = viewCoordinator.statusBackground.frame.height
-        let bottom: CGFloat
-        if isToolbarHidden {
-            bottom = 0
-        } else if appSettings.currentAddressBarPosition.isBottom {
-            bottom = viewCoordinator.toolbar.frame.height
-                + viewCoordinator.navigationBarContainer.frame.height
-                + view.safeAreaInsets.bottom + additionalSafeAreaInsets.bottom
-                + keyboardHeight
-        } else {
-            bottom = viewCoordinator.toolbar.frame.height
-                + view.safeAreaInsets.bottom + additionalSafeAreaInsets.bottom
-                + keyboardHeight
-        }
-        
-        // webView.scrollView.contentInset = .init(top: top, left: 0, bottom: bottom, right: 0)
-        // webView.invalidateIntrinsicContentSize()
     }
     
     func setNavigationBarHidden(_ hidden: Bool) {
@@ -1832,7 +1805,6 @@ extension MainViewController: TabDelegate {
 
     func showBars() {
         chromeManager.reset()
-        refreshWebViewContentInsets()
     }
     
     func tabDidRequestFindInPage(tab: TabViewController) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1205688349294686/f
Tech Design URL:
CC:

**Description**:

Fixes a problem with the bottom offset. 

**Steps to test this PR**:
1. Visit reddit.com - ensure "continue with prompt" is aligned with bottom of the screen and easily accessible to the user
2. Visit TikTok.com - ensure prompts are aligned with bottom of the screen and easily accessible to the user
3. Browse the web and ensure the page position is not forgotten when browsing to the previous page.
4. Validate on iPhone and iPad

