### PR TITLE
Disable refresh control when zooming

### DIFF
--- a/DuckDuckGo/BrowserChromeManager.swift
+++ b/DuckDuckGo/BrowserChromeManager.swift
@@ -23,7 +23,8 @@ protocol BrowserChromeDelegate: AnyObject {
 
     func setBarsHidden(_ hidden: Bool, animated: Bool)
     func setNavigationBarHidden(_ hidden: Bool)
-    
+    func setRefreshControlEnabled(_ isEnabled: Bool)
+
     func setBarsVisibility(_ percent: CGFloat, animated: Bool)
     
     var canHideBars: Bool { get }
@@ -104,6 +105,11 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     
     func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
         startZoomScale = scrollView.zoomScale
+        delegate?.setRefreshControlEnabled(false)
+    }
+
+    func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        delegate?.setRefreshControlEnabled(true)
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1636,7 +1636,11 @@ extension MainViewController: BrowserChromeDelegate {
         viewCoordinator.statusBackground.alpha = hidden ? 0 : 1
         
     }
-    
+
+    func setRefreshControlEnabled(_ isEnabled: Bool) {
+        currentTab?.setRefreshControlEnabled(isEnabled)
+    }
+
     var canHideBars: Bool {
         return !DaxDialogs.shared.shouldShowFireButtonPulse
     }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -180,8 +180,8 @@ class TabViewController: UIViewController {
         let refreshControl = UIRefreshControl()
         refreshControl.addAction(UIAction { [weak self] _ in
             guard let self else { return }
-            self.reload()
-            self.delegate?.tabDidRequestRefresh(tab: self)
+            reload()
+            delegate?.tabDidRequestRefresh(tab: self)
             Pixel.fire(pixel: .pullToRefresh)
             AppDependencyProvider.shared.userBehaviorMonitor.handleAction(.refresh)
         }, for: .valueChanged)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -835,11 +835,7 @@ class TabViewController: UIViewController {
     }
 
     func setRefreshControlEnabled(_ isEnabled: Bool) {
-        if isEnabled {
-            webView.scrollView.refreshControl = refreshControl
-        } else {
-            webView.scrollView.refreshControl = nil
-        }
+        webView.scrollView.refreshControl = isEnabled ? refreshControl : nil
     }
 
     private var didGoBackForward: Bool = false

--- a/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -155,6 +155,7 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
         case setBarsHidden(Bool)
         case setNavigationBarHidden(Bool)
         case setBarsVisibility(CGFloat)
+        case setRefreshControlEnabled(Bool)
     }
 
     var receivedMessages: [Message] = []
@@ -169,6 +170,10 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     func setBarsVisibility(_ percent: CGFloat, animated: Bool) {
         receivedMessages.append(.setBarsVisibility(percent))
+    }
+
+    func setRefreshControlEnabled(_ isEnabled: Bool) {
+        receivedMessages.append(.setRefreshControlEnabled(isEnabled))
     }
 
     var canHideBars: Bool = false


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/715106103902962/1206963678807672/f
Tech Design URL:
CC:

**Description**:
One could accidentally refresh the page by performing zoom. This change removes refresh control while performing pinch-to-zoom gestures.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open a site
2. Start zooming
3. During zooming pulling to refresh should not be possible

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
