### PR TITLE
VPN: Replace available interfaces in VPN metadata

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10177,8 +10177,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 0921e440364d660aad76be28d6fc128d5a35f677;
+				kind = exactVersion;
+				version = "134.1.0-1";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10177,8 +10177,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 134.0.1;
+				kind = revision;
+				revision = 0921e440364d660aad76be28d6fc128d5a35f677;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "b0749d25996c0fa18be07b7851f02ebb3b9fab50",
-        "version" : "134.0.1"
+        "revision" : "0921e440364d660aad76be28d6fc128d5a35f677"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "0921e440364d660aad76be28d6fc128d5a35f677"
+        "revision" : "543398a776f522998918eefd3df4150fae041838",
+        "version" : "134.1.0-1"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207087903608440/f

macOS PR: https://github.com/duckduckgo/macos-browser/pull/2634
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/782

## Description

Removes `availableInterfaces` from VPN metadata and instead replaces it with the type of the first available interface, a count of tunnels and DNS interfaces.

## Testing

1. Send feedback
2. Place a breakpoint [here](https://github.com/duckduckgo/BrowserServicesKit/pull/782/files#diff-23f00201585daed436d5fbd92aa32966dbe3fb89c17fe2a67ef5313629d0fb5aR175) to `po` the description.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)