### PR TITLE
Revert to the previous label as changes on SERP have been reverted

### DIFF
--- a/.maestro/data_clearing_tests/02_duckduckgo_settings.yml
+++ b/.maestro/data_clearing_tests/02_duckduckgo_settings.yml
@@ -31,7 +31,7 @@ tags:
         - tapOn: "Phew!"
 
 # Change settings
-- tapOn: "Safe search: moderate"
+- tapOn: "Safe search: moderate ▼"
 - tapOn: "Off"
 
 # Fire Button - twice, just to be sure
@@ -54,4 +54,4 @@ tags:
     id: "searchEntry"
 - inputText: "creepy trackers"
 - pressKey: Enter
-- assertVisible: "Safe search: off"
+- assertVisible: "Safe search: off ▼"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207557397285113/f
Tech Design URL:
CC:

**Description**:
Reverting https://github.com/duckduckgo/iOS/pull/2940 as it looks like SERP changes have been reverted. 
<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check CI is green. 
2. Run locally and validate the test succeeds.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
