### PR TITLE
defer loading until after any clear event

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -147,6 +147,9 @@ class MainViewController: UIViewController {
     private var skipSERPFlow = true
         
     private var keyboardHeight: CGFloat = 0.0
+    
+    var postClear: (() -> Void)?
+    var clearInProgress = false
 
     required init?(coder: NSCoder) {
         fatalError("Use init?(code:")
@@ -785,22 +788,30 @@ class MainViewController: UIViewController {
     }
 
     func loadUrlInNewTab(_ url: URL, reuseExisting: Bool = false, inheritedAttribution: AdClickAttributionLogic.State?) {
-        allowContentUnderflow = false
-        viewCoordinator.navigationBarContainer.alpha = 1
-        loadViewIfNeeded()
-        if reuseExisting, let existing = tabManager.first(withUrl: url) {
-            selectTab(existing)
-            return
-        } else if reuseExisting, let existing = tabManager.firstHomeTab() {
-            tabManager.selectTab(existing)
-            loadUrl(url)
-        } else {
-            addTab(url: url, inheritedAttribution: inheritedAttribution)
+        func worker() {
+            allowContentUnderflow = false
+            viewCoordinator.navigationBarContainer.alpha = 1
+            loadViewIfNeeded()
+            if reuseExisting, let existing = tabManager.first(withUrl: url) {
+                selectTab(existing)
+                return
+            } else if reuseExisting, let existing = tabManager.firstHomeTab() {
+                tabManager.selectTab(existing)
+                loadUrl(url)
+            } else {
+                addTab(url: url, inheritedAttribution: inheritedAttribution)
+            }
+            refreshOmniBar()
+            refreshTabIcon()
+            refreshControls()
+            tabsBarController?.refresh(tabsModel: tabManager.model)
         }
-        refreshOmniBar()
-        refreshTabIcon()
-        refreshControls()
-        tabsBarController?.refresh(tabsModel: tabManager.model)
+        
+        if clearInProgress {
+            postClear = worker
+        } else {
+            worker()
+        }
     }
     
     func enterSearch() {
@@ -2087,6 +2098,11 @@ extension MainViewController: AutoClearWorker {
     }
     
     func forgetData() {
+        guard !clearInProgress else {
+            assertionFailure("Shouldn't get called multiple times")
+            return
+        }
+        clearInProgress = true
         URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
 
         let pixel = TimedPixel(.forgetAllDataCleared)
@@ -2101,6 +2117,10 @@ extension MainViewController: AutoClearWorker {
             }
 
             self.refreshUIAfterClear()
+            self.clearInProgress = false
+            
+            self.postClear?()
+            self.postClear = nil
         }
 
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1206454582708636/f
Tech Design URL: 
CC:

**Description**:
Defers launching a URL until data clearing has finished.

**Steps to test this PR**:
1. Visit setcookie.net and set a cookie (favourite this page for speed)
2. Check the fire button works as expected (cookie is cleared, fireproofing works)
3. With browser set as default, launch a URL - should load correctly without any tabs closed or data cleared
4. Remove any fireproofing for the setcookie.net
4. Set a new cookie
5. Enable autoclear and kill the app
6. Launch a URL - page should load
7. Check setcookie.net has no cookies and all tabs were closed

General smoke testing:
1. Browse several websites
2. Set cookies with https://www.setcookie.net
3. Use the fire button and ensure data is cleared and app is ready to search again
