### PR TITLE
Improves pixel information

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -271,16 +271,6 @@ private extension Pixel.Event {
     
 }
 
-/// NSError supports this through `NSUnderlyingError`, but there's no support for this for Swift's `Error`.  This protocol does that.
-///
-/// The reason why this protocol returns a code and a domain instead of just an `Error` or `NSError` is so that the error implementing
-/// this protocol has full control over these values, and is able to override them as it best sees fit.
-///
-protocol ErrorWithUnderlyingError: Error {
-    var underlyingErrorCode: Int { get }
-    var underlyingErrorDomain: String { get }
-}
-
 extension Dictionary where Key == String, Value == String {
     mutating func appendErrorPixelParams(error: Error) {
         let nsError = error as NSError
@@ -288,10 +278,7 @@ extension Dictionary where Key == String, Value == String {
         self[PixelParameters.errorCode] = "\(nsError.code)"
         self[PixelParameters.errorDomain] = nsError.domain
 
-        if let underlyingError = error as? ErrorWithUnderlyingError {
-            self[PixelParameters.underlyingErrorCode] = "\(underlyingError.underlyingErrorCode)"
-            self[PixelParameters.underlyingErrorDomain] = underlyingError.underlyingErrorDomain
-        } else if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
+        if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
             self[PixelParameters.underlyingErrorCode] = "\(underlyingError.code)"
             self[PixelParameters.underlyingErrorDomain] = underlyingError.domain
         } else if let sqlErrorCode = nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10033,7 +10033,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 29dbccfc61283359fd218a9ef709917d6f6c984d;
+				revision = 562cd0f7419565a209c07c2ceb1014893730f397;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10033,7 +10033,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 31281809a97f6b071314011f34ea5e7dee3ff073;
+				revision = 29dbccfc61283359fd218a9ef709917d6f6c984d;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1430,6 +1430,7 @@
 		6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimatorTests.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
 		6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressDisplayHelper.swift; sourceTree = "<group>"; };
+		7B6590672BB1A36700BED0DA /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../../BrowserServicesKit; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
 		83004E832193E14C00DA013C /* UIAlertControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtension.swift; path = ../Core/UIAlertControllerExtension.swift; sourceTree = "<group>"; };
 		83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerBrowsingMenuExtension.swift; sourceTree = "<group>"; };
@@ -3488,6 +3489,7 @@
 		31E69A60280F4BAD00478327 /* LocalPackages */ = {
 			isa = PBXGroup;
 			children = (
+				7B6590672BB1A36700BED0DA /* BrowserServicesKit */,
 				85875B5F29912A2D00115F05 /* SyncUI */,
 				37FCAACB2993149A000E420A /* Waitlist */,
 				31794BFF2821DFB600F18633 /* DuckUI */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1430,7 +1430,6 @@
 		6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimatorTests.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
 		6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressDisplayHelper.swift; sourceTree = "<group>"; };
-		7B6590672BB1A36700BED0DA /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../../BrowserServicesKit; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
 		83004E832193E14C00DA013C /* UIAlertControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtension.swift; path = ../Core/UIAlertControllerExtension.swift; sourceTree = "<group>"; };
 		83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerBrowsingMenuExtension.swift; sourceTree = "<group>"; };
@@ -3489,7 +3488,6 @@
 		31E69A60280F4BAD00478327 /* LocalPackages */ = {
 			isa = PBXGroup;
 			children = (
-				7B6590672BB1A36700BED0DA /* BrowserServicesKit */,
 				85875B5F29912A2D00115F05 /* SyncUI */,
 				37FCAACB2993149A000E420A /* Waitlist */,
 				31794BFF2821DFB600F18633 /* DuckUI */,
@@ -10034,8 +10032,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 129.1.7;
+				kind = revision;
+				revision = 31281809a97f6b071314011f34ea5e7dee3ff073;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10033,7 +10033,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 562cd0f7419565a209c07c2ceb1014893730f397;
+				revision = 62bf94e230a67283c1ba3c1a6e8881d610245e29;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10033,7 +10033,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 805f6acce95825dba2f6107f26c65bf73d5f9cdc;
+				revision = 743928f2ff2610bf630b1f32f53b383849605f52;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "31281809a97f6b071314011f34ea5e7dee3ff073"
+        "revision" : "562cd0f7419565a209c07c2ceb1014893730f397"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "browserserviceskit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
-      "state" : {
-        "revision" : "c34a4d0298a33c4c7f3b8c0ac4ca249b51e350db",
-        "version" : "129.1.7"
-      }
-    },
-    {
       "identity" : "cocoaasyncsocket",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/robbiehanson/CocoaAsyncSocket",
@@ -183,7 +174,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
         "revision" : "a6b7ba151d9dc6684484f3785293875ec01cc1ff",
         "version" : "1.2.2"

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "562cd0f7419565a209c07c2ceb1014893730f397"
+        "revision" : "62bf94e230a67283c1ba3c1a6e8881d610245e29"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,14 @@
       }
     },
     {
+      "identity" : "browserserviceskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
+      "state" : {
+        "revision" : "31281809a97f6b071314011f34ea5e7dee3ff073"
+      }
+    },
+    {
       "identity" : "cocoaasyncsocket",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/robbiehanson/CocoaAsyncSocket",

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "805f6acce95825dba2f6107f26c65bf73d5f9cdc"
+        "revision" : "743928f2ff2610bf630b1f32f53b383849605f52"
       }
     },
     {

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -137,11 +137,19 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 pixelEvent = .networkProtectionClientFailedToParseServerListResponse
             case .failedToEncodeRegisterKeyRequest:
                 pixelEvent = .networkProtectionClientFailedToEncodeRegisterKeyRequest
+            case .noResponseFromRegisterEndpoint:
+                return
+            case .unexpectedStatusFromRegisterEndpoint:
+                return
             case .failedToFetchRegisteredServers(let eventError):
                 pixelEvent = .networkProtectionClientFailedToFetchRegisteredServers
                 pixelError = eventError
             case .failedToParseRegisteredServersResponse:
                 pixelEvent = .networkProtectionClientFailedToParseRegisteredServersResponse
+            case .noResponseFromRedeemEndpoint:
+                return
+            case .unexpectedStatusFromRedeemEndpoint:
+                return
             case .failedToEncodeRedeemRequest, .invalidInviteCode, .failedToRedeemInviteCode, .failedToParseRedeemResponse:
                 pixelEvent = .networkProtectionUnhandledError
                 // Should never be sent from the extension

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -137,19 +137,11 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 pixelEvent = .networkProtectionClientFailedToParseServerListResponse
             case .failedToEncodeRegisterKeyRequest:
                 pixelEvent = .networkProtectionClientFailedToEncodeRegisterKeyRequest
-            case .noResponseFromRegisterEndpoint:
-                return
-            case .unexpectedStatusFromRegisterEndpoint:
-                return
             case .failedToFetchRegisteredServers(let eventError):
                 pixelEvent = .networkProtectionClientFailedToFetchRegisteredServers
                 pixelError = eventError
             case .failedToParseRegisteredServersResponse:
                 pixelEvent = .networkProtectionClientFailedToParseRegisteredServersResponse
-            case .noResponseFromRedeemEndpoint:
-                return
-            case .unexpectedStatusFromRedeemEndpoint:
-                return
             case .failedToEncodeRedeemRequest, .invalidInviteCode, .failedToRedeemInviteCode, .failedToParseRedeemResponse:
                 pixelEvent = .networkProtectionUnhandledError
                 // Should never be sent from the extension


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206919998699658/f

macOS: https://github.com/duckduckgo/macos-browser/pull/2498
BSK: https://github.com/duckduckgo/BrowserServicesKit/pull/748

## Description

Adds some new errors to improve tracking of pixel errors.

## Testing

Launch console.app and wartch for pixel logs.

1. Force an error [here](https://github.com/duckduckgo/BrowserServicesKit/blob/743928f2ff2610bf630b1f32f53b383849605f52/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift#L199).
2. Run the app and ensure that you see a tunnel start failure showing **underlying error information** matching `GetLocationsError.noResponse`
3. Force an error [here](https://github.com/duckduckgo/BrowserServicesKit/blob/743928f2ff2610bf630b1f32f53b383849605f52/Sources/NetworkProtection/Networking/NetworkProtectionClient.swift#L205)
4. Run the app and ensure that you see a tunnel start failure showing **underlying error information** matching `GetLocationsError.unexpectedStatus`

Repeat this test for the other errors that were added to `NetworkProtectionClientError`.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
