### PR TITLE
use old provisioning profile template for the alpha build

### DIFF
--- a/DuckDuckGo/DuckDuckGoAlpha.entitlements
+++ b/DuckDuckGo/DuckDuckGoAlpha.entitlements
@@ -8,8 +8,6 @@
 	</array>
 	<key>com.apple.developer.web-browser</key>
 	<true/>
-	<key>com.apple.developer.browser.app-installation</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.duckduckgo.alpha.bookmarks</string>

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -16,6 +16,7 @@ for_lane :sync_signing_alpha_adhoc do
     type "adhoc"
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension"]
     force_for_new_devices true
+    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :adhoc do
@@ -27,12 +28,15 @@ for_lane :alpha_adhoc do
     type "adhoc"
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension"]
     force_for_new_devices true
+    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :sync_signing_alpha do
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension"]
+    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :release_alpha do
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension"]
+    template_name "Default Web Browser iOS (Dist)"
 end


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207312974413960/f
Tech Design URL:
CC:

**Description**:
Alpha builds need to use the template in order to get default browser capability.

**Steps to test this PR**:
1. After updating profiles in Xcode ensure you can run the alpha target
