### PR TITLE
Fix missing tab delegate on launch

### DIFF
--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -52,12 +52,6 @@ class TabManager {
         self.bookmarksDatabase = bookmarksDatabase
         self.historyManager = historyManager
         self.syncService = syncService
-        let index = model.currentIndex
-        let tab = model.tabs[index]
-        if tab.link != nil {
-            let controller = buildController(forTab: tab, inheritedAttribution: nil)
-            tabControllerCache.append(controller)
-        }
 
         registerForNotifications()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207004361509188/f
Tech Design URL:
CC:

**Description**:
Fixes a bug in recent PR which means the settings menu doesn't work when launching the app with a tab selected.

**Steps to test this PR**:
1. Open a tab and browse to a site
2. Terminate the app
3. Launch the app - page should load
4. Access browsing menu, select settings - settings should load
5. Open some more tabs
6. Close some tabs
7. Use the tab switcher a bit
