### PR TITLE
Update the `adhoc` lane to generate an alpha build

### DIFF
--- a/alphaAdhocExportOptions.plist
+++ b/alphaAdhocExportOptions.plist
@@ -8,18 +8,24 @@
     <string>HKE973VLUW</string>
     <key>method</key>
     <string>ad-hoc</string>
+
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>com.duckduckgo.mobile.ios.alpha</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha</string>
+
 		<key>com.duckduckgo.mobile.ios.alpha.ShareExtension</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.ShareExtension</string>
+
 		<key>com.duckduckgo.mobile.ios.alpha.OpenAction2</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.OpenAction2</string>
+
 		<key>com.duckduckgo.mobile.ios.alpha.Widgets</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.Widgets</string>
+
 		<key>com.duckduckgo.mobile.ios.alpha.NetworkExtension</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.NetworkExtension</string>
 	</dict>
+
 </dict>
 </plist>

--- a/alphaAdhocExportOptions.plist
+++ b/alphaAdhocExportOptions.plist
@@ -8,24 +8,18 @@
     <string>HKE973VLUW</string>
     <key>method</key>
     <string>ad-hoc</string>
-
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>com.duckduckgo.mobile.ios.alpha</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha</string>
-
 		<key>com.duckduckgo.mobile.ios.alpha.ShareExtension</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.ShareExtension</string>
-
 		<key>com.duckduckgo.mobile.ios.alpha.OpenAction2</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.OpenAction2</string>
-
 		<key>com.duckduckgo.mobile.ios.alpha.Widgets</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.Widgets</string>
-
 		<key>com.duckduckgo.mobile.ios.alpha.NetworkExtension</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.NetworkExtension</string>
 	</dict>
-
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,7 +138,6 @@ lane :alpha_adhoc do |options|
     end
   end
 
-  sync_signing_alpha(options)
   sync_signing_alpha_adhoc(options)
 
   suffix = ""
@@ -148,7 +147,6 @@ lane :alpha_adhoc do |options|
 
   timestamp = Time.now.strftime("%Y-%m-%d-%H-%M")
   output_name = "DuckDuckGo-Alpha-#{suffix}#{timestamp}"
-
 
   build_app(
     output_directory: options[:output],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,7 +131,7 @@ lane :alpha_adhoc do |options|
     configurations.each do |config|
       update_code_signing_settings(
         use_automatic_signing: false,
-        build_configurations: ["Release"],
+        build_configurations: ["Alpha"],
         code_sign_identity: "iPhone Distribution",
         **config
       )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,8 +28,13 @@ lane :sync_signing_alpha_adhoc do |options|
   do_sync_signing(options)
 end
 
-desc 'Makes Ad-Hoc build with a specified name in a given directory'
+desc 'Makes Ad-Hoc build with a specified name and alpha bundle ID in a given directory'
 lane :adhoc do |options|
+  alpha_adhoc(options)
+end
+
+desc 'Makes Ad-Hoc build with a specified name and release bundle ID in a given directory'
+lane :release_adhoc do |options|
 
   # Workaround for match + gym failing at build phase https://forums.swift.org/t/xcode-14-beta-code-signing-issues-when-spm-targets-include-resources/59685/32
   if is_ci
@@ -75,7 +80,7 @@ lane :adhoc do |options|
 
   timestamp = Time.now.strftime("%Y-%m-%d-%H-%M")
   output_name = "DuckDuckGo-#{suffix}#{timestamp}"
-  
+
   build_app(
     output_directory: options[:output],
     output_name: output_name,
@@ -95,7 +100,7 @@ lane :adhoc do |options|
   end
 end
 
-desc 'Makes Ad-Hoc build for alpha with a specified name in a given directory'
+desc 'Makes Ad-Hoc build for alpha with a specified name and alpha bundle ID in a given directory'
 lane :alpha_adhoc do |options|
 
   # Workaround for match + gym failing at build phase https://forums.swift.org/t/xcode-14-beta-code-signing-issues-when-spm-targets-include-resources/59685/32
@@ -143,7 +148,7 @@ lane :alpha_adhoc do |options|
 
   timestamp = Time.now.strftime("%Y-%m-%d-%H-%M")
   output_name = "DuckDuckGo-Alpha-#{suffix}#{timestamp}"
-  
+
 
   build_app(
     output_directory: options[:output],
@@ -236,11 +241,11 @@ lane :increment_build_number_for_version do |options|
     app_identifier = options[:app_identifier]
   end
   increment_build_number({
-    build_number: 
+    build_number:
       latest_testflight_build_number(
         api_key: get_api_key,
         version: options[:version],
-        app_identifier: app_identifier, 
+        app_identifier: app_identifier,
         initial_build_number: -1,
         username: get_username(options)) + 1,
     skip_info_plist: "true"

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -21,7 +21,9 @@ end
 
 for_lane :adhoc do
     type "adhoc"
+    app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension"]
     force_for_new_devices true
+    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :alpha_adhoc do

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -51,7 +51,7 @@ Fetches and updates certificates and provisioning profiles for Ad-Hoc distributi
 [bundle exec] fastlane adhoc
 ```
 
-Makes Ad-Hoc build with a specified name and release bundle ID in a given directory
+Makes Ad-Hoc build with a specified name and alpha bundle ID in a given directory
 
 ### release_adhoc
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -51,7 +51,15 @@ Fetches and updates certificates and provisioning profiles for Ad-Hoc distributi
 [bundle exec] fastlane adhoc
 ```
 
-Makes Ad-Hoc build with a specified name in a given directory
+Makes Ad-Hoc build with a specified name and release bundle ID in a given directory
+
+### release_adhoc
+
+```sh
+[bundle exec] fastlane release_adhoc
+```
+
+Makes Ad-Hoc build with a specified name and release bundle ID in a given directory
 
 ### alpha_adhoc
 
@@ -59,7 +67,7 @@ Makes Ad-Hoc build with a specified name in a given directory
 [bundle exec] fastlane alpha_adhoc
 ```
 
-Makes Ad-Hoc build for alpha with a specified name in a given directory
+Makes Ad-Hoc build for alpha with a specified name and alpha bundle ID in a given directory
 
 ### release_appstore
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207309089780665/f
Tech Design URL:
CC:

**Description**:

This PR changes the `adhoc` workflow to create an alpha build. Until now it has created builds with the release bundle ID, which complicates testing for those who use the DDG app already.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that the `fastlane adhoc` lane succeeds locally and the build it creates can be installed on a device
2. Check that the adhoc GHA workflow on this branch generates a functional alpha build
3. Check that the `release_adhoc` lane creates an adhoc build with the release bundle ID

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
