### PR TITLE
Subscriptions: Fix thread issue on Subscription Restore

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -845,6 +845,7 @@
 		D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */; };
 		D670E5BB2BB6A75300941A42 /* SubscriptionNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */; };
 		D670E5BD2BB6AA0000941A42 /* View+AppearModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D670E5BC2BB6AA0000941A42 /* View+AppearModifiers.swift */; };
+		D67969112BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */; };
 		D68A21442B7EC08500BB372E /* SubscriptionExternalLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68A21432B7EC08500BB372E /* SubscriptionExternalLinkView.swift */; };
 		D68A21462B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */; };
 		D68DF81C2B58302E0023DBEA /* SubscriptionRestoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68DF81B2B58302E0023DBEA /* SubscriptionRestoreView.swift */; };
@@ -2543,6 +2544,7 @@
 		D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerView.swift; sourceTree = "<group>"; };
 		D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionNavigationCoordinator.swift; sourceTree = "<group>"; };
 		D670E5BC2BB6AA0000941A42 /* View+AppearModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AppearModifiers.swift"; sourceTree = "<group>"; };
+		D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewModel.swift; sourceTree = "<group>"; };
 		D68A21432B7EC08500BB372E /* SubscriptionExternalLinkView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExternalLinkView.swift; sourceTree = "<group>"; };
 		D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExternalLinkViewModel.swift; sourceTree = "<group>"; };
 		D68DF81B2B58302E0023DBEA /* SubscriptionRestoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionRestoreView.swift; sourceTree = "<group>"; };
@@ -4769,13 +4771,14 @@
 		D664C7932B289AA000CBFA76 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */,
+				D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */,
 				D664C7942B289AA000CBFA76 /* SubscriptionFlowViewModel.swift */,
 				D68DF81D2B5830380023DBEA /* SubscriptionRestoreViewModel.swift */,
 				D668D9262B6937D2008E2FF2 /* SubscriptionITPViewModel.swift */,
 				D64648AE2B5993890033090B /* SubscriptionEmailViewModel.swift */,
 				D652498D2B515A6A0056B0DE /* SubscriptionSettingsViewModel.swift */,
 				D6BFCB602B7525160051FF81 /* SubscriptionPIRViewModel.swift */,
-				D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -6947,6 +6950,7 @@
 				F194FAED1F14E2B3009B4DF8 /* UIFontExtension.swift in Sources */,
 				F1CDD3F21F16911700BE0581 /* AboutViewControllerOld.swift in Sources */,
 				98F0FC2021FF18E700CE77AB /* AutoClearSettingsViewController.swift in Sources */,
+				D67969112BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift in Sources */,
 				027F487A2A4B66CD001A1C6C /* AppTPFAQViewModel.swift in Sources */,
 				F1E90C201E678E7C005E7E21 /* HomeControllerDelegate.swift in Sources */,
 				F17922DE1E7192E6006E3D97 /* SuggestionTableViewCell.swift in Sources */,

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionContainerViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionContainerViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  SubscriptionContainerViewModel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Combine
+
+#if SUBSCRIPTION
+@available(iOS 15.0, *)
+final class SubscriptionContainerViewModel: ObservableObject {
+    
+    let userScript: SubscriptionPagesUserScript
+    let subFeature: SubscriptionPagesUseSubscriptionFeature
+    
+    let flow: SubscriptionFlowViewModel
+    let restore: SubscriptionRestoreViewModel
+    let email: SubscriptionEmailViewModel
+    
+    
+    init(userScript: SubscriptionPagesUserScript = SubscriptionPagesUserScript(),
+         subFeature: SubscriptionPagesUseSubscriptionFeature = SubscriptionPagesUseSubscriptionFeature()) {
+        self.userScript = userScript
+        self.subFeature = subFeature
+        self.flow = SubscriptionFlowViewModel(userScript: userScript, subFeature: subFeature)
+        self.restore = SubscriptionRestoreViewModel(userScript: userScript, subFeature: subFeature)
+        self.email = SubscriptionEmailViewModel(userScript: userScript, subFeature: subFeature)
+    }
+    
+    deinit {
+        subFeature.cleanup()
+    }
+}
+#endif

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionEmailViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionEmailViewModel.swift
@@ -116,7 +116,6 @@ final class SubscriptionEmailViewModel: ObservableObject {
     
     private func cleanUp() {
         canGoBackCancellable?.cancel()
-        subFeature.cleanup()
         cancellables.removeAll()
     }
     

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -255,7 +255,6 @@ final class SubscriptionFlowViewModel: ObservableObject {
         transactionStatusTimer?.invalidate()
         canGoBackCancellable?.cancel()
         urlCancellable?.cancel()
-        subFeature.cleanup()
         cancellables.removeAll()
     }
 

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionRestoreViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionRestoreViewModel.swift
@@ -83,7 +83,6 @@ final class SubscriptionRestoreViewModel: ObservableObject {
     }
     
     private func cleanUp() {
-        subFeature.cleanup()
         cancellables.removeAll()
     }
     

--- a/DuckDuckGo/Subscription/Views/SubscriptionContainerView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionContainerView.swift
@@ -31,18 +31,20 @@ struct SubscriptionContainerView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var subscriptionNavigationCoordinator: SubscriptionNavigationCoordinator
     @State private var currentViewState: CurrentView
+    private let viewModel: SubscriptionContainerViewModel
     private let flowViewModel: SubscriptionFlowViewModel
     private let restoreViewModel: SubscriptionRestoreViewModel
     private let emailViewModel: SubscriptionEmailViewModel
-    
-    init(currentView: CurrentView) {
-        _currentViewState = State(initialValue: currentView)
         
-        let userScript = SubscriptionPagesUserScript()
-        let subFeature = SubscriptionPagesUseSubscriptionFeature()
-        flowViewModel = SubscriptionFlowViewModel(userScript: userScript, subFeature: subFeature)
-        restoreViewModel = SubscriptionRestoreViewModel(userScript: userScript, subFeature: subFeature)
-        emailViewModel = SubscriptionEmailViewModel(userScript: userScript, subFeature: subFeature)
+    init(currentView: CurrentView,
+         viewModel: SubscriptionContainerViewModel = SubscriptionContainerViewModel()) {
+        _currentViewState = State(initialValue: currentView)
+        self.viewModel = viewModel
+        let userScript = viewModel.userScript
+        let subFeature = viewModel.subFeature
+        flowViewModel = viewModel.flow
+        restoreViewModel = viewModel.restore
+        emailViewModel = viewModel.email
     }
     
     var body: some View {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1207054737385929/f

**Description**:
There is a threading issue on deInit for the SubscriptionFlow and SubscriptionRestore Viewmodels causing simultaneous calls to `cleanup()` in the SubFeature. (While I was unable to reproduce the issue, it’s there.)

Since subFeature is now a single instance everywhere, this adds a new ViewModel that holds and cleans the subFeature object instead of delegating the tasks to the internal viewModels.

![Screenshot 2024-04-11 at 13 11 54](https://github.com/duckduckgo/iOS/assets/1156669/18db174b-bf91-49d9-bb79-6a2514d8bc8b)


<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Get a subscription
2. Close settings
3. Remove from device and restore again
4. Close settings

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
