### PR TITLE
Improve VPN underlying error detail

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9710,8 +9710,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 141.1.2;
+				kind = revision;
+				revision = 06040516c8d5b68fa04dce26884ba0e4272c2f26;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9710,8 +9710,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 06040516c8d5b68fa04dce26884ba0e4272c2f26;
+				kind = exactVersion;
+				version = "141.1.2-1";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "f8c73292d4d6724ec81f98bd29dbb2061f1a8cf6",
-        "version" : "141.1.2"
+        "revision" : "06040516c8d5b68fa04dce26884ba0e4272c2f26"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "06040516c8d5b68fa04dce26884ba0e4272c2f26"
+        "revision" : "35730c74d0600a57d90690867722ea2b615b6935",
+        "version" : "141.1.2-1"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207221937455192/f

## Description

Improves VPN underlying error detail for `NetworkProtectionClientError` and `WireGuardError`.

## Testing

1. Disable `dryMode` for the packet tunnel provider.
2. In `PacketTunnelProvider` right after the tunnel starts throw any `NetworkProtectionClientError` or `WireGuardError` with underlying error information.
3. Check in Kibana after a bit that you see the pixel data.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)