### PR TITLE
Makes network path metadata description anonymous

### DIFF
--- a/DuckDuckGo/Feedback/VPNMetadataCollector.swift
+++ b/DuckDuckGo/Feedback/VPNMetadataCollector.swift
@@ -142,7 +142,6 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
         let monitor = NWPathMonitor()
         monitor.start(queue: DispatchQueue(label: "VPNMetadataCollector.NWPathMonitor.paths"))
 
-        var path: Network.NWPath?
         let startTime = CFAbsoluteTimeGetCurrent()
 
         let dateFormatter = DateFormatter()
@@ -163,10 +162,10 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
 
         while true {
             if !monitor.currentPath.availableInterfaces.isEmpty {
-                path = monitor.currentPath
+                let path = monitor.currentPath
                 monitor.cancel()
 
-                return .init(currentPath: path.debugDescription,
+                return .init(currentPath: path.anonymousDescription,
                              lastPathChangeDate: lastPathChangeDate,
                              lastPathChange: lastPathChange,
                              secondsSincePathChange: secondsSincePathChange)
@@ -243,5 +242,26 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
             notifyStatusChangesEnabled: settings.notifyStatusChanges,
             selectedServer: settings.selectedServer.stringValue ?? "automatic"
         )
+    }
+}
+
+extension Network.NWPath {
+    /// A description that's safe from a privacy standpoint.
+    ///
+    /// Ref: https://app.asana.com/0/0/1206712493935053/1206712516729780/f
+    ///
+    var anonymousDescription: String {
+        var description = "NWPath("
+
+        description += "status: \(status), "
+
+        if #available(iOS 14.2, *), case .unsatisfied = status {
+            description += "unsatisfiedReason: \(unsatisfiedReason), "
+        }
+
+        description += "availableInterfaces: \(availableInterfaces)"
+        description += ")"
+
+        return description
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206714043828475/f

macOS PR: https://github.com/duckduckgo/macos-browser/pull/2327

## Description

Update network path metadata to derive string manually

For context about why we're doing this, please see: https://app.asana.com/0/0/1206712493935053/1206712516729780/f

## Testing

Note: I don't know if it's possible to make the path unsatisfied while testing - I couldn't do it

1. Place a breakpoint [here](https://github.com/duckduckgo/iOS/blob/4c0eb1add74a8d2ec4a629c611579b826fd67daa/DuckDuckGo/Feedback/VPNMetadataCollector.swift#L265).
2. Go to More Menu > Network Description > Send Feedback type something and submit
3. `po description`

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)