### PR TITLE
Send correct platform value for App Store purchase options

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10032,8 +10032,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 129.1.4;
+				branch = "michal/proper-purchase-options-platform";
+				kind = branch;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9963,7 +9963,7 @@
 		9825F9D4293F2DE900F220F2 /* Build configuration list for PBXNativeTarget "PerformanceTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9825F9D5293F2DE900F220F2 /* Debg */,
+				9825F9D5293F2DE900F220F2 /* Debug */,
 				D664C7EA2B28A0FD00CBFA76 /* Alpha Debug */,
 				EE5A7C522A82BBB700387C84 /* Alpha */,
 				9825F9D6293F2DE900F220F2 /* Release */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10032,8 +10032,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "michal/proper-purchase-options-platform";
-				kind = branch;
+				kind = exactVersion;
+				version = 129.1.7;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "91b012d9450af211f7c47b9fde811e3a8292b16b",
-        "version" : "129.1.4"
+        "branch" : "michal/proper-purchase-options-platform",
+        "revision" : "1179ae051c39049bc8907575b96077592a8ab4c2"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "michal/proper-purchase-options-platform",
-        "revision" : "1179ae051c39049bc8907575b96077592a8ab4c2"
+        "revision" : "c34a4d0298a33c4c7f3b8c0ac4ca249b51e350db",
+        "version" : "129.1.7"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200019156869587/1206918870699980/f

**Description**:
Send correct platform value for App Store purchase options.


**Steps to test this PR**:
1. Open the purchase page
2. Put a brakpoint in `SubscriptionPagesUseSubscriptionFeature` in `func getSubscriptionOptions(params: Any, original: WKScriptMessage)` confirm if `subscriptionOptions` have a platform set to `ios`

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
