### PR TITLE
Subscription: Fix 'Back' button not present

### DIFF
--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -227,7 +227,7 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
             purchaseTransactionJWS = transactionJWS
 
         case .failure(let error):
-            
+            setTransactionStatus(.idle)
             switch error {
             case .cancelledByUser:
                 setTransactionError(.cancelledByUser)
@@ -241,7 +241,6 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
                 setTransactionError(.purchaseFailed)
             }
             originalMessage = original
-            setTransactionStatus(.idle)
             return nil
         }
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207054736335272/f

**Description**:
Fixes an issue causing the back button to not be re-enabled when cancelling a subscription purchase.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
- Go to duckduckgo.com/pro
- Click on a subscription option
- Click subscribe
- Observe the '< Settings' back button is NOT visible while purchasing
- Cancel the App Store purchase confirmation
- Observe the '< Settings' back button is visible in the top left.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
