### PR TITLE
Do not signout user on API failure

### DIFF
--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -430,9 +430,6 @@ extension SettingsViewModel {
             // Account is active but there's not a valid subscription / entitlements
             if await PurchaseManager.hasActiveSubscription() {
                 state.subscription.isSubscriptionPendingActivation = true
-            } else {
-                // Sign out in case access token is present but no subscription and there is no active transaction on Apple ID
-                signOutUser()
             }
         }
         

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -84,11 +84,9 @@ final class SubscriptionSettingsViewModel: ObservableObject {
                                                 date: subscription.expiresOrRenewsAt,
                                                 product: subscription.productId,
                                                 billingPeriod: subscription.billingPeriod)
-            case .failure:
-                AccountManager().signOut()
-                DispatchQueue.main.async {
-                    self.state.shouldDismissView = true
-                }
+            default:
+                return
+                
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207023339673018/f

**Description**:
- Do not signOut user on Backend Failure

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.  Get a subscription, put app in background
2. Wait 25 minutes
3. Turn of Data
4. Open Settings
5. Subscription should still be visible

