### PR TITLE
Re-add the autocomplete settings toggle pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -656,12 +656,12 @@ extension Pixel {
         case settingsWebTrackingProtectionOpen
         case settingsGpcOn
         case settingsGpcOff
-        case settingsAutocompleteOn
-        case settingsAutocompleteOff
-        case settingsRecentlyVisitedOn
-        case settingsRecentlyVisitedOff
         case settingsGeneralAutocompleteOn
         case settingsGeneralAutocompleteOff
+        case settingsPrivateSearchAutocompleteOn
+        case settingsPrivateSearchAutocompleteOff
+        case settingsRecentlyVisitedOn
+        case settingsRecentlyVisitedOff
         case settingsAddressBarSelectorPressed
         case settingsAccessibilityOpen
         case settingsAccessiblityTextSize
@@ -1335,12 +1335,12 @@ extension Pixel.Event {
         case .settingsWebTrackingProtectionOpen: return "m_settings_web_tracking_protection_open"
         case .settingsGpcOn: return "m_settings_gpc_on"
         case .settingsGpcOff: return "m_settings_gpc_off"
-        case .settingsAutocompleteOn: return "m_settings_autocomplete_on"
-        case .settingsAutocompleteOff: return "m_settings_autocomplete_off"
-        case .settingsRecentlyVisitedOn: return "m_settings_autocomplete_recently-visited_on"
-        case .settingsRecentlyVisitedOff: return "m_settings_autocomplete_recently-visited_off"
         case .settingsGeneralAutocompleteOn: return "m_settings_general_autocomplete_on"
         case .settingsGeneralAutocompleteOff: return "m_settings_general_autocomplete_off"
+        case .settingsPrivateSearchAutocompleteOn: return "m_settings_private_search_autocomplete_on"
+        case .settingsPrivateSearchAutocompleteOff: return "m_settings_private_search_autocomplete_off"
+        case .settingsRecentlyVisitedOn: return "m_settings_autocomplete_recently-visited_on"
+        case .settingsRecentlyVisitedOff: return "m_settings_autocomplete_recently-visited_off"
         case .settingsAddressBarSelectorPressed: return "m_settings_address_bar_selector_pressed"
         case .settingsAccessibilityOpen: return "m_settings_accessibility_open"
         case .settingsAccessiblityTextSize: return "m_settings_accessiblity_text_size"

--- a/DuckDuckGo/PrivateSearchView.swift
+++ b/DuckDuckGo/PrivateSearchView.swift
@@ -51,9 +51,8 @@ struct PrivateSearchViewSettings: View {
         Section(footer: Text(UserText.settingsAutocompleteSubtitle)) {
             // Autocomplete Suggestions
             SettingsCellView(label: UserText.settingsAutocompleteLabel,
-                             accesory: .toggle(isOn: viewModel.autocompleteBinding))
+                             accesory: .toggle(isOn: viewModel.autocompletePrivateSearchBinding))
         }
-
 
         if viewModel.shouldShowRecentlyVisitedSites {
             Section(footer: Text(UserText.settingsAutocompleteRecentlyVisitedSubtitle)) {

--- a/DuckDuckGo/SettingsGeneralView.swift
+++ b/DuckDuckGo/SettingsGeneralView.swift
@@ -39,7 +39,7 @@ struct SettingsGeneralView: View {
                     footer: Text(UserText.settingsAutocompleteSubtitle)) {
                 // Autocomplete Suggestions
                 SettingsCellView(label: UserText.settingsAutocompleteLabel,
-                                 accesory: .toggle(isOn: viewModel.autocompleteBinding))
+                                 accesory: .toggle(isOn: viewModel.autocompleteGeneralBinding))
             }
 
             if viewModel.shouldShowRecentlyVisitedSites {

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -31,6 +31,7 @@ import Subscription
 import NetworkProtection
 #endif
 
+// swiftlint:disable type_body_length
 final class SettingsViewModel: ObservableObject {
 
     // Dependencies
@@ -344,6 +345,7 @@ final class SettingsViewModel: ObservableObject {
         subscriptionSignOutObserver = nil
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: Private methods
 extension SettingsViewModel {

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -154,13 +154,36 @@ final class SettingsViewModel: ObservableObject {
         )
     }
 
-    var autocompleteBinding: Binding<Bool> {
+    var autocompleteGeneralBinding: Binding<Bool> {
         Binding<Bool>(
             get: { self.state.autocomplete },
             set: {
                 self.appSettings.autocomplete = $0
                 self.state.autocomplete = $0
                 self.updateRecentlyVisitedSitesVisibility()
+                
+                if $0 {
+                    Pixel.fire(pixel: .settingsGeneralAutocompleteOn)
+                } else {
+                    Pixel.fire(pixel: .settingsGeneralAutocompleteOff)
+                }
+            }
+        )
+    }
+
+    var autocompletePrivateSearchBinding: Binding<Bool> {
+        Binding<Bool>(
+            get: { self.state.autocomplete },
+            set: {
+                self.appSettings.autocomplete = $0
+                self.state.autocomplete = $0
+                self.updateRecentlyVisitedSitesVisibility()
+
+                if $0 {
+                    Pixel.fire(pixel: .settingsPrivateSearchAutocompleteOn)
+                } else {
+                    Pixel.fire(pixel: .settingsPrivateSearchAutocompleteOff)
+                }
             }
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207656851886242/f
Tech Design URL:
CC:

**Description**:
Re-add the autocomplete settings toggle pixels which were removed accidentally during a clean up.

**Steps to test this PR**:
1. Go to settings 
2. Toggle autocomplete on and off in general 
3. Toggle autocomplete on and off in private search
4. Ensure correct pixel is fired for each state
