### PR TITLE
fix missing navigation bar from blank preview

### DIFF
--- a/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/DuckDuckGo/BlankSnapshotViewController.swift
@@ -110,6 +110,17 @@ class BlankSnapshotViewController: UIViewController {
     }
     
     private func configureOmniBar() {
+        viewCoordinator.navigationBarCollectionView.register(OmniBarCell.self, forCellWithReuseIdentifier: "omnibar")
+        viewCoordinator.navigationBarCollectionView.isPagingEnabled = true
+
+        let layout = viewCoordinator.navigationBarCollectionView.collectionViewLayout as? UICollectionViewFlowLayout
+        layout?.scrollDirection = .horizontal
+        layout?.itemSize = CGSize(width: viewCoordinator.superview.frame.size.width, height: viewCoordinator.omniBar.frame.height)
+        layout?.minimumLineSpacing = 0
+        layout?.minimumInteritemSpacing = 0
+        layout?.scrollDirection = .horizontal
+
+        viewCoordinator.navigationBarCollectionView.dataSource = self
         if AppWidthObserver.shared.isLargeWidth {
             viewCoordinator.omniBar.enterPadState()
         }
@@ -124,6 +135,25 @@ class BlankSnapshotViewController: UIViewController {
         Pixel.fire(pixel: .blankOverlayNotDismissed)
         delegate?.recoverFromPresenting(controller: self)
     }
+}
+
+extension BlankSnapshotViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "omnibar", for: indexPath) as? OmniBarCell else {
+            fatalError("Not \(OmniBarCell.self)")
+        }
+        cell.omniBar = viewCoordinator.omniBar
+        return cell
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
 }
 
 extension BlankSnapshotViewController: OmniBarDelegate {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206634573412032/f
Tech Design URL:
CC:

**Description**:

Fix missing navigation bar from blank preview.

**Steps to test this PR**:
1. Launch the app and open a tab
2. In settings enable auto clear
3. Background (don't close) the app
4. Use iOS application switcher and it should show the correctly presented blank preview 

