### PR TITLE
New Autofill pixels for KPIs

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -140,6 +140,9 @@ public struct PixelParameters {
     public static let adAttributionCountryOrRegion = "country_or_region"
     public static let adAttributionKeywordID = "keyword_id"
     public static let adAttributionAdID = "ad_id"
+
+    // Autofill
+    public static let countBucket = "count_bucket"
 }
 
 public struct PixelValues {

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -258,6 +258,11 @@ extension Pixel {
         case autofillLoginsImportSuccess
         case autofillLoginsImportFailure
 
+        case autofillActiveUser
+        case autofillEnabledUser
+        case autofillOnboardedUser
+        case autofillLoginsStacked
+
         case getDesktopCopy
         case getDesktopShare
         
@@ -933,6 +938,11 @@ extension Pixel.Event {
         case .autofillLoginsImportNoAction: return "m_autofill_logins_import_no-action"
         case .autofillLoginsImportSuccess: return "m_autofill_logins_import_success"
         case .autofillLoginsImportFailure: return "m_autofill_logins_import_failure"
+
+        case .autofillActiveUser: return "m_autofill_activeuser"
+        case .autofillEnabledUser: return "m_autofill_enableduser"
+        case .autofillOnboardedUser: return "m_autofill_onboardeduser"
+        case .autofillLoginsStacked: return "m_autofill_logins_stacked"
 
         case .getDesktopCopy: return "m_get_desktop_copy"
         case .getDesktopShare: return "m_get_desktop_share"

--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -103,6 +103,8 @@ public class StatisticsLoader {
             if let data = response?.data, let atb = try? self.parser.convert(fromJsonData: data) {
                 self.statisticsStore.searchRetentionAtb = atb.version
                 self.storeUpdateVersionIfPresent(atb)
+                NotificationCenter.default.post(name: .searchDAU,
+                                                object: nil, userInfo: nil)
             }
             completion()
         }
@@ -138,4 +140,8 @@ public class StatisticsLoader {
             returnUserMeasurement.updateStoredATB(atb)
         }
     }
+}
+
+extension NSNotification.Name {
+    public static let searchDAU: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.searchDAU")
 }

--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -84,6 +84,9 @@ public struct UserDefaultsWrapper<T> {
                 "com.duckduckgo.ios.autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary"
         case autofillImportViaSyncStart = "com.duckduckgo.ios.autofillImportViaSyncStart"
         case autofillSurveyEnabled = "com.duckduckgo.ios.autofillSurveyEnabled"
+        case autofillSearchDauDate = "com.duckduckgo.ios.autofillSearchDauDate"
+        case autofillFillDate = "com.duckduckgo.ios.autofillFillDate"
+        case autofillOnboardedUser = "com.duckduckgo.ios.autofillOnboardedUser"
 
         // .v2 suffix added to fix https://app.asana.com/0/547792610048271/1206524375402369/f
         case featureFlaggingDidVerifyInternalUser = "com.duckduckgo.app.featureFlaggingDidVerifyInternalUser.v2"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -663,6 +663,8 @@
 		C12726EE2A5FF88C00215B02 /* EmailSignupPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12726ED2A5FF88C00215B02 /* EmailSignupPromptView.swift */; };
 		C12726F02A5FF89900215B02 /* EmailSignupPromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12726EF2A5FF89900215B02 /* EmailSignupPromptViewModel.swift */; };
 		C12726F22A5FF8CB00215B02 /* EmailSignupPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12726F12A5FF8CB00215B02 /* EmailSignupPromptViewController.swift */; };
+		C12B6E7A2BED639500050D93 /* AutofillPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12B6E792BED639500050D93 /* AutofillPixelReporter.swift */; };
+		C12B6E7C2BED69C100050D93 /* AutofillPixelReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12B6E7B2BED69C100050D93 /* AutofillPixelReporterTests.swift */; };
 		C136C7542BEB8CFC00ACC3B0 /* PasswordsSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C136C7532BEB8CFC00ACC3B0 /* PasswordsSurveyView.swift */; };
 		C13B32D22A0E750700A59236 /* AutofillSettingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */; };
 		C13F3F682B7F88100083BE40 /* AuthConfirmationPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13F3F672B7F88100083BE40 /* AuthConfirmationPromptView.swift */; };
