### PR TITLE
Disable ad attribution reporting

### DIFF
--- a/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
+++ b/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
@@ -26,7 +26,7 @@ protocol PixelFiring {
 
 final class AdAttributionPixelReporter {
 
-    static let isAdAttributionReportingEnabled = true
+    static let isAdAttributionReportingEnabled = false
 
     static var shared = AdAttributionPixelReporter()
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1206226850447395/1206713899329024/f
Tech Design URL:
CC:

**Description**:

Disabling ad attribution reporting, effectively causing the pixel to stop being sent. I don't want to make bigger changes in pending release, so I'll plan a bigger cleanup for next week (see https://app.asana.com/0/0/1205960777889069/f).

**Steps to test this PR**:
1. Make sure `reportAttributionIfNeeded` is not being called.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
