### PR TITLE
Adds pixels to track main VPN funnels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -249,6 +249,16 @@ extension Pixel {
     }
 }
 
+/// NSError supports this through `NSUnderlyingError`, but there's no support for this for Swift's `Error`.  This protocol does that.
+///
+/// The reason why this protocol returns a code and a domain instead of just an `Error` or `NSError` is so that the error implementing
+/// this protocol has full control over these values, and is able to override them as it best sees fit.
+///
+protocol ErrorWithUnderlyingError: Error {
+    var underlyingErrorCode: Int { get }
+    var underlyingErrorDomain: String { get }
+}
+
 extension Dictionary where Key == String, Value == String {
     mutating func appendErrorPixelParams(error: Error) {
         let nsError = error as NSError
@@ -256,7 +266,10 @@ extension Dictionary where Key == String, Value == String {
         self[PixelParameters.errorCode] = "\(nsError.code)"
         self[PixelParameters.errorDomain] = nsError.domain
 
-        if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
+        if let underlyingError = error as? ErrorWithUnderlyingError {
+            self[PixelParameters.underlyingErrorCode] = "\(underlyingError.underlyingErrorCode)"
+            self[PixelParameters.underlyingErrorDomain] = underlyingError.underlyingErrorDomain
+        } else if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
             self[PixelParameters.underlyingErrorCode] = "\(underlyingError.code)"
             self[PixelParameters.underlyingErrorDomain] = underlyingError.domain
         } else if let sqlErrorCode = nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -266,6 +266,18 @@ extension Pixel {
         case networkProtectionActiveUser
         case networkProtectionNewUser
 
+        case networkProtectionControllerStartAttempt
+        case networkProtectionControllerStartSuccess
+        case networkProtectionControllerStartFailure
+
+        case networkProtectionTunnelStartAttempt
+        case networkProtectionTunnelStartSuccess
+        case networkProtectionTunnelStartFailure
+
+        case networkProtectionTunnelUpdateAttempt
+        case networkProtectionTunnelUpdateSuccess
+        case networkProtectionTunnelUpdateFailure
+
         case networkProtectionEnableAttemptConnecting
         case networkProtectionEnableAttemptSuccess
         case networkProtectionEnableAttemptFailure
@@ -280,6 +292,8 @@ extension Pixel {
 
         case networkProtectionBreakageReport
 
+        case networkProtectionRekeyAttempt
+        case networkProtectionRekeyFailure
         case networkProtectionRekeyCompleted
 
         case networkProtectionTunnelConfigurationNoServerRegistrationInfo
@@ -781,10 +795,19 @@ extension Pixel.Event {
         case .appTPDBTrackerStoreFailure: return "m_apptp_db_tracker_store_failure"
         case .appTPCouldNotLoadDatabase: return "m_apptp_could_not_load_database"
 
-        // MARK: Network Protection pixels
+            // MARK: Network Protection pixels
 
         case .networkProtectionActiveUser: return "m_netp_daily_active_d"
         case .networkProtectionNewUser: return "m_netp_daily_active_u"
+        case .networkProtectionControllerStartAttempt: return "m_netp_controller_start_attempt"
+        case .networkProtectionControllerStartSuccess: return "m_netp_controller_start_success"
+        case .networkProtectionControllerStartFailure: return "m_netp_controller_start_failure"
+        case .networkProtectionTunnelStartAttempt: return "m_netp_tunnel_start_attempt"
+        case .networkProtectionTunnelStartSuccess: return "m_netp_tunnel_start_success"
+        case .networkProtectionTunnelStartFailure: return "m_netp_tunnel_start_failure"
+        case .networkProtectionTunnelUpdateAttempt: return "m_netp_tunnel_update_attempt"
+        case .networkProtectionTunnelUpdateSuccess: return "m_netp_tunnel_update_success"
+        case .networkProtectionTunnelUpdateFailure: return "m_netp_tunnel_update_failure"
         case .networkProtectionEnableAttemptConnecting: return "m_netp_ev_enable_attempt"
         case .networkProtectionEnableAttemptSuccess: return "m_netp_ev_enable_attempt_success"
         case .networkProtectionEnableAttemptFailure: return "m_netp_ev_enable_attempt_failure"
@@ -792,7 +815,9 @@ extension Pixel.Event {
         case .networkProtectionTunnelFailureRecovered: return "m_netp_ev_tunnel_failure_recovered"
         case .networkProtectionLatency(let quality): return "m_netp_ev_\(quality.rawValue)_latency"
         case .networkProtectionLatencyError: return "m_netp_ev_latency_error_d"
+        case .networkProtectionRekeyAttempt: return "m_mac_netp_rekey_attempt"
         case .networkProtectionRekeyCompleted: return "m_netp_rekey_completed"
+        case .networkProtectionRekeyFailure: return "m_netp_rekey_failure"
         case .networkProtectionEnabledOnSearch: return "m_netp_ev_enabled_on_search"
         case .networkProtectionBreakageReport: return "m_vpn_breakage_report"
         case .networkProtectionTunnelConfigurationNoServerRegistrationInfo: return "m_netp_tunnel_config_error_no_server_registration_info"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -795,7 +795,7 @@ extension Pixel.Event {
         case .appTPDBTrackerStoreFailure: return "m_apptp_db_tracker_store_failure"
         case .appTPCouldNotLoadDatabase: return "m_apptp_could_not_load_database"
 
-            // MARK: Network Protection pixels
+        // MARK: Network Protection pixels
 
         case .networkProtectionActiveUser: return "m_netp_daily_active_d"
         case .networkProtectionNewUser: return "m_netp_daily_active_u"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9981,7 +9981,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 22162521992a20e5736b703fbbe3d467f87da3ce;
+				revision = a05b619aed9911f41718ae44889174b08a213e52;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9980,8 +9980,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = a05b619aed9911f41718ae44889174b08a213e52;
+				kind = exactVersion;
+				version = "114.1.0-1";
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9980,8 +9980,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 114.1.0;
+				kind = revision;
+				revision = 22162521992a20e5736b703fbbe3d467f87da3ce;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "22162521992a20e5736b703fbbe3d467f87da3ce"
+        "revision" : "a05b619aed9911f41718ae44889174b08a213e52"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "a05b619aed9911f41718ae44889174b08a213e52"
+        "revision" : "d9de416d3b77082f818a91b065bee1a2025c8e46",
+        "version" : "114.1.0-1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "045a8782c3dbbf79fc088b38120dea1efadc13e1",
-        "version" : "114.1.0"
+        "revision" : "22162521992a20e5736b703fbbe3d467f87da3ce"
       }
     },
     {

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -49,9 +49,14 @@ final class NetworkProtectionTunnelController: TunnelController {
     /// Starts the VPN connection used for Network Protection
     ///
     func start() async {
+        Pixel.fire(pixel: .networkProtectionControllerStartAttempt)
+
         do {
             try await startWithError()
+            Pixel.fire(pixel: .networkProtectionControllerStartSuccess)
         } catch {
+            Pixel.fire(pixel: .networkProtectionControllerStartFailure, error: error)
+
             #if DEBUG
             errorStore.lastErrorMessage = error.localizedDescription
             #endif

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -28,6 +28,8 @@ import NetworkExtension
 import NetworkProtection
 import Subscription
 
+// swiftlint:disable type_body_length
+
 // Initial implementation for initial Network Protection tests. Will be fleshed out with https://app.asana.com/0/1203137811378537/1204630829332227/f
 final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
@@ -311,5 +313,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
         }
     }
 }
+
+// swiftlint:enable type_body_length
 
 #endif

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -68,8 +68,33 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 guard quality != .unknown else { return }
                 DailyPixel.fireDailyAndCount(pixel: .networkProtectionLatency(quality: quality))
             }
-        case .rekeyCompleted:
-            Pixel.fire(pixel: .networkProtectionRekeyCompleted)
+        case .rekeyAttempt(let step):
+            switch step {
+            case .begin:
+                Pixel.fire(pixel: .networkProtectionRekeyAttempt)
+            case .failure(let error):
+                Pixel.fire(pixel: .networkProtectionRekeyFailure, error: error)
+            case .success:
+                Pixel.fire(pixel: .networkProtectionRekeyCompleted)
+            }
+        case .tunnelStartAttempt(let step):
+            switch step {
+            case .begin:
+                Pixel.fire(pixel: .networkProtectionTunnelStartAttempt)
+            case .failure(let error):
+                Pixel.fire(pixel: .networkProtectionTunnelStartFailure, error: error)
+            case .success:
+                Pixel.fire(pixel: .networkProtectionTunnelStartSuccess)
+            }
+        case .tunnelUpdateAttempt(let step):
+            switch step {
+            case .begin:
+                Pixel.fire(pixel: .networkProtectionTunnelUpdateAttempt)
+            case .failure(let error):
+                Pixel.fire(pixel: .networkProtectionTunnelUpdateFailure, error: error)
+            case .success:
+                Pixel.fire(pixel: .networkProtectionTunnelUpdateSuccess)
+            }
         }
     }
 

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -71,29 +71,29 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
         case .rekeyAttempt(let step):
             switch step {
             case .begin:
-                Pixel.fire(pixel: .networkProtectionRekeyAttempt)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionRekeyAttempt)
             case .failure(let error):
-                Pixel.fire(pixel: .networkProtectionRekeyFailure, error: error)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionRekeyFailure, error: error)
             case .success:
-                Pixel.fire(pixel: .networkProtectionRekeyCompleted)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionRekeyCompleted)
             }
         case .tunnelStartAttempt(let step):
             switch step {
             case .begin:
-                Pixel.fire(pixel: .networkProtectionTunnelStartAttempt)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelStartAttempt)
             case .failure(let error):
