### PR TITLE
Check entitlements before showing VPN screen from notification

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -1006,13 +1006,18 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
 #if NETWORK_PROTECTION
             if NetworkProtectionNotificationIdentifier(rawValue: identifier) != nil {
-                presentNetworkProtectionStatusSettingsModal()
+                Task {
+                    let accountManager = AccountManager()
+                    if case .success(let hasEntitlements) = await accountManager.hasEntitlement(for: .networkProtection),
+                        hasEntitlements {
+                        presentNetworkProtectionStatusSettingsModal()
+                    }
+                }
             }
 
             if vpnFeatureVisibility.shouldKeepVPNAccessViaWaitlist(), identifier == VPNWaitlist.notificationIdentifier {
                 presentNetworkProtectionWaitlistModal()
             }
-
 #endif
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1207077903361923/f

**Description**:

Found an issue where you can still launch the VPN controls screen after signing out of Privacy Pro by tapping an old notification. Not much impact as the VPN won’t work without a token, but worth fixing nonetheless.

**Steps to test this PR**:
1. Sign up to Privacy Pro
2. Follow VPN flow to connect and add a configuration granting notification permissions
3. Disconnect
4. Go to the iOS VPN Settings
5. Connect from here triggering a notification. Don’t interact with it
6. Open DDG again and remove the subscription from the device
7. Go to the device Notification Center
8. Tap the connection notification from before

Expected:
The app should be launched but not the VPN controls

Observed:
VPN controls are shown

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
