### PR TITLE
refresh the model after the tab has been closed

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1919,6 +1919,7 @@ extension MainViewController: TabSwitcherDelegate {
         hideSuggestionTray()
         tabManager.remove(at: index)
         updateCurrentTab()
+        tabsBarController?.refresh(tabsModel: tabManager.model)
     }
 
     func tabSwitcherDidRequestForgetAll(tabSwitcher: TabSwitcherViewController) {


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/0/414709148257752/1206390999092189/f
Tech Design URL:
CC:

**Description**:

Fixes a bug where the current tab wouldn't close properly when requested.

**Steps to test this PR**:

On iPad:
1. Open a bunch of tabs
2. Select the first, close it - should update to the next tab 
3. Select the last, close it - should update to the previous tab
4. Select a tab in the middle, close it - should update to the previous tab

Smoke test opening and closing tabs on iPhone.
