### PR TITLE
Load child Privacy Pro views lazily

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -374,7 +374,7 @@ extension Pixel {
         
         case networkProtectionDisconnected
         
-        case networkProtectionNoAuthTokenFoundError
+        case networkProtectionNoAccessTokenFoundError
         
         case networkProtectionMemoryWarning
         case networkProtectionMemoryCritical
@@ -1061,7 +1061,7 @@ extension Pixel.Event {
         case .networkProtectionActivationRequestFailed: return "m_netp_network_extension_error_activation_request_failed"
         case .networkProtectionFailedToStartTunnel: return "m_netp_failed_to_start_tunnel"
         case .networkProtectionDisconnected: return "m_netp_vpn_disconnect"
-        case .networkProtectionNoAuthTokenFoundError: return "m_netp_no_auth_token_found_error"
+        case .networkProtectionNoAccessTokenFoundError: return "m_netp_no_access_token_found_error"
         case .networkProtectionMemoryWarning: return "m_netp_vpn_memory_warning"
         case .networkProtectionMemoryCritical: return "m_netp_vpn_memory_critical"
         case .networkProtectionUnhandledError: return "m_netp_unhandled_error"

--- a/DuckDuckGo/EventMapping+NetworkProtectionError.swift
+++ b/DuckDuckGo/EventMapping+NetworkProtectionError.swift
@@ -69,7 +69,7 @@ extension EventMapping where Event == NetworkProtectionError {
             pixelEvent = .networkProtectionKeychainDeleteError
             params[PixelParameters.keychainErrorCode] = String(status)
         case .noAuthTokenFound:
-            pixelEvent = .networkProtectionNoAuthTokenFoundError
+            pixelEvent = .networkProtectionNoAccessTokenFoundError
         case .vpnAccessRevoked:
             return
         case .noServerRegistrationInfo,

--- a/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionEmailView.swift
@@ -43,13 +43,13 @@ struct SubscriptionEmailView: View {
         
     var body: some View {
         // Hidden Navigation Links for Onboarding sections
-        NavigationLink(destination: NetworkProtectionRootView().navigationViewStyle(.stack),
+        NavigationLink(destination: LazyView(NetworkProtectionRootView().navigationViewStyle(.stack)),
                        isActive: $isShowingNetP,
                        label: { EmptyView() })
-        NavigationLink(destination: SubscriptionITPView().navigationViewStyle(.stack),
+        NavigationLink(destination: LazyView(SubscriptionITPView().navigationViewStyle(.stack)),
                        isActive: $isShowingITR,
                        label: { EmptyView() })
-        NavigationLink(destination: SubscriptionPIRView().navigationViewStyle(.stack),
+        NavigationLink(destination: LazyView(SubscriptionPIRView().navigationViewStyle(.stack)),
                        isActive: $isShowingDBP,
                        label: { EmptyView() })
                         

--- a/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
@@ -55,13 +55,13 @@ struct SubscriptionFlowView: View {
     var body: some View {
         
         // Hidden Navigation Links for Onboarding sections
-        NavigationLink(destination: NetworkProtectionRootView().navigationViewStyle(.stack),
+        NavigationLink(destination: LazyView(NetworkProtectionRootView().navigationViewStyle(.stack)),
                        isActive: $isShowingNetP,
                        label: { EmptyView() })
-        NavigationLink(destination: SubscriptionITPView().navigationViewStyle(.stack),
+        NavigationLink(destination: LazyView(SubscriptionITPView().navigationViewStyle(.stack)),
                        isActive: $isShowingITR,
                        label: { EmptyView() })
-        NavigationLink(destination: SubscriptionPIRView().navigationViewStyle(.stack),
+        NavigationLink(destination: LazyView(SubscriptionPIRView().navigationViewStyle(.stack)),
                        isActive: $isShowingDBP,
                        label: { EmptyView() })
         

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -213,7 +213,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 pixelEvent = .networkProtectionWireguardErrorCannotStartWireguardBackend
                 params[PixelParameters.wireguardErrorCode] = String(code)
             case .noAuthTokenFound:
-                pixelEvent = .networkProtectionNoAuthTokenFoundError
+                pixelEvent = .networkProtectionNoAccessTokenFoundError
             case .vpnAccessRevoked:
                 return
             case .unhandledError(function: let function, line: let line, error: let error):


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/547792610048271/1207482157703809/f
Tech Design URL:
CC:

**Description**:

This PR updates Privacy Pro child views to load lazily. Without this, we were loading all of them as soon as the Privacy Pro flow was opened, and attempting to check auth state etc.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure you are attached to the debugger and can see pixel logs
2. Sign out of Privacy Pro completely
3. Open the Privacy Pro purchase flow and check that you do not see a bunch of auth token noise, or VPN configuration loading failures
4. Complete the purchase flow and make sure that at the end you can tap the "Open VPN" links etc that open the child views, and that connecting the VPN works from here

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
