### PR TITLE
fix progress bar missing after cold launch

### DIFF
--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -41,6 +41,7 @@ class ProgressView: UIView, CAAnimationDelegate {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        decorate()
         configureLayers()
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207169996046095/f
Tech Design URL:
CC: @dus7 

**Description**:

Wasn't being inited properly, but trait collection change would finish the init off and this happens when the app is backgrounded.

**Steps to test this PR**:
1. Load a tab with a web page
2. Kill the app
3. Load the progress bar should show as the page loads on start up
4. Background / Foreground the app
5. Progress bar should still show 
