### PR TITLE
Link documentation in e2e failure task description

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -80,7 +80,7 @@ jobs:
           --header "Accept: application/json" \
           --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
           --header "Content-Type: application/json" \
-          --data ' { "data": { "name": "GH Workflow Failure - End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}" } }'
+          --data ' { "data": { "name": "GH Workflow Failure - End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'
 
     - name: Upload logs when workflow failed
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206423571874504/f

**Description**:

_Background_
I had some confusion about what to do when e2e test failures arrive in [iOS App Development](https://app.asana.com/0/414709148257752/1204991834453425) - Incoming.

_Objective_
Create a documentation subtask explaining how to handle e2e test failures and link it from the auto-created task

**Steps to test this PR**:
Only affects test GHA so could be (easier to) tested after merge
1. Check [iOS App Development](https://app.asana.com/0/414709148257752/1204991834453425) - Incoming tomorrow and, if there is a failing test task created, check that it includes the link to the instructions.

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
