### PR TITLE
Subscriptions: 24. Properly dismiss view on selecting feature

### DIFF
--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionEmailViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionEmailViewModel.swift
@@ -152,6 +152,11 @@ final class SubscriptionEmailViewModel: ObservableObject {
                     self.selectedFeature = .dbp
                 }
                 self.state.shouldDismissStack = true
+                
+                // Reset shouldDismissStack after dismissal to ensure it can be triggered again
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.state.shouldDismissStack = false
+                }
             }
             
         }

--- a/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
@@ -86,6 +86,10 @@ struct SubscriptionEmailView: View {
             shouldDisplayNavigationError = value
         }
         
+        .onChange(of: viewModel.state.shouldDismissStack) { _ in
+                onDismissStack?()
+        }
+        
         // Observe changes to shouldDismissView
         .onChange(of: viewModel.state.shouldDismissView) { shouldDismiss in
             if shouldDismiss {

--- a/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
@@ -87,7 +87,7 @@ struct SubscriptionEmailView: View {
         }
         
         .onChange(of: viewModel.state.shouldDismissStack) { _ in
-                onDismissStack?()
+            onDismissStack?()
         }
         
         // Observe changes to shouldDismissView


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1206905872820900/f

**Description**:
- Fixes issue causing onboarding CTAs not working after restoring via email

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
⚠️ You should use a device to test

1. Restore a subscription using email (Settings > Privacy Pro > I have a subscription)
2. Once restored, tan any of the options in the "Welcome to Privacy Pro" page
3. Observe the view is dismissed, and you're taken to the correct section (VPN, ITP, etc).

