### PR TITLE
Require device auth to be set in order to use Sync

### DIFF
--- a/DuckDuckGo/UserAuthenticator.swift
+++ b/DuckDuckGo/UserAuthenticator.swift
@@ -23,7 +23,7 @@ import LocalAuthentication
 import Core
 
 class UserAuthenticator {
-    enum AuthError: Equatable {
+    enum AuthError: Error, Equatable {
         case noAuthAvailable
         case failedToAuthenticate
     }

--- a/DuckDuckGoTests/SyncManagementViewModelTests.swift
+++ b/DuckDuckGoTests/SyncManagementViewModelTests.swift
@@ -106,11 +106,13 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
 
     func testWhenSaveRecoveryPDFPressed_recoveryMethodShown() {
         model.saveRecoveryPDF()
+        waitForInvocation()
 
         // You can either test one individual call was made x number of times or check for a whole number of calls
-        monitor.assert(#selector(shareRecoveryPDF).description, calls: 1)
+        // async functions selector description apparently contain 'WithCompletionHandler'
+        monitor.assert(#selector(authenticateUser).description.dropping(suffix: "WithCompletionHandler:"), calls: 1)
         monitor.assertCalls([
-            #selector(shareRecoveryPDF).description: 1
+            #selector(authenticateUser).description.dropping(suffix: "WithCompletionHandler:"): 1
         ])
     }
 
@@ -137,11 +139,13 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
 
     func testWhenRecoverSyncDataPressed_RecoverDataViewShown() {
         model.recoverSyncDataPressed()
+        waitForInvocation()
 
         // You can either test one individual call was made x number of times or check for a whole number of calls
-        monitor.assert(#selector(showRecoverData).description, calls: 1)
+        // async functions selector description apparently contain 'WithCompletionHandler'
+        monitor.assert(#selector(authenticateUser).description.dropping(suffix: "WithCompletionHandler:"), calls: 1)
         monitor.assertCalls([
-            #selector(showRecoverData).description: 1
+            #selector(authenticateUser).description.dropping(suffix: "WithCompletionHandler:"): 1
         ])
     }
     // MARK: Delegate functions

--- a/DuckDuckGoTests/SyncManagementViewModelTests.swift
+++ b/DuckDuckGoTests/SyncManagementViewModelTests.swift
@@ -34,6 +34,15 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
     var createAccountAndStartSyncingCalled = false
     var capturedOptionModel: SyncSettingsViewModel?
 
+    func waitForInvocation() {
+        let expectation = expectation(description: "Inv")
+        let cancellable = monitor.$functionCalls.dropFirst().sink { val in
+            print(val)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+
     func testWhenSingleDeviceSetUpPressed_ThenManagerBecomesBusy_AndAccounCreationRequested() {
         model.startSyncPressed()
         XCTAssertTrue(model.isBusy)
@@ -54,11 +63,13 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
 
     func testWhenScanQRCodePressed_ThenSyncWithAnotherDeviceViewIsShown() {
         model.scanQRCode()
+        waitForInvocation()
 
         // You can either test one individual call was made x number of times or check for a whole number of calls
-        monitor.assert(#selector(showSyncWithAnotherDevice).description, calls: 1)
+        // async functions selector description apparently contain 'WithCompletionHandler'
+        monitor.assert(#selector(authenticateUser).description.dropping(suffix: "WithCompletionHandler:"), calls: 1)
         monitor.assertCalls([
-            #selector(showSyncWithAnotherDevice).description: 1
+            #selector(authenticateUser).description.dropping(suffix: "WithCompletionHandler:"): 1
         ])
     }
 
@@ -136,6 +147,7 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
     // MARK: Delegate functions
 
     func authenticateUser() async throws {
+        monitor.incrementCalls(function: #function.cleaningFunctionName())
     }
 
     func showSyncWithAnotherDeviceEnterText() {
@@ -216,7 +228,7 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
 
 private class Monitor<T> {
 
-    var functionCalls = [String: Int]()
+    @Published var functionCalls = [String: Int]()
 
     /// Whatever is passed as function is used as the key, the same key should be used for assertions.
     ///  Use `String.cleaningFunctionName()` with `#function` but be aware that overloaded function names will not be tracked accurately.

--- a/DuckDuckGoTests/SyncManagementViewModelTests.swift
+++ b/DuckDuckGoTests/SyncManagementViewModelTests.swift
@@ -135,8 +135,7 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
     }
     // MARK: Delegate functions
 
-    func authenticateUser() async -> Bool {
-        return true
+    func authenticateUser() async throws {
     }
 
     func showSyncWithAnotherDeviceEnterText() {

--- a/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
@@ -155,7 +155,11 @@ public class SyncSettingsViewModel: ObservableObject {
     }
 
     func saveRecoveryPDF() {
-        delegate?.shareRecoveryPDF()
+        Task { @MainActor in
+            if await commonAuthenticate() {
+                delegate?.shareRecoveryPDF()
+            }
+        }
     }
 
     func scanQRCode() {
@@ -214,6 +218,10 @@ public class SyncSettingsViewModel: ObservableObject {
     }
 
     public func recoverSyncDataPressed() {
-        delegate?.showRecoverData()
+        Task { @MainActor in
+            if await commonAuthenticate() {
+                delegate?.showRecoverData()
+            }
+        }
     }
 }

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -29,6 +29,7 @@ public struct SyncSettingsView: View {
     @State var isSyncWithSetUpSheetVisible = false
     @State var isRecoverSyncedDataSheetVisible = false
     @State var isEnvironmentSwitcherInstructionsVisible = false
+    @State var isDeviceAuthenticationSetupAlertVisible = false
 
     public init(model: SyncSettingsViewModel) {
         self.model = model

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -88,6 +88,18 @@ public struct SyncSettingsView: View {
             .navigationTitle(UserText.syncTitle)
             .applyListStyle()
             .environmentObject(model)
+            .alert(isPresented: $model.shouldShowPasscodeRequiredAlert) {
+                Alert(
+                    title: Text("Secure Your Device to Use Sync & Backup"),
+                    message: Text("A device password is required to use Sync & Backup."),
+                    dismissButton: .default(Text("Go to Settings"), action: {
+                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!,
+                                                  options: [:],
+                                                  completionHandler: nil)
+                        model.shouldShowPasscodeRequiredAlert = false
+                    })
+                )
+            }
         }
 
     }

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsViewExtension.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsViewExtension.swift
@@ -21,6 +21,8 @@ import DesignResourcesKit
 import DuckUI
 import SwiftUI
 
+// swiftlint:disable file_length
+
 extension SyncSettingsView {
 
     @ViewBuilder
@@ -413,3 +415,5 @@ extension View {
         closure(self)
     }
 }
+
+// swiftlint:enable file_length

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsViewExtension.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsViewExtension.swift
@@ -74,11 +74,6 @@ extension SyncSettingsView {
 
     @ViewBuilder
     func otherOptions() -> some View {
-        let alertBinding = Binding<Bool>(
-            get: { model.shouldShowPasscodeRequiredAlert },
-            set: { value in model.shouldShowPasscodeRequiredAlert = value }
-        )
-        
         Section {
             Button(UserText.syncAndBackUpThisDeviceLink) {
                 Task { @MainActor in
@@ -107,18 +102,6 @@ extension SyncSettingsView {
                 })
             })
             .disabled(!model.isAccountRecoveryAvailable)
-            .alert(isPresented: alertBinding) {
-                Alert(
-                    title: Text("Secure Your Device to Use Sync & Backup"),
-                    message: Text("A device password is required to use Sync & Backup."),
-                    dismissButton: .default(Text("Go to Settings"), action: {
-                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!,
-                                                  options: [:],
-                                                  completionHandler: nil)
-                        model.shouldShowPasscodeRequiredAlert = false
-                    })
-                )
-            }
 
         } header: {
             Text(UserText.otherOptionsSectionHeader)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1206876054968715/f
Tech Design URL:
CC:

**Description**:

Require device auth to be set in order to use Sync

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

Test this on a device that has no password set, or test by changing `UserAuthenticator.canAuthenticate()` to return false.

When sync is not set up:
* [x] Connecting with device should be protected.
* [x] Setting sync for current device should be protected.
* [x] Recovering data should be protected.

When sync is set up:
* [x] Connecting with device should be protected.
* [x] Saving recovery code should be protected.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Device Testing**:

* [ ] iPhone 
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
