### PR TITLE
VPN Widget Pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -378,6 +378,11 @@ extension Pixel {
         case networkProtectionFailureRecoveryCompletedHealthy
         case networkProtectionFailureRecoveryCompletedUnhealthy
 
+        case networkProtectionWidgetConnectAttempt
+        case networkProtectionWidgetConnectSuccess
+        case networkProtectionWidgetDisconnectAttempt
+        case networkProtectionWidgetDisconnectSuccess
+
         // MARK: remote messaging pixels
         
         case remoteMessageShown
@@ -1337,7 +1342,12 @@ extension Pixel.Event {
         case .networkProtectionFailureRecoveryFailed: return "m_netp_ev_failure_recovery_failed"
         case .networkProtectionFailureRecoveryCompletedHealthy: return "m_netp_ev_failure_recovery_completed_server_healthy"
         case .networkProtectionFailureRecoveryCompletedUnhealthy: return "m_netp_ev_failure_recovery_completed_server_unhealthy"
-            
+
+        case .networkProtectionWidgetConnectAttempt: return "m_netp_widget_connect_attempt"
+        case .networkProtectionWidgetConnectSuccess: return "m_netp_widget_connect_success"
+        case .networkProtectionWidgetDisconnectAttempt: return "m_netp_widget_disconnect_attempt"
+        case .networkProtectionWidgetDisconnectSuccess: return "m_netp_widget_disconnect_success"
+
             // MARK: Secure Vault
         case .secureVaultL1KeyMigration: return "m_secure-vault_keystore_event_l1-key-migration"
         case .secureVaultL2KeyMigration: return "m_secure-vault_keystore_event_l2-key-migration"

--- a/DuckDuckGo/VPNIntents.swift
+++ b/DuckDuckGo/VPNIntents.swift
@@ -17,8 +17,6 @@
 //  limitations under the License.
 //
 
-#if ALPHA
-
 import AppIntents
 import NetworkExtension
 import WidgetKit
@@ -104,5 +102,3 @@ struct EnableVPNIntent: AppIntent {
     }
 
 }
-
-#endif

--- a/DuckDuckGo/VPNIntents.swift
+++ b/DuckDuckGo/VPNIntents.swift
@@ -20,6 +20,7 @@
 import AppIntents
 import NetworkExtension
 import WidgetKit
+import Core
 
 @available(iOS 17.0, *)
 struct DisableVPNIntent: AppIntent {
@@ -32,6 +33,8 @@ struct DisableVPNIntent: AppIntent {
     @MainActor
     func perform() async throws -> some IntentResult {
         do {
+            DailyPixel.fire(pixel: .networkProtectionWidgetDisconnectAttempt)
+
             let managers = try await NETunnelProviderManager.loadAllFromPreferences()
             guard let manager = managers.first else {
                 return .result()
@@ -48,6 +51,7 @@ struct DisableVPNIntent: AppIntent {
                 try? await Task.sleep(interval: .seconds(0.5))
 
                 if manager.connection.status == .disconnected {
+                    DailyPixel.fire(pixel: .networkProtectionWidgetDisconnectSuccess)
                     return .result()
                 }
 
@@ -73,6 +77,8 @@ struct EnableVPNIntent: AppIntent {
     @MainActor
     func perform() async throws -> some IntentResult {
         do {
+            DailyPixel.fire(pixel: .networkProtectionWidgetConnectAttempt)
+
             let managers = try await NETunnelProviderManager.loadAllFromPreferences()
             guard let manager = managers.first else {
                 return .result()
@@ -89,6 +95,7 @@ struct EnableVPNIntent: AppIntent {
                 try? await Task.sleep(interval: .seconds(0.5))
 
                 if manager.connection.status == .connected {
+                    DailyPixel.fire(pixel: .networkProtectionWidgetConnectSuccess)
                     return .result()
                 }
 

--- a/Widgets/VPNWidget.swift
+++ b/Widgets/VPNWidget.swift
@@ -26,8 +26,6 @@ import WidgetKit
 import NetworkExtension
 import NetworkProtection
 
-#if ALPHA
-
 enum VPNStatus {
     case status(NEVPNStatus)
     case error
@@ -295,7 +293,4 @@ struct VPNStatusView_Previews: PreviewProvider {
             Text("iOS 17 required")
         }
     }
-
 }
-
-#endif


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207219813216460/f

**Description**:

Fires Pixels from the VPN widget on connection/disconnection atttempt/success. Also adds a compiler flag so the widget specific pixels are only fired from the widget extension.

**Steps to test this PR**:
1.

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