-                Pixel.fire(pixel: .networkProtectionTunnelStartFailure, error: error)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelStartFailure, error: error)
             case .success:
-                Pixel.fire(pixel: .networkProtectionTunnelStartSuccess)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelStartSuccess)
             }
         case .tunnelUpdateAttempt(let step):
             switch step {
             case .begin:
-                Pixel.fire(pixel: .networkProtectionTunnelUpdateAttempt)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelUpdateAttempt)
             case .failure(let error):
-                Pixel.fire(pixel: .networkProtectionTunnelUpdateFailure, error: error)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelUpdateFailure, error: error)
             case .success:
-                Pixel.fire(pixel: .networkProtectionTunnelUpdateSuccess)
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionTunnelUpdateSuccess)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206737255908394/f

macOS PR: https://github.com/duckduckgo/macos-browser/pull/2304
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/698

## Description

Add pixels to better track all main VPN funnels:
- VPN Controller Start
- VPN Tunnel Start
- VPN Tunnel Update (change location, etc)

## Testing

### Setup

- Open Console.app
- Filter by "Pixel fired"
- To clear pixels in iOS, uninstall the app.

### Test 1: start success

1. Fully uninstall the VPN or Debug Menu > Network Protection > Reset > Reset All State Keeping Invite
2. Start the tunnel.
3. Complete the installation.
4. Make sure you see these as both daily and count (order of success ones can vary):
- `m_netp_controller_start_attempt`
- `m_netp_controller_start_success`
- `m_netp_tunnel_start_attempt`
- `m_netp_tunnel_start_success`

