### PR TITLE
Don't refresh swipe tabs model on background changes

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1906,6 +1906,7 @@ extension MainViewController: TabDelegate {
         tabManager?.save()
         tabsBarController?.refresh(tabsModel: tabManager.model)
         // note: model in swipeTabsCoordinator doesn't need to be updated here
+        // https://app.asana.com/0/414235014887631/1206847376910045/f
     }
     
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1905,7 +1905,7 @@ extension MainViewController: TabDelegate {
         }
         tabManager?.save()
         tabsBarController?.refresh(tabsModel: tabManager.model)
-        swipeTabsCoordinator?.refresh(tabsModel: tabManager.model)
+        // note: model in swipeTabsCoordinator doesn't need to be updated here
     }
     
     func tab(_ tab: TabViewController, didUpdatePreview preview: UIImage) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206847376910045/f
Tech Design URL:
CC:

**Description**:

Fixes an issue when a tab reloading in the background caused the URL address field to resign first responder.

**Steps to test this PR**:
1. Open https://x.zok.pw/reload.html along with a few other tabs
2. Try to edit address while the [zok.pw](https://x.zok.pw/reload.html) is reloading in multiple tabs (including the one which is reloading)
3. Keyboard should not be dismissed

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
