### PR TITLE
Use search term as title for search related history items in suggestions

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "8dabf4495ba93aaab87640b68240f7420e3ce4f9",
-        "version" : "159.0.1"
+        "revision" : "28687a848cff47267e64e3bfcdf5c92effbee5ce",
+        "version" : "159.0.2"
       }
     },
     {

--- a/DuckDuckGo/AutocompleteView.swift
+++ b/DuckDuckGo/AutocompleteView.swift
@@ -199,15 +199,25 @@ private struct SuggestionView: View {
                 SuggestionListItem(icon: Image("Globe-24"),
                                    title: url.formattedForSuggestion())
 
-            case .bookmark(let title, let url, let isFavorite, _):
-                SuggestionListItem(icon: Image(isFavorite ? "Bookmark-Fav-24" :"Bookmark-24"),
+            case .bookmark(let title, let url, let isFavorite, _) where isFavorite:
+                SuggestionListItem(icon: Image("Bookmark-Fav-24"),
                                    title: title,
                                    subtitle: url.formattedForSuggestion())
+
+            case .bookmark(let title, let url, _, _):
+                SuggestionListItem(icon: Image("Bookmark-24"),
+                                   title: title,
+                                   subtitle: url.formattedForSuggestion())
+
+            case .historyEntry(_, let url, _) where url.isDuckDuckGoSearch:
+                SuggestionListItem(icon: Image("History-24"),
+                                   title: url.searchQuery ?? "",
+                                   subtitle: UserText.autocompleteSearchDuckDuckGo)
 
             case .historyEntry(let title, let url, _):
                 SuggestionListItem(icon: Image("History-24"),
                                    title: title ?? "",
-                                   subtitle: url.isDuckDuckGoSearch ? UserText.autocompleteSearchDuckDuckGo : url.formattedForSuggestion())
+                                   subtitle: url.formattedForSuggestion())
 
             case .internalPage, .unknown:
                 FailedAssertionView("Unknown or unsupported suggestion type")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207625167306167/f
Tech Design URL:
CC:

**Description**:
Just use the search term as the title for search history and explode switch to be more explicit.

**Steps to test this PR**:
1. Ensure recently visited sites enabled (internal user and setting enabled)
2. Perform a search
3. Type search into field again -> should show the search term only as the history item title with 'search DuckDuckGo' as the subtitle
4. Visit a page
5. Ensure that page appears in history
6. Check that bookmarks and favorites appear as such in suggestions
