### PR TITLE
Set proper border color for widgets

### DIFF
--- a/Widgets/WidgetViews.swift
+++ b/Widgets/WidgetViews.swift
@@ -206,7 +206,7 @@ struct FavoritesWidgetView: View {
             .padding(EdgeInsets(top: widgetFamily == .systemLarge ? 48 : 60, leading: 0, bottom: 0, trailing: 0))
 
         }
-        .widgetContainerBackground()
+        .widgetContainerBackground(color: .widgetBackground)
     }
 }
 
@@ -240,17 +240,17 @@ struct SearchWidgetView: View {
                 }
             }.accessibilityHidden(true)
         }
-        .widgetContainerBackground()
+        .widgetContainerBackground(color: .widgetBackground)
     }
 }
 
 // See https://stackoverflow.com/a/59228385/73479
 extension View {
 
-    @ViewBuilder func widgetContainerBackground() -> some View {
+    @ViewBuilder func widgetContainerBackground(color: Color = .clear) -> some View {
         if #available(iOSApplicationExtension 17.0, *) {
             containerBackground(for: .widget) {
-                Color.clear
+                color
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1206466403660548/f

**Description**:
Sets a proper background color for widgets, removing the border visible in dark mode.

**Steps to test this PR**:
1. Add Search and Favorites widget to home screen
2. Test on light and dark mode

**Theme Testing**:
* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
