### PR TITLE
Dismiss keyboard on scroll in autocomplete suggestions

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		6FBF0F8B2BD7C0A900136CF0 /* AllProtectedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */; };
 		6FDA1FB32B59584400AC962A /* AddressDisplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */; };
 		6FDB3F192BD11A4400F7A307 /* AutocompleteSuggestionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB3F182BD11A4400F7A307 /* AutocompleteSuggestionsModel.swift */; };
+		6FE095D82BD90AFB00490FF8 /* UniversalOmniBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE095D72BD90AFB00490FF8 /* UniversalOmniBarState.swift */; };
 		83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */; };
 		83004E862193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */; };
 		83004E882193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83004E872193E8C700DA013C /* TabViewControllerLongPressMenuExtension.swift */; };
@@ -1492,6 +1493,7 @@
 		6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllProtectedCell.swift; sourceTree = "<group>"; };
 		6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressDisplayHelper.swift; sourceTree = "<group>"; };
 		6FDB3F182BD11A4400F7A307 /* AutocompleteSuggestionsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteSuggestionsModel.swift; sourceTree = "<group>"; };
+		6FE095D72BD90AFB00490FF8 /* UniversalOmniBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalOmniBarState.swift; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
 		83004E832193E14C00DA013C /* UIAlertControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtension.swift; path = ../Core/UIAlertControllerExtension.swift; sourceTree = "<group>"; };
 		83004E852193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerBrowsingMenuExtension.swift; sourceTree = "<group>"; };
@@ -5567,6 +5569,7 @@
 				98D16975250CE707009513CC /* OmniBar.xib */,
 				F130D7391E5776C500C45811 /* OmniBarDelegate.swift */,
 				F1D477C51F2126CC0031ED49 /* OmniBarState.swift */,
+				6FE095D72BD90AFB00490FF8 /* UniversalOmniBarState.swift */,
 				85DFEDF024C7EEA400973FE7 /* LargeOmniBarState.swift */,
 				85DFEDEE24C7EA3B00973FE7 /* SmallOmniBarState.swift */,
 				98AA92B22456FBE100ED4B9E /* SearchFieldContainerView.swift */,
@@ -6755,6 +6758,7 @@
 				8528AE81212F15D600D0BD74 /* AppRatingPrompt.xcdatamodeld in Sources */,
 				1E24295E293F57FA00584836 /* LottieView.swift in Sources */,
 				8577A1C5255D2C0D00D43FCD /* HitTestingToolbar.swift in Sources */,
+				6FE095D82BD90AFB00490FF8 /* UniversalOmniBarState.swift in Sources */,
 				1DEAADE82BA38AA500E25A97 /* SettingsGeneralView.swift in Sources */,
 				4BB697A42B1D99C4003699B5 /* VPNWaitlistActivationDateStore.swift in Sources */,
 				853C5F5B21BFF0AE001F7A05 /* HomeCollectionView.swift in Sources */,

