### PR TITLE
Fix selected VPN location consistency

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -45,10 +45,12 @@ struct NetworkProtectionLocationStatusModel {
         case .location(let location):
             let countryLabelsModel = NetworkProtectionVPNCountryLabelsModel(country: location.country, useFullCountryName: true)
             if let city = location.city {
-                title = UserText.netPVPNSettingsLocationSubtitleFormattedCityAndCountry(
+                let formattedCityAndCountry = UserText.netPVPNSettingsLocationSubtitleFormattedCityAndCountry(
                     city: city,
                     country: countryLabelsModel.title
                 )
+
+                title = "\(countryLabelsModel.emoji) \(formattedCityAndCountry)"
             } else {
                 title = "\(countryLabelsModel.emoji) \(countryLabelsModel.title)"
             }

--- a/DuckDuckGo/NetworkProtectionStatusViewModel.swift
+++ b/DuckDuckGo/NetworkProtectionStatusViewModel.swift
@@ -256,7 +256,7 @@ final class NetworkProtectionStatusViewModel: ObservableObject {
 
     private func setUpServerInfoPublishers() {
         serverInfoObserver.publisher
-            .compactMap { serverInfo in
+            .map { serverInfo in
                 guard let attributes = serverInfo.serverLocation else {
                     return nil
                 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207039751587576/f
Tech Design URL:
CC:

**Description**:

This PR fixes two issues with location selection:

1. When you have connected and then disconnected the VPN, the status view was remembering the last connected location and showing it as your location instead of your selection in settings
2. When selecting a city, the flag emoji wasn't being included in the title

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Select a specific location in the VPN settings
2. Connect then disconnect
3. Change your location in settings and check that the location changes in the status UI
4. Finally, select a specific US city and check that the flag emoji appears

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
