### PR TITLE
fix ddg cookies on fire button

### DIFF
--- a/Core/CookieStorage.swift
+++ b/Core/CookieStorage.swift
@@ -114,7 +114,7 @@ public class CookieStorage {
         }
         
         persistedCookiesByDomain.keys.forEach {
-            guard $0 != "duckduckgo.com" else { return } // DDG cookies are for SERP settings only
+            guard !URL.isDuckDuckGo(domain: $0) else { return } // DDG cookies are for SERP settings only
             
             if !preservedLogins.isAllowed(cookieDomain: $0) {
                 persistedCookiesByDomain.removeValue(forKey: $0)

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -389,7 +389,7 @@ extension WKWebsiteDataStore: WebCacheManagerDataStore {
     public func preservedCookies(_ preservedLogins: PreserveLogins) async -> [HTTPCookie] {
         let allCookies = await self.httpCookieStore.allCookies()
         return allCookies.filter {
-            preservedLogins.isAllowed(cookieDomain: $0.domain)
+            "duckduckgo.com" == $0.domain || preservedLogins.isAllowed(cookieDomain: $0.domain)
         }
     }
 

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -56,10 +56,6 @@ extension WebCacheManagerDataStore {
 }
 
 public class WebCacheManager {
-
-    private struct Constants {
-        static let cookieDomainsToPreserve = ["duckduckgo.com", "surveys.duckduckgo.com"]
-    }
     
     public static var shared = WebCacheManager()
 
@@ -223,7 +219,7 @@ public class WebCacheManager {
 
         func keep(_ cookie: HTTPCookie) -> Bool {
             return logins.isAllowed(cookieDomain: cookie.domain) ||
-                Constants.cookieDomainsToPreserve.contains(cookie.domain)
+                URL.isDuckDuckGo(domain: cookie.domain)
         }
 
         let dataStore = WKWebsiteDataStore.default()
@@ -270,7 +266,7 @@ public class WebCacheManager {
                     // Remove legacy HTTPCookieStorage cookies
                     let storageCookies = HTTPCookieStorage.shared.cookies ?? []
                     let storageCookiesToRemove = storageCookies.filter {
-                        !logins.isAllowed(cookieDomain: $0.domain) && !Constants.cookieDomainsToPreserve.contains($0.domain)
+                        !logins.isAllowed(cookieDomain: $0.domain) && !URL.isDuckDuckGo(domain: $0.domain)
                     }
 
                     let protectedStorageCookiesCount = storageCookies.count - storageCookiesToRemove.count
@@ -389,7 +385,7 @@ extension WKWebsiteDataStore: WebCacheManagerDataStore {
     public func preservedCookies(_ preservedLogins: PreserveLogins) async -> [HTTPCookie] {
         let allCookies = await self.httpCookieStore.allCookies()
         return allCookies.filter {
-            "duckduckgo.com" == $0.domain || preservedLogins.isAllowed(cookieDomain: $0.domain)
+            URL.isDuckDuckGo(domain: $0.domain) || preservedLogins.isAllowed(cookieDomain: $0.domain)
         }
     }
 

--- a/DuckDuckGoTests/CookieStorageTests.swift
+++ b/DuckDuckGoTests/CookieStorageTests.swift
@@ -51,6 +51,12 @@ public class CookieStorageTests: XCTestCase {
 
         XCTAssertEqual(2, storage.cookies.count)
 
+        storage.updateCookies([
+            make("usedev1.duckduckgo.com", name: "x", value: "1"),
+        ], keepingPreservedLogins: logins)
+
+        XCTAssertEqual(3, storage.cookies.count)
+
     }
     
     func testWhenUpdatedThenCookiesWithFutureExpirationAreNotRemoved() {

--- a/DuckDuckGoTests/WebCacheManagerTests.swift
+++ b/DuckDuckGoTests/WebCacheManagerTests.swift
@@ -128,7 +128,8 @@ class WebCacheManagerTests: XCTestCase {
 
         let dataStore = MockDataStore()
         let cookieStore = MockHTTPCookieStore(cookies: [
-            .make(domain: "duckduckgo.com")
+            .make(domain: "duckduckgo.com"),
+            .make(domain: "subdomain.duckduckgo.com")
         ])
 
         dataStore.cookieStore = cookieStore
@@ -139,8 +140,9 @@ class WebCacheManagerTests: XCTestCase {
         }
         wait(for: [expect], timeout: 5.0)
         
-        XCTAssertEqual(cookieStore.cookies.count, 1)
-        XCTAssertEqual(cookieStore.cookies[0].domain, "duckduckgo.com")
+        XCTAssertEqual(cookieStore.cookies.count, 2)
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == "duckduckgo.com" }))
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == "subdomain.duckduckgo.com" }))
     }
     
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1206511646424647/f
Tech Design URL:
CC:

**Description**:

Keep DDG cookies when fire button is used.

**Steps to test this PR**:
1. Change 'safe search' to 'off' on the SERP (or via settings in SERP menu).  Change other settings too.
2. Use the fire button
3. Check the settings are retained. 

**DDG domain test**:
1. Login into use-devtesting2.duckduckgo.com (sorry)
5. Change some settings on that site
6. Ensure they are retained 

