### PR TITLE
Fall back to accentColor for iOS 15 and below

### DIFF
--- a/DuckDuckGo/AboutView.swift
+++ b/DuckDuckGo/AboutView.swift
@@ -91,8 +91,7 @@ extension View {
         if #available(iOS 16.0, *) {
             tint(color)
         } else {
-            self
+            accentColor(color)
         }
     }
-
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207573264233602/f
Tech Design URL:
CC: @brindy 

**Description**:

`accentColor` was deprecated in favor of `tint`, which should be used as a fallback function for our `tintIfAvailable` function.

**Steps to test this PR**:
Verify if the following places are properly colored:
* Autocomplete (search suggestions)
* Privacy settings items containing "Learn More" link

**Before and after screenshots:**

<img src="https://github.com/duckduckgo/iOS/assets/223346/107984b2-6cc2-4d10-86fa-8b2763fedb85" width=200 /><img src="https://github.com/duckduckgo/iOS/assets/223346/9c0d6dca-5ed5-4e51-9660-f5ebc535db81" width=200 />

<img src="https://github.com/duckduckgo/iOS/assets/223346/a6d02439-b497-4c78-acf1-4f0ae51deb45" width=200 /><img src="https://github.com/duckduckgo/iOS/assets/223346/5191da75-306f-447d-bed9-f65e99e83606" width=200 />

<img src="https://github.com/duckduckgo/iOS/assets/223346/c0c39c14-5f67-41cf-a9a3-05369a96b36c" width=200 /><img src="https://github.com/duckduckgo/iOS/assets/223346/a8c8c06f-a298-463c-b0a1-de15e9b3b185" width=200 />

   
**OS Testing**:

* [x] iOS 15
* [x] iOS 16

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
