### PR TITLE
Tweaks to autofill pixels for KPIs

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -84,9 +84,9 @@ public struct UserDefaultsWrapper<T> {
                 "com.duckduckgo.ios.autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary"
         case autofillImportViaSyncStart = "com.duckduckgo.ios.autofillImportViaSyncStart"
         case autofillSurveyEnabled = "com.duckduckgo.ios.autofillSurveyEnabled"
-        case autofillSearchDauDate = "com.duckduckgo.ios.autofillSearchDauDate"
-        case autofillFillDate = "com.duckduckgo.ios.autofillFillDate"
-        case autofillOnboardedUser = "com.duckduckgo.ios.autofillOnboardedUser"
+        case autofillSearchDauDate = "com.duckduckgo.app.autofill.SearchDauDate"
+        case autofillFillDate = "com.duckduckgo.app.autofill.FillDate"
+        case autofillOnboardedUser = "com.duckduckgo.app.autofill.OnboardedUser"
 
         // .v2 suffix added to fix https://app.asana.com/0/547792610048271/1206524375402369/f
         case featureFlaggingDidVerifyInternalUser = "com.duckduckgo.app.featureFlaggingDidVerifyInternalUser.v2"

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -673,6 +673,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         AppDependencyProvider.shared.userBehaviorMonitor.handleAction(.reopenApp)
+
+        autofillPixelReporter.checkIfOnboardedUser()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {

--- a/DuckDuckGo/AutofillPixelReporter.swift
+++ b/DuckDuckGo/AutofillPixelReporter.swift
@@ -96,15 +96,16 @@ final class AutofillPixelReporter {
 
         if shouldFireActiveUserPixel() {
             pixelsToFire.append(.autofillActiveUser)
+            pixelsToFire.append(.autofillLoginsStacked)
         }
 
         switch type {
-        case .fill:
-            pixelsToFire.append(.autofillLoginsStacked)
         case .searchDAU:
             if shouldFireEnabledUserPixel() {
                 pixelsToFire.append(.autofillEnabledUser)
             }
+        default:
+            break
         }
 
         return pixelsToFire

--- a/DuckDuckGo/AutofillPixelReporter.swift
+++ b/DuckDuckGo/AutofillPixelReporter.swift
@@ -46,9 +46,7 @@ final class AutofillPixelReporter {
 
         createNotificationObservers()
 
-        if shouldFireOnboardedUserPixel() {
-            DailyPixel.fire(pixel: .autofillOnboardedUser)
-        }
+        checkIfOnboardedUser()
     }
 
     private func createNotificationObservers() {
@@ -83,6 +81,14 @@ final class AutofillPixelReporter {
         autofillFillDate = Date()
 
         firePixels(pixelsToFireFor(.fill))
+    }
+
+    func checkIfOnboardedUser() {
+        guard !autofillOnboardedUser else { return }
+
+        if shouldFireOnboardedUserPixel() {
+            firePixels([.autofillOnboardedUser])
+        }
     }
 
     func pixelsToFireFor(_ type: EventType) -> [Pixel.Event] {

--- a/DuckDuckGo/AutofillPixelReporter.swift
+++ b/DuckDuckGo/AutofillPixelReporter.swift
@@ -101,11 +101,26 @@ final class AutofillPixelReporter {
         for pixel in pixels {
             switch pixel {
             case .autofillLoginsStacked:
-                let bucket = (try? secureVault?.accountsCountBucket()) ?? ""
-                DailyPixel.fire(pixel: pixel, withAdditionalParameters: [PixelParameters.countBucket: bucket])
+                if let count = try? vault()?.accountsCount() {
+                    DailyPixel.fire(pixel: pixel, withAdditionalParameters: [PixelParameters.countBucket: accountsBucketNameFrom(count: count)])
+                }
             default:
                 DailyPixel.fire(pixel: pixel)
             }
+        }
+    }
+
+    public func accountsBucketNameFrom(count: Int) -> String {
+        if count == 0 {
+            return "none"
+        } else if count < 4 {
+            return "few"
+        } else if count < 11 {
+            return "some"
+        } else if count < 50 {
+            return "many"
+        } else {
+            return "lots"
         }
     }
 

--- a/DuckDuckGoTests/AutofillPixelReporterTests.swift
+++ b/DuckDuckGoTests/AutofillPixelReporterTests.swift
@@ -66,28 +66,28 @@ final class AutofillPixelReporterTests: XCTestCase {
         XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.fill).count, 1)
     }
 
-    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsLessThanTenThenOnePixelWillBeFired() {
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsLessThanTenThenTwoPixelWillBeFired() {
         autofillPixelReporter.autofillSearchDauDate = Date()
         autofillPixelReporter.autofillFillDate = Date()
         createAccountsInVault(count: 4)
 
-        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 1)
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 2)
     }
 
-    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsTenThenTwoPixelsWillBeFired() {
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsTenThenThreePixelsWillBeFired() {
         autofillPixelReporter.autofillSearchDauDate = Date()
         autofillPixelReporter.autofillFillDate = Date()
         createAccountsInVault(count: 10)
 
-        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 2)
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 3)
     }
 
-    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsGreaterThanTenThenTwoPixelsWillBeFired() {
+    func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsGreaterThanTenThenThreePixelsWillBeFired() {
         autofillPixelReporter.autofillSearchDauDate = Date()
         autofillPixelReporter.autofillFillDate = Date()
         createAccountsInVault(count: 15)
 
-        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 2)
+        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.searchDAU).count, 3)
     }
 
     func testWhenUserSearchDauIsTodayAndAutofillDateIsNotTodayAndEventTypeIsSearchDauAndAccountsCountIsLessThanTenThenNoPixelsWillBeFired() {

--- a/DuckDuckGoTests/AutofillPixelReporterTests.swift
+++ b/DuckDuckGoTests/AutofillPixelReporterTests.swift
@@ -59,11 +59,11 @@ final class AutofillPixelReporterTests: XCTestCase {
         XCTAssertTrue(autofillPixelReporter.pixelsToFireFor(.searchDAU).isEmpty)
     }
 
-    func testWhenUserSearchDauIsNotTodayAndEventTypeIsFillThenOnePixelWillBeFired() {
+    func testWhenUserSearchDauIsNotTodayAndEventTypeIsFillThenNoPixelsWillBeFired() {
         autofillPixelReporter.autofillSearchDauDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
         autofillPixelReporter.autofillFillDate = Date().addingTimeInterval(-2 * 60 * 60 * 24)
 
-        XCTAssertEqual(autofillPixelReporter.pixelsToFireFor(.fill).count, 1)
+        XCTAssertTrue(autofillPixelReporter.pixelsToFireFor(.fill).isEmpty)
     }
 
     func testWhenUserSearchDauIsTodayAndAutofillDateIsTodayAndEventTypeIsSearchDauAndAccountsCountIsLessThanTenThenTwoPixelWillBeFired() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207338955294273/f
Tech Design URL:
CC:

**Description**:
Updates logic slightly around the new pixels added as part of unified autofill KPIs across platforms


<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

**NOTE** - if you have an existing build with 10 or more passwords, feel free to start with Step 9 & 10 first 🙂 
1. Starting with a new install of the app, visit https://fill.dev/form/registration-username and save a new login using a generated password (triggering a fill event)
2. Confirm these pixels DO NOT fire: `m.autofill.activeuser` or `m.autofill.logins.stacked`
3. Perform a search in the browser
4. Confirm these pixels fire: `m.autofill.activeuser` and `m.autofill.logins.stacked ["count_bucket": "few"]`
5. Minimise the app and return to foreground + confirm this pixel fires: `m.autofill.onboardeduser`  (defined as user who has stored at least 1 password within the first week)
6. Perform another search and confirm none of the above pixels fire again
7. Visit to https://fill.dev/form/login-simple and fill the previously saved login and again confirm none of the above pixels fire again
8. Delete and re-install the app
9. Save (or sync & import) 10+ logins and then perform a search
10. Confirm this pixel fires: `m.autofill.enableduser` (defined as a user who is a search DAU and has at least 10 passwords saved)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
