### PR TITLE
Do not refresh collection view when we are changing the display mode

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -275,8 +275,9 @@ class TabSwitcherViewController: UIViewController {
                           duration: 0.3,
                           options: .transitionCrossDissolve, animations: {
             self.collectionView.reloadData()
+        }, completion: { _ in
             self.isProcessingUpdates = false
-        }, completion: nil)
+        })
     }
 
     @IBAction func onAddPressed(_ sender: UIBarButtonItem) {

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -260,6 +260,7 @@ class TabSwitcherViewController: UIViewController {
     }
     
     @IBAction func onDisplayModeButtonPressed(_ sender: UIButton) {
+        isProcessingUpdates = true
         tabSwitcherSettings.isGridViewEnabled = !tabSwitcherSettings.isGridViewEnabled
         
         if tabSwitcherSettings.isGridViewEnabled {
@@ -273,7 +274,8 @@ class TabSwitcherViewController: UIViewController {
         UIView.transition(with: view,
                           duration: 0.3,
                           options: .transitionCrossDissolve, animations: {
-                            self.collectionView.reloadData()
+            self.collectionView.reloadData()
+            self.isProcessingUpdates = false
         }, completion: nil)
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1205002344719381/f
Tech Design URL:
CC:

**Description**:

Do not refresh collection view when we are changing the display mode as it may result in a crash.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open https://privacy-test-pages.site/features/auto-refresh.html in few tabs.
2. Open TabSwitcher.
3. Start toggling Grid/List mode quickly.

General TabSwitcher smoke tests
<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
