### PR TITLE
don't attach a new home screen if autoclear is in progress

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -726,6 +726,8 @@ class MainViewController: UIViewController {
     }
     
     fileprivate func attachHomeScreen() {
+        guard !autoClearInProgress else { return }
+        
         viewCoordinator.logoContainer.isHidden = false
         findInPageView.isHidden = true
         chromeManager.detach()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207536057103452/f
Tech Design URL:
CC:

**Description**:
With auto clear enabled the Home Screen is attached twice.

**Steps to test this PR**:
1. Enable to autoclear. 
2. Load some pages.
3. Kill the app and restart it. 
4. `mh` pixel should only be fired once.
5. Repeat above with autoclear expiry
6. Turn off autoclear
7. Load some pages
8. Background the app and wait 30 seconds
9. Foreground the app, make sure app state is as expected
10. Kill the app and relaunch, make sure app state is expected
11. Retest with no pages loaded. `mh` should only fire once.
