### PR TITLE
Delegate SecureVault KeyStore Events in All Scenarios 

### DIFF
--- a/DuckDuckGo/EmailSignupViewController.swift
+++ b/DuckDuckGo/EmailSignupViewController.swift
@@ -365,6 +365,10 @@ extension EmailSignupViewController: SecureVaultManagerDelegate {
         SecureVaultReporter.shared.secureVaultError(error)
     }
 
+    func secureVaultKeyStoreEvent(_ event: SecureStorageKeyStoreEvent) {
+        SecureVaultReporter.shared.secureVaultKeyStoreEvent(event)
+    }
+
     func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType?) -> Bool {
         let isEnabled = AutofillSettingStatus.isAutofillEnabledInSettings && featureFlagger.isFeatureOn(.autofillCredentialInjecting)
         return isEnabled

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2409,6 +2409,10 @@ extension TabViewController: SecureVaultManagerDelegate {
         SecureVaultReporter.shared.secureVaultError(error)
     }
 
+    func secureVaultKeyStoreEvent(_ event: SecureStorageKeyStoreEvent) {
+        SecureVaultReporter.shared.secureVaultKeyStoreEvent(event)
+    }
+
     func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType?) -> Bool {
         let isEnabled = AutofillSettingStatus.isAutofillEnabledInSettings &&
                         featureFlagger.isFeatureOn(.autofillCredentialInjecting) &&


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207236816134198/f

**Description**:

**Context**
As part of [✓ macOS: Reduce Negative User Feedback Relating to Password Entry Prompts](https://app.asana.com/0/0/1206924205159008), we added Pixel event reporting for Keychain migrations. These events are reported via calls to SecureVaultReporter

**Current Behavior**
In some cases where an intermediate is used to communicate with SecureVaultReporter, we are not delegating SecureVault events

**Expected Behavior**
In all cases where an intermediate is used to communicate with SecureVaultReporter, we should delegate SecureVault events

**Steps to test this PR**:
1. As this is straightforward delegation of an event call, only smoke testing of the app is required

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
