### PR TITLE
BSK bump: macOS geoswitching nearest city bug-fix

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10160,8 +10160,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 133.0.1;
+				branch = "graeme/fix-nearest-city-bug";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "39d74829150a9ecffea2f503c01851e54eda8ad1",
-        "version" : "133.0.1"
+        "branch" : "graeme/fix-nearest-city-bug",
+        "revision" : "bd43122fe58c08b4c030b69ebfd555fef2ab1969"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "6053999d6af384a716ab0ce7205dbab5d70ed1b3",
-        "version" : "11.0.1"
+        "revision" : "6493e296934bf09277c03df45f11f4619711cb24",
+        "version" : "10.2.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/fix-nearest-city-bug",
-        "revision" : "bd43122fe58c08b4c030b69ebfd555fef2ab1969"
+        "revision" : "ab1bdc3d99c8f1a660d558afb21eccb82da94dfc"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1207044169885477/f

**Description**:
Just the BSK bump for a macOS fix. See https://github.com/duckduckgo/macos-browser/pull/2589 for details.

**Steps to test this PR**:
1. Make sure you’re hitting the production VPN environment (so you get the full countries + cities).
2. Go to VPN Location screen
3. Go to a country with multiple cities (currently only the US) and select any specific city
4. Now select Nearest (explicitly using the drop-down)
5. Go to the VPN management popover (e.g nav bar → … → VPN) and connect

**Expected**
VPN connects to the nearest city in that country

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
