### PR TITLE
Fix forceful sign outs during purchase

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -524,8 +524,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                                                            cachePolicy: .reloadIgnoringLocalCacheData) {
                 if subscription.isActive {
                     DailyPixel.fire(pixel: .privacyProSubscriptionActive)
-                } else {
-                    accountManager.signOut()
                 }
             }
 

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -52,7 +52,6 @@ final class SettingsViewModel: ObservableObject {
 #if SUBSCRIPTION
     private var accountManager: AccountManager
     private var signOutObserver: Any?
-    private var subscriptionDidChangeObserver: Any?
     private var isPrivacyProEnabled: Bool {
         AppDependencyProvider.shared.subscriptionFeatureAvailability.isFeatureAvailable
     }
@@ -244,7 +243,6 @@ final class SettingsViewModel: ObservableObject {
     
     deinit {
         signOutObserver = nil
-        subscriptionDidChangeObserver = nil
     }
     
 #else
@@ -440,15 +438,6 @@ extension SettingsViewModel {
         
     private func setupNotificationObservers() {
         signOutObserver = NotificationCenter.default.addObserver(forName: .accountDidSignOut, object: nil, queue: .main) { [weak self] _ in
-            if #available(iOS 15.0, *) {
-                guard let strongSelf = self else { return }
-                Task { await strongSelf.setupSubscriptionEnvironment() }
-            }
-        }
-
-        subscriptionDidChangeObserver = NotificationCenter.default.addObserver(forName: .subscriptionDidChange,
-                                                                               object: nil,
-                                                                               queue: .main) { [weak self] _ in
             if #available(iOS 15.0, *) {
                 guard let strongSelf = self else { return }
                 Task { await strongSelf.setupSubscriptionEnvironment() }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -446,7 +446,9 @@ extension SettingsViewModel {
             }
         }
 
-        subscriptionDidChangeObserver = NotificationCenter.default.addObserver(forName: .subscriptionDidChange, object: nil, queue: .main) { [weak self] _ in
+        subscriptionDidChangeObserver = NotificationCenter.default.addObserver(forName: .subscriptionDidChange,
+                                                                               object: nil,
+                                                                               queue: .main) { [weak self] _ in
             if #available(iOS 15.0, *) {
                 guard let strongSelf = self else { return }
                 Task { await strongSelf.setupSubscriptionEnvironment() }


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/0/0/1206926700687559/f

**Description**:
Due to recent changes we are force refreshing subscription and entitlements cache on `applicationDidBecomeActive`. 
We also did a check to sign out the user in case expired subscription was found.
This may cause problems during the purchase process as apple's modals are multiple times making the app non active and then active again causing the `applicationDidBecomeActive` to be called. 

When doing the purchase we attempt to retrieve past account from Apple ID transaction. If the account has been used previously and has an expired subscription there is a change we will trigger a sign out during the purchase flow. This will result in purchase seemingly going through, the purchase view being preemptively dismissed and the settings being in unsubscribed state. Attempt at restoring the purchase fixes it and brings back the recent purchase.

**Steps to test this PR**:
- Smoke test the successful purchase using Apple ID account that has expired/cancelled subscriptions
- Confirm if when the subscription is cancelled and the app is left in the settings after the cancellation is registered in the BE and coming back to the app the state will be reloaded accordingly (sign out) 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
