### PR TITLE
DBP: Bump C-S-S version to 5.19.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "juan/dbp/bump-css-version-to-include-no-results-selector";
-				kind = branch;
+				kind = exactVersion;
+				version = 152.0.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 152.0.0;
+				branch = "juan/dbp/bump-css-version-to-include-no-results-selector";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "e32733e0e0b03bbac2fec160a2f967a15ed1794b",
-        "version" : "152.0.0"
+        "branch" : "juan/dbp/bump-css-version-to-include-no-results-selector",
+        "revision" : "7513783bcfbed8e675b73527009d37a4cb477dd8"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "fa861c4eccb21d235e34070b208b78bdc32ece08",
-        "version" : "5.17.0"
+        "revision" : "ba2ad0c3a14a8c07d7be8b50a20b47efea207e86",
+        "version" : "5.19.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "juan/dbp/bump-css-version-to-include-no-results-selector",
-        "revision" : "7513783bcfbed8e675b73527009d37a4cb477dd8"
+        "revision" : "43d6c090699ddc1b92c0c016dc31b923fb06f59f",
+        "version" : "152.0.1"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/414235014887631/1207457690535605/f
Tech Design URL:
CC:

**Description**
This only bumps the C-S-S version to 5.19.0 for some Data Broker Protection changes. There should not be any impact on iOS.


**Steps to test this PR**:
1. A smoke test just in case.
