### PR TITLE
Don't crash on assert in alpha builds

### DIFF
--- a/Configuration/Configuration-Alpha.xcconfig
+++ b/Configuration/Configuration-Alpha.xcconfig
@@ -29,3 +29,6 @@ GROUP_ID_PREFIX = group.com.duckduckgo.alpha
 
 // The keychain access group for subscriptions
 SUBSCRIPTION_APP_GROUP = com.duckduckgo.subscriptions.alpha
+
+// Prevents asserts from crashing alpha TF builds
+OTHER_SWIFT_FLAGS[config=Alpha][arch=*][sdk=*] = $(inherited) -assert-config Release


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206985884087562/f

**Description**:
As we saw in [Crashes when opening from external links with auto-clear+expiry](https://app.asana.com/0/414709148257752/1206731143449260/f) alpha builds can crash on asserts

**Steps to test this PR**:
Can only be tested after merge. Use https://app.asana.com/0/414709148257752/1206731143449260 as a test case that was previously crashing. But if you want to test the added config, you could.
1. Change the added Configuration-Alpha.xcconfig `OTHER_SWIFT_FLAGS` line to be `Alpha Debug`.
2. Follow the steps in the above task.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
