### PR TITLE
Update BSK to 141.1.1

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9639,7 +9639,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 141.0.1;
+				version = 141.1.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "786272601414243b391c22d370bf807e406a0e71",
-        "version" : "141.0.1"
+        "revision" : "9ebcfd17a2dd1422407a24e9e4331a46c3b7733a",
+        "version" : "141.1.1"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207182733795625/f

**Description**:
Update BSK to 141.1.1 No changes to iOS. Only updates to prepare for Stripe repurchase flow on macOS. 

**Steps to test this PR**:
Verify that tests are green. 

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
