### PR TITLE
Password screen UI improvements: New open website & show password buttons

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -502,6 +502,8 @@ private struct CopyableCell: View {
                         }
                     }
                     .buttonStyle(.plain) // Prevent taps from being forwarded to the container view
+                    // can't use .clear here or else both button padded area and container both respond to tap events
+                    .background(BackgroundColor(isSelected: selectedCell == id).color.opacity(0))
                     .accessibilityLabel(buttonAccessibilityLabel)
                     .contentShape(Rectangle())
                     .frame(width: Constants.textFieldTapSize, height: Constants.textFieldTapSize)
@@ -527,6 +529,7 @@ private struct CopyableCell: View {
                             }
                         }
                         .buttonStyle(.plain) // Prevent taps from being forwarded to the container view
+                        .background(BackgroundColor(isSelected: selectedCell == id).color.opacity(0))
                         .accessibilityLabel(secondaryButtonAccessibilityLabel)
                         .contentShape(Rectangle())
                         .frame(width: Constants.textFieldTapSize, height: Constants.textFieldTapSize)
@@ -634,8 +637,8 @@ private struct Constants {
     static let verticalPadding: CGFloat = 4
     static let minRowHeight: CGFloat = 60
     static let textFieldImageOpacity: CGFloat = 0.84
-    static let textFieldImageSize: CGFloat = 20
-    static let textFieldTapSize: CGFloat = 32
+    static let textFieldImageSize: CGFloat = 24
+    static let textFieldTapSize: CGFloat = 36
     static let insets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
 }
 

--- a/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -324,9 +324,12 @@ struct AutofillLoginDetailsView: View {
                      action: { viewModel.isPasswordHidden.toggle() },
                      secondaryActionTitle: UserText.autofillCopyPrompt(for: UserText.autofillLoginDetailsPassword),
                      secondaryAction: { viewModel.copyToPasteboard(.password) },
-                     buttonImageName: "Copy-24",
-                     buttonAccessibilityLabel: UserText.autofillCopyPrompt(for: UserText.autofillLoginDetailsPassword),
-                     buttonAction: { viewModel.copyToPasteboard(.password) })
+                     buttonImageName: viewModel.isPasswordHidden ? "Eye-24" : "Eye-Closed-24",
+                     buttonAccessibilityLabel: viewModel.isPasswordHidden ? UserText.autofillShowPassword : UserText.autofillHidePassword,
+                     buttonAction: { viewModel.isPasswordHidden.toggle() },
+                     secondaryButtonImageName: "Copy-24",
+                     secondaryButtonAccessibilityLabel: UserText.autofillCopyPrompt(for: UserText.autofillLoginDetailsPassword),
+                     secondaryButtonAction: { viewModel.copyToPasteboard(.password) })
     }
 
 
