### PR TITLE
Hide 'Set your address bar position' for iPad

### DIFF
--- a/DuckDuckGo/SettingsAppearanceView.swift
+++ b/DuckDuckGo/SettingsAppearanceView.swift
@@ -42,17 +42,17 @@ struct SettingsAppearanceView: View {
                                        selectedOption: viewModel.themeBinding)
             }
 
-            if viewModel.state.addressbar.enabled {
-                Section(header: Text(UserText.addressBar)) {
+            Section(header: Text(UserText.addressBar)) {
+                if viewModel.state.addressbar.enabled {
                     // Address Bar Position
                     SettingsPickerCellView(label: UserText.settingsAddressBar,
                                            options: AddressBarPosition.allCases,
                                            selectedOption: viewModel.addressBarPositionBinding)
-
-                    // Show Full Site Address
-                    SettingsCellView(label: UserText.settingsFullURL,
-                                     accesory: .toggle(isOn: viewModel.addressBarShowsFullURL))
                 }
+
+                // Show Full Site Address
+                SettingsCellView(label: UserText.settingsFullURL,
+                                 accesory: .toggle(isOn: viewModel.addressBarShowsFullURL))
             }
         }
         .applySettingsListModifiers(title: UserText.settingsAppearanceSection,

--- a/DuckDuckGo/SettingsNextStepsView.swift
+++ b/DuckDuckGo/SettingsNextStepsView.swift
@@ -39,9 +39,11 @@ struct SettingsNextStepsView: View {
             }
 
             // Set Your Address Bar Position
-            NavigationLink(destination: SettingsAppearanceView().environmentObject(viewModel)) {
-                SettingsCellView(label: UserText.setYourAddressBarPosition,
-                                 image: Image("SettingsAddressBarPosition"))
+            if viewModel.state.addressbar.enabled {
+                NavigationLink(destination: SettingsAppearanceView().environmentObject(viewModel)) {
+                    SettingsCellView(label: UserText.setYourAddressBarPosition,
+                                     image: Image("SettingsAddressBarPosition"))
+                }
             }
 
             // Enable Voice Search


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1148564399326804/1207447274447082/f
Tech Design URL:
CC:

**Description**:
Hide 'Set your address bar position' for iPad, because users can't set the address bar position on iPads

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the app on iPhone and make sure **you can see** 'Set your address bar position' in the Next Steps section
1. Run the app on iPad and make sure **you don't see** 'Set your address bar position' in the Next Steps section

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [x] iPhone 8
* [x] iPhone X
* [X] iPhone 14 Pro
* [X] iPad

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
