### PR TITLE
Guard swipe tabs scroll state

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -559,6 +559,7 @@ extension Pixel {
         case syncWrongEnvironment
 
         case swipeTabsUsed
+        case swipeTabsIncorrectScrollState
         case swipeTabsUsedDaily
         case swipeToOpenNewTab
 
@@ -1227,6 +1228,7 @@ extension Pixel.Event {
         case .syncWrongEnvironment: return "m_d_sync_wrong_environment_u"
 
         case .swipeTabsUsed: return "m_swipe-tabs-used"
+        case .swipeTabsIncorrectScrollState: return "m_swipe-tabs.incorrect-scrollview-state"
         case .swipeTabsUsedDaily: return "m_swipe-tabs-used-daily"
         case .swipeToOpenNewTab: return "m_addressbar_swipe_new_tab"
 

--- a/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import Core
 
 class SwipeTabsCoordinator: NSObject {
     
@@ -85,6 +86,14 @@ class SwipeTabsCoordinator: NSObject {
         case starting(CGPoint)
         case swiping(CGPoint, FloatingPointSign)
         
+        var isIdle: Bool {
+            if case .idle = self {
+                return true
+            }
+
+            return false
+        }
+
     }
     
     var state: State = .idle
@@ -217,6 +226,12 @@ extension SwipeTabsCoordinator: UICollectionViewDelegate {
     }
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        guard !state.isIdle else {
+            Pixel.fire(pixel: .swipeTabsIncorrectScrollState)
+            assertionFailure("invalid state")
+            return
+        }
+
         defer {
             cleanUpViews()
             state = .idle


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207372554889944/f
Tech Design URL:
CC:

**Description**:
Guard against wrong state in swipe tabs.

**Steps to test this PR**:
1. Ensure swipe tabs still behaves as before.

