### PR TITLE
25. Subscriptions: Memory management improvements

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -819,6 +819,7 @@
 		D668D9272B6937D2008E2FF2 /* SubscriptionITPViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */; };
 		D668D9292B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */; };
 		D668D92B2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */; };
+		D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */; };
 		D68A21442B7EC08500BB372E /* SubscriptionExternalLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68A21432B7EC08500BB372E /* SubscriptionExternalLinkView.swift */; };
 		D68A21462B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */; };
 		D68DF81C2B58302E0023DBEA /* SubscriptionRestoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68DF81B2B58302E0023DBEA /* SubscriptionRestoreView.swift */; };
@@ -2491,6 +2492,7 @@
 		D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionITPViewModel.swift; sourceTree = "<group>"; };
 		D668D9282B69681C008E2FF2 /* IdentityTheftRestorationPagesUserScript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesUserScript.swift; sourceTree = "<group>"; };
 		D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesFeature.swift; sourceTree = "<group>"; };
+		D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerView.swift; sourceTree = "<group>"; };
 		D68A21432B7EC08500BB372E /* SubscriptionExternalLinkView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExternalLinkView.swift; sourceTree = "<group>"; };
 		D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExternalLinkViewModel.swift; sourceTree = "<group>"; };
 		D68DF81B2B58302E0023DBEA /* SubscriptionRestoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionRestoreView.swift; sourceTree = "<group>"; };
@@ -4663,6 +4665,7 @@
 			isa = PBXGroup;
 			children = (
 				D664C7AD2B289AA000CBFA76 /* PurchaseInProgressView.swift */,
+				D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */,
 				D664C7AE2B289AA000CBFA76 /* SubscriptionFlowView.swift */,
 				D68DF81B2B58302E0023DBEA /* SubscriptionRestoreView.swift */,
 				D64648AC2B59936B0033090B /* SubscriptionEmailView.swift */,
@@ -6749,6 +6752,7 @@
 				B60DFF072872B64B0061E7C2 /* JSAlertController.swift in Sources */,
 				981FED6E22025151008488D7 /* BlankSnapshotViewController.swift in Sources */,
 				98F3A1DC217B373E0011A0D4 /* DarkTheme.swift in Sources */,
+				D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */,
 				851B128822200575004781BC /* Onboarding.swift in Sources */,
 				3151F0EE2735800800226F58 /* VoiceSearchFeedbackView.swift in Sources */,
 				857EEB752095FFAC008A005C /* HomeRowInstructionsViewController.swift in Sources */,

--- a/DuckDuckGo/SettingsView.swift
+++ b/DuckDuckGo/SettingsView.swift
@@ -133,9 +133,9 @@ struct SettingsView: View {
         case .itr:
             SubscriptionITPView()
         case .subscriptionFlow:
-            SubscriptionFlowView()
+            SubscriptionContainerView(currentView: .subscribe)
         case .subscriptionRestoreFlow:
-            SubscriptionRestoreView()
+            SubscriptionContainerView(currentView: .restore)
         default:
             EmptyView()
         }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -438,7 +438,7 @@ extension SettingsViewModel {
         signOutObserver = NotificationCenter.default.addObserver(forName: .accountDidSignOut, object: nil, queue: .main) { [weak self] _ in
             if #available(iOS 15.0, *) {
                 guard let strongSelf = self else { return }
-                Task { await strongSelf.setupSubscriptionEnvironment() }
+                Task { await strongSelf.getSubscriptionState() }
             }
         }
     }

--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -413,6 +413,10 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
         setTransactionStatus(.idle)
         setTransactionError(nil)
         broker = nil
