### PR TITLE
Handle is_nav flag in ac suggestions

### DIFF
--- a/Core/AppURLs.swift
+++ b/Core/AppURLs.swift
@@ -62,13 +62,6 @@ public extension URL {
 
     static func makeExtiURL(atb: String) -> URL { URL.exti.appendingParameter(name: Param.atb, value: atb) }
 
-    static func makeAutocompleteURL(for text: String) throws -> URL {
-        URL.autocomplete.appendingParameters([
-            Param.search: text,
-            Param.enableNavSuggestions: ParamValue.enableNavSuggestions
-        ])
-    }
-
     static func isDuckDuckGo(domain: String?) -> Bool {
         guard let domain = domain, let url = URL(string: "https://\(domain)") else { return false }
         return url.isDuckDuckGo
@@ -120,7 +113,6 @@ public extension URL {
         static let vertical = "ia"
         static let verticalRewrite = "iar"
         static let verticalMaps = "iaxm"
-        static let enableNavSuggestions = "is_nav"
         static let email = "email"
 
     }
@@ -130,7 +122,6 @@ public extension URL {
         static let source = "ddg_ios"
         static let appUsage = "app_use"
         static let searchHeader = "-1"
-        static let enableNavSuggestions = "1"
         static let emailEnabled = "1"
         static let emailDisabled = "0"
         static let majorVerticals: Set<String> = ["images", "videos", "news"]

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 153.0.0;
+				kind = revision;
+				revision = 8db3ee8648d126559e0c45522157cdb987967f6b;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9770,7 +9770,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = revision;
-				revision = 8db3ee8648d126559e0c45522157cdb987967f6b;
+				revision = 9b76bc62c8ededc911aca846c04b2b1d6b68121f;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 2bf3f1c7738afa0a134cbedb44a219b2aa256947;
+				kind = exactVersion;
+				version = 154.1.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 154.0.1;
+				kind = revision;
+				revision = 2bf3f1c7738afa0a134cbedb44a219b2aa256947;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "2bf3f1c7738afa0a134cbedb44a219b2aa256947"
+        "revision" : "4a4735455ac5c49e3928fc841cbffdd80d9274e3",
+        "version" : "154.1.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "b78ae617c7fe66244741f489158a1f40e567e674",
-        "version" : "153.0.0"
+        "revision" : "8db3ee8648d126559e0c45522157cdb987967f6b"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "8db3ee8648d126559e0c45522157cdb987967f6b"
+        "revision" : "9b76bc62c8ededc911aca846c04b2b1d6b68121f"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "918f29281acf07e66a59cf343d12fd676b90e446",
-        "version" : "154.0.1"
+        "revision" : "2bf3f1c7738afa0a134cbedb44a219b2aa256947"
       }
     },
     {

--- a/DuckDuckGoTests/AppURLsTests.swift
+++ b/DuckDuckGoTests/AppURLsTests.swift
@@ -158,13 +158,6 @@ final class AppURLsTests: XCTestCase {
         let result = URL(string: "http://www.duckduckgo.com")!.isDuckDuckGo
         XCTAssertTrue(result)
     }
-    
-    func testAutocompleteUrlCreatesCorrectUrlWithParams() throws {
-        let actual = try URL.makeAutocompleteURL(for: "a term")
-        XCTAssertTrue(actual.isDuckDuckGo)
-        XCTAssertEqual("/ac", actual.path)
-        XCTAssertEqual("a term", actual.getParameter(named: "q"))
-    }
 
     func testInitialAtbDoesNotContainAtbParams() throws {
         let url = URL.atb


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207526652903004/f
Tech Design URL:
CC:

**Description**:
Re-add `is_nav` support for suggestions.

**Steps to test this PR**:
 See BSK https://github.com/duckduckgo/BrowserServicesKit/pull/842
