### PR TITLE
keep strong reference to omnibar while we use it and add a ui test

### DIFF
--- a/.maestro/browser_features/swipe_tabs.yaml
+++ b/.maestro/browser_features/swipe_tabs.yaml
@@ -1,0 +1,68 @@
+# swipe_tabs.yaml
+appId: com.duckduckgo.mobile.ios
+tags:
+    - release
+
+---
+
+# Set up
+- clearState
+- launchApp
+- runFlow:
+    when:
+      visible:
+        text: "Let’s Do It!"
+        index: 0
+    file: ../shared/onboarding.yaml
+
+# Load Site
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://duckduckgo.com"
+- pressKey: Enter
+
+# Manage onboarding
+- runFlow:
+    when:
+      visible:
+        text: "Got It"
+        index: 0
+    file: ../shared/onboarding_browsing.yaml
+
+- assertVisible: "Privacy, simplified."
+
+# Open New Tab
+- tapOn: "Tab Switcher"
+- tapOn:
+    id: Add
+
+# Perform a search
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/features/favicon/"
+- pressKey: Enter
+
+- assertVisible: "Favicon Tests"
+
+# Swipe to first tab
+- swipe:  
+    start: 10%, 10%
+    end: 90%, 10%
+
+- assertVisible: "Privacy, simplified."
+
+# Ensure address bar still works
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/features/download/"
+- pressKey: Enter
+
+- assertVisible: "Download PDF"
+
+# TODO when settings experiment finishes update this test to open settings and move bar to bottom then test swipe again

--- a/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -291,7 +291,10 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
         if !isEnabled || tabsModel.currentIndex == indexPath.row {
             cell.omniBar = coordinator.omniBar
         } else {
-            cell.omniBar = OmniBar.loadFromXib()
+            // Strong reference while we use the omnibar
+            let omniBar = OmniBar.loadFromXib()
+
+            cell.omniBar = omniBar
             cell.omniBar?.translatesAutoresizingMaskIntoConstraints = false
             cell.updateConstraints()
             


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1207372554889895/f
Tech Design URL:
CC:

**Description**:
See if keeping a strong reference to the omnibar reduces the number of crashes in this area.

**Steps to test this PR**:
1. Check swipe tabs in the top and bottom bar position
2. Run the new UI test