@@ -430,6 +433,10 @@ private struct CopyableCell: View {
     var buttonAccessibilityLabel: String?
     var buttonAction: (() -> Void)?
 
+    var secondaryButtonImageName: String?
+    var secondaryButtonAccessibilityLabel: String?
+    var secondaryButtonAction: (() -> Void)?
+
     var body: some View {
         ZStack {
             HStack {
@@ -455,7 +462,11 @@ private struct CopyableCell: View {
                 }
                 .padding(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 8))
                 
-                Spacer(minLength: buttonImageName != nil ? Constants.textFieldImageSize : 8)
+                if secondaryButtonImageName != nil {
+                    Spacer(minLength: Constants.textFieldImageSize * 2)
+                } else {
+                    Spacer(minLength: buttonImageName != nil ? Constants.textFieldImageSize : 8)
+                }
             }
             .copyable(isSelected: selectedCell == id,
                       menuTitle: actionTitle,
@@ -469,7 +480,7 @@ private struct CopyableCell: View {
             
             if let buttonImageName = buttonImageName, let buttonAccessibilityLabel = buttonAccessibilityLabel {
                 let differenceBetweenImageSizeAndTapAreaPerEdge = (Constants.textFieldTapSize - Constants.textFieldImageSize) / 2.0
-                HStack(alignment: .center) {
+                HStack(alignment: .center, spacing: 0) {
                     Spacer()
                     
                     Button {
@@ -495,6 +506,34 @@ private struct CopyableCell: View {
                     .accessibilityLabel(buttonAccessibilityLabel)
                     .contentShape(Rectangle())
                     .frame(width: Constants.textFieldTapSize, height: Constants.textFieldTapSize)
+
+                    if let secondaryButtonImageName = secondaryButtonImageName,
+                        let secondaryButtonAccessibilityLabel = secondaryButtonAccessibilityLabel {
+                        Button {
+                            secondaryButtonAction?()
+                            self.selectedCell = nil
+                        } label: {
+                            VStack(alignment: .trailing) {
+                                Spacer()
+                                HStack {
+                                    Spacer()
+                                    Image(secondaryButtonImageName)
+                                        .resizable()
+                                        .frame(width: Constants.textFieldImageSize, height: Constants.textFieldImageSize)
+                                        .foregroundColor(Color(UIColor.label).opacity(Constants.textFieldImageOpacity))
+                                        .opacity(subtitle.isEmpty ? 0 : 1)
+                                    Spacer()
+                                }
+                                Spacer()
+                            }
+                        }
+                        .buttonStyle(.plain) // Prevent taps from being forwarded to the container view
+                        .background(BackgroundColor(isSelected: selectedCell == id).color)
+                        .accessibilityLabel(secondaryButtonAccessibilityLabel)
+                        .contentShape(Rectangle())
+                        .frame(width: Constants.textFieldTapSize, height: Constants.textFieldTapSize)
+                    }
+
                 }
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: -differenceBetweenImageSizeAndTapAreaPerEdge))
             }
@@ -598,7 +637,7 @@ private struct Constants {
     static let minRowHeight: CGFloat = 60
     static let textFieldImageOpacity: CGFloat = 0.84
     static let textFieldImageSize: CGFloat = 20
-    static let textFieldTapSize: CGFloat = 44
+    static let textFieldTapSize: CGFloat = 32
     static let insets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
 }
 

--- a/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -148,7 +148,10 @@ struct AutofillLoginDetailsView: View {
                              actionTitle: UserText.autofillCopyPrompt(for: UserText.autofillLoginDetailsAddress),
                              action: { viewModel.copyToPasteboard(.address) },
                              secondaryActionTitle: viewModel.websiteIsValidUrl ? UserText.autofillOpenWebsitePrompt : nil,
-                             secondaryAction: viewModel.websiteIsValidUrl ? { viewModel.openUrl() } : nil)
+                             secondaryAction: viewModel.websiteIsValidUrl ? { viewModel.openUrl() } : nil,
+                             buttonImageName: "Globe-24",
+                             buttonAccessibilityLabel: UserText.autofillOpenWebsitePrompt,
+                             buttonAction: viewModel.websiteIsValidUrl ? { viewModel.openUrl() } : nil)
             }
 
             Section {

--- a/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -463,7 +463,7 @@ private struct CopyableCell: View {
                 .padding(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 8))
                 
                 if secondaryButtonImageName != nil {
-                    Spacer(minLength: Constants.textFieldImageSize * 2)
+                    Spacer(minLength: Constants.textFieldImageSize * 2 + 8)
                 } else {
                     Spacer(minLength: buttonImageName != nil ? Constants.textFieldImageSize : 8)
                 }

--- a/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -502,7 +502,6 @@ private struct CopyableCell: View {
                         }
                     }
                     .buttonStyle(.plain) // Prevent taps from being forwarded to the container view
-                    .background(BackgroundColor(isSelected: selectedCell == id).color)
                     .accessibilityLabel(buttonAccessibilityLabel)
                     .contentShape(Rectangle())
                     .frame(width: Constants.textFieldTapSize, height: Constants.textFieldTapSize)
@@ -528,7 +527,6 @@ private struct CopyableCell: View {
                             }
                         }
                         .buttonStyle(.plain) // Prevent taps from being forwarded to the container view
-                        .background(BackgroundColor(isSelected: selectedCell == id).color)
                         .accessibilityLabel(secondaryButtonAccessibilityLabel)
                         .contentShape(Rectangle())
                         .frame(width: Constants.textFieldTapSize, height: Constants.textFieldTapSize)

--- a/DuckDuckGo/PasswordHider.swift
+++ b/DuckDuckGo/PasswordHider.swift
@@ -22,7 +22,7 @@ import Foundation
 struct PasswordHider {
     let password: String
     var hiddenPassword: String {
-        let maximumPasswordDisplayCount = 40
+        let maximumPasswordDisplayCount = 22
         let passwordCount = password.count > maximumPasswordDisplayCount ? maximumPasswordDisplayCount : password.count
         return String(repeating: "•", count: passwordCount)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1200930669568058/1206365535975347/f
Tech Design URL:
CC:

**Description**:
Adds small UI improvements to the Passwords screen including:
- New website link button to open websites with a single tap (globe icon)
- New password visibility toggle button to show / hide passwords with a single tap
- Hidden password character count limit reduced from 40 to 22 so that the hidden version of the password displays as a single line 

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go to Passwords screen and access a saved credential with a saved username, password and website
2. Tap the eye icon button next to the password and confirm the password is unmasked and the eye icon updates to one with a line through it
3. Tap the updated eye icon button again and confirm the password is masked again
4. Tap the copy button and confirm it still copies the password to clipboard
5. Tap the password row and confirm the menu options to "Show Password" and "Copy Password" still present as before
6. Modify the saved password to be so long that its text will wrap when done editing. 
7. Confirm that the masked password displays as a single line and doesn't wrap, but does wrap to multi-line when unmasked
8. Tap the globe icon next to the website and confirm that you are taken to a new tab and that that website loads (note: website must be a valid url for this to trigger)
9. Tap the website row and confirm the menu options to "Copy Website URL" and "Open Website" still present as before


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
