### PR TITLE
Create Asana Subtask on PR requested

### DIFF
--- a/.github/workflows/pr-task-url.yml
+++ b/.github/workflows/pr-task-url.yml
@@ -2,7 +2,7 @@ name: Asana PR Task URL
 
 on: 
   pull_request:
-    types: [opened, edited, closed, unlabeled, synchronize]
+    types: [opened, edited, closed, unlabeled, synchronize, review_requested]
 
 jobs:
 
@@ -111,6 +111,24 @@ jobs:
     - name: Report status
       if: ${{ needs.assert-project-membership.outputs.task_id }}
       run: exit ${{ needs.assert-project-membership.outputs.failure }}
+
+  # When reviewer is assigned create a subtask in Asana if not existing already
+  create-asana-pr-subtask-if-needed:
+
+    name: "Create the PR subtask in Asana"
+
+    runs-on: ubuntu-latest
+    if: github.event.action == 'review_requested'
+
+    needs: [assert-project-membership]
+
+    steps:
+    - name: Create or Update PR Subtask
+      uses: duckduckgo/apple-toolbox/actions/asana-create-pr-subtask@main
+      with:
+        access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        asana-task-id: ${{ needs.assert-project-membership.outputs.task_id }}
+        github-reviewer-user: ${{ github.event.requested_reviewer.login }}
 
   # When a PR is merged, move the task to the Waiting for Release section of the App Board.
   mark-waiting-for-release:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207193414517319/f

Description:

This PR automates the creation of the Asana PR ticket when a GitHub reviewer is added to the PR.

Steps to test this PR:

Scenario 1: Task does not exist

Assign a reviewer to the PR.
Expected Result: Check on Asana that PR task is created, the assignee is the reviewer and the PR link is correct.
Scenario 2: Task exists and it is already completed

Complete the previously created task.
Remove and re-assign the same reviewer to the PR.
Expected Result: The Asana PR task should be marked not completed.
Scenario 3: Task exists and it is not completed

Remove and re-assign the same reviewer to the PR.
Expected Result: Nothing should really happen, no duplicates task should be created.
Scenario 3: Multiple reviewers

Assign another reviewer to the PR.
Expected Result: Check on Asana that PR task is created, the assignee is the new reviewer and the PR link is correct.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