@@ -2289,6 +2291,8 @@
 		C12726ED2A5FF88C00215B02 /* EmailSignupPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignupPromptView.swift; sourceTree = "<group>"; };
 		C12726EF2A5FF89900215B02 /* EmailSignupPromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignupPromptViewModel.swift; sourceTree = "<group>"; };
 		C12726F12A5FF8CB00215B02 /* EmailSignupPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSignupPromptViewController.swift; sourceTree = "<group>"; };
+		C12B6E792BED639500050D93 /* AutofillPixelReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutofillPixelReporter.swift; sourceTree = "<group>"; };
+		C12B6E7B2BED69C100050D93 /* AutofillPixelReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillPixelReporterTests.swift; sourceTree = "<group>"; };
 		C136C7532BEB8CFC00ACC3B0 /* PasswordsSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordsSurveyView.swift; sourceTree = "<group>"; };
 		C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutofillSettingStatus.swift; sourceTree = "<group>"; };
 		C13F3F672B7F88100083BE40 /* AuthConfirmationPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmationPromptView.swift; sourceTree = "<group>"; };
@@ -5389,6 +5393,7 @@
 				F40F843528C938370081AE75 /* AutofillLoginListViewModelTests.swift */,
 				C1D21E2E293A599C006E5A05 /* AutofillLoginSessionTests.swift */,
 				C1CDA31D2AFBF811006D1476 /* AutofillNeverPromptWebsitesManagerTests.swift */,
+				C12B6E7B2BED69C100050D93 /* AutofillPixelReporterTests.swift */,
 			);
 			name = Autofill;
 			sourceTree = "<group>";
