### PR TITLE
Fixes the name of a pixel

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -846,7 +846,7 @@ extension Pixel.Event {
         case .networkProtectionTunnelFailureRecovered: return "m_netp_ev_tunnel_failure_recovered"
         case .networkProtectionLatency(let quality): return "m_netp_ev_\(quality.rawValue)_latency"
         case .networkProtectionLatencyError: return "m_netp_ev_latency_error_d"
-        case .networkProtectionRekeyAttempt: return "m_mac_netp_rekey_attempt"
+        case .networkProtectionRekeyAttempt: return "m_netp_rekey_attempt"
         case .networkProtectionRekeyCompleted: return "m_netp_rekey_completed"
         case .networkProtectionRekeyFailure: return "m_netp_rekey_failure"
         case .networkProtectionEnabledOnSearch: return "m_netp_ev_enabled_on_search"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206819771949640/f

## Description

One of the pixel names was off as it includes the word "mac".