### PR TITLE
Do not use UI as URL source when refreshing

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2185,7 +2185,7 @@ extension TabViewController: UIGestureRecognizerDelegate {
     func refresh() {
         let url: URL?
         if isError || webView.url == nil {
-            url = URL(string: chromeDelegate?.omniBar.textField.text ?? "")
+            url = self.url
         } else {
             url = webView.url
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1206226850447395/1207343265491189/f
Tech Design URL:
CC:

**Description**:

When website was not loaded, URL was taken from the UI text field, which is not correct when using short URL option. The last URL is already stored in local variable, so this one will be used instead.

**Steps to test this PR**:
1. Disable "Show full site address" 
2. Load https://badssl.com
3. Open link with "expired" certificate (or any other that won't load successfully)
4. Refresh the page
5. App should not ask to open the link in another app

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
