### PR TITLE
Fix settings navigation bar colors after reopening

### DIFF
--- a/DuckDuckGo/SettingsHostingController.swift
+++ b/DuckDuckGo/SettingsHostingController.swift
@@ -64,7 +64,7 @@ class SettingsHostingController: UIHostingController<AnyView> {
 
         // If this is not called, settings navigation bar (UIKIt) is going wild with colors after reopening settings (?!)
         // Root cause will be investigated later as part of https://app.asana.com/0/414235014887631/1207098219526666/f
-        self.decorate()
+        decorate()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/DuckDuckGo/SettingsHostingController.swift
+++ b/DuckDuckGo/SettingsHostingController.swift
@@ -59,6 +59,14 @@ class SettingsHostingController: UIHostingController<AnyView> {
         decorate()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // If this is not called, settings navigation bar (UIKIt) is going wild with colors after reopening settings (?!)
+        // Root cause will be investigated later as part of https://app.asana.com/0/414235014887631/1207098219526666/f
+        self.decorate()
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -78,19 +86,7 @@ class SettingsHostingController: UIHostingController<AnyView> {
 extension SettingsHostingController {
     
     private func decorate() {
-        let theme = ThemeManager.shared.currentTheme
-        // Apply Theme
-        navigationController?.navigationBar.barTintColor = theme.barBackgroundColor
-        navigationController?.navigationBar.tintColor = theme.navigationBarTintColor
-
-        if #available(iOS 15.0, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.shadowColor = .clear
-            appearance.backgroundColor = theme.backgroundColor
-
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        }
+        decorateNavigationBar()
     }
-    
+
 }

--- a/DuckDuckGo/SettingsHostingController.swift
+++ b/DuckDuckGo/SettingsHostingController.swift
@@ -27,7 +27,7 @@ import Subscription
 class SettingsHostingController: UIHostingController<AnyView> {
     var viewModel: SettingsViewModel
     var viewProvider: SettingsLegacyViewProvider
-    
+
     init(viewModel: SettingsViewModel, viewProvider: SettingsLegacyViewProvider) {
         self.viewModel = viewModel
         self.viewProvider = viewProvider
@@ -36,15 +36,15 @@ class SettingsHostingController: UIHostingController<AnyView> {
         viewModel.onRequestPushLegacyView = { [weak self] vc in
             self?.pushLegacyViewController(vc)
         }
-        
+
         viewModel.onRequestPresentLegacyView = { [weak self] vc, modal in
             self?.presentLegacyViewController(vc, modal: modal)
         }
-        
+
         viewModel.onRequestPopLegacyView = { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         }
-        
+
         viewModel.onRequestDismissSettings = { [weak self] in
             self?.navigationController?.dismiss(animated: true)
         }
@@ -56,7 +56,7 @@ class SettingsHostingController: UIHostingController<AnyView> {
         }
         self.rootView = AnyView(settingsView)
 
-        decorate()
+        decorateNavigationBar()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -64,7 +64,7 @@ class SettingsHostingController: UIHostingController<AnyView> {
 
         // If this is not called, settings navigation bar (UIKIt) is going wild with colors after reopening settings (?!)
         // Root cause will be investigated later as part of https://app.asana.com/0/414235014887631/1207098219526666/f
-        decorate()
+        decorateNavigationBar()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -74,19 +74,11 @@ class SettingsHostingController: UIHostingController<AnyView> {
     func pushLegacyViewController(_ vc: UIViewController) {
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
     func presentLegacyViewController(_ vc: UIViewController, modal: Bool = false) {
         if modal {
             vc.modalPresentationStyle = .fullScreen
         }
         navigationController?.present(vc, animated: true)
     }
-}
-
-extension SettingsHostingController {
-    
-    private func decorate() {
-        decorateNavigationBar()
-    }
-
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207081314608691/f
Tech Design URL: 
CC:

**Description**:
Prevents weird coloring of NavigationBar in Settings after opening SwiftUI subsection containing NavigationBar. I’ll investigate root cause as part of https://app.asana.com/0/414235014887631/1207098219526666/f.

**Steps to test this PR**:

#### Scenario 1
1. Open Settings
2. Open DuckDuckGo App for Mac
3. NavBar elements should remain grayish color
4. Go back

#### Scenario 2
1. Open Settings
2. Go to Get Privacy Pro
3. Navigate back
4. Close Settings
5. Open Settings
6. While scrolling Settings Navigation bar should remain properly colored
