### PR TITLE
apply user agent overrides to downloads

### DIFF
--- a/Core/UserAgentManager.swift
+++ b/Core/UserAgentManager.swift
@@ -32,6 +32,8 @@ public protocol UserAgentManager {
 
     func userAgent(isDesktop: Bool) -> String
 
+    func userAgent(isDesktop: Bool, url: URL?) -> String
+
 }
 
 public class DefaultUserAgentManager: UserAgentManager {
@@ -58,6 +60,10 @@ public class DefaultUserAgentManager: UserAgentManager {
 
     public func userAgent(isDesktop: Bool) -> String {
         return userAgent.agent(forUrl: nil, isDesktop: isDesktop)
+    }
+
+    public func userAgent(isDesktop: Bool, url: URL?) -> String {
+        return userAgent.agent(forUrl: url, isDesktop: isDesktop)
     }
 
     public func update(request: inout URLRequest, isDesktop: Bool) {

--- a/DuckDuckGo/URLDownloadSession.swift
+++ b/DuckDuckGo/URLDownloadSession.swift
@@ -39,7 +39,7 @@ class URLDownloadSession: NSObject, DownloadSession {
             self.session = session
         } else {
             let configuration = URLSessionConfiguration.ephemeral
-            let userAgent = DefaultUserAgentManager.shared.userAgent(isDesktop: false)
+            let userAgent = DefaultUserAgentManager.shared.userAgent(isDesktop: false, url: url)
             configuration.httpAdditionalHeaders = ["user-agent": userAgent]
             self.session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
         }

--- a/DuckDuckGoTests/MockUserAgent.swift
+++ b/DuckDuckGoTests/MockUserAgent.swift
@@ -48,6 +48,10 @@ class MockUserAgentManager: UserAgentManager {
         return userAgent.agent(forUrl: nil, isDesktop: isDesktop, privacyConfig: privacyConfig)
     }
 
+    func userAgent(isDesktop: Bool, url: URL?) -> String {
+        return userAgent.agent(forUrl: url, isDesktop: isDesktop)
+    }
+
     public func update(request: inout URLRequest, isDesktop: Bool) {
         request.addValue(userAgent.agent(forUrl: nil, isDesktop: isDesktop, privacyConfig: privacyConfig), forHTTPHeaderField: "User-Agent")
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207292250628004/f
Tech Design URL:
CC:

**Description**:
Applies user agent override to downloads. 

**Steps to test this PR**:
1. On an iPhone (simulator will do) visit this page https://pub1.pskt.io/5kA5Z0ILwxrTSmQL2TWZh5 or create a new pass at passkit.com - this site in particular is sensitive to the user agent.
2. Site will not show add to pass button.
3. Apple this config https://jsonblob.com/api/1239922527202828288 via the debug screen
4. Reload the page
5. Tap the add to wallet page
6. Pass should appear ready to add to wallet

On iPad nothing should happen.
