### PR TITLE
Fix widgets init due to crash of availability check inside builder on iOS 16

### DIFF
--- a/Widgets/Widgets.swift
+++ b/Widgets/Widgets.swift
@@ -214,25 +214,39 @@ struct Widgets: WidgetBundle {
 
     @WidgetBundleBuilder
     var body: some Widget {
-        SearchWidget()
-        PasswordsWidget()
-        FavoritesWidget()
-
-        if #available(iOSApplicationExtension 17.0, *) {
-            VPNStatusWidget()
-        }
-
-        if #available(iOSApplicationExtension 16.0, *) {
-            SearchLockScreenWidget()
-            VoiceSearchLockScreenWidget()
-            EmailProtectionLockScreenWidget()
-            FireButtonLockScreenWidget()
-            FavoritesLockScreenWidget()
-            PasswordsLockScreenWidget()
-        }
-
+        makeWidgets()
     }
 
+    private func makeWidgets() -> some Widget {
+        if #available(iOS 17, *) {
+            return WidgetBundleBuilder.buildBlock(SearchWidget(),
+                                                  PasswordsWidget(),
+                                                  FavoritesWidget(),
+                                                  VPNStatusWidget(),
+                                                  SearchLockScreenWidget(),
+                                                  VoiceSearchLockScreenWidget(),
+                                                  EmailProtectionLockScreenWidget(),
+                                                  FireButtonLockScreenWidget(),
+                                                  FavoritesLockScreenWidget(),
+                                                  PasswordsLockScreenWidget())
+        }
+
+        if #available(iOS 16.0, *) {
+            return WidgetBundleBuilder.buildBlock(SearchWidget(),
+                                                  PasswordsWidget(),
+                                                  FavoritesWidget(),
+                                                  SearchLockScreenWidget(),
+                                                  VoiceSearchLockScreenWidget(),
+                                                  EmailProtectionLockScreenWidget(),
+                                                  FireButtonLockScreenWidget(),
+                                                  FavoritesLockScreenWidget(),
+                                                  PasswordsLockScreenWidget())
+        } else {
+            return WidgetBundleBuilder.buildBlock(SearchWidget(),
+                                                  PasswordsWidget(),
+                                                  FavoritesWidget())
+        }
+    }
 }
 
 extension UIImage {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207512958665865/f

**Description**:
It turns out that `if #available(iOSApplicationExtension 17.0, *)` check within the body of the builder is causing a crash on iOS 16. The change was introduced in most recent version by making the widget available in release target.

**Steps to test this PR**:
- Build `WidgetsExtension` target against iOS 16 simulator - it should not crash
- Run the app on iOS 16 and try adding home screen widgets from DDG app - the VPN one should not be available
- Run the app on iOS 17 and try adding home screen widgets from DDG app - the VPN one should be available


**Device Testing**:

* [ ] iPhone
* [ ] iPad

**OS Testing**:
* [ ] iOS 17
* [ ] iOS 16

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
