### PR TITLE
When Thank You messaging is shown, stop the tunnel

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -499,9 +499,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 #if NETWORK_PROTECTION
         widgetRefreshModel.refreshVPNWidget()
 
-        if vpnFeatureVisibility.shouldShowThankYouMessaging() {
-            stopTunnelAndShowThankYouMessagingIfNeeded()
-        }
+        stopTunnelAndShowThankYouMessagingIfNeeded()
 
         if tunnelDefaults.showEntitlementAlert {
             presentExpiredEntitlementAlert()
@@ -514,20 +512,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func stopTunnelAndShowThankYouMessagingIfNeeded() {
-        Task {
-            let controller = NetworkProtectionTunnelController()
+        if vpnFeatureVisibility.shouldShowThankYouMessaging() && !tunnelDefaults.vpnEarlyAccessOverAlertAlreadyShown {
+            presentVPNEarlyAccessOverAlert()
 
-            if await controller.isConnected {
-                DailyPixel.fireDailyAndCount(pixel: .privacyProVPNBetaStoppedWhenPrivacyProEnabled)
-            }
+            Task {
+                let controller = NetworkProtectionTunnelController()
 
-            await controller.stop()
-            await controller.removeVPN()
-
-            if !tunnelDefaults.vpnEarlyAccessOverAlertAlreadyShown {
-                await MainActor.run {
-                    self.presentVPNEarlyAccessOverAlert()
+                if await controller.isConnected {
+                    DailyPixel.fireDailyAndCount(pixel: .privacyProVPNBetaStoppedWhenPrivacyProEnabled)
                 }
+
+                await controller.stop()
+                await controller.removeVPN()
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206944215322925/f
Tech Design URL:
CC:

**Description**:

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Under Debug > NetP > Choose Reset Thank you messaging
2. Remove all builds from your device after making sure you are waitlisted
3. Install the new build
4. Connect to the VPN and authenticate as internal user
5. Expect: Thank you messaging and tunnel should be stopped

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
