### PR TITLE
Prevent duplicate reporting on VPN feedback form

### DIFF
--- a/DuckDuckGo/Feedback/VPNFeedbackFormView.swift
+++ b/DuckDuckGo/Feedback/VPNFeedbackFormView.swift
@@ -81,7 +81,6 @@ struct VPNFeedbackFormCategoryView: View {
 struct VPNFeedbackFormView: View {
     @ObservedObject var viewModel: VPNFeedbackFormViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var showsError = false
     @FocusState private var isTextEditorFocused: Bool
 
     var onDismiss: () -> Void
@@ -90,11 +89,6 @@ struct VPNFeedbackFormView: View {
         configuredForm()
         .applyBackground()
         .navigationTitle(UserText.netPStatusViewShareFeedback)
-        .alert(isPresented: $showsError) {
-            Alert(title: Text(UserText.vpnFeedbackFormErrorTitle),
-                  message: Text(UserText.vpnFeedbackFormErrorMessage),
-                  dismissButton: .default(Text(UserText.vpnFeedbackFormErrorAction)))
-        }
     }
 
     @ViewBuilder
@@ -204,14 +198,10 @@ struct VPNFeedbackFormView: View {
     private func submitButton() -> some View {
         Button {
             Task {
-                let success = await viewModel.process()
-                if success {
-                    dismiss()
-                    onDismiss()
-                } else {
-                    showsError = true
-                }
+                _ = await viewModel.process()
             }
+            dismiss()
+            onDismiss()
         } label: {
             Text(UserText.vpnFeedbackFormButtonSubmit)
                 .daxButton()

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -657,9 +657,6 @@ In addition to the details entered into this form, your app issue report will co
     static let vpnFeedbackFormButtonSubmitting = NSLocalizedString("vpn.feedback-form.button.submitting", value: "Submitting…", comment: "Title for the Submitting state of the VPN feedback form")
 
     static let vpnFeedbackFormSubmittedMessage = NSLocalizedString("vpn.feedback-form.submitted.message", value: "Thank You! Feedback submitted.", comment: "Toast message when the VPN feedback form is submitted successfully")
-    static let vpnFeedbackFormErrorTitle = NSLocalizedString("vpn.feedback-form.error.title", value: "Error", comment: "Title for the alert when the VPN feedback form can't be submitted")
-    static let vpnFeedbackFormErrorMessage = NSLocalizedString("vpn.feedback-form.error.message", value: "Failed to share your feedback. Please try again.", comment: "Message for the alert when the VPN feedback form can't be submitted")
-    static let vpnFeedbackFormErrorAction = NSLocalizedString("vpn.feedback-form.error.action", value: "OK", comment: "Action title for the alert when the VPN feedback form can't be submitted")
 
     // MARK: Notifications
     

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -2005,7 +2005,7 @@ But if you *do* want a peek under the hood, you can find more information about 
 "subscription.manage.devices" = "Manage Devices";
 
 /* Description for Email Management options */
-"subscription.manage.email.description" = "You can use this email to activate your subscription on your other devices.";
+"subscription.manage.email.description" = "You can use this email to activate your subscription from browser settings in the DuckDuckGo app on your other devices.";
 
 /* Manage Plan header */
 "subscription.manage.plan" = "Manage Plan";
@@ -2231,15 +2231,6 @@ But if you *do* want a peek under the hood, you can find more information about 
 
 /* Title for the 'unable to install' category of the VPN feedback form */
 "vpn.feedback-form.category.unable-to-install" = "Unable to install VPN";
-
-/* Action title for the alert when the VPN feedback form can't be submitted */
-"vpn.feedback-form.error.action" = "OK";
-
-/* Message for the alert when the VPN feedback form can't be submitted */
-"vpn.feedback-form.error.message" = "Failed to share your feedback. Please try again.";
-
-/* Title for the alert when the VPN feedback form can't be submitted */
-"vpn.feedback-form.error.title" = "Error";
 
 /* Title for the feedback sent view description of the VPN feedback form */
 "vpn.feedback-form.sending-confirmation.description" = "Your feedback will help us improve the\nDuckDuckGo VPN.";


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206699692273754/f
Tech Design URL:
CC:

**Description**:

This PR removes VPN feedback form error handling and always pops it to root to prevent duplicate reporting. This leaves the possibility that the send fails and the user isn't aware of it, but if this approach has been good enough for AppTP in the Android app then it would work here

**Steps to test this PR**:
1. Go to Settings > Network Protection > Share feedback
2. Follow the steps and hit Submit
3. The form always pops to root regardless of the outcome

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
