### PR TITLE
Fix voice search settings 

### DIFF
--- a/DuckDuckGo/SettingsCustomizeView.swift
+++ b/DuckDuckGo/SettingsCustomizeView.swift
@@ -37,7 +37,7 @@ struct SettingsCustomizeView: View {
             SettingsCellView(label: UserText.settingsAutocomplete,
                              accesory: .toggle(isOn: viewModel.autocompleteBinding))
             
-            if viewModel.state.speechRecognitionEnabled {
+            if viewModel.state.speechRecognitionAvailable {
                 SettingsCellView(label: UserText.settingsVoiceSearch,
                                  accesory: .toggle(isOn: viewModel.voiceSearchEnabledBinding))
             }

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -78,7 +78,7 @@ struct SettingsState {
     // Features
     var debugModeEnabled: Bool
     var voiceSearchEnabled: Bool
-    var speechRecognitionEnabled: Bool
+    var speechRecognitionAvailable: Bool // Returns if the device has speech recognition available
     var loginsEnabled: Bool
     
     // Network Protection properties
@@ -108,7 +108,7 @@ struct SettingsState {
             version: "0.0.0.0",
             debugModeEnabled: false,
             voiceSearchEnabled: false,
-            speechRecognitionEnabled: false,
+            speechRecognitionAvailable: false,
             loginsEnabled: false,
             networkProtection: NetworkProtection(enabled: false, status: ""),
             subscription: Subscription(enabled: false, canPurchase: false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1206454436350674/f

Cherry picked from: https://github.com/duckduckgo/iOS/pull/2394

**Description**:
Fix voice-search toggle in Settings
See parent task for steps to reproduce the issue

**Steps to test this PR**:
1. Delete app to start clean
2. Open the app, check if voice-search is default to off and there's no mic in the address bar
3. Change the settings to ON, accept the permission alert.
4. Close the settings screen, check if the mic icon is visible in the address bar. Tap the mic to see if the feature is working (better to test on a real device)
6. Force close the app, check if the settings is still ON.
7. Turn it off, force close app, and check if settings is still OFF