Note: I'm sometimes not seeing `m_netp_controller_start_success` but when I place a breakpoint it's hit.  Not sure what's up with that.

### Test 2: controller start failure

1. Force an error by [throwing here](https://github.com/duckduckgo/iOS/blob/802a3ee16c5286064436e8f6c02dbd21105a47ab/DuckDuckGo/NetworkProtectionTunnelController.swift#L109).
2. Fully uninstall the VPN or Debug Menu > Network Protection > Reset > Reset All State Keeping Invite
3. Start the tunnel.  The installation should fail.
4. Make sure you see these as both daily and count:
- `m_netp_controller_start_attempt`
- `m_netp_controller_start_failure` (this should include error info)

### Test 3: tunnel start failure

1. Force error by [throwing here](https://github.com/duckduckgo/BrowserServicesKit/blob/1aa89c9449ed66b55abc8a81abfbe781f90d63bb/Sources/NetworkProtection/PacketTunnelProvider.swift#L549).
2. Fully uninstall the VPN or Debug Menu > Network Protection > Reset > Reset All State Keeping Invite
3. Start the tunnel.  The installation should fail.
4. Make sure you see these as both daily and count:
- `m_netp_controller_start_attempt`
- `m_netp_controller_start_success `
- `m_netp_tunnel_start_attempt`
- `m_netp_tunnel_start_falure` (this should include error info)

### Test 4: tunnel update success

1. Start the tunnel.
2. Once connected change your geolocation.
3. Make sure you see these as both daily and count:
- `m_netp_tunnel_update_attempt`
- `m_netp_tunnel_update_success`

### Test 5: tunnel update failure

1. Force an error by [throwing here](https://github.com/duckduckgo/BrowserServicesKit/blob/1aa89c9449ed66b55abc8a81abfbe781f90d63bb/Sources/NetworkProtection/PacketTunnelProvider.swift#L731).
2. Fully uninstall the VPN or Debug Menu > Network Protection > Reset > Reset All State Keeping Invite
3. Start the tunnel.
4. Once connected change your geolocation.
5. Make sure you see these as both daily and count:
- `m_netp_tunnel_update_attempt`
- `m_netp_tunnel_update_failure` (this should include error info)

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
