### PR TITLE
maestro: hide dax dialogs if visible and cancel keyboard after fireproof

### DIFF
--- a/.maestro/data_clearing_tests/01_fire_proofing.yml
+++ b/.maestro/data_clearing_tests/01_fire_proofing.yml
@@ -21,6 +21,8 @@ tags:
     id: "searchEntry"
 - inputText: "https://setcookie.net"
 - pressKey: Enter
+- runFlow:
+    file: ../shared/hide_daxdialogs.yaml
 
 # Set a cookie
 - assertVisible: "Cookie Test"
@@ -44,6 +46,8 @@ tags:
 - tapOn: "Close Tabs and Clear Data"
 - tapOn:
     id: "alert.forget-data.confirm"
+- assertVisible: "Cancel"
+- tapOn: "Cancel"
 - assertVisible:
     id: "searchEntry"
 - tapOn: "Close Tabs and Clear Data"

--- a/.maestro/shared/hide_daxdialogs.yaml
+++ b/.maestro/shared/hide_daxdialogs.yaml
@@ -1,0 +1,11 @@
+appId: com.duckduckgo.mobile.ios
+---
+
+- runFlow:
+    when:
+        visible: 
+            id: "DaxIcon"
+    commands:
+        - tapOn: "Hide"
+        - tapOn: "Hide Tips Forever"
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207014419221336/f
Tech Design URL:
CC:

**Description**:
Improves the stability of the fire proofing end to end test.  Adds short cut to hide dax dialogs.

**Steps to test this PR**:
1. Run the test locally
2. Admire the passing state of the tests here https://github.com/duckduckgo/iOS/actions/runs/8599167350/job/23561488619
