### PR TITLE
Show subscription settings section either when subscription purchase is possible or user is authenticated

### DIFF
--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -261,9 +261,7 @@ struct SettingsSubscriptionView: View {
 
             }
         }.onReceive(viewModel.$state) { state in
-            if state.subscription.enabled && (state.subscription.isSignedIn || state.subscription.canPurchase) {
-                isShowingPrivacyPro = true
-            }
+            isShowingPrivacyPro = state.subscription.enabled && (state.subscription.isSignedIn || state.subscription.canPurchase)
         }
     }
 }

--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -261,7 +261,7 @@ struct SettingsSubscriptionView: View {
 
             }
         }.onReceive(viewModel.$state) { state in
-            if state.subscription.enabled && state.subscription.canPurchase {
+            if state.subscription.enabled && (state.subscription.isSignedIn || state.subscription.canPurchase) {
                 isShowingPrivacyPro = true
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207502776093440/f

**Description**:
Logic for displaying Privacy Pro section in settings always relies on canPurchase value (base on availability of subscription products for your region in the App Store). This check is even applied when the subscription was already purchased/activated on this device.
This logic is not aligned with macOS where we check for canPurchase only for unauthenticated state, otherwise if the user is already authenticated (we stored their accessToken) the Privacy Pro is made accessible in the UI.

**Steps to test this PR**:
1. Purchase a subscription
2. Open settings and confirm that subscription section is visible
3. Ensure `canPurchase` to be false by launching the app while device is offline or hardcode it in `SettingsViewModel.swift`  in line 768: `state.subscription.canPurchase = false  // subscriptionManager.canPurchase`
4. Open settings and confirm that subscription section is still visible
5. Remove subscription from the device
6. Confirm that the subscription section is gone (due to the forced disabled `canPurchase`)
7. Re-enable `canPurchase` by undoing step 3.
4. Open settings and confirm that subscription section is visible once again

**Device Testing**:

* [ ] iPhone
* [ ] iPad

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
