### PR TITLE
Fix some issues with handling when the adapter is started up

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9908,7 +9908,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = d95448c1bd6cb8b413907acf770316f22dac58f8;
+				revision = 262f6c6449466efac00c7a6818747da3a2900c4d;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9907,8 +9907,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 109.0.1;
+				kind = revision;
+				revision = d95448c1bd6cb8b413907acf770316f22dac58f8;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9907,8 +9907,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 262f6c6449466efac00c7a6818747da3a2900c4d;
+				kind = exactVersion;
+				version = 110.0.1;
 			};
 		};
 		C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -31,8 +31,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "063b560e59a50e03d9b00b88a7fcb2ed2b562395",
-        "version" : "4.61.0"
+        "revision" : "36ddba2cbac52a41b9a9275af06d32fa8a56d2d7",
+        "version" : "4.64.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "d95448c1bd6cb8b413907acf770316f22dac58f8"
+        "revision" : "262f6c6449466efac00c7a6818747da3a2900c4d"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "262f6c6449466efac00c7a6818747da3a2900c4d"
+        "revision" : "483427db845410f10121cf2200f5a940c9bbf70b",
+        "version" : "110.0.1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,9 @@
     {
       "identity" : "browserserviceskit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/BrowserServicesKit",
+      "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "da6a822844922401d80e26963b8b11dcd6ef221a",
-        "version" : "109.0.1"
+        "revision" : "d95448c1bd6cb8b413907acf770316f22dac58f8"
       }
     },
     {

--- a/LocalPackages/DuckUI/Package.swift
+++ b/LocalPackages/DuckUI/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             targets: ["DuckUI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "110.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "110.0.1"),
     ],
     targets: [
         .target(

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../DuckUI"),
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "110.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "110.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [

--- a/LocalPackages/Waitlist/Package.swift
+++ b/LocalPackages/Waitlist/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Waitlist", "WaitlistMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "110.0.0"),
+        .package(url: "https://github.com/duckduckgo/BrowserServicesKit", exact: "110.0.1"),
         .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "2.0.0")
     ],
     targets: [

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -221,7 +221,6 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                    settings: settings)
         startMonitoringMemoryPressureEvents()
         observeServerChanges()
-        observeStatusChanges()
         APIRequest.Headers.setUserAgent(DefaultUserAgentManager.duckDuckGoUserAgent)
     }
 
@@ -259,14 +258,11 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
     private let activationDateStore = DefaultVPNWaitlistActivationDateStore()
 
-    private func observeStatusChanges() {
-        connectionStatusPublisher.sink { [weak self] status in
-            if case .connected = status {
-                self?.activationDateStore.setActivationDateIfNecessary()
-                self?.activationDateStore.updateLastActiveDate()
-            }
-        }
-        .store(in: &cancellables)
+    public override func handleConnectionStatusChange(old: ConnectionStatus, new: ConnectionStatus) {
+        super.handleConnectionStatusChange(old: old, new: new)
+
+        activationDateStore.setActivationDateIfNecessary()
+        activationDateStore.updateLastActiveDate()
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206634919441353/f
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2251
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/674

## Description

Fixes how we handle the event of the tunnel adapter started.  More broadly, this PR tries to ensure we don't "histerically" start and stop our monitors, since that could result in a lot of noise in our metrics.

## Testing:

1. Open Console.app
2. Select the iPhone device and start streaming (needs a wired connection I believe)
3. Filter by "⚫️"
4. Run the app and start the VPN
5. Check that the status updates in Console.app don't show any repeating status changes.
6. Check that the monitors are started and stopped correctly in the following steps.
7. Start / stop the VPN to test further.
8. Try changing server locations

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
