### PR TITLE
Fixes the firing of `mh` pixel

### DIFF
--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -264,12 +264,18 @@ class HomeViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        if presentedViewController == nil { // prevents these being called when settings forces this controller to be reattached
+
+        // If there's no tab switcher then this will be true, if there is a tabswitcher then only allow the
+        //  stuff below to happen if it's being dismissed
+        guard (parent as? MainViewController)?.tabSwitcherController?.isBeingDismissed ?? true  else { return }
+
+        Pixel.fire(pixel: .homeScreenShown)
+
+        // But settings etc might cause the home view controller to be re-attached so don't show the next dialog until we're properly in the clear
+        if presentedViewController == nil {
             showNextDaxDialog()
         }
 
-        Pixel.fire(pixel: .homeScreenShown)
         collectionView.didAppear()
 
         viewHasAppeared = true

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -267,15 +267,11 @@ class HomeViewController: UIViewController {
 
         // If there's no tab switcher then this will be true, if there is a tabswitcher then only allow the
         //  stuff below to happen if it's being dismissed
-        guard (parent as? MainViewController)?.tabSwitcherController?.isBeingDismissed ?? true  else { return }
+        guard presentedViewController?.isBeingDismissed ?? true else { return }
 
         Pixel.fire(pixel: .homeScreenShown)
-
-        // But settings etc might cause the home view controller to be re-attached so don't show the next dialog until we're properly in the clear
-        if presentedViewController == nil {
-            showNextDaxDialog()
-        }
-
+        showNextDaxDialog()
+        
         collectionView.didAppear()
 
         viewHasAppeared = true

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2058,8 +2058,12 @@ extension MainViewController: TabSwitcherDelegate {
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, didRemoveTab tab: Tab) {
         if tabManager.count == 1 {
             // Make sure UI updates finish before dimissing the view.
+            // However, as a result, viewDidAppear on the home controller thinks the tab 
+            //  switcher is still presented.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                tabSwitcher.dismiss()
+                tabSwitcher.dismiss(animated: true) {
+                    self.homeController?.viewDidAppear(true)
+                }
             }
         }
         closeTab(tab)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1206674614649925/f
Tech Design URL:
CC:

**Description**:
Fixes the firing of `mh` pixel

**Steps to test this PR**:
1. Launch the app, ensure `mh` pixel is fired when the the new tab is shown
2. Create tabs from the tab switcher.  `mh` should only be fired when the the user ends up on the Home Screen
3. Check RMF message still displays as expected
