### PR TITLE
Fast egress server draining

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -319,7 +319,11 @@ extension Pixel {
         case networkProtectionEnableAttemptConnecting
         case networkProtectionEnableAttemptSuccess
         case networkProtectionEnableAttemptFailure
-        
+
+        case networkProtectionServerMigrationAttempt
+        case networkProtectionServerMigrationAttemptSuccess
+        case networkProtectionServerMigrationAttemptFailure
+
         case networkProtectionTunnelFailureDetected
         case networkProtectionTunnelFailureRecovered
         
@@ -342,6 +346,8 @@ extension Pixel {
         
         case networkProtectionClientFailedToFetchServerList
         case networkProtectionClientFailedToParseServerListResponse
+        case networkProtectionClientFailedToFetchServerStatus
+        case networkProtectionClientFailedToParseServerStatusResponse
         case networkProtectionClientFailedToEncodeRegisterKeyRequest
         case networkProtectionClientFailedToFetchRegisteredServers
         case networkProtectionClientFailedToParseRegisteredServersResponse
@@ -1064,7 +1070,14 @@ extension Pixel.Event {
         case .networkProtectionGeoswitchingSetNearest: return "m_netp_ev_geoswitching_set_nearest"
         case .networkProtectionGeoswitchingSetCustom: return "m_netp_ev_geoswitching_set_custom"
         case .networkProtectionGeoswitchingNoLocations: return "m_netp_ev_geoswitching_no_locations"
-            
+
+        case .networkProtectionClientFailedToFetchServerStatus: return "m_netp_server_migration_failed_to_fetch_status"
+        case .networkProtectionClientFailedToParseServerStatusResponse: return "m_netp_server_migration_failed_to_parse_response"
+
+        case .networkProtectionServerMigrationAttempt: return "m_netp_ev_server_migration_attempt"
+        case .networkProtectionServerMigrationAttemptSuccess: return "m_netp_ev_server_migration_attempt_success"
+        case .networkProtectionServerMigrationAttemptFailure: return "m_netp_ev_server_migration_attempt_failed"
+
             // MARK: remote messaging pixels
             
         case .remoteMessageShown: return "m_remote_message_shown"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "sam/fast-egress-server-switching";
-				kind = branch;
+				kind = exactVersion;
+				version = 154.0.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -9769,8 +9769,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 153.0.0;
+				branch = "sam/fast-egress-server-switching";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "sam/fast-egress-server-switching",
-        "revision" : "7a1500c2c6d642fb527e5372a0479f95863e422b"
+        "revision" : "961596e889196d29c22d4a8a22a355f5bd2e5586"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "b78ae617c7fe66244741f489158a1f40e567e674",
-        "version" : "153.0.0"
+        "branch" : "sam/fast-egress-server-switching",
+        "revision" : "7a1500c2c6d642fb527e5372a0479f95863e422b"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "sam/fast-egress-server-switching",
-        "revision" : "961596e889196d29c22d4a8a22a355f5bd2e5586"
+        "revision" : "2045f13479f3da34b827198b43ae7a47e01551cf",
+        "version" : "154.0.0"
       }
     },
     {

--- a/DuckDuckGo/EventMapping+NetworkProtectionError.swift
+++ b/DuckDuckGo/EventMapping+NetworkProtectionError.swift
@@ -88,7 +88,9 @@ extension EventMapping where Event == NetworkProtectionError {
                 .wireGuardDnsResolution,
                 .wireGuardSetNetworkSettings,
                 .startWireGuardBackend,
-                .failedToRetrieveAuthToken:
+                .failedToRetrieveAuthToken,
+                .failedToFetchServerStatus,
+                .failedToParseServerStatusResponse:
             pixelEvent = .networkProtectionUnhandledError
             params[PixelParameters.function] = #function
             params[PixelParameters.line] = String(#line)

--- a/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -135,6 +135,15 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             case .failed(let error):
                 DailyPixel.fireDailyAndCount(pixel: .networkProtectionFailureRecoveryFailed, error: error)
             }
+        case .serverMigrationAttempt(let step):
+            switch step {
+            case .begin:
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionServerMigrationAttempt)
+            case .failure(let error):
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionServerMigrationAttemptFailure, error: error)
+            case .success:
+                DailyPixel.fireDailyAndCount(pixel: .networkProtectionServerMigrationAttemptSuccess)
+            }
         }
     }
 
@@ -227,6 +236,12 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 return
             case .failedToParseLocationListResponse:
                 return
+            case .failedToFetchServerStatus(let error):
+                pixelEvent = .networkProtectionClientFailedToFetchServerStatus
+                pixelError = error
+            case .failedToParseServerStatusResponse(let error):
+                pixelEvent = .networkProtectionClientFailedToParseServerStatusResponse
+                pixelError = error
             }
             DailyPixel.fireDailyAndCount(pixel: pixelEvent, error: pixelError, withAdditionalParameters: params)
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1203137811378537/1207555842602667/f
Tech Design URL:
CC:

**Description**:

This PR adds support for fast egress server draining.

All of the real work happens on the BSK side, this PR just wires up events to pixels.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. First, check out this branch and the BSK branch so that you can modify BSK locally
2. In `NetworkProtectionServerStatusMonitor`, change the `minutes(5)` timer to something shorter like `seconds(30)`
3. Now run the app and connect the VPN, and wait a couple minutes - check that the VPN works as expected, and you never get any notification about being reconnected
4. Now we want to simulate a server migration - in `NetworkProtectionClient`, change the `getServerStatus` function to return a hardcoded migration object. In this case, replacing NetworkProtectionClient.swift line 353 with `return .success(NetworkProtectionServerStatus(shouldMigrate: true))` would work
5. Run the VPN again, and check that every 30 seconds the VPN reconnects
6. For bonus points, filter by `Server Status` in Console.app logs and verify that the server status monitor is being stopped and restarted every time this reconnection happens - we need to ensure that the monitor is always checking the current server for the migration to work

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