--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -109,6 +109,7 @@ class AutocompleteViewController: UIViewController {
 
         tableView.backgroundColor = UIColor.clear
         tableView.sectionFooterHeight = 1.0 / UIScreen.main.scale
+        tableView.keyboardDismissMode = .onDrag
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -139,6 +140,9 @@ class AutocompleteViewController: UIViewController {
 
     func updateQuery(query: String) {
         selectedItemIndex = -1
+
+        guard self.query != query else { return }
+
         cancelInFlightRequests()
         self.query = query
     }

--- a/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/DuckDuckGo/BlankSnapshotViewController.swift
@@ -162,7 +162,11 @@ extension BlankSnapshotViewController: OmniBarDelegate {
     func onVoiceSearchPressed() {
        // No-op
     }
-    
+
+    func onEditingEnd() -> OmniBarEditingEndResult {
+        .dismissed
+    }
+
     func selectedSuggestion() -> Suggestion? {
         return nil
     }

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -237,6 +237,10 @@ class OmniBar: UIView {
         separatorToBottom.constant = 0
     }
 
+    func cancel() {
+        refreshState(state.onEditingStoppedState)
+    }
+
     func startBrowsing() {
         refreshState(state.onBrowsingStartedState)
     }
@@ -450,6 +454,7 @@ class OmniBar: UIView {
 
     @IBAction func onCancelPressed(_ sender: Any) {
         omniDelegate?.onCancelPressed()
+        refreshState(state.onEditingStoppedState)
     }
     
     @IBAction func onRefreshPressed(_ sender: Any) {
@@ -522,8 +527,12 @@ extension OmniBar: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        omniDelegate?.onDismissed()
-        refreshState(state.onEditingStoppedState)
+        switch omniDelegate?.onEditingEnd() {
+        case .dismissed, .none:
+            refreshState(state.onEditingStoppedState)
+        case .suspended:
+            refreshState(state.onEditingSuspendedState)
+        }
     }
 }
 

--- a/DuckDuckGo/OmniBarDelegate.swift
+++ b/DuckDuckGo/OmniBarDelegate.swift
@@ -20,6 +20,11 @@
 import Foundation
 import Suggestions
 
+enum OmniBarEditingEndResult {
+    case suspended
+    case dismissed
+}
+
 protocol OmniBarDelegate: AnyObject {
 
     func onOmniQueryUpdated(_ query: String)
@@ -28,8 +33,8 @@ protocol OmniBarDelegate: AnyObject {
 
     func onOmniSuggestionSelected(_ suggestion: Suggestion)
     
-    func onDismissed()
-    
+    func onEditingEnd() -> OmniBarEditingEndResult
+
     func onPrivacyIconPressed()
     
     func onMenuPressed()
@@ -74,10 +79,6 @@ extension OmniBarDelegate {
     }
     
     func onOmniQuerySubmitted(_ query: String) {
-        
-    }
-    
-    func onDismissed() {
         
     }
     

--- a/DuckDuckGo/OmniBarState.swift
+++ b/DuckDuckGo/OmniBarState.swift
@@ -41,6 +41,7 @@ protocol OmniBarState {
     var showVoiceSearch: Bool { get }
     var name: String { get }
     var onEditingStoppedState: OmniBarState { get }
+    var onEditingSuspendedState: OmniBarState { get }
     var onEditingStartedState: OmniBarState { get }
     var onTextClearedState: OmniBarState { get }
     var onTextEnteredState: OmniBarState { get }
@@ -49,4 +50,10 @@ protocol OmniBarState {
     var onEnterPhoneState: OmniBarState { get }
     var onEnterPadState: OmniBarState { get }
     var onReloadState: OmniBarState { get }
+}
+
+extension OmniBarState {
+    var onEditingSuspendedState: OmniBarState {
+        UniversalOmniBarState.EditingSuspendedState(baseState: self.onEditingStartedState)
+    }
 }

--- a/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/DuckDuckGo/SuggestionTrayViewController.swift
@@ -38,7 +38,10 @@ class SuggestionTrayViewController: UIViewController {
     weak var favoritesOverlayDelegate: FavoritesOverlayDelegate?
     
     var dismissHandler: (() -> Void)?
-    
+    var isShowingAutocompleteSuggestions: Bool {
+        autocompleteController != nil
+    }
+
     private let appSettings = AppUserDefaults()
 
     private var autocompleteController: AutocompleteViewController?

--- a/DuckDuckGo/UniversalOmniBarState.swift
+++ b/DuckDuckGo/UniversalOmniBarState.swift
@@ -1,0 +1,54 @@
+//
+//  UniversalOmniBarState.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+
+enum UniversalOmniBarState {
+    struct EditingSuspendedState: OmniBarState {
+        let baseState: OmniBarState
+
+        var hasLargeWidth: Bool { baseState.hasLargeWidth }
+        var showBackButton: Bool { baseState.showBackButton }
+        var showForwardButton: Bool { baseState.showForwardButton }
+        var showBookmarksButton: Bool { baseState.showBookmarksButton }
+        var showShareButton: Bool { baseState.showShareButton }
+        var clearTextOnStart: Bool { baseState.clearTextOnStart }
+        var allowsTrackersAnimation: Bool { baseState.allowsTrackersAnimation }
+        var showSearchLoupe: Bool { baseState.showSearchLoupe }
+        var showCancel: Bool { true }
+        var showPrivacyIcon: Bool { baseState.showPrivacyIcon }
+        var showBackground: Bool { baseState.showBackground }
+        var showClear: Bool { false }
+        var showRefresh: Bool { baseState.showRefresh }
+        var showMenu: Bool { baseState.showMenu }
+        var showSettings: Bool { baseState.showSettings }
+        var showVoiceSearch: Bool { baseState.showVoiceSearch }
+        var name: String { Type.name(self) }
+        var onEditingStoppedState: OmniBarState { baseState.onEditingStoppedState }
+        var onEditingStartedState: OmniBarState { baseState.onEditingStartedState }
+        var onTextClearedState: OmniBarState { baseState.onTextClearedState }
+        var onTextEnteredState: OmniBarState { baseState.onTextEnteredState }
+        var onBrowsingStartedState: OmniBarState { baseState.onBrowsingStartedState }
+        var onBrowsingStoppedState: OmniBarState { baseState.onBrowsingStoppedState }
+        var onEnterPhoneState: OmniBarState { baseState.onEnterPhoneState }
+        var onEnterPadState: OmniBarState { baseState.onEnterPadState }
+        var onReloadState: OmniBarState { baseState.onReloadState }
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206947974920876/f
Tech Design URL:
CC:

**Description**:

Dismisses the keyboard when autocomplete list is scrolled and brings it back once the Search field is in focus again.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Type something in the search field
2. Scroll results list
3. Keyboard should dismiss
4. Tapping on search field again should resume phrase editing resulting in updating suggestions
5. Tapping "Cancel" on iPhone or outside of suggestions tray on iPad should close suggestions

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone 14 Pro
* [ ] iPad

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
