### PR TITLE
Fix VPN view model memory leak

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -158,12 +158,11 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
         // Each event cancels the previous delayed publisher
         $shouldDisableToggle
             .filter { $0 }
-            .map {
-                Just(!$0)
-                    .delay(for: 2.0, scheduler: DispatchQueue.main)
-                    .assign(to: \.shouldDisableToggle, onWeaklyHeld: self)
+            .map { _ -> AnyPublisher<Bool, Never> in
+                Just(false).delay(for: 2.0, scheduler: DispatchQueue.main).eraseToAnyPublisher()
             }
-            .assign(to: \.delayedToggleReenableCancellable, onWeaklyHeld: self)
+            .switchToLatest()
+            .assign(to: \.shouldDisableToggle, onWeaklyHeld: self)
             .store(in: &cancellables)
     }
 

--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -37,7 +37,6 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
     private let serverInfoObserver: ConnectionServerInfoObserver
     private let errorObserver: ConnectionErrorObserver
     private var cancellables: Set<AnyCancellable> = []
-    private var delayedToggleReenableCancellable: Cancellable?
 
     // MARK: Error
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1206803287661273/f
Tech Design URL:
CC: @graeme 

**Description**:

This PR fixes a view model memory leak in the VPN code.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. On this branch, open the VPN screen and dismiss it multiple times
2. Check that the memory graph debugger doesn't contain multiple instances of the view model
3. Next, run the app on a device, and when you get to the VPN status screen turn the Network Link Conditioner on with 100% loss
4. Try to connect, and after 2 seconds check that the toggle is re-enabled

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
