### PR TITLE
don't refresh swipe tabs data source if autoclearing

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2414,7 +2414,12 @@ extension MainViewController: AutoClearWorker {
         showBars()
         attachHomeScreen()
         tabsBarController?.refresh(tabsModel: tabManager.model)
-        swipeTabsCoordinator?.refresh(tabsModel: tabManager.model)
+
+        if !autoClearInProgress {
+            // We don't need to refresh tabs if autoclear is in progress as nothing has happened yet
+            swipeTabsCoordinator?.refresh(tabsModel: tabManager.model)
+        }
+
         Favicons.shared.clearCache(.tabs)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207578201865177/f
Tech Design URL:
CC:

**Description**:
Fix problem showing keyboard if auto clear and show keyboard on app launch is set

**Steps to test this PR**:
1. Turn on auto clear after 5 minutes and turn on keyboard on app launch
2. Update `shouldClearData` Autoclear.swift so that 5 minutes is just 5 seconds
3. Load a page 
4. Kill the app
5. Launch the app
6. Data should be cleared and keyboard should show (remember if you're in the simulator to make sure it's visible by default and that using the hardware keyboard will dismiss it)
7. Load another page
8. Background the app and wait for > 20 seconds (the threshold for the keyboard on app launch is is 20 seconds)
9. Foreground the app
10. Data should be cleared and the keyboard should show 
11. Smoke test regular data clearing activities
