### PR TITLE
fix address bar weirdness

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -288,7 +288,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         autoClear = AutoClear(worker: main)
         Task {
-            await autoClear?.clearDataIfEnabled()
+            await autoClear?.clearDataIfEnabled(launching: true)
         }
 
         AppDependencyProvider.shared.voiceSearchHelper.migrateSettingsFlagIfNecessary()

--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -45,7 +45,7 @@ class AutoClear {
     }
     
     @MainActor
-    func clearDataIfEnabled() async {
+    func clearDataIfEnabled(launching: Bool = false) async {
         guard let settings = AutoClearSettingsModel(settings: appSettings) else { return }
         
         if settings.action.contains(.clearTabs) {
@@ -56,7 +56,9 @@ class AutoClear {
             await worker.forgetData()
         }
 
-        worker.clearDataFinished(self)
+        if !launching {
+            worker.clearDataFinished(self)
+        }
     }
     
     /// Note: function is parametrised because of tests.

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -497,7 +497,6 @@ extension OmniBar: UITextFieldDelegate {
 
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         omniDelegate?.onTextFieldWillBeginEditing(self, tapped: textFieldTapped)
-        textFieldTapped = false
         return true
     }
 

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -174,17 +174,9 @@ class OmniBar: UIView {
             guard let range = field.selectedTextRange else { return }
             UIPasteboard.general.string = field.text(in: range)
         }
-
-        textField.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector( onTextFieldTapped )))
     }
     
-    var textFieldTapped = false
-
-    @objc
-    private func onTextFieldTapped() {
-        textFieldTapped = true
-        textField.becomeFirstResponder()
-    }
+    var textFieldTapped = true
 
     private func configureSeparator() {
         separatorHeightConstraint.constant = 1.0 / UIScreen.main.scale
@@ -374,6 +366,10 @@ class OmniBar: UIView {
     }
 
     @discardableResult override func becomeFirstResponder() -> Bool {
+        textFieldTapped = false
+        defer {
+            textFieldTapped = true
+        }
         return textField.becomeFirstResponder()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207197707567292/f
Tech Design URL:
CC:

**Description**:
Use less intrusive mechanism to detect user tap on field.

**Steps to test this PR**:
1. Open a new tab and tap on the address field.  Should fire `m.addressbar.click.ntp` pixel
2. Perform a search and tap on the address field. Should fire `m.addressbar.click.serp` pixel
3. Visit a website and tap on the address field. Should fire `m.addressbar.click.website` pixel
4. In settings ensure 'show keyboard on new tab' is enabled then long press the tab bar switcher button to open a new tab.  The ntp pixel should NOT fire.
5. In settings ensure 'show keyboard on app launch' is enabled then launch the app from cold.  The address bar click pixel should NOT fire.
6. Smoke test auto clear and fireproofing 
