### PR TITLE
VPN: Specific TunnelController start failure reporting

### DIFF
--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -179,7 +179,6 @@ final class NetworkProtectionTunnelController: TunnelController {
                 )
             }
         } catch {
-            // Not this one
             Pixel.fire(pixel: .networkProtectionActivationRequestFailed, error: error)
             throw StartError.startVPNFailed(error)
         }

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -53,6 +53,20 @@ final class NetworkProtectionTunnelController: TunnelController {
             case .fetchAuthTokenFailed: 4
             }
         }
+
+        public var errorUserInfo: [String: Any] {
+            switch self {
+            case
+                    .simulateControllerFailureError:
+                return [:]
+            case
+                    .loadFromPreferencesFailed(let error),
+                    .saveToPreferencesFailed(let error),
+                    .startVPNFailed(let error),
+                    .fetchAuthTokenFailed(let error):
+                return ["NSUnderlyingError": error]
+            }
+        }
     }
 
     init() {

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -64,7 +64,7 @@ final class NetworkProtectionTunnelController: TunnelController {
                     .saveToPreferencesFailed(let error),
                     .startVPNFailed(let error),
                     .fetchAuthTokenFailed(let error):
-                return ["NSUnderlyingError": error]
+                return [NSUnderlyingErrorKey: error]
             }
         }
     }

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -44,8 +44,6 @@ final class NetworkProtectionTunnelController: TunnelController {
         case startVPNFailed(Error)
         case fetchAuthTokenFailed(Error)
 
-        public static let errorDomain = "com.duckduckgo.NetworkProtectionTunnelController.StartError.domain"
-
         public var errorCode: Int {
             switch self {
             case .simulateControllerFailureError: 0

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -243,6 +243,14 @@ final class NetworkProtectionTunnelController: TunnelController {
         do {
             try await tunnelManager.saveToPreferences()
         } catch {
+            let nsError = error as NSError
+            if nsError.code == NEVPNError.Code.configurationReadWriteFailed.rawValue,
+               nsError.localizedDescription == "permission denied" {
+                // This is a user denying the system permissions prompt to add the config
+                // Maybe we should fire another pixel here, but not a start failure as this is an imaginable scenario
+                // The code could be caused by a number of problems so I'm using the localizedDescription to catch that case
+                return
+            }
             throw StartError.saveToPreferencesFailed(error)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207056623910446/f

**Background**
We’re seeing [a rise in tunnel controller start failures](https://kibana.duckduckgo.com/goto/3975034b93e1f9a4fe098e846e77c602) but are lacking which specific function calls to the SDK are causing the failure.

**Objective**
Add more specific errors that can be sent with the m.netp.controller.start.failure.ios pixel to help with diagnosing the issue.

**Steps to test this PR**:
- Sort of hard to test without changing code.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
