### PR TITLE
Update BSK with autofill 11.0.1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10036,8 +10036,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 133.0.0;
+				kind = revision;
+				revision = 86f5fd16119ea1aec4fc69d4f454f3e2b7c65c6c;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10036,8 +10036,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 86f5fd16119ea1aec4fc69d4f454f3e2b7c65c6c;
+				kind = exactVersion;
+				version = 133.0.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "c0b0cb55e7ac2f69d10452e1a5c06713155d798e",
-        "version" : "133.0.0"
+        "revision" : "39d74829150a9ecffea2f503c01851e54eda8ad1",
+        "version" : "133.0.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "6493e296934bf09277c03df45f11f4619711cb24",
-        "version" : "10.2.0"
+        "revision" : "6053999d6af384a716ab0ce7205dbab5d70ed1b3",
+        "version" : "11.0.1"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207038392239720/1207038392239720
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.1
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/769

## Description
Updates Autofill to version [11.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/11.0.1).

### Autofill 11.0.1 release notes
## What's Changed
* Fix regression by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/549
* Major version change 11.0.0 only affecting Android.
* Android: enable iframe support by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/536


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/11.0.0...11.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).