### PR TITLE
Fix a division-by-zero crash in the VPN code

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9833,8 +9833,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = d3bd44976f6252e3f0276343116bb02ec22fdad8;
+				kind = exactVersion;
+				version = "144.0.7-3";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9833,8 +9833,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = "144.0.7-2";
+				kind = revision;
+				revision = 923eefc2042a0352d61a39fff2fd3aac69934c9a;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9834,7 +9834,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 923eefc2042a0352d61a39fff2fd3aac69934c9a;
+				revision = d3bd44976f6252e3f0276343116bb02ec22fdad8;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "923eefc2042a0352d61a39fff2fd3aac69934c9a"
+        "revision" : "d3bd44976f6252e3f0276343116bb02ec22fdad8"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "d3bd44976f6252e3f0276343116bb02ec22fdad8"
+        "revision" : "ada5f68970f098b3230dbd80a25cd048a606ac12",
+        "version" : "144.0.7-3"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "7d5ddc9680f0ac2b4af1eba5e08b350dbe907cdd",
-        "version" : "144.0.7-2"
+        "revision" : "923eefc2042a0352d61a39fff2fd3aac69934c9a"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203137811378537/1207299387361586/f

macOS PR: https://github.com/duckduckgo/macos-browser/pull/2785
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/823

## Description

Fixes a crash caused by a division by zero.

## Testing

Just ensure the VPN starts correctly, works, stops, etc.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)
