### PR TITLE
Reenable toggle on disallowing vpn (#2404)

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -156,7 +156,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
 
         // Set up a delayed publisher to fire just once that reenables the toggle
         // Each event cancels the previous delayed publisher
-        isLoadingPublisher
+        $shouldDisableToggle
             .filter { $0 }
             .map {
                 Just(!$0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206463994034099/f

**Description**:

When “Don’t Allow” is tapped, the dialog is dismissed and the toggle is greyed out. We have to back out of the screen and reopen the VPN screen to give it another attempt.

Reenable the button again when the VPN permission is denied.

This can be solved by simply reenabling the toggle after it’s been disabled for 2 seconds, something we were already sort of doing to stop spamming. This just slightly reworks the logic to cover more scenarios.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure your device is set to internal user mode
2. Run this branch on a physical device
3. Open the NetP waitlist screen from settings and enter an invite code from the "VPN Invite Codes" task in Asana
4. After unlocking the app, hit the toggle to turn NetP on
5. **Decline** the prompt
6. Make sure that the toggle becomes active again after a month, and you can then activate it one more time and finish setting up the VPN

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
