### PR TITLE
Fix subscriptions glitch in Settings

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -129,7 +129,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "46989693916f56d1186bd59ac15124caef896560",
         "version" : "1.3.1"

--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -34,6 +34,7 @@ struct SettingsSubscriptionView: View {
     @State var isShowingGoogleView = false
     @State var isShowingStripeView = false
     @State var isShowingSubscriptionError = false
+    @State var isShowingPrivacyPro = false
     
     enum Constants {
         static let purchaseDescriptionPadding = 5.0
@@ -205,47 +206,53 @@ struct SettingsSubscriptionView: View {
     }
         
     var body: some View {
-        if viewModel.state.subscription.enabled && viewModel.state.subscription.canPurchase {
-            
-            Section(header: Text(UserText.settingsPProSection)) {
-                                
-                switch (
-                    viewModel.state.subscription.isSignedIn,
-                    viewModel.state.subscription.hasActiveSubscription,
-                    viewModel.state.subscription.entitlements.isEmpty
-                ) {
-                    
-                    // Signed In, Subscription Expired
-                case (true, false, _):
-                    subscriptionExpiredView
-                    
-                    // Signed in, Subscription Active, Valid entitlements
-                case (true, true, false):
-                    subscriptionDetailsView  // View for valid subscription details
-                    
-                    // Signed in, Subscription Active, Empty Entitlements
-                case (true, true, true):
-                    noEntitlementsAvailableView  // View for no entitlements
-                    
-                    // Signed out
-                case (false, _, _):
-                    purchaseSubscriptionView  // View for signing up or purchasing a subscription
+        Group {
+            if isShowingPrivacyPro {
+                
+                Section(header: Text(UserText.settingsPProSection)) {
+                                    
+                    switch (
+                        viewModel.state.subscription.isSignedIn,
+                        viewModel.state.subscription.hasActiveSubscription,
+                        viewModel.state.subscription.entitlements.isEmpty
+                    ) {
+                        
+                        // Signed In, Subscription Expired
+                    case (true, false, _):
+                        subscriptionExpiredView
+                        
+                        // Signed in, Subscription Active, Valid entitlements
+                    case (true, true, false):
+                        subscriptionDetailsView  // View for valid subscription details
+                        
+                        // Signed in, Subscription Active, Empty Entitlements
+                    case (true, true, true):
+                        noEntitlementsAvailableView  // View for no entitlements
+                        
+                        // Signed out
+                    case (false, _, _):
+                        purchaseSubscriptionView  // View for signing up or purchasing a subscription
+                    }
                 }
-            }
-            
-            .onChange(of: viewModel.state.subscription.shouldDisplayRestoreSubscriptionError) { value in
-                if value {
-                    isShowingSubscriptionError = true
+                
+                .onChange(of: viewModel.state.subscription.shouldDisplayRestoreSubscriptionError) { value in
+                    if value {
+                        isShowingSubscriptionError = true
+                    }
                 }
-            }
-            
-            .onReceive(subscriptionNavigationCoordinator.$shouldPopToAppSettings) { shouldDismiss in
-                if shouldDismiss {
-                    isShowingRestoreFlow = false
-                    isShowingSubscribeFlow = false
+                
+                .onReceive(subscriptionNavigationCoordinator.$shouldPopToAppSettings) { shouldDismiss in
+                    if shouldDismiss {
+                        isShowingRestoreFlow = false
+                        isShowingSubscribeFlow = false
+                    }
                 }
+                
             }
-            
+        }.onReceive(viewModel.$state) { state in
+            if state.subscription.enabled && state.subscription.canPurchase {
+                isShowingPrivacyPro = true
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207214261396124/f

**Description**:
Caches subscription availability state in the view, so is not refreshed on view rendering.  

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.  Open Settings
2. Remove any active privacy pro subscription from your device
3. Tap 'General'
4. Confirm the 'glitch' in the subscription view (below) no longer happens.

**Before:**
![RPReplay_Final1714652760](https://github.com/duckduckgo/iOS/assets/1156669/54b73db4-3c29-497e-8a55-0af3b764806f)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
