### PR TITLE
rename cookie and ensure timeout does not fire prematurely

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -899,7 +899,7 @@ extension Pixel.Event {
             
         case .blankOverlayNotDismissed: return "m_d_ovs"
             
-        case .cookieDeletionTimedOut: return "m_d_csto"
+        case .cookieDeletionTimedOut: return "m_debug_cookie-clearing-timeout"
         case .cookieDeletionLeftovers: return "m_cookie_deletion_leftovers"
             
         case .cachedTabPreviewsExceedsTabCount: return "m_d_tpetc"

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -132,6 +132,7 @@ extension WebCacheManager {
     
     private func legacyDataClearing() async -> [HTTPCookie]? {
         let timeoutTask = Task.detached {
+            try? await Task.sleep(interval: 5.0)
             if !Task.isCancelled {
                 Pixel.fire(pixel: .cookieDeletionTimedOut, withAdditionalParameters: [
                     PixelParameters.clearWebDataTimedOut: "1"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206707849446765/f
Tech Design URL:
CC:

**Description**:

rename cookie and ensure timeout does not fire prematurely

**Steps to test this PR**:
1. Use the fire button - the cookie timeout pixel should not fire
1. Add `try? await Task.sleep(interval: 6.0)` to the `legacyDataClearing()` function before the timeout task gets cancelled
3. Use the fire button - the cookie timeout pixel will fire 
