### PR TITLE
Fix Kingfisher deprecation warnings

### DIFF
--- a/Core/FaviconsHelper.swift
+++ b/Core/FaviconsHelper.swift
@@ -24,11 +24,11 @@ struct FaviconsHelper {
 
     // this function is now static and outside of Favicons, otherwise there is a circular dependency between
     // Favicons and NotFoundCachingDownloader
-    public static func defaultResource(forDomain domain: String?, sourcesProvider: FaviconSourcesProvider) -> Kingfisher.ImageResource? {
+    public static func defaultResource(forDomain domain: String?, sourcesProvider: FaviconSourcesProvider) -> KF.ImageResource? {
         guard let domain = domain,
               let source = sourcesProvider.mainSource(forDomain: domain) else { return nil }
 
         let key = Favicons.createHash(ofDomain: domain)
-        return ImageResource(downloadURL: source, cacheKey: key)
+        return KF.ImageResource(downloadURL: source, cacheKey: key)
     }
 }

--- a/DuckDuckGo/Favicons.swift
+++ b/DuckDuckGo/Favicons.swift
@@ -441,7 +441,7 @@ public class Favicons {
         return image
     }
 
-    public func defaultResource(forDomain domain: String?) -> Kingfisher.ImageResource? {
+    public func defaultResource(forDomain domain: String?) -> KF.ImageResource? {
         return FaviconsHelper.defaultResource(forDomain: domain, sourcesProvider: sourcesProvider)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207185436384594/f
Tech Design URL:
CC:

**Description**:

This PR fixes Kingfisher deprecation warnings.

These appear on every PR, like [this one](https://github.com/duckduckgo/iOS/pull/2797/files), where you can see a list of warnings at the bottom of the diff.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that favicon fetching works (favourite a web page and check that its favicon appears in the new tab page)
2. Check that there are no warnings related to Kingfisher either in Xcode or here in the PR diff

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