@@ -5396,17 +5401,18 @@
 		F44D279327F331930037F371 /* Autofill */ = {
 			isa = PBXGroup;
 			children = (
-				C1641EAD2BC2F46C0012607A /* Import */,
 				D63657182A7BAE7C001AF19D /* EmailManagerRequestDelegate.swift */,
 				F4147353283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift */,
 				C1D21E2C293A5965006E5A05 /* AutofillLoginSession.swift */,
 				C1CDA3152AFB9C7F006D1476 /* AutofillNeverPromptWebsitesManager.swift */,
+				C12B6E792BED639500050D93 /* AutofillPixelReporter.swift */,
 				C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */,
 				319A370F28299A850079FBCE /* PasswordHider.swift */,
 				C136C7532BEB8CFC00ACC3B0 /* PasswordsSurveyView.swift */,
 				31C70B5428045E3500FB6AD1 /* SecureVaultReporter.swift */,
 				C1AFFC4B2B8773060060448E /* AuthConfirmation */,
 				F407605328131910006B1E0B /* AutofillLoginUI */,
+				C1641EAD2BC2F46C0012607A /* Import */,
 				310C4B4A281B69BC00BA79A9 /* Management */,
 				C17B59552A03AAC40055F2D1 /* PasswordGeneration */,
 				31951E9328230D8900CAF535 /* Shared */,
@@ -6354,6 +6360,7 @@
 				BDFF03222BA3D8E200F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */,
 				B652DEFD287BE67400C12A9C /* UserScripts.swift in Sources */,
 				1D200C992BA3176D00108701 /* SettingsOthersView.swift in Sources */,
+				C12B6E7A2BED639500050D93 /* AutofillPixelReporter.swift in Sources */,
 				31DD208427395A5A008FB313 /* VoiceSearchHelper.swift in Sources */,
 				9874F9EE2187AFCE00CAF33D /* Themable.swift in Sources */,
 				F44D279E27F331BB0037F371 /* AutofillLoginPromptViewModel.swift in Sources */,
@@ -6859,6 +6866,7 @@
 				B6AD9E3A28D456820019CDE9 /* PrivacyConfigurationManagerMock.swift in Sources */,
 				F189AED71F18F6DE001EBAE1 /* TabTests.swift in Sources */,
 				F13B4BFB1F18E3D900814661 /* TabsModelPersistenceExtensionTests.swift in Sources */,
+				C12B6E7C2BED69C100050D93 /* AutofillPixelReporterTests.swift in Sources */,
 				CB48D3372B90DF2000631D8B /* UserBehaviorMonitorTests.swift in Sources */,
 				8528AE7E212EF5FF00D0BD74 /* AppRatingPromptTests.swift in Sources */,
 				981FED692201FE69008488D7 /* AutoClearSettingsScreenTests.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -85,6 +85,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let crashCollection = CrashCollection(platform: .iOS, log: .generalLog)
     private var crashReportUploaderOnboarding: CrashCollectionOnboarding?
 
+    private let autofillPixelReporter = AutofillPixelReporter()
+
     // MARK: lifecycle
 
     @UserDefaultsWrapper(key: .privacyConfigCustomURL, defaultValue: nil)

--- a/DuckDuckGo/AutofillPixelReporter.swift
+++ b/DuckDuckGo/AutofillPixelReporter.swift
@@ -1,0 +1,149 @@
+//
+//  AutofillPixelReporter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import BrowserServicesKit
+
+final class AutofillPixelReporter {
+
+    @UserDefaultsWrapper(key: .autofillSearchDauDate, defaultValue: .distantPast)
+    var autofillSearchDauDate: Date
+
+    @UserDefaultsWrapper(key: .autofillFillDate, defaultValue: .distantPast)
+    var autofillFillDate: Date
+
+    @UserDefaultsWrapper(key: .autofillOnboardedUser, defaultValue: false)
+    var autofillOnboardedUser: Bool
+
+    private let statisticsStorage: StatisticsStore
+    private let secureVault: (any AutofillSecureVault)?
+
+    enum EventType {
+        case fill
+        case searchDAU
+    }
+
+    init(statisticsStorage: StatisticsStore = StatisticsUserDefaults(), secureVault: (any AutofillSecureVault)? = try? AutofillSecureVaultFactory.makeVault(reporter: SecureVaultReporter.shared)) {
+        self.statisticsStorage = statisticsStorage
+        self.secureVault = secureVault
+
+        createNotificationObservers()
+
+        if shouldFireOnboardedUserPixel() {
+            DailyPixel.fire(pixel: .autofillOnboardedUser)
+        }
+    }
+
+    private func createNotificationObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveSearchDAU), name: .searchDAU, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveFillEvent), name: .autofillFillEvent, object: nil)
+    }
+
+    @objc
+    private func didReceiveSearchDAU() {
+        guard !Date().isSameDay(autofillSearchDauDate) else {
+            return
+        }
+
+        autofillSearchDauDate = Date()
+
+        firePixels(pixelsToFireFor(.searchDAU))
+    }
+
+    @objc
+    private func didReceiveFillEvent() {
+        guard !Date().isSameDay(autofillFillDate) else {
+            return
+        }
+
+        autofillFillDate = Date()
+
+        firePixels(pixelsToFireFor(.fill))
+    }
+
+    func pixelsToFireFor(_ type: EventType) -> [Pixel.Event] {
+        var pixelsToFire: [Pixel.Event] = []
+
+        if shouldFireActiveUserPixel() {
+            pixelsToFire.append(.autofillActiveUser)
+        }
+
+        switch type {
+        case .fill:
+            pixelsToFire.append(.autofillLoginsStacked)
+        case .searchDAU:
+            if shouldFireEnabledUserPixel() {
+                pixelsToFire.append(.autofillEnabledUser)
+            }
+        }
+
+        return pixelsToFire
+    }
+
+    private func firePixels(_ pixels: [Pixel.Event]) {
+        for pixel in pixels {
+            switch pixel {
+            case .autofillLoginsStacked:
+                let bucket = (try? secureVault?.accountsCountBucket()) ?? ""
+                DailyPixel.fire(pixel: pixel, withAdditionalParameters: [PixelParameters.countBucket: bucket])
+            default:
+                DailyPixel.fire(pixel: pixel)
+            }
+        }
+    }
+
+    private func shouldFireActiveUserPixel() -> Bool {
+        let today = Date()
+        if today.isSameDay(autofillSearchDauDate) && today.isSameDay(autofillFillDate) {
+            return true
+        }
+        return false
+    }
+
+    private func shouldFireEnabledUserPixel() -> Bool {
+        if Date().isSameDay(autofillSearchDauDate), let count = try? secureVault?.accountsCount(), count >= 10 {
+            return true
+        }
+        return false
+    }
+
+    func shouldFireOnboardedUserPixel() -> Bool {
+        guard !autofillOnboardedUser, let installDate = statisticsStorage.installDate, UIApplication.shared.isProtectedDataAvailable else {
+            return false
+        }
+
+        let pastWeek = Date().addingTimeInterval(.days(-7))
+
+        if installDate >= pastWeek {
+            if let count = try? secureVault?.accountsCount(), count > 0 {
+                autofillOnboardedUser = true
+                return true
+            }
+        } else {
+            autofillOnboardedUser = true
+        }
+        return false
+    }
+
+}
+
+extension NSNotification.Name {
+    static let autofillFillEvent: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.autofillFillEvent")
+}

--- a/DuckDuckGo/EmailAddressPromptViewController.swift
+++ b/DuckDuckGo/EmailAddressPromptViewController.swift
@@ -87,6 +87,8 @@ extension EmailAddressPromptViewController: EmailAddressPromptViewModelDelegate 
 
         completion(.user, false)
 
+        NotificationCenter.default.post(name: .autofillFillEvent, object: nil)
+
         dismiss(animated: true)
     }
 
@@ -98,6 +100,8 @@ extension EmailAddressPromptViewController: EmailAddressPromptViewModelDelegate 
 
         completion(.generated, true)
 
+        NotificationCenter.default.post(name: .autofillFillEvent, object: nil)
+        
         dismiss(animated: true)
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2496,6 +2496,9 @@ extension TabViewController: SecureVaultManagerDelegate {
             presentAutofillPromptViewController(accountMatches: accountMatches, domain: domain, trigger: trigger, useLargeDetent: false) { account in
                 onAccountSelected(account)
             } completionHandler: { account in
+                if account != nil {
+                    NotificationCenter.default.post(name: .autofillFillEvent, object: nil)
+                }
                 completionHandler(account)
             }
         } else {
@@ -2508,6 +2511,9 @@ extension TabViewController: SecureVaultManagerDelegate {
                             promptUserWithGeneratedPassword password: String,
                             completionHandler: @escaping (Bool) -> Void) {
         let passwordGenerationPromptViewController = PasswordGenerationPromptViewController(generatedPassword: password) { useGeneratedPassword in
+                if useGeneratedPassword {
+                    NotificationCenter.default.post(name: .autofillFillEvent, object: nil)
+                }
                 completionHandler(useGeneratedPassword)
         }
 

--- a/DuckDuckGoTests/AutofillPixelReporterTests.swift
+++ b/DuckDuckGoTests/AutofillPixelReporterTests.swift
@@ -1,0 +1,193 @@
+//
+//  AutofillPixelReporterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+@testable import Core
+@testable import BrowserServicesKit
+
+final class AutofillPixelReporterTests: XCTestCase {
+
+    var statisticsStorage: MockStatisticsStore!
+    private let vault = (try? MockSecureVaultFactory.makeVault(reporter: nil))!
+    var autofillPixelReporter: AutofillPixelReporter!
+
+    override func setUpWithError() throws {
+        statisticsStorage = MockStatisticsStore()
+
+        setupUserDefault(with: #file)
+        UserDefaults.app.removeObject(forKey: UserDefaultsWrapper<String>.Key.autofillSearchDauDate.rawValue)
+        UserDefaults.app.removeObject(forKey: UserDefaultsWrapper<String>.Key.autofillFillDate.rawValue)
+        UserDefaults.app.removeObject(forKey: UserDefaultsWrapper<String>.Key.autofillOnboardedUser.rawValue)
+
+        autofillPixelReporter = AutofillPixelReporter(statisticsStorage: statisticsStorage,
+                                                      secureVault: vault)
+    }
+
+    override func tearDownWithError() throws {
+        statisticsStorage = nil
+        autofillPixelReporter = nil
+    }
+
+    func testWhenUserSearchDauIsNotTodayAndAutofillDateIsNotTodayAndEventTypeIsSearchDauThenNoPixelsWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date().addingTimeInterval(.days(-2))
+        autofillPixelReporter.autofillFillDate = Date().addingTimeInterval(.days(-2))
+
+        XCTAssertTrue(autofillPixelReporter.pixelsToFireFor(.searchDAU).isEmpty)
+    }
+
+    func testWhenUserSearchDauIsNotTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauThenNoPixelsWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date().addingTimeInterval(.days(-2))
+        autofillPixelReporter.autofillFillDate = Date()
+
+        XCTAssertTrue(autofillPixelReporter.pixelsToFireFor(.searchDAU).isEmpty)
+    }
+
+    func testWhenUserSearchDauIsNotTodayAndEventTypeIsFillThenOnePixelWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
+        autofillPixelReporter.autofillFillDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
+
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.fill).count, 1)
+    }
+
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsLessThanTenThenOnePixelWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date()
+        autofillPixelReporter.autofillFillDate = Date()
+        createAccountsInVault(count: 4)
+
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 1)
+    }
+
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsTenThenTwoPixelsWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date()
+        autofillPixelReporter.autofillFillDate = Date()
+        createAccountsInVault(count: 10)
+
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 2)
+    }
+
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsGreaterThanTenThenTwoPixelsWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date()
+        autofillPixelReporter.autofillFillDate = Date()
+        createAccountsInVault(count: 15)
+
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 2)
+    }
+
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsNotTodayAndEventTypeIsSearchDauAndAccountsCountIsLessThanTenThenNoPixelsWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date()
+        autofillPixelReporter.autofillFillDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
+        createAccountsInVault(count: 4)
+
+        XCTAssertTrue(autofillPixelReporter.pixelsToFireFor(.searchDAU).isEmpty)
+    }
+
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsNotTodayAndEventTypeIsSearchDauAndAccountsCountIsTenThenOnePixelWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date()
+        autofillPixelReporter.autofillFillDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
+        createAccountsInVault(count: 10)
+
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 1)
+    }
+
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsNotTodayAndEventTypeIsSearchDauAndAccountsCountIsGreaterThanTenThenOnePixelWillBeFired() {
+        autofillPixelReporter.autofillSearchDauDate = Date()
+        autofillPixelReporter.autofillFillDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
+        createAccountsInVault(count: 15)
+
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 1)
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsNilThenOnboardedUserPixelShouldNotBeFired() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = nil
+
+        XCTAssertFalse(autofillPixelReporter.shouldFireOnboardedUserPixel())
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsTodayThenOnboardedUserPixelShouldNotBeFired() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = Date()
+
+        XCTAssertFalse(autofillPixelReporter.shouldFireOnboardedUserPixel())
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsYesterdayAndAccountsCountIsZeroThenOnboardedUserPixelShouldNotBeFired() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = Date().addingTimeInterval(.days(-1))
+        createAccountsInVault(count: 0)
+
+        XCTAssertFalse(autofillPixelReporter.shouldFireOnboardedUserPixel())
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsYesterdayAndAccountsCountIsGreaterThanZeroThenOnboardedUserPixelShouldBeFiredAndAutofillOnboardedUserShouldBeTrue() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = Date().addingTimeInterval(.days(-1))
+        createAccountsInVault(count: 4)
+
+        XCTAssertTrue(autofillPixelReporter.shouldFireOnboardedUserPixel())
+        XCTAssertTrue(autofillPixelReporter.autofillOnboardedUser)
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsLessThanSevenDaysAgoAndAccountsCountIsZeroThenOnboardedUserPixelShouldNotBeFired() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = Date().addingTimeInterval(.days(-4))
+        createAccountsInVault(count: 0)
+
+        XCTAssertFalse(autofillPixelReporter.shouldFireOnboardedUserPixel())
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsLessThanSevenDaysAgoAndAccountsCountIsGreaterThanZeroThenOnboardedUserPixelShouldBeFiredAndAutofillOnboardedUserShouldBeTrue() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = Date().addingTimeInterval(.days(-4))
+        createAccountsInVault(count: 4)
+
+        XCTAssertTrue(autofillPixelReporter.shouldFireOnboardedUserPixel())
+        XCTAssertTrue(autofillPixelReporter.autofillOnboardedUser)
+    }
+
+    func testWhenUserIsNotOnboardedAndInstallDateIsMoreThanSevenDaysAgoThenOnboardedUserPixelShouldNotBeFiredAndAutofillOnboardedUserShouldBeTrue() {
+        autofillPixelReporter.autofillOnboardedUser = false
+        statisticsStorage.installDate = Date().addingTimeInterval(.days(-8))
+
+        XCTAssertFalse(autofillPixelReporter.shouldFireOnboardedUserPixel())
+        XCTAssertTrue(autofillPixelReporter.autofillOnboardedUser)
+    }
+
+    func testWhenUserIsOnboardedThenOnboardedUserPixelShouldNotBeFired() {
+        autofillPixelReporter.autofillOnboardedUser = true
+
+        XCTAssertFalse(autofillPixelReporter.shouldFireOnboardedUserPixel())
+    }
+
+    private func createAccountsInVault(count: Int) {
+        try? vault.deleteAllWebsiteCredentials()
+
+        for i in 0..<count {
+            vault.storedAccounts.append(
+                SecureVaultModels.WebsiteAccount(id: "\(i)",
+                                                 title: "Title \(i)",
+                                                 username: "dax-\(i)@duck.com",
+                                                 domain: "testsite.com",
+                                                 created: Date(),
+                                                 lastUpdated: Date())
+            )
+        }
+    }
+}

--- a/DuckDuckGoTests/AutofillPixelReporterTests.swift
+++ b/DuckDuckGoTests/AutofillPixelReporterTests.swift
@@ -24,9 +24,9 @@ import XCTest
 
 final class AutofillPixelReporterTests: XCTestCase {
 
-    var statisticsStorage: MockStatisticsStore!
+    private var statisticsStorage: MockStatisticsStore!
     private let vault = (try? MockSecureVaultFactory.makeVault(reporter: nil))!
-    var autofillPixelReporter: AutofillPixelReporter!
+    private  var autofillPixelReporter: AutofillPixelReporter!
 
     override func setUpWithError() throws {
         statisticsStorage = MockStatisticsStore()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1206508535741136/f
Tech Design URL:
CC:

**Description**:
Adds new pixels as part of unified autofill KPIs across platforms

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

**NOTE** - if you have an existing build with 10 or more passwords, feel free to start with Step 9 & 10 first 🙂 
1. Starting with a new install of the app, visit https://fill.dev/form/registration-username and save a new login using a generated password (triggering a fill event)
2. Confirm this pixel fires: `m.autofill.logins.stacked ["count_bucket": "none"]`
3. Perform a search in the browser
4. Confirm this pixel fires: `m.autofill.activeuser` (defined as a user that has performed both an autofill fill action & a search today)
5. Re-launch the app and confirm this pixel fires: `m.autofill.onboardeduser`  (defined as user who has stored at least 1 password within the first week)
6. Perform another search and confirm none of the above pixels fire again
7. Visit to https://fill.dev/form/login-simple and fill the previously saved login and again confirm none of the above pixels fire again
8. Delete and re-install the app
9. Save 10+ logins and then perform a search
10. Confirm this pixel fires: `m.autofill.enableduser` (defined as a user who is a search DAU and has at least 10 passwords saved)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
