### PR TITLE
Fix `site:` queries escaping with iOS 17 SDK (#640)

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9976,8 +9976,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "mariusz/url-escaping-ios17";
-				kind = branch;
+				kind = exactVersion;
+				version = 103.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9976,8 +9976,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 103.0.0;
+				branch = "mariusz/url-escaping-ios17";
+				kind = branch;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "mariusz/url-escaping-ios17",
-        "revision" : "0ac84b2582f96209495916c80715333387311cb0"
+        "revision" : "055cc2d86c0ac085d032fc28665c3115ea3f325a",
+        "version" : "103.0.1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "5af8fbcff0913aa543ba3eea60cc24e706a3a4e5",
-        "version" : "103.0.0"
+        "branch" : "mariusz/url-escaping-ios17",
+        "revision" : "0ac84b2582f96209495916c80715333387311cb0"
       }
     },
     {

--- a/LocalPackages/DuckUI/Package.swift
+++ b/LocalPackages/DuckUI/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             targets: ["DuckUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../DuckUI"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [

--- a/LocalPackages/Waitlist/Package.swift
+++ b/LocalPackages/Waitlist/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Waitlist", "WaitlistMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "103.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206343150540010/f

**Description**:
Linking to iOS 17 SDK modifies how URLs are being parsed and escaped (see [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes)). This change re-uses the solution done for macOS.

**Steps to test this PR**:
See [PR in BSK](https://github.com/duckduckgo/BrowserServicesKit/pull/640)
