### PR TITLE
Fire a pixel when removing the VPN configuration

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -1106,6 +1106,7 @@ extension Pixel.Event {
         case .networkProtectionDNSUpdateDefault: return "m_netp_ev_update_dns_default"
 
         case .networkProtectionVPNConfigurationRemoved: return "m_netp_vpn_configuration_removed"
+        case .networkProtectionVPNConfigurationRemovalFailed: return "m_netp_vpn_configuration_removal_failed"
 
             // MARK: remote messaging pixels
             

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -416,6 +416,9 @@ extension Pixel {
         case networkProtectionDNSUpdateCustom
         case networkProtectionDNSUpdateDefault
 
+        case networkProtectionVPNConfigurationRemoved
+        case networkProtectionVPNConfigurationRemovalFailed
+
         // MARK: remote messaging pixels
         
         case remoteMessageShown
@@ -1101,6 +1104,8 @@ extension Pixel.Event {
 
         case .networkProtectionDNSUpdateCustom: return "m_netp_ev_update_dns_custom"
         case .networkProtectionDNSUpdateDefault: return "m_netp_ev_update_dns_default"
+
+        case .networkProtectionVPNConfigurationRemoved: return "m_netp_vpn_configuration_removed"
 
             // MARK: remote messaging pixels
             

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -512,8 +512,6 @@ import WebKit
 #if NETWORK_PROTECTION
         widgetRefreshModel.refreshVPNWidget()
 
-        stopTunnelAndShowThankYouMessagingIfNeeded()
-
         if tunnelDefaults.showEntitlementAlert {
             presentExpiredEntitlementAlert()
         }
@@ -521,6 +519,7 @@ import WebKit
         presentExpiredEntitlementNotificationIfNeeded()
 
         Task {
+            await stopAndRemoveVPNIfNotAuthenticated()
             await refreshShortcuts()
             await vpnWorkaround.installRedditSessionWorkaround()
         }
@@ -536,25 +535,14 @@ import WebKit
         importPasswordsStatusHandler.checkSyncSuccessStatus()
     }
 
-    private func stopTunnelAndShowThankYouMessagingIfNeeded() {
-        if accountManager.isUserAuthenticated {
-            return
-        }
-
-        if AppDependencyProvider.shared.vpnFeatureVisibility.isPrivacyProLaunched() && !accountManager.isUserAuthenticated {
-            Task {
-                await self.stopAndRemoveVPN(with: "subscription-check")
-            }
-        }
-    }
-
-    private func stopAndRemoveVPN(with reason: String) async {
-        guard await AppDependencyProvider.shared.networkProtectionTunnelController.isInstalled else {
+    private func stopAndRemoveVPNIfNotAuthenticated() async {
+        // Only remove the VPN if the user is not authenticated, and it's installed:
+        guard !accountManager.isUserAuthenticated, await AppDependencyProvider.shared.networkProtectionTunnelController.isInstalled else {
             return
         }
 
         await AppDependencyProvider.shared.networkProtectionTunnelController.stop()
-        await AppDependencyProvider.shared.networkProtectionTunnelController.removeVPN()
+        await AppDependencyProvider.shared.networkProtectionTunnelController.removeVPN(reason: .didBecomeActiveCheck)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1503,7 +1503,7 @@ class MainViewController: UIViewController {
             }
 
             await networkProtectionTunnelController.stop()
-            await networkProtectionTunnelController.removeVPN()
+            await networkProtectionTunnelController.removeVPN(reason: .entitlementCheck)
         }
     }
 
@@ -1511,7 +1511,7 @@ class MainViewController: UIViewController {
     private func onNetworkProtectionAccountSignOut(_ notification: Notification) {
         Task {
             await networkProtectionTunnelController.stop()
-            await networkProtectionTunnelController.removeVPN()
+            await networkProtectionTunnelController.removeVPN(reason: .signedOut)
         }
     }
 #endif

--- a/DuckDuckGo/NetworkProtectionDebugViewController.swift
+++ b/DuckDuckGo/NetworkProtectionDebugViewController.swift
@@ -700,7 +700,7 @@ shouldShowVPNShortcut: \(vpnVisibility.shouldShowVPNShortcut() ? "YES" : "NO")
     private func deleteVPNConfiguration() {
         Task {
             await AppDependencyProvider.shared.networkProtectionTunnelController.stop()
-            await AppDependencyProvider.shared.networkProtectionTunnelController.removeVPN()
+            await AppDependencyProvider.shared.networkProtectionTunnelController.removeVPN(reason: .debugMenu)
         }
     }
 }

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -114,8 +114,25 @@ final class NetworkProtectionTunnelController: TunnelController {
         tunnelManager.connection.stopVPNTunnel()
     }
 
-    func removeVPN() async {
-        try? await tunnelManager?.removeFromPreferences()
+    enum RemovalReason: String {
+        case didBecomeActiveCheck
+        case entitlementCheck
+        case signedOut
+        case debugMenu
+    }
+
+    func removeVPN(reason: RemovalReason) async {
+        do {
+            try await tunnelManager?.removeFromPreferences()
+
+            Pixel.fire(pixel: .networkProtectionVPNConfigurationRemoved, withAdditionalParameters: [
+                "reason": reason.rawValue
+            ])
+        } catch {
+            Pixel.fire(pixel: .networkProtectionVPNConfigurationRemovalFailed, withAdditionalParameters: [
+                "reason": reason.rawValue
+            ])
+        }
     }
 
     // MARK: - Connection Status Querying

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -125,12 +125,12 @@ final class NetworkProtectionTunnelController: TunnelController {
         do {
             try await tunnelManager?.removeFromPreferences()
 
-            Pixel.fire(pixel: .networkProtectionVPNConfigurationRemoved, withAdditionalParameters: [
-                "reason": reason.rawValue
+            DailyPixel.fireDailyAndCount(pixel: .networkProtectionVPNConfigurationRemoved, withAdditionalParameters: [
+                PixelParameters.reason: reason.rawValue
             ])
         } catch {
-            Pixel.fire(pixel: .networkProtectionVPNConfigurationRemovalFailed, withAdditionalParameters: [
-                "reason": reason.rawValue
+            DailyPixel.fireDailyAndCount(pixel: .networkProtectionVPNConfigurationRemovalFailed, error: error, withAdditionalParameters: [
+                PixelParameters.reason: reason.rawValue
             ])
         }
     }

--- a/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -26,6 +26,13 @@ import NetworkExtension
 import NetworkProtection
 import Subscription
 
+enum VPNConfigurationRemovalReason: String {
+    case didBecomeActiveCheck
+    case entitlementCheck
+    case signedOut
+    case debugMenu
+}
+
 final class NetworkProtectionTunnelController: TunnelController {
     static var shouldSimulateFailure: Bool = false
 
@@ -114,14 +121,7 @@ final class NetworkProtectionTunnelController: TunnelController {
         tunnelManager.connection.stopVPNTunnel()
     }
 
-    enum RemovalReason: String {
-        case didBecomeActiveCheck
-        case entitlementCheck
-        case signedOut
-        case debugMenu
-    }
-
-    func removeVPN(reason: RemovalReason) async {
+    func removeVPN(reason: VPNConfigurationRemovalReason) async {
         do {
             try await tunnelManager?.removeFromPreferences()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207698850203829/f
Tech Design URL:
CC:

**Description**:

This PR adds a pixel that reports when the VPN configuration has been removed, and why.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Install the VPN and then sign out of Privacy Pro
2. Check that you see a pixel in the logs, and that the configuration was removed
3. Check the codebase to make sure we aren't calling `removeFromPreferences()` anywhere outside of the tunnel controller, to make sure there are no paths that aren't covered by the pixel
4. Check that the removal reasons make sense

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
