### PR TITLE
Remove URLs from suggestion search terms

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10032,8 +10032,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 132.0.1;
+				branch = "alessandro/autocomplete-search-term-remove-urls";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "73f68ee1c0dda3cd4a0b0cc3cc38a6cc7e605829",
-        "version" : "132.0.1"
+        "branch" : "alessandro/autocomplete-search-term-remove-urls",
+        "revision" : "5a6b0de96b14aec867ca0b9544dfd4fb0256fab8"
       }
     },
     {
@@ -183,7 +183,7 @@
     {
       "identity" : "trackerradarkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/TrackerRadarKit",
+      "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
         "revision" : "a6b7ba151d9dc6684484f3785293875ec01cc1ff",
         "version" : "1.2.2"

--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -183,16 +183,7 @@ class AutocompleteViewController: UIViewController {
         selectedItem = -1
         tableView.reloadData()
 
-        loader = SuggestionLoader(dataSource: self, urlFactory: { phrase in
-            guard let url = URL(trimmedAddressBarString: phrase),
-                  let scheme = url.scheme,
-                  scheme.description.hasPrefix("http"),
-                  url.isValid else {
-                return nil
-            }
-
-            return url
-        })
+        loader = SuggestionLoader(dataSource: self, urlFactory: URL.makeURL(fromSuggestionPhrase:))
         pendingRequest = true
 
         loader?.getSuggestions(query: query) { [weak self] result, error in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1206836396714144/f

**Description:**

Removes URLs suggestions from the search term when typing on the address bar.

**Steps to test this PR:**

Type “face”, “ama” or “ace" on the address bar.
Expected Result: The search term suggestions should not include “www.facebook.com”, “www.amazon.com”, “www.acer.com/“

**Orientation Testing**:

* [x] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad
* [x] iPhone 15 (Simulator)

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16
* [x] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
