### PR TITLE
Show last NetP disconnect error in Debug view

### DIFF
--- a/DuckDuckGo/Feedback/VPNMetadataCollector.swift
+++ b/DuckDuckGo/Feedback/VPNMetadataCollector.swift
@@ -195,7 +195,7 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
                      connectedServerIP: connectedServerIP)
     }
 
-    private func lastDisconnectError() async -> String {
+    public func lastDisconnectError() async -> String {
         if #available(iOS 16, *) {
             guard let tunnelManager = try? await NETunnelProviderManager.loadAllFromPreferences().first else {
                 return "none"

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -2067,18 +2067,6 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Subscription Expiration Data */
 "subscription.subscription.active.caption" = "Your Privacy Pro subscription renews on %@";
 
-/* Cancel action for the existing subscription dialog */
-"subscription.subscription.found.cancel" = "Cancel";
-
-/* Restore action for the existing subscription dialog */
-"subscription.subscription.found.restore" = "Restore";
-
-/* Message for the existing subscription dialog */
-"subscription.subscription.found.text" = "We found a subscription associated with this Apple ID.";
-
-/* Title for the existing subscription dialog */
-"subscription.subscription.found.title" = "Subscription Found";
-
 /* Message confirming that recovery code was copied to clipboard */
 "sync.code.copied" = "Recovery code copied to clipboard";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1206432315839142/f
Tech Design URL:
CC:

**Description**:

This PR adds Last Disconnect Error to NetP debug menu.

**Steps to test this PR**:
1. Get NetP to disconnect 
2. Go to Settings > Debug > NetP 
3. Check the Last Disconnect Error
4. Profit!

![F01B2313-6D0B-4B0C-ADAF-18B612CF4393](https://github.com/duckduckgo/iOS/assets/18567/4860c947-befc-4ba7-87b7-398858fa2d03)

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
