### PR TITLE
fix iPad tabs crash

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -857,8 +857,13 @@ class MainViewController: UIViewController {
     func select(tabAt index: Int) {
         viewCoordinator.navigationBarContainer.alpha = 1
         allowContentUnderflow = false
-        let tab = tabManager.select(tabAt: index)
-        select(tab: tab)
+        
+        if tabManager.model.tabs.indices.contains(index) {
+            let tab = tabManager.select(tabAt: index)
+            select(tab: tab)
+        } else {
+            assertionFailure("Invalid index selected")
+        }
     }
 
     fileprivate func select(tab: TabViewController) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206390999092189/f
Tech Design URL:
CC:

**Description**:

Add some range guard for tab selection.

**Steps to test this PR**:
1. Launch iPad
2. Add a bunch of tabs
3. Open + close, a few times
4. Open enough to scroll
5. Long press a tab - no crash should occur.  If assertion occurs, capture the stack trace.

To force the issue update TabBarViewController.swift and change the following line:

> delegate?.tabsBar(self, didSelectTabAtIndex: path.row + 1)

to 

> delegate?.tabsBar(self, didSelectTabAtIndex: path.row)

Then long press the last tab - an assertion should occur. 
