### PR TITLE
Support partially failed purchase triggering "Subscription is being activated" state 

### DIFF
--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -44,6 +44,7 @@ struct SettingsState {
         var enabled: Bool
         var canPurchase: Bool
         var hasActiveSubscription: Bool
+        var isSubscriptionPendingActivation: Bool
     }
     
     struct SyncSettings {
@@ -113,8 +114,10 @@ struct SettingsState {
             speechRecognitionAvailable: false,
             loginsEnabled: false,
             networkProtection: NetworkProtection(enabled: false, status: ""),
-            subscription: Subscription(enabled: false, canPurchase: false,
-                                   hasActiveSubscription: false),
+            subscription: Subscription(enabled: false,
+                                       canPurchase: false,
+                                       hasActiveSubscription: false,
+                                       isSubscriptionPendingActivation: false),
             sync: SyncSettings(enabled: false, title: "")
         )
     }

--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -182,7 +182,6 @@ struct SettingsSubscriptionView: View {
     var body: some View {
         if viewModel.state.subscription.enabled {
             Section(header: Text(UserText.settingsPProSection)) {
-                
                 if viewModel.state.subscription.hasActiveSubscription {
                                         
                     if !viewModel.isLoadingSubscriptionState {
@@ -196,13 +195,13 @@ struct SettingsSubscriptionView: View {
                             noEntitlementsAvailableView
                         }
                     }
+                } else if viewModel.state.subscription.isSubscriptionPendingActivation {
+                    noEntitlementsAvailableView
                 } else {
                     purchaseSubscriptionView
-                    
                 }
-            
             }
-            
+
             // Selected Feature handler for Subscription Flow
             .onChange(of: subscriptionFlowViewModel.selectedFeature) { value in
                 guard let value else { return }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -310,7 +310,8 @@ extension SettingsViewModel {
             var enabled = false
             var canPurchase = false
             var hasActiveSubscription = false
-        
+            var isSubscriptionPendingActivation = false
+
     #if SUBSCRIPTION
         if #available(iOS 15, *) {
             enabled = isPrivacyProEnabled
@@ -318,15 +319,21 @@ extension SettingsViewModel {
             await setupSubscriptionEnvironment()
             if let token = AccountManager().accessToken {
                 let subscriptionResult = await SubscriptionService.getSubscription(accessToken: token)
-                if case .success(let subscription) = subscriptionResult {
+                switch subscriptionResult {
+                case .success(let subscription):
                     hasActiveSubscription = subscription.isActive
+                case .failure:
+                    if await PurchaseManager.hasActiveSubscription() {
+                        isSubscriptionPendingActivation = true
+                    }
                 }
             }
         }
     #endif
         return SettingsState.Subscription(enabled: enabled,
                                         canPurchase: canPurchase,
-                                        hasActiveSubscription: hasActiveSubscription)
+                                        hasActiveSubscription: hasActiveSubscription,
+                                        isSubscriptionPendingActivation: isSubscriptionPendingActivation)
         }
     
     private func getSyncState() -> SettingsState.SyncSettings {
@@ -374,31 +381,42 @@ extension SettingsViewModel {
         // Fetch available subscriptions from the backend (or sign out)
         switch await SubscriptionService.getSubscription(accessToken: token) {
         
-        case .success(let subscription) where subscription.isActive:
-            
-            // Check entitlements and update UI accordingly
-            let entitlements: [Entitlement.ProductName] = [.networkProtection, .dataBrokerProtection, .identityTheftRestoration]
-            for entitlement in entitlements {
-                if case let .success(result) = await AccountManager().hasEntitlement(for: entitlement) {
-                    switch entitlement {
-                    case .identityTheftRestoration:
-                        self.shouldShowITP = result
-                    case .dataBrokerProtection:
-                        self.shouldShowDBP = result
-                    case .networkProtection:
-                        self.shouldShowNetP = result
-                    case .unknown:
-                        return
+        case .success(let subscription):
+            if subscription.isActive {
+                state.subscription.hasActiveSubscription = true
+                state.subscription.isSubscriptionPendingActivation = false
+
+                // Check entitlements and update UI accordingly
+                let entitlements: [Entitlement.ProductName] = [.networkProtection, .dataBrokerProtection, .identityTheftRestoration]
+                for entitlement in entitlements {
+                    if case let .success(result) = await AccountManager().hasEntitlement(for: entitlement) {
+                        switch entitlement {
+                        case .identityTheftRestoration:
+                            self.shouldShowITP = result
+                        case .dataBrokerProtection:
+                            self.shouldShowDBP = result
+                        case .networkProtection:
+                            self.shouldShowNetP = result
+                        case .unknown:
+                            return
+                        }
                     }
                 }
+            } else {
+                // Sign out in case subscription is no longer active
+                signOutUser()
             }
-            isLoadingSubscriptionState = false
-                        
-        default:
+
+        case .failure:
             // Account is active but there's not a valid subscription / entitlements
-            isLoadingSubscriptionState = false
-            signOutUser()
+            if await PurchaseManager.hasActiveSubscription() {
+                state.subscription.isSubscriptionPendingActivation = true
+            } else {
+                // Sign out in case access token is present but no subscription and there is no active transaction on Apple ID
+                signOutUser()
+            }
         }
+        isLoadingSubscriptionState = false
     }
     
     @available(iOS 15.0, *)

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -149,6 +149,7 @@ final class SubscriptionFlowViewModel: ObservableObject {
             state.transactionError = .purchaseFailed
         case .missingEntitlements:
             isBackendError = true
+            state.shouldDismissView = true
             state.transactionError = .missingEntitlements
         case .failedToGetSubscriptionOptions:
             isStoreError = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1206921969381917/f

**Description**:
When the purchase goes through on Apple side but we fail to receive subscription and entitlements from confirmation endpoint (e.g. it is down) we should show the "Subscription is being activated" state informing the user and enabling user to re-sync the purchase with our BE.

**Steps to test this PR**:
It is hard to test since it requires the confirmation endpoint to go down, but can be simulated applying  the following patches on iOS and local BSK:
- [bsk-broken-subs-service.patch](https://github.com/duckduckgo/iOS/files/14749243/bsk-broken-subs-service.patch)
- [ios-fix-broken-subs-service-on-restore.patch](https://github.com/duckduckgo/iOS/files/14749254/ios-fix-broken-subs-service-on-restore.patch)

1. The BSK patch simulates failing confirmation endpoint and subscription endpoint.
2. When doing the purchase the state of the app will be that the user has purchased on Apple side, has matching account with access token but lacks the subscription and entitlements
3. As a result is presented in the settings with "...is being activated" state.
4. State should be persisted through out app restarts
5. When hitting "restore purchase" button it will result in failure but the SubscriptionService will resume normal execution in 10s from that
6. After 10s hitting restore purchase will successfully re-sync the state of the purchased subscription.

Also please smoke test normal happy path purchase without these testing patches in place.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
