### PR TITLE
Fix inconsistent bars state when scrolling

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1562,12 +1562,12 @@ extension MainViewController: BrowserChromeDelegate {
         let updateBlock = {
             self.updateToolbarConstant(percent)
             self.updateNavBarConstant(percent)
-          
-            self.view.layoutIfNeeded()
-            
+
             self.viewCoordinator.navigationBarContainer.alpha = percent
             self.viewCoordinator.tabBarContainer.alpha = percent
             self.viewCoordinator.toolbar.alpha = percent
+
+            self.view.layoutIfNeeded()
         }
            
         if animated {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207045192875790/f
Tech Design URL:
CC:

**Description**:

When scrolling content which almost fits in the screen height, top and bottom bar could end up in an inconsistent state with alpha channel set on the controls. This makes sure layout pass is always done after all the properties are set. More details can be found in a [subtask](https://app.asana.com/0/0/1207063082863564/f).

**Steps to test this PR**:
1. Go to https://kitese.duckdns.org:8080/
2. Rotate device to landscape
3. Scroll quite rapidly to hide bars
4. Bars should become visible again by the scroll finishes with alpha on controls set to 1.0 (see video in the task for details)

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
