### PR TITLE
Fixes goBack() behavior

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -724,23 +724,30 @@ class TabViewController: UIViewController {
     func goBack() {
         dismissJSAlertIfNeeded()
         
-        if let handler = youtubeNavigationHandler {
+        if let url = url, url.isDuckPlayer, let handler = youtubeNavigationHandler {
             handler.goBack(webView: webView)
             chromeDelegate?.omniBar.resignFirstResponder()
-        } else {
-            if isError {
-                hideErrorMessage()
-                url = webView.url
-                onWebpageDidStartLoading(httpsForced: false)
-                onWebpageDidFinishLoading()
-            } else if webView.canGoBack {
-                webView.goBack()
-                chromeDelegate?.omniBar.resignFirstResponder()
-            } else if openingTab != nil {
-                delegate?.tabDidRequestClose(self)
-            }
+            return
         }
 
+        if isError {
+            hideErrorMessage()
+            url = webView.url
+            onWebpageDidStartLoading(httpsForced: false)
+            onWebpageDidFinishLoading()
+            return
+        }
+
+        if webView.canGoBack {
+            webView.goBack()
+            chromeDelegate?.omniBar.resignFirstResponder()
+            return
+        }
+
+        if openingTab != nil {
+            delegate?.tabDidRequestClose(self)
+        }
+        
     }
     
     func goForward() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207663375808651/f

**Description**:
- Fixes an issue caused by incomplete logic for the goBack() behavior when implementing DuckPlayer
- Cleans up the goBack() method for clarity and early returns (remove if/else)

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Navigate to https://privacy-test-pages.site/
2. Click "Link Open In a New Window" from Browser Features Section
3. Click "Opens in new Window"
4. Hit the "Back button"
5. Confirm the tab is closed and you're back int he previous one. (Only two tabs are open)

Alternatively, run maestro tests for browser features:

➜  iOS git:(main) maestro test .maestro/browser_features 
```
Running on iPhone (17.4) - iOS 17.4 - D1F122BF-1A9D-4B6B-9AD9-A6F088DD51A0

Waiting for flows to complete...

[Passed] search_bar (53s)
[Passed] opening_tabs (58s)
[Passed] swipe_tabs (47s)

3/3 Flows Passed in 2m 38s
```

###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
