### PR TITLE
Fix crash when quickly adding/removing tabs in switcher

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2245,7 +2245,7 @@ extension MainViewController: TabSwitcherButtonDelegate {
     }
 
     func showTabSwitcher() {
-        guard let currentTab = currentTab ?? tabManager.current(createIfNeeded: true) else {
+        guard currentTab ?? tabManager.current(createIfNeeded: true) != nil else {
             fatalError("Unable to get current tab")
         }
 

--- a/DuckDuckGo/TabSwitcherViewController+KeyCommands.swift
+++ b/DuckDuckGo/TabSwitcherViewController+KeyCommands.swift
@@ -54,6 +54,7 @@ extension TabSwitcherViewController {
     }
     
     @objc func keyboardNewTab() {
+        guard !isProcessingUpdates else { return }
         delegate?.tabSwitcherDidRequestNewTab(tabSwitcher: self)
         dismiss()
     }

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -71,7 +71,7 @@ class TabSwitcherViewController: UIViewController {
     var currentSelection: Int?
     
     private var tabSwitcherSettings: TabSwitcherSettings = DefaultTabSwitcherSettings()
-    private var isProcessingUpdates = false
+    private(set) var isProcessingUpdates = false
     private var canUpdateCollection = true
 
     let favicons = Favicons.shared
@@ -278,6 +278,7 @@ class TabSwitcherViewController: UIViewController {
     }
 
     @IBAction func onAddPressed(_ sender: UIBarButtonItem) {
+        guard !isProcessingUpdates else { return }
         delegate.tabSwitcherDidRequestNewTab(tabSwitcher: self)
         dismiss()
     }

--- a/DuckDuckGo/TabViewCell.swift
+++ b/DuckDuckGo/TabViewCell.swift
@@ -123,12 +123,12 @@ class TabViewCell: UICollectionViewCell {
     }
 
     private func startRemoveAnimation() {
+        self.isDeleting = true
+        self.deleteTab()
         UIView.animate(withDuration: 0.2, animations: {
             self.transform = CGAffineTransform.identity.translatedBy(x: -self.frame.width, y: 0)
         }, completion: { _ in
             self.isHidden = true
-            self.isDeleting = true
-            self.deleteTab()
         })
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1204624719960838/f
Tech Design URL:
CC:

**Description**:

This PR prevents internal inconsistency during CollectionView updates by not allowing to add a tab to model during batch updates execution block.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go to Tab Switcher
2. Make sure there are at least two tabs
3. Drag tab to delete and immediately try to add a new tab
4. Attempt similar scenario with keyboard shortcuts (cmd+n)

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
