### PR TITLE
only show app store prompt on the serp

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1052,7 +1052,9 @@ extension TabViewController: WKNavigationDelegate {
         
         appRatingPrompt.registerUsage()
      
-        if let scene = self.view.window?.windowScene, appRatingPrompt.shouldPrompt() {
+        if let scene = self.view.window?.windowScene,
+           appRatingPrompt.shouldPrompt(),
+           webView.url?.isDuckDuckGoSearch == true {
             SKStoreReviewController.requestReview(in: scene)
             appRatingPrompt.shown()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1206350009744859/f
Tech Design URL:
CC:

**Description**:
Only show App Store review on SERP.

**Steps to test this PR**:
1. Change AppRatingPrompt.swift so that `shouldPrompt()` returns true
2. Visit some websites (not DuckDuckGo)
3. Then do a search - the App Store rating should show
