### PR TITLE
Subscriptions: Fix back navigation button on user.cancel

### DIFF
--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -227,7 +227,7 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
             purchaseTransactionJWS = transactionJWS
 
         case .failure(let error):
-            
+            setTransactionStatus(.idle)
             switch error {
             case .cancelledByUser:
                 setTransactionError(.cancelledByUser)
@@ -241,7 +241,6 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
                 setTransactionError(.purchaseFailed)
             }
             originalMessage = original
-            setTransactionStatus(.idle)
             return nil
         }
         

--- a/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
@@ -80,7 +80,7 @@ struct SubscriptionFlowView: View {
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(viewModel.state.canNavigateBack || viewModel.subFeature.transactionStatus != .idle)
+            .navigationBarBackButtonHidden(true)
             .interactiveDismissDisabled(viewModel.subFeature.transactionStatus != .idle)
             .edgesIgnoringSafeArea(.bottom)
             .tint(Color(designSystemColor: .textPrimary))
@@ -94,7 +94,7 @@ struct SubscriptionFlowView: View {
             }, label: {
                 HStack(spacing: 0) {
                     Image(systemName: Constants.backButtonImage)
-                    Text(UserText.backButtonTitle)
+                    Text(viewModel.state.backButtonTitle)
                 }
                 
             })
@@ -165,6 +165,10 @@ struct SubscriptionFlowView: View {
                     isPresentingError = true
                 }
             }
+        }
+        
+        .onChange(of: viewModel.state.shouldDismissView) { _ in
+            dismiss()
         }
         
         .onFirstAppear {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207054736335272/f

**Description**:
- Fixes the back button not re-appearing correctly after cancelling a subscription purchase

**Steps to test this PR**:
1.  Go to [duckduckgo.com/pro](https://duckduckgo.com/pro)
2. Click on a subscription option
3. Click subscribe
4. Cancel the App Store purchase confirmation
5. Observe the '< Settings' button is present in the top left.
 