### PR TITLE
soft revert history suggestions

### DIFF
--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -26,8 +26,8 @@ extension FeatureName {
     // Define your feature e.g.:
     // public static let experimentalFeature = FeatureName(rawValue: "experimentalFeature")
 
-    // Experiment coming soon
     public static let history = FeatureName(rawValue: "history")
+    public static let newSuggestionLogic = FeatureName(rawValue: "newSuggestionLogic")
 }
 
 public struct VariantIOS: Variant {
@@ -63,7 +63,7 @@ public struct VariantIOS: Variant {
         VariantIOS(name: "sd", weight: doNotAllocate, isIncluded: When.always, features: []),
         VariantIOS(name: "se", weight: doNotAllocate, isIncluded: When.always, features: []),
 
-        VariantIOS(name: "mc", weight: 1, isIncluded: When.inEnglish, features: []),
+        VariantIOS(name: "mc", weight: 1, isIncluded: When.inEnglish, features: [.newSuggestionLogic]),
         VariantIOS(name: "md", weight: 1, isIncluded: When.inEnglish, features: [.history]),
 
         returningUser

--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -27,6 +27,7 @@ import CoreData
 import Persistence
 import History
 import Combine
+import BrowserServicesKit
 
 class AutocompleteViewController: UIViewController {
     
@@ -54,8 +55,14 @@ class AutocompleteViewController: UIViewController {
     private var historyCoordinator: HistoryCoordinating!
     private var bookmarksDatabase: CoreDataDatabase!
     private var appSettings: AppSettings!
+    private var variantManager: VariantManager!
+
     private lazy var cachedBookmarks: CachedBookmarks = {
         CachedBookmarks(bookmarksDatabase)
+    }()
+
+    private lazy var cachedBookmarksSearch: BookmarksStringSearch = {
+        BookmarksCachingSearch(bookmarksStore: CoreDataBookmarksSearchStore(bookmarksStore: bookmarksDatabase))
     }()
 
     var backgroundColor: UIColor {
@@ -82,7 +89,8 @@ class AutocompleteViewController: UIViewController {
     
     static func loadFromStoryboard(bookmarksDatabase: CoreDataDatabase,
                                    historyCoordinator: HistoryCoordinating,
-                                   appSettings: AppSettings = AppDependencyProvider.shared.appSettings) -> AutocompleteViewController {
+                                   appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
+                                   variantManager: VariantManager = DefaultVariantManager()) -> AutocompleteViewController {
         let storyboard = UIStoryboard(name: "Autocomplete", bundle: nil)
         guard let controller = storyboard.instantiateInitialViewController() as? AutocompleteViewController else {
             fatalError("Failed to instatiate correct Autocomplete view controller")
@@ -90,6 +98,7 @@ class AutocompleteViewController: UIViewController {
         controller.bookmarksDatabase = bookmarksDatabase
         controller.historyCoordinator = historyCoordinator
         controller.appSettings = appSettings
+        controller.variantManager = variantManager
         return controller
     }
 
@@ -178,6 +187,16 @@ class AutocompleteViewController: UIViewController {
         selectedItem = -1
         tableView.reloadData()
 
+        let bookmarks: [Suggestion]
+
+        if variantManager.inSuggestionExperiment {
+            bookmarks = [] // We'll supply bookmarks elsewhere
+        } else {
+            bookmarks = cachedBookmarksSearch.search(query: query).prefix(2).map {
+                .bookmark(title: $0.title, url: $0.url, isFavorite: $0.isFavorite, allowedInTopHits: true)
+            }
+        }
+
         loader = SuggestionLoader(dataSource: self, urlFactory: { phrase in
             guard let url = URL(trimmedAddressBarString: phrase),
                   let scheme = url.scheme,
@@ -195,7 +214,10 @@ class AutocompleteViewController: UIViewController {
                 self?.pendingRequest = false
             }
             guard error == nil else { return }
-            self?.updateSuggestions(result?.all ?? [])
+            
+            let remoteResults = result?.all ?? []
+
+            self?.updateSuggestions(bookmarks + remoteResults)
         }
     }
 
@@ -333,11 +355,11 @@ extension AutocompleteViewController {
 extension AutocompleteViewController: SuggestionLoadingDataSource {
     
     func history(for suggestionLoading: Suggestions.SuggestionLoading) -> [HistorySuggestion] {
-        return historyCoordinator.history ?? []
+        return variantManager.inSuggestionExperiment ? (historyCoordinator.history ?? []) : []
     }
 
     func bookmarks(for suggestionLoading: Suggestions.SuggestionLoading) -> [Suggestions.Bookmark] {
-        return cachedBookmarks.all
+        return variantManager.inSuggestionExperiment ? cachedBookmarks.all : []
     }
 
     func suggestionLoading(_ suggestionLoading: Suggestions.SuggestionLoading, suggestionDataFromUrl url: URL, withParameters parameters: [String: String], completion: @escaping (Data?, Error?) -> Void) {
@@ -360,6 +382,14 @@ extension HistoryEntry: HistorySuggestion {
 
     public var numberOfVisits: Int {
         return numberOfTotalVisits
+    }
+
+}
+
+extension VariantManager {
+
+    var inSuggestionExperiment: Bool {
+        isSupported(feature: .newSuggestionLogic) || isSupported(feature: .history)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207038972999258/f
Tech Design URL:
CC:

**Description**:
Reverts change to new logic for existing users not in the experiment. 

**Steps to test this PR**:
1. Run the app and check you're not allocated to a variant (e.g. because you're a return user, which should be the case unless you reset the simulator) - the output from Xcode will say 
2. Ensure previous logic works, ie matching bookmarks should appear in the top two slots of suggestions.
3. Run the app with the `md` variant (via launch arguments)
4. Ensure new logic with history works
5. Run the app with the `mc` variant
6. Ensure new logic without history works
7. Reset the simulator so you're a new user and check you get allocated to a variant 



