### PR TITLE
Bring back accessibility identifiers for onboarding buttons

### DIFF
--- a/DuckDuckGo/OnboardingButtonsView.swift
+++ b/DuckDuckGo/OnboardingButtonsView.swift
@@ -36,6 +36,7 @@ struct OnboardingActions: View {
             })
             .buttonStyle(PrimaryButtonStyle())
             .disabled(!viewModel.isContinueEnabled)
+            .accessibilityIdentifier("Continue")
 
             Button(action: {
                 self.secondaryAction?()
@@ -43,6 +44,7 @@ struct OnboardingActions: View {
                 Text(viewModel.secondaryButtonTitle)
             })
             .buttonStyle(GhostButtonStyle())
+            .accessibilityIdentifier("Skip")
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207052144590087/f
Tech Design URL:
CC:

**Description**:

Sets accessibility identifiers for onboarding buttons. 
Caused by #2694 
Failed run: https://github.com/duckduckgo/iOS/actions/runs/8641327075/job/23690670876#step:7:29

I’ve verified locally if failed tests are passing.

**Steps to test this PR**:
1. Run e2e tests

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
