### PR TITLE
Fix tab loading

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -108,6 +108,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         ContentBlocking.shared.onCriticalError = presentPreemptiveCrashAlert
+        // Explicitly prepare ContentBlockingUpdating instance before Tabs are created
+        _ = ContentBlockingUpdating.shared
 
         // Can be removed after a couple of versions
         cleanUpMacPromoExperiment2()

--- a/DuckDuckGo/ContentBlockingUpdating.swift
+++ b/DuckDuckGo/ContentBlockingUpdating.swift
@@ -37,7 +37,7 @@ extension ContentBlockerRulesIdentifier.Difference {
 }
 
 public final class ContentBlockingUpdating {
-    fileprivate static let shared = ContentBlockingUpdating()
+    static let shared = ContentBlockingUpdating()
 
     private typealias Update = ContentBlockerRulesManager.UpdateEvent
     struct NewContent: UserContentControllerNewContent {
@@ -55,7 +55,7 @@ public final class ContentBlockingUpdating {
 
     private(set) var userContentBlockingAssets: AnyPublisher<NewContent, Never>!
 
-    init(appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
+    init(appSettings: AppSettings = AppUserDefaults(),
          contentBlockerRulesManager: ContentBlockerRulesManagerProtocol = ContentBlocking.shared.contentBlockingManager,
          privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager) {
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -847,9 +847,6 @@ class MainViewController: UIViewController {
             if tabManager.current(createIfNeeded: true) == nil {
                 fatalError("failed to create tab")
             }
-
-            // Likely this hasn't happened yet so the publishers won't be loaded and will block the webview from loading
-            _ = ContentBlocking.shared.contentBlockingManager.scheduleCompilation()
         }
 
         guard let tab = currentTab else { fatalError("no tab") }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1206457470836092/f
Tech Design URL:
CC:

**Description**:

Fix tab loading on first navigation by ensuring assets are processed from the moment app is created.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

Check content blocking and privacy tests.

1. Load website in the tab, then open another tab with Home screen. Stay on home screen and kill the app.
2. Restart the app, wait 10s so rules are processed.
3. Switch to tab with website - it should load.
4. Create new tab and navigate somewhere - it should load.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone 
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