+        onFeatureSelected = nil
+        onSetSubscription = nil
+        onActivateSubscription = nil
+        onBackToSettings = nil
     }
     
 }

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionEmailViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionEmailViewModel.swift
@@ -65,8 +65,8 @@ final class SubscriptionEmailViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(userScript: SubscriptionPagesUserScript = SubscriptionPagesUserScript(),
-         subFeature: SubscriptionPagesUseSubscriptionFeature = SubscriptionPagesUseSubscriptionFeature(),
+    init(userScript: SubscriptionPagesUserScript,
+         subFeature: SubscriptionPagesUseSubscriptionFeature,
          accountManager: AccountManager = AccountManager()) {
         self.userScript = userScript
         self.subFeature = subFeature
@@ -214,6 +214,7 @@ final class SubscriptionEmailViewModel: ObservableObject {
     
     deinit {
         cancellables.removeAll()
+        canGoBackCancellable = nil
        
     }
 

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionRestoreViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionRestoreViewModel.swift
@@ -58,12 +58,9 @@ final class SubscriptionRestoreViewModel: ObservableObject {
     
     // Read only View State - Should only be modified from the VM
     @Published private(set) var state = State()
-    
-    // Email View Model
-    var emailViewModel = SubscriptionEmailViewModel()
         
-    init(userScript: SubscriptionPagesUserScript = SubscriptionPagesUserScript(),
-         subFeature: SubscriptionPagesUseSubscriptionFeature = SubscriptionPagesUseSubscriptionFeature(),
+    init(userScript: SubscriptionPagesUserScript,
+         subFeature: SubscriptionPagesUseSubscriptionFeature,
          purchaseManager: PurchaseManager = PurchaseManager.shared,
          accountManager: AccountManager = AccountManager(),
          isAddingDevice: Bool = false) {
@@ -74,14 +71,25 @@ final class SubscriptionRestoreViewModel: ObservableObject {
         self.state.isAddingDevice = false
     }
     
-    func initializeView() {
+    
+    func onAppear() async {
+        DispatchQueue.main.async {
+            self.resetState()
+        }
         Pixel.fire(pixel: .privacyProSettingsAddDevice)
-        Task { await setupTransactionObserver() }
+        await setupTransactionObserver()
+    }
+        
+    func onDissappear() async {
+        DispatchQueue.main.async {
+            self.resetState()
+        }
+        cleanUp()
     }
     
-    @MainActor
-    func onAppear() {
-        resetState()
+    private func cleanUp() {
+        cancellables.removeAll()
+        
     }
     
     @MainActor
@@ -168,7 +176,6 @@ final class SubscriptionRestoreViewModel: ObservableObject {
     @MainActor
     func showPlans() {
         state.shouldShowPlans = true
-        state.shouldDismissView = true
     }
     
     @MainActor

--- a/DuckDuckGo/Subscription/Views/SubscriptionContainerView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionContainerView.swift
@@ -1,0 +1,55 @@
+//
+//  SubscriptionContainerView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftUI
+
+#if SUBSCRIPTION
+@available(iOS 15.0, *)
+struct SubscriptionContainerView: View {
+    
+    enum CurrentView {
+        case subscribe, restore
+    }
+    
+    @State var currentView: CurrentView
+    private var flowViewModel: SubscriptionFlowViewModel
+    private var restoreViewModel: SubscriptionRestoreViewModel
+    private var emailViewModel: SubscriptionEmailViewModel
+    
+    init(currentView: CurrentView) {
+        let userScript = SubscriptionPagesUserScript()
+        let subFeature = SubscriptionPagesUseSubscriptionFeature()
+        self.currentView = currentView
+        flowViewModel = SubscriptionFlowViewModel(userScript: userScript, subFeature: subFeature)
+        restoreViewModel = SubscriptionRestoreViewModel(userScript: userScript, subFeature: subFeature)
+        emailViewModel = SubscriptionEmailViewModel(userScript: userScript, subFeature: subFeature)
+    }
+    
+    var body: some View {
+        switch currentView {
+        case .subscribe:
+            SubscriptionFlowView(viewModel: flowViewModel, onRequireRestore: { currentView = .restore })
+        case .restore:
+            SubscriptionRestoreView(viewModel: restoreViewModel, emailViewModel: emailViewModel, onRequirePurchase: { currentView = .subscribe })
+        }
+        
+    }
+}
+#endif

--- a/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
@@ -21,16 +21,16 @@
 import SwiftUI
 import Foundation
 import Core
+import Combine
 
 @available(iOS 15.0, *)
 struct SubscriptionEmailView: View {
         
-    @StateObject var viewModel = SubscriptionEmailViewModel()
+    @ObservedObject var viewModel: SubscriptionEmailViewModel
     @Environment(\.dismiss) var dismiss
     
     @State var shouldDisplayInactiveError = false
     @State var shouldDisplayNavigationError = false
-    @State var isModal = true
     
     var onDismissStack: (() -> Void)?
     
@@ -111,9 +111,7 @@ struct SubscriptionEmailView: View {
     
     @ViewBuilder
     private var closeButton: some View {
-        if isModal {
             Button(UserText.subscriptionCloseButton) { onDismissStack?() }
-        }
     }
     
     private var baseView: some View {

--- a/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -89,7 +89,7 @@ struct SubscriptionSettingsView: View {
     private var devicesSection: some View {
         Section(header: Text(UserText.subscriptionManageDevices)) {
             
-            NavigationLink(destination: SubscriptionRestoreView(isModal: false)) {
+            NavigationLink(destination: SubscriptionContainerView(currentView: .restore)) {
                 SettingsCustomCell(content: {
                     Text(UserText.subscriptionAddDeviceButton)
                         .daxBodyRegular()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:
Tech Design URL:
CC:

**Description**:
- Use a single view for both Subscribe and Restore flows, reducing weird Dismiss/Present actions and memory footprint
- Centralizes userScript and subFeature dependencies in the container and inject to views
- Ensure state and callBacks and state are properly reset after views are dismissed
- Fixes an issue causing an incorrect error to be shown when navigating within webviews


<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Purchase a subscription
2. Add an email
3. Remove from Device
4. Restore from email

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
