### PR TITLE
Fix HomeViewController retain cycle

### DIFF
--- a/DuckDuckGo/HomeCollectionView.swift
+++ b/DuckDuckGo/HomeCollectionView.swift
@@ -85,8 +85,12 @@ class HomeCollectionView: UICollectionView {
                 
             case .favorites:
                 let renderer = FavoritesHomeViewSectionRenderer(viewModel: favoritesViewModel)
-                renderer.onFaviconMissing = { _ in
-                    controller.faviconsFetcherOnboarding.presentOnboardingIfNeeded(from: controller)
+                renderer.onFaviconMissing = { [weak self] _ in
+                    guard let self else {
+                        return
+                    }
+
+                    self.controller.faviconsFetcherOnboarding.presentOnboardingIfNeeded(from: self.controller)
                 }
                 renderers.install(renderer: renderer)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1206561582798187/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue with every HomeViewController instance being affected by a retain cycle.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that basic web browsing and tab manipulation works
2. Open a bunch of tabs then close them all
3. Check the memory graph debugger to verify that there aren't tons of HomeViewController instances leaking

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
