### PR TITLE
Do not refresh UI only if AutoClear was triggered

### DIFF
--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -27,7 +27,9 @@ protocol AutoClearWorker {
     func forgetData() async
     func forgetData(applicationState: DataStoreWarmup.ApplicationState) async
     func forgetTabs()
-    func clearDataFinished(_: AutoClear)
+
+    func willStartClearing(_: AutoClear)
+    func autoClearDidFinishClearing(_: AutoClear, isLaunching: Bool)
 }
 
 class AutoClear {
@@ -50,6 +52,8 @@ class AutoClear {
     func clearDataIfEnabled(launching: Bool = false, applicationState: DataStoreWarmup.ApplicationState = .unknown) async {
         guard let settings = AutoClearSettingsModel(settings: appSettings) else { return }
 
+        worker.willStartClearing(self)
+
         if settings.action.contains(.clearTabs) {
             worker.forgetTabs()
         }
@@ -58,9 +62,7 @@ class AutoClear {
             await worker.forgetData(applicationState: applicationState)
         }
 
-        if !launching {
-            worker.clearDataFinished(self)
-        }
+        worker.autoClearDidFinishClearing(self, isLaunching: launching)
     }
 
     /// Note: function is parametrised because of tests.

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -90,8 +90,9 @@ class MainViewController: UIViewController {
     let previewsSource: TabPreviewsSource
     let appSettings: AppSettings
     private var launchTabObserver: LaunchTabNotification.Observer?
-    
-    var doRefreshAfterClear = true
+
+    var autoClearInProgress = false
+    var autoClearShouldRefreshUIAfterClear = true
 
     let bookmarksDatabase: CoreDataDatabase
     private weak var bookmarksDatabaseCleaner: BookmarkDatabaseCleaner?
@@ -835,7 +836,9 @@ class MainViewController: UIViewController {
                 selectTab(existing)
                 return
             } else if reuseExisting, let existing = tabManager.firstHomeTab() {
-                doRefreshAfterClear = false
+                if autoClearInProgress {
+                    autoClearShouldRefreshUIAfterClear = false
+                }
                 tabManager.selectTab(existing)
                 loadUrl(url, fromExternalLink: fromExternalLink)
             } else {
@@ -2403,7 +2406,7 @@ extension MainViewController: GestureToolbarButtonDelegate {
 }
 
 extension MainViewController: AutoClearWorker {
-    
+
     func clearNavigationStack() {
         dismissOmniBar()
 
@@ -2421,10 +2424,6 @@ extension MainViewController: AutoClearWorker {
     }
 
     func refreshUIAfterClear() {
-        guard doRefreshAfterClear else {
-            doRefreshAfterClear = true
-            return
-        }
         showBars()
         attachHomeScreen()
         tabsBarController?.refresh(tabsModel: tabManager.model)
@@ -2433,8 +2432,18 @@ extension MainViewController: AutoClearWorker {
     }
 
     @MainActor
-    func clearDataFinished(_: AutoClear) {
-        refreshUIAfterClear()
+    func willStartClearing(_: AutoClear) {
+        autoClearInProgress = true
+    }
+
+    @MainActor
+    func autoClearDidFinishClearing(_: AutoClear, isLaunching: Bool) {
+        if autoClearShouldRefreshUIAfterClear && isLaunching == false {
+            refreshUIAfterClear()
+        }
+
+        autoClearInProgress = false
+        autoClearShouldRefreshUIAfterClear = true
     }
 
     @MainActor

--- a/DuckDuckGoTests/AutoClearTests.swift
+++ b/DuckDuckGoTests/AutoClearTests.swift
@@ -47,7 +47,11 @@ class AutoClearTests: XCTestCase {
             forgetTabsInvocationCount += 1
         }
 
-        func clearDataFinished(_: AutoClear) {
+        func willStartClearing(_: DuckDuckGo.AutoClear) {
+
+        }
+
+        func autoClearDidFinishClearing(_: DuckDuckGo.AutoClear, isLaunching: Bool) {
             clearDataFinishedInvocationCount += 1
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/856498667320406/1207474102025833/f
Tech Design URL:
CC:

**Description**:

Make sure that we correctly refresh the UI once we forget data. Right now there is a case when we do not refresh UI despite correctly clearing data.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

See asana task for details, as there are about 20+ cases.

Basically we need to validate opening app/links in the app when:
- app is killed/ backgrounded
- auto clear is on/off
- tabs are populated, link is already loaded or home screen is present

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
