### PR TITLE
fix opening tabs with transitional

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -165,7 +165,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
         "revision" : "a6b7ba151d9dc6684484f3785293875ec01cc1ff",
         "version" : "1.2.2"

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1833,7 +1833,8 @@ extension MainViewController: TabDelegate {
         showBars()
         currentTab?.dismiss()
 
-        let newTab = tabManager.addURLRequest(navigationAction.request,
+        // Don't use a request or else the page gets stuck on "about:blank"
+        let newTab = tabManager.addURLRequest(nil,
                                               with: configuration,
                                               inheritedAttribution: inheritingAttribution)
         newTab.openedByPage = true

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -120,7 +120,7 @@ class TabManager {
         return current(createIfNeeded: true)!
     }
 
-    func addURLRequest(_ request: URLRequest,
+    func addURLRequest(_ request: URLRequest?,
                        with configuration: WKWebViewConfiguration,
                        inheritedAttribution: AdClickAttributionLogic.State?) -> TabViewController {
 
@@ -128,7 +128,12 @@ class TabManager {
             fatalError("Failed to copy configuration")
         }
 
-        let tab = Tab(link: request.url == nil ? nil : Link(title: nil, url: request.url!))
+        let tab: Tab
+        if let request {
+            tab = Tab(link: request.url == nil ? nil : Link(title: nil, url: request.url!))
+        } else {
+            tab = Tab()
+        }
         model.insert(tab: tab, at: model.currentIndex + 1)
         model.select(tabAt: model.currentIndex + 1)
 


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/0/414235014887631/1206769708570992/f
Tech Design URL:
CC:

**Description**:
Pages that open new tabs in a certain way will get stuck on `about:blank`

**Steps to test this PR**:
1. Visit https://finance.yahoo.com/news/ocean-biomedical-inc-announces-publication-131500736.html?guccounter=1 and get to the article content
2. Click on a link in the article. 
3. A new tab should open and navigate to the content
4. Visit https://chrisbrind.rocks and click on one of the Connect buttons (instagram, tiktok, mastodon) - should all open in a new tab and load successfully (I know this website is awful sorry)
