### PR TITLE
Use custom back button for Purchase Flow

### DIFF
--- a/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
@@ -80,7 +80,7 @@ struct SubscriptionFlowView: View {
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(viewModel.state.canNavigateBack || viewModel.subFeature.transactionStatus != .idle)
+            .navigationBarBackButtonHidden(true)
             .interactiveDismissDisabled(viewModel.subFeature.transactionStatus != .idle)
             .edgesIgnoringSafeArea(.bottom)
             .tint(Color(designSystemColor: .textPrimary))
@@ -94,7 +94,7 @@ struct SubscriptionFlowView: View {
             }, label: {
                 HStack(spacing: 0) {
                     Image(systemName: Constants.backButtonImage)
-                    Text(UserText.backButtonTitle)
+                    Text(viewModel.state.backButtonTitle)
                 }
                 
             })
@@ -165,6 +165,10 @@ struct SubscriptionFlowView: View {
                     isPresentingError = true
                 }
             }
+        }
+        
+        .onChange(of: viewModel.state.shouldDismissView) { _ in
+            dismiss()
         }
         
         .onFirstAppear {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:  https://app.asana.com/0/414709148257752/1207054736335272/f

**Description**:
- Fixes issue causing the 'Back' button to not re-appear if the user cancels the subscription purchase mid-transaction.

This removes the native navigation button and uses a custom navBar item to handle both webview navigation and dismissal.


**Steps to test this PR**:
1. Go to Settings Get Privacy Pro
2. Select a plan
3. Hit Subscribe
4. Cancel the transaction on the Apple dialog
5. Observe the "Settings" button is visible in the top-left
6. Tap the button to go back to Settings

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
