### PR TITLE
Replace deprecated tab preview renderer

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1199,15 +1199,15 @@ extension TabViewController: WKNavigationDelegate {
             let size = CGSize(width: webView.frame.size.width,
                               height: webView.frame.size.height - webView.scrollView.contentInset.top - webView.scrollView.contentInset.bottom)
             
-            UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.main.scale)
-            UIGraphicsGetCurrentContext()?.translateBy(x: 0, y: -webView.scrollView.contentInset.top)
-            webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: true)
-            if let jsAlertController = self?.jsAlertController {
-                jsAlertController.view.drawHierarchy(in: jsAlertController.view.bounds,
-                                                     afterScreenUpdates: false)
+            let renderer = UIGraphicsImageRenderer(size: size)
+            let image = renderer.image { context in
+                context.cgContext.translateBy(x: 0, y: -webView.scrollView.contentInset.top)
+                webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: true)
+                if let jsAlertController = self?.jsAlertController {
+                    jsAlertController.view.drawHierarchy(in: jsAlertController.view.bounds, afterScreenUpdates: false)
+                }
             }
-            let image = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
+
             completion(image)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207228085347616/f
Tech Design URL:
CC:

**Description**:

This PR replaces usage of `UIGraphicsBeginImageContextWithOptions` with `UIGraphicsImageRenderer`.

`UIGraphicsBeginImageContextWithOptions` was deprecated in iOS 17, and is reported to be unstable. We're seeing crashes with it ourselves, and the assertion suggests migrating to the new API, so here we are.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Stress test tab previews - create a bunch of tabs, check that the tab list renders previews as expected in both modes, close a bunch of tabs, etc.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
