### PR TITLE
Fix status bar color on regular width size class

### DIFF
--- a/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/DuckDuckGo/BlankSnapshotViewController.swift
@@ -202,15 +202,30 @@ extension BlankSnapshotViewController: TabSwitcherButtonDelegate {
 
 extension BlankSnapshotViewController {
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        updateStatusBarBackgroundColor()
+    }
+
+    private func updateStatusBarBackgroundColor() {
+        let theme = ThemeManager.shared.currentTheme
+
+        if appSettings.currentAddressBarPosition == .bottom {
+            viewCoordinator.statusBackground.backgroundColor = theme.backgroundColor
+        } else {
+            if AppWidthObserver.shared.isPad && traitCollection.horizontalSizeClass == .regular {
+                viewCoordinator.statusBackground.backgroundColor = theme.tabsBarBackgroundColor
+            } else {
+                viewCoordinator.statusBackground.backgroundColor = theme.omniBarBackgroundColor
+            }
+        }
+    }
+
     private func decorate() {
         let theme = ThemeManager.shared.currentTheme
-        setNeedsStatusBarAppearanceUpdate()
 
-        if AppWidthObserver.shared.isLargeWidth {
-            viewCoordinator.statusBackground.backgroundColor = theme.tabsBarBackgroundColor
-        } else {
-            viewCoordinator.statusBackground.backgroundColor = theme.omniBarBackgroundColor
-        }
+        setNeedsStatusBarAppearanceUpdate()
 
         view.backgroundColor = theme.mainViewBackgroundColor
 
@@ -223,11 +238,6 @@ extension BlankSnapshotViewController {
         viewCoordinator.toolbarTabSwitcherButton.tintColor = theme.barTintColor
 
         viewCoordinator.logoText.tintColor = theme.ddgTextTintColor
-
-        if appSettings.currentAddressBarPosition == .bottom {
-            viewCoordinator.statusBackground.backgroundColor = theme.backgroundColor
-        }
-        
      }
     
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -548,7 +548,7 @@ class MainViewController: UIViewController {
     @objc func onAddressBarPositionChanged() {
         viewCoordinator.moveAddressBarToPosition(appSettings.currentAddressBarPosition)
         refreshViewsBasedOnAddressBarPosition(appSettings.currentAddressBarPosition)
-        updateAddressBarPositionRelatedColors()
+        updateStatusBarBackgroundColor()
     }
 
     @objc private func onShowFullURLAddressChanged() {
@@ -2411,13 +2411,19 @@ extension MainViewController: AutoClearWorker {
 
 extension MainViewController {
 
-    private func updateAddressBarPositionRelatedColors() {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        updateStatusBarBackgroundColor()
+    }
+
+    private func updateStatusBarBackgroundColor() {
         let theme = ThemeManager.shared.currentTheme
 
         if appSettings.currentAddressBarPosition == .bottom {
             viewCoordinator.statusBackground.backgroundColor = theme.backgroundColor
         } else {
-            if AppWidthObserver.shared.isLargeWidth {
+            if AppWidthObserver.shared.isPad && traitCollection.horizontalSizeClass == .regular {
                 viewCoordinator.statusBackground.backgroundColor = theme.tabsBarBackgroundColor
             } else {
                 viewCoordinator.statusBackground.backgroundColor = theme.omniBarBackgroundColor
@@ -2428,21 +2434,19 @@ extension MainViewController {
     private func decorate() {
         let theme = ThemeManager.shared.currentTheme
 
-        setNeedsStatusBarAppearanceUpdate()
+        updateStatusBarBackgroundColor()
 
-        updateAddressBarPositionRelatedColors()
+        setNeedsStatusBarAppearanceUpdate()
 
         view.backgroundColor = theme.mainViewBackgroundColor
 
         viewCoordinator.navigationBarContainer.backgroundColor = theme.barBackgroundColor
         viewCoordinator.navigationBarContainer.tintColor = theme.barTintColor
-        
-        
+
         viewCoordinator.toolbar.barTintColor = theme.barBackgroundColor
         viewCoordinator.toolbar.tintColor = theme.barTintColor
 
         viewCoordinator.toolbarTabSwitcherButton.tintColor = theme.barTintColor
-        
         
         viewCoordinator.logoText.tintColor = theme.ddgTextTintColor
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207036066535091/f
Tech Design URL:
CC: @federicocappelli 

**Description**:

Fixes invalid status bar color when in dark mode in iPad. Original check was not working since the decorate function was called only in `viewDidLoad` and the width was set to `0`. I’ve modified the check to include size class.

**Steps to test this PR**:
1. Open app on iPad.
2. Enable dark mode.
3. Enable split view and play with the size ratio.

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone 14 Pro
* [x] iPad

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
