### PR TITLE
Integrate RemoteMessaging with NewTabPage

### DIFF
--- a/Core/PixelFiring.swift
+++ b/Core/PixelFiring.swift
@@ -1,0 +1,50 @@
+//
+//  PixelFiring.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Networking
+
+public protocol PixelFiring {
+
+    static func fire(_ pixel: Pixel.Event,
+                     withAdditionalParameters params: [String: String],
+                     includedParameters: [Pixel.QueryParameters],
+                     onComplete: @escaping (Error?) -> Void)
+
+    static func fire(_ pixel: Pixel.Event,
+                     withAdditionalParameters params: [String: String])
+}
+
+extension Pixel: PixelFiring {
+    public static func fire(_ pixel: Pixel.Event,
+                            withAdditionalParameters params: [String: String],
+                            includedParameters: [Pixel.QueryParameters],
+                            onComplete: @escaping (Error?) -> Void) {
+        
+        Pixel.fire(pixel: pixel,
+                   withAdditionalParameters: params,
+                   includedParameters: includedParameters,
+                   onComplete: onComplete)
+    }
+
+    public static func fire(_ pixel: Pixel.Event,
+                            withAdditionalParameters params: [String: String]) {
+        Pixel.fire(pixel: pixel, withAdditionalParameters: params)
+    }
+}

--- a/Core/PixelFiringAsync.swift
+++ b/Core/PixelFiringAsync.swift
@@ -1,0 +1,43 @@
+//
+//  PixelFiringAsync.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public protocol PixelFiringAsync {
+    static func fire(pixel: Pixel.Event,
+                     withAdditionalParameters params: [String: String],
+                     includedParameters: [Pixel.QueryParameters]) async throws
+}
+
+extension Pixel: PixelFiringAsync {
+    public static func fire(pixel: Event,
+                            withAdditionalParameters params: [String: String],
+                            includedParameters: [QueryParameters]) async throws {
+        
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            Pixel.fire(pixel: pixel, withAdditionalParameters: params, includedParameters: includedParameters) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -252,6 +252,9 @@
 		6AC98419288055C1005FA9CA /* BarsAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */; };
 		6F03CAFC2C32C6F6004179A8 /* NewTabPageMessagesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */; };
 		6F03CAFE2C32DD08004179A8 /* HomePageMessagesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */; };
+		6F03CB052C32EFCC004179A8 /* MockPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB032C32EFA8004179A8 /* MockPixelFiring.swift */; };
+		6F03CB072C32F173004179A8 /* PixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB062C32F173004179A8 /* PixelFiring.swift */; };
+		6F03CB092C32F331004179A8 /* PixelFiringAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB082C32F331004179A8 /* PixelFiringAsync.swift */; };
 		6F5CC0812C2AFFE400AFC840 /* ToggleExpandButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonView.swift */; };
 		6F655BE22BAB289E00AC3597 /* DefaultTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F655BE12BAB289E00AC3597 /* DefaultTheme.swift */; };
 		6F8496412BC3D8EE00ADA54E /* OnboardingButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */; };
@@ -1358,6 +1361,9 @@
 		6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimatorTests.swift; sourceTree = "<group>"; };
 		6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageMessagesModel.swift; sourceTree = "<group>"; };
 		6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageMessagesConfiguration.swift; sourceTree = "<group>"; };
+		6F03CB032C32EFA8004179A8 /* MockPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPixelFiring.swift; sourceTree = "<group>"; };
+		6F03CB062C32F173004179A8 /* PixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFiring.swift; sourceTree = "<group>"; };
+		6F03CB082C32F331004179A8 /* PixelFiringAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFiringAsync.swift; sourceTree = "<group>"; };
 		6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleExpandButtonView.swift; sourceTree = "<group>"; };
 		6F655BE12BAB289E00AC3597 /* DefaultTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTheme.swift; sourceTree = "<group>"; };
 		6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButtonsView.swift; sourceTree = "<group>"; };
@@ -4819,6 +4825,8 @@
 				CB2A7EF028410DF700885F67 /* PixelEvent.swift */,
 				BDC234F62B27F51100D3C798 /* UniquePixel.swift */,
 				853A717520F62FE800FE60BC /* Pixel.swift */,
+				6F03CB062C32F173004179A8 /* PixelFiring.swift */,
+				6F03CB082C32F331004179A8 /* PixelFiringAsync.swift */,
 				1E05D1D729C46EDA00BF9A1F /* TimedPixel.swift */,
 				1E05D1D529C46EBB00BF9A1F /* DailyPixel.swift */,
 				85E242162AB1B54D000F3E28 /* ReturnUserMeasurement.swift */,
@@ -5184,6 +5192,7 @@
 				CBDD5DE029A6741300832877 /* MockBundle.swift */,
 				C1B0F6412AB08BE9001EAF05 /* MockPrivacyConfiguration.swift */,
 				C185ED652BD43A5500BAE9DC /* MockDDGSyncing.swift */,
+				6F03CB032C32EFA8004179A8 /* MockPixelFiring.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -7002,6 +7011,7 @@
 				31B1FA87286EFC5C00CA3C1C /* XCTestCaseExtension.swift in Sources */,
 				D62EC3BC2C2470E000FC9D04 /* DuckPlayerTests.swift in Sources */,
 				1E8146AE28C8ABF400D1AF63 /* PrivacyIconLogicTests.swift in Sources */,
+				6F03CB052C32EFCC004179A8 /* MockPixelFiring.swift in Sources */,
 				987130C4294AAB9F00AB05E0 /* FavoriteListViewModelTests.swift in Sources */,
 				8565A34D1FC8DFE400239327 /* LaunchTabNotificationTests.swift in Sources */,
 				310E79BD2949CAA5007C49E8 /* FireButtonReferenceTests.swift in Sources */,
@@ -7229,6 +7239,7 @@
 				85CA53AA24BB376800A6288C /* NotFoundCachingDownloader.swift in Sources */,
 				4B60ACA1252EC0B100E8D219 /* FullScreenVideoUserScript.swift in Sources */,
 				F1A886781F29394E0096251E /* WebCacheManager.swift in Sources */,
+				6F03CB072C32F173004179A8 /* PixelFiring.swift in Sources */,
 				C14882DA27F2011C00D59F0C /* BookmarksExporter.swift in Sources */,
 				854858E32937BC550063610B /* CollectionExtension.swift in Sources */,
 				1E6A4D692984208800A371D3 /* LocaleExtension.swift in Sources */,
@@ -7256,6 +7267,7 @@
 				836A941D247F23C600BF8EF5 /* UserAgentManager.swift in Sources */,
 				85CA53A824BB343700A6288C /* Favicons.swift in Sources */,
 				F143C3181E4A99D200CFDE3A /* Link.swift in Sources */,
+				6F03CB092C32F331004179A8 /* PixelFiringAsync.swift in Sources */,
 				1E61BC2A27074BED00B2854D /* TextSizeUserScript.swift in Sources */,
 				37CEFCAC2A673B90001EF741 /* CredentialsCleanupErrorHandling.swift in Sources */,
 				CB2A7EF128410DF700885F67 /* PixelEvent.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -250,6 +250,8 @@
 		56D8556C2BEA91C4009F9698 /* SyncAlertsPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D8556B2BEA91C4009F9698 /* SyncAlertsPresenting.swift */; };
 		6AC6DAB328804F97002723C0 /* BarsAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC6DAB228804F97002723C0 /* BarsAnimator.swift */; };
 		6AC98419288055C1005FA9CA /* BarsAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */; };
+		6F03CAFC2C32C6F6004179A8 /* NewTabPageMessagesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */; };
+		6F03CAFE2C32DD08004179A8 /* HomePageMessagesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */; };
 		6F5CC0812C2AFFE400AFC840 /* ToggleExpandButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonView.swift */; };
 		6F655BE22BAB289E00AC3597 /* DefaultTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F655BE12BAB289E00AC3597 /* DefaultTheme.swift */; };
 		6F8496412BC3D8EE00ADA54E /* OnboardingButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */; };
@@ -1354,6 +1356,8 @@
 		56D8556B2BEA91C4009F9698 /* SyncAlertsPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAlertsPresenting.swift; sourceTree = "<group>"; };
 		6AC6DAB228804F97002723C0 /* BarsAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimator.swift; sourceTree = "<group>"; };
 		6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimatorTests.swift; sourceTree = "<group>"; };
+		6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageMessagesModel.swift; sourceTree = "<group>"; };
+		6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageMessagesConfiguration.swift; sourceTree = "<group>"; };
 		6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleExpandButtonView.swift; sourceTree = "<group>"; };
 		6F655BE12BAB289E00AC3597 /* DefaultTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTheme.swift; sourceTree = "<group>"; };
 		6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButtonsView.swift; sourceTree = "<group>"; };
@@ -3377,6 +3381,14 @@
 			name = Mock;
 			sourceTree = "<group>";
 		};
+		6F03CAF82C32C3AA004179A8 /* Messages */ = {
+			isa = PBXGroup;
+			children = (
+				6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */,
+			);
+			name = Messages;
+			sourceTree = "<group>";
+		};
 		6FB1FE9C2C24D4060075B68B /* NewTabPageSectionsDebugView */ = {
 			isa = PBXGroup;
 			children = (
@@ -3408,6 +3420,7 @@
 		6FE127362C20436A00EB5724 /* HomeRedesign */ = {
 			isa = PBXGroup;
 			children = (
+				6F03CAF82C32C3AA004179A8 /* Messages */,
 				6FE127372C20492500EB5724 /* NewTabPage.swift */,
 				6FE127392C204BD000EB5724 /* NewTabPageView.swift */,
 				6FE127452C2054A900EB5724 /* NewTabPageViewController.swift */,
@@ -4964,6 +4977,7 @@
 				853C5F5A21BFF0AE001F7A05 /* HomeCollectionView.swift */,
 				F1E90C1F1E678E7C005E7E21 /* HomeControllerDelegate.swift */,
 				85058365219AE9EA00ED4EDB /* HomePageConfiguration.swift */,
+				6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */,
 				F16390811E648B7A005B4550 /* HomeViewController.swift */,
 				85058367219C49E000ED4EDB /* HomeViewSectionRenderers.swift */,
 				85C861E528FF1B5F00189466 /* HomeViewSectionRenderersExtension.swift */,
@@ -6458,6 +6472,7 @@
 				8540BD5423D8D5080057FDD2 /* PreserveLoginsAlert.swift in Sources */,
 				F15E9F3E2BEE128200DEFDDE /* SubscriptionManageriOS14.swift in Sources */,
 				1E87615928A1517200C7C5CE /* PrivacyDashboardViewController.swift in Sources */,
+				6F03CAFE2C32DD08004179A8 /* HomePageMessagesConfiguration.swift in Sources */,
 				EE9D68D12AE00CF300B55EF4 /* NetworkProtectionVPNSettingsView.swift in Sources */,
 				319A371028299A850079FBCE /* PasswordHider.swift in Sources */,
 				982C87C42255559A00919035 /* UITableViewCellExtension.swift in Sources */,
@@ -6931,6 +6946,7 @@
 				1E4DCF4A27B6A38000961E25 /* DownloadListRepresentable.swift in Sources */,
 				1DEAADFB2BA71E9A00E25A97 /* SettingsPrivacyProtectionDescriptionView.swift in Sources */,
 				2DC3FC65C6D9DA634426672D /* AutofillNoAuthAvailableView.swift in Sources */,
+				6F03CAFC2C32C6F6004179A8 /* NewTabPageMessagesModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		6AC98419288055C1005FA9CA /* BarsAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */; };
 		6F03CAFC2C32C6F6004179A8 /* NewTabPageMessagesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */; };
 		6F03CAFE2C32DD08004179A8 /* HomePageMessagesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */; };
+		6F03CB022C32ED47004179A8 /* NewTabPageMessagesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB002C32ED42004179A8 /* NewTabPageMessagesModelTests.swift */; };
 		6F03CB052C32EFCC004179A8 /* MockPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB032C32EFA8004179A8 /* MockPixelFiring.swift */; };
 		6F03CB072C32F173004179A8 /* PixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB062C32F173004179A8 /* PixelFiring.swift */; };
 		6F03CB092C32F331004179A8 /* PixelFiringAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F03CB082C32F331004179A8 /* PixelFiringAsync.swift */; };
@@ -1361,6 +1362,7 @@
 		6AC98418288055C1005FA9CA /* BarsAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarsAnimatorTests.swift; sourceTree = "<group>"; };
 		6F03CAFB2C32C6F6004179A8 /* NewTabPageMessagesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageMessagesModel.swift; sourceTree = "<group>"; };
 		6F03CAFD2C32DD08004179A8 /* HomePageMessagesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageMessagesConfiguration.swift; sourceTree = "<group>"; };
+		6F03CB002C32ED42004179A8 /* NewTabPageMessagesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageMessagesModelTests.swift; sourceTree = "<group>"; };
 		6F03CB032C32EFA8004179A8 /* MockPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPixelFiring.swift; sourceTree = "<group>"; };
 		6F03CB062C32F173004179A8 /* PixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFiring.swift; sourceTree = "<group>"; };
 		6F03CB082C32F331004179A8 /* PixelFiringAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFiringAsync.swift; sourceTree = "<group>"; };
@@ -3395,6 +3397,14 @@
 			name = Messages;
 			sourceTree = "<group>";
 		};
+		6F03CAFF2C32ED22004179A8 /* NewTabPage */ = {
+			isa = PBXGroup;
+			children = (
+				6F03CB002C32ED42004179A8 /* NewTabPageMessagesModelTests.swift */,
+			);
+			name = NewTabPage;
+			sourceTree = "<group>";
+		};
 		6FB1FE9C2C24D4060075B68B /* NewTabPageSectionsDebugView */ = {
 			isa = PBXGroup;
 			children = (
@@ -4931,6 +4941,7 @@
 		F12D98401F266B30003C2EE3 /* DuckDuckGo */ = {
 			isa = PBXGroup;
 			children = (
+				6F03CAFF2C32ED22004179A8 /* NewTabPage */,
 				569437222BDD402600C0881B /* Sync */,
 				6FF9157F2B88E04F0042AC87 /* AdAttribution */,
 				CB48D3342B90CEBD00631D8B /* UserBehaviorMonitor */,
@@ -7081,6 +7092,7 @@
 				317045C02858C6B90016ED1F /* AutofillInterfaceEmailTruncatorTests.swift in Sources */,
 				6FD3AEE32B8F4EEB0060FCCC /* AdAttributionPixelReporterTests.swift in Sources */,
 				987130C6294AAB9F00AB05E0 /* BookmarkListViewModelTests.swift in Sources */,
+				6F03CB022C32ED47004179A8 /* NewTabPageMessagesModelTests.swift in Sources */,
 				F1134ED21F40EF3A00B73467 /* JsonTestDataLoader.swift in Sources */,
 				850250B520D80419002199C7 /* AtbAndVariantCleanupTests.swift in Sources */,
 				834DF992248FDE1A0075EA48 /* UserAgentTests.swift in Sources */,

--- a/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
+++ b/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
@@ -20,10 +20,6 @@
 import Foundation
 import Core
 
-protocol PixelFiring {
-    static func fire(pixel: Pixel.Event, withAdditionalParameters params: [String: String], includedParameters: [Pixel.QueryParameters]) async throws
-}
-
 final actor AdAttributionPixelReporter {
 
     static let isAdAttributionReportingEnabled = false
@@ -32,12 +28,12 @@ final actor AdAttributionPixelReporter {
 
     private var fetcherStorage: AdAttributionReporterStorage
     private let attributionFetcher: AdAttributionFetcher
-    private let pixelFiring: PixelFiring.Type
+    private let pixelFiring: PixelFiringAsync.Type
     private var isSendingAttribution: Bool = false
 
     init(fetcherStorage: AdAttributionReporterStorage = UserDefaultsAdAttributionReporterStorage(),
          attributionFetcher: AdAttributionFetcher = DefaultAdAttributionFetcher(),
-         pixelFiring: PixelFiring.Type = Pixel.self) {
+         pixelFiring: PixelFiringAsync.Type = Pixel.self) {
         self.fetcherStorage = fetcherStorage
         self.attributionFetcher = attributionFetcher
         self.pixelFiring = pixelFiring
@@ -94,20 +90,5 @@ final actor AdAttributionPixelReporter {
         params[PixelParameters.adAttributionAdID] = attribution.adId.map(String.init)
 
         return params
-    }
-}
-
-extension Pixel: PixelFiring {
-    static func fire(pixel: Event, withAdditionalParameters params: [String: String], includedParameters: [QueryParameters]) async throws {
-
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            Pixel.fire(pixel: pixel, withAdditionalParameters: params, includedParameters: includedParameters) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
     }
 }

--- a/DuckDuckGo/HomePageConfiguration.swift
+++ b/DuckDuckGo/HomePageConfiguration.swift
@@ -24,7 +24,7 @@ import Common
 import Core
 import Bookmarks
 
-final class HomePageConfiguration {
+final class HomePageConfiguration: HomePageMessagesConfiguration {
     
     enum Component: Equatable {
         case navigationBarSearch(fixed: Bool)

--- a/DuckDuckGo/HomePageMessagesConfiguration.swift
+++ b/DuckDuckGo/HomePageMessagesConfiguration.swift
@@ -1,0 +1,29 @@
+//
+//  HomePageMessagesConfiguration.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+protocol HomePageMessagesConfiguration {
+    var homeMessages: [HomeMessage] { get }
+
+    func refresh()
+    
+    func dismissHomeMessage(_ homeMessage: HomeMessage)
+    func didAppear(_ homeMessage: HomeMessage)
+}

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -748,7 +748,7 @@ class MainViewController: UIViewController {
         }
 
         if homeTabManager.isNewTabPageSectionsEnabled {
-            let controller = NewTabPageViewController(rootView: NewTabPageView(favoritesModel: FavoritesModel()))
+            let controller = NewTabPageViewController()
             newTabPageViewController = controller
             addToContentContainer(controller: controller)
             viewCoordinator.logoContainer.isHidden = true

--- a/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -85,28 +85,28 @@ final class NewTabPageMessagesModel: ObservableObject {
                         let self else { return }
 
                 switch action {
-                    
+
                 case .action(let isSharing):
                     if !isSharing {
                         self.dismissHomeMessage(message)
                     }
                     pixelFiring.fire(.remoteMessageActionClicked,
                                      withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
-                    
+
                 case .primaryAction(let isSharing):
                     if !isSharing {
                         self.dismissHomeMessage(message)
                     }
                     pixelFiring.fire(.remoteMessagePrimaryActionClicked,
                                      withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
-                    
+
                 case .secondaryAction(let isSharing):
                     if !isSharing {
                         self.dismissHomeMessage(message)
                     }
                     pixelFiring.fire(.remoteMessageSecondaryActionClicked,
                                      withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
-                    
+
                 case .close:
                     self.dismissHomeMessage(message)
                     pixelFiring.fire(.remoteMessageDismissed,

--- a/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -1,0 +1,118 @@
+//
+//  NewTabPageMessagesModel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+import Foundation
+import RemoteMessaging
+
+final class NewTabPageMessagesModel: ObservableObject {
+
+    @Published private(set) var homeMessageViewModels: [HomeMessageViewModel] = []
+
+    private var observable: NSObjectProtocol?
+
+    private let homePageMessagesConfiguration: HomePageMessagesConfiguration
+    private let notificationCenter: NotificationCenter
+
+    init(homePageMessagesConfiguration: HomePageMessagesConfiguration = AppDependencyProvider.shared.homePageConfiguration,
+         notificationCenter: NotificationCenter = .default) {
+        self.homePageMessagesConfiguration = homePageMessagesConfiguration
+        self.notificationCenter = notificationCenter
+    }
+
+    func load() {
+        observable = notificationCenter.addObserver(
+            forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+            object: nil,
+            queue: .main) { [weak self] _ in
+                self?.refresh()
+        }
+
+        refresh()
+    }
+
+    func dismissHomeMessage(_ homeMessage: HomeMessage) {
+        homePageMessagesConfiguration.dismissHomeMessage(homeMessage)
+        updateHomeMessageViewModel()
+    }
+
+    func didAppear(_ homeMessage: HomeMessage) {
+        homePageMessagesConfiguration.didAppear(homeMessage)
+    }
+
+    // MARK: - Private
+
+    private func refresh() {
+        homePageMessagesConfiguration.refresh()
+        updateHomeMessageViewModel()
+    }
+
+    private func updateHomeMessageViewModel() {
+        self.homeMessageViewModels = homePageMessagesConfiguration.homeMessages.compactMap(self.homeMessageViewModel(for:))
+    }
+
+    private func homeMessageViewModel(for message: HomeMessage) -> HomeMessageViewModel? {
+        switch message {
+        case .placeholder:
+            return HomeMessageViewModel(messageId: "", modelType: .small(titleText: "", descriptionText: "")) { [weak self] _ in
+                self?.dismissHomeMessage(message)
+            } onDidAppear: {
+                // no-op
+            }
+        case .remoteMessage(let remoteMessage):
+            return HomeMessageViewModelBuilder.build(for: remoteMessage) { [weak self] action in
+
+                guard let action,
+                        let self else { return }
+
+                switch action {
+
+                case .action(let isSharing):
+                    if !isSharing {
+                        self.dismissHomeMessage(message)
+                    }
+                    Pixel.fire(pixel: .remoteMessageActionClicked,
+                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+
+                case .primaryAction(let isSharing):
+                    if !isSharing {
+                        self.dismissHomeMessage(message)
+                    }
+                    Pixel.fire(pixel: .remoteMessagePrimaryActionClicked,
+                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+
+                case .secondaryAction(let isSharing):
+                    if !isSharing {
+                        self.dismissHomeMessage(message)
+                    }
+                    Pixel.fire(pixel: .remoteMessageSecondaryActionClicked,
+                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+
+                case .close:
+                    self.dismissHomeMessage(message)
+                    Pixel.fire(pixel: .remoteMessageDismissed,
+                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+
+                }
+            } onDidAppear: { [weak self] in
+                self?.homePageMessagesConfiguration.didAppear(message)
+            }
+        }
+    }
+}

--- a/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -29,11 +29,14 @@ final class NewTabPageMessagesModel: ObservableObject {
 
     private let homePageMessagesConfiguration: HomePageMessagesConfiguration
     private let notificationCenter: NotificationCenter
+    private let pixelFiring: PixelFiring.Type
 
     init(homePageMessagesConfiguration: HomePageMessagesConfiguration = AppDependencyProvider.shared.homePageConfiguration,
-         notificationCenter: NotificationCenter = .default) {
+         notificationCenter: NotificationCenter = .default,
+         pixelFiring: PixelFiring.Type = Pixel.self) {
         self.homePageMessagesConfiguration = homePageMessagesConfiguration
         self.notificationCenter = notificationCenter
+        self.pixelFiring = pixelFiring
     }
 
     func load() {
@@ -82,32 +85,32 @@ final class NewTabPageMessagesModel: ObservableObject {
                         let self else { return }
 
                 switch action {
-
+                    
                 case .action(let isSharing):
                     if !isSharing {
                         self.dismissHomeMessage(message)
                     }
-                    Pixel.fire(pixel: .remoteMessageActionClicked,
-                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
-
+                    pixelFiring.fire(.remoteMessageActionClicked,
+                                     withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+                    
                 case .primaryAction(let isSharing):
                     if !isSharing {
                         self.dismissHomeMessage(message)
                     }
-                    Pixel.fire(pixel: .remoteMessagePrimaryActionClicked,
-                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
-
+                    pixelFiring.fire(.remoteMessagePrimaryActionClicked,
+                                     withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+                    
                 case .secondaryAction(let isSharing):
                     if !isSharing {
                         self.dismissHomeMessage(message)
                     }
-                    Pixel.fire(pixel: .remoteMessageSecondaryActionClicked,
-                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
-
+                    pixelFiring.fire(.remoteMessageSecondaryActionClicked,
+                                     withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+                    
                 case .close:
                     self.dismissHomeMessage(message)
-                    Pixel.fire(pixel: .remoteMessageDismissed,
-                               withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
+                    pixelFiring.fire(.remoteMessageDismissed,
+                                     withAdditionalParameters: [PixelParameters.message: "\(remoteMessage.id)"])
 
                 }
             } onDidAppear: { [weak self] in

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -84,29 +84,6 @@ struct NewTabPageView: View {
     NewTabPageView(messagesModel: NewTabPageMessagesModel(), favoritesModel: FavoritesModel())
 }
 
-#if DEBUG
-final class PreviewMessagesConfiguration: HomePageMessagesConfiguration {
-    private(set) var homeMessages: [HomeMessage]
-
-    init(homeMessages: [HomeMessage]) {
-        self.homeMessages = homeMessages
-    }
-
-    func refresh() {
-
-    }
-
-    func didAppear(_ homeMessage: HomeMessage) {
-        // no-op
-    }
-
-    func dismissHomeMessage(_ homeMessage: HomeMessage) {
-        homeMessages = homeMessages.dropLast()
-    }
-}
-#endif
-
-
 #Preview("With message") {
     NewTabPageView(
         messagesModel: NewTabPageMessagesModel(
@@ -125,4 +102,24 @@ final class PreviewMessagesConfiguration: HomePageMessagesConfiguration {
         ),
         favoritesModel: FavoritesModel()
     )
+}
+
+private final class PreviewMessagesConfiguration: HomePageMessagesConfiguration {
+    private(set) var homeMessages: [HomeMessage]
+
+    init(homeMessages: [HomeMessage]) {
+        self.homeMessages = homeMessages
+    }
+
+    func refresh() {
+
+    }
+
+    func didAppear(_ homeMessage: HomeMessage) {
+        // no-op
+    }
+
+    func dismissHomeMessage(_ homeMessage: HomeMessage) {
+        homeMessages = homeMessages.dropLast()
+    }
 }

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -41,7 +41,7 @@ struct NewTabPageView: View {
                 ForEach(messagesModel.homeMessageViewModels, id: \.messageId) { messageModel in
                     HomeMessageView(viewModel: messageModel)
                         .frame(maxWidth: horizontalSizeClass == .regular ? Constant.messageMaximumWidthPad : Constant.messageMaximumWidth)
-                        .padding()
+                        .padding(16)
                 }
 
                 // MARK: Favorites

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -21,6 +21,17 @@ import SwiftUI
 
 final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTabPage {
 
+    init() {
+        let newTabPageView = NewTabPageView(messagesModel: NewTabPageMessagesModel(),
+                                            favoritesModel: FavoritesModel())
+        super.init(rootView: newTabPageView)
+    }
+    
+    @available(*, unavailable)
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     let isDragging: Bool = false
 
     weak var chromeDelegate: BrowserChromeDelegate?

--- a/DuckDuckGoTests/AdAttributionPixelReporterTests.swift
+++ b/DuckDuckGoTests/AdAttributionPixelReporterTests.swift
@@ -159,7 +159,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
     private func createSUT() -> AdAttributionPixelReporter {
         AdAttributionPixelReporter(fetcherStorage: fetcherStorage,
                                    attributionFetcher: attributionFetcher,
-                                   pixelFiring: PixelFiringMock.self)
+                                   pixelFiring: PixelFiringsAsyncMock.self)
     }
 }
 
@@ -178,7 +178,7 @@ class AdAttributionFetcherMock: AdAttributionFetcher {
     }
 }
 
-final actor PixelFiringMock: PixelFiring {
+final actor PixelFiringsAsyncMock: PixelFiringAsync {
     static var expectedFireError: Error?
 
     static var lastParams: [String: String]?

--- a/DuckDuckGoTests/AdAttributionPixelReporterTests.swift
+++ b/DuckDuckGoTests/AdAttributionPixelReporterTests.swift
@@ -159,7 +159,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
     private func createSUT() -> AdAttributionPixelReporter {
         AdAttributionPixelReporter(fetcherStorage: fetcherStorage,
                                    attributionFetcher: attributionFetcher,
-                                   pixelFiring: PixelFiringsAsyncMock.self)
+                                   pixelFiring: PixelFiringMock.self)
     }
 }
 
@@ -176,34 +176,6 @@ class AdAttributionFetcherMock: AdAttributionFetcher {
     func fetch() async -> AdServicesAttributionResponse? {
         fetchResponse
     }
-}
-
-final actor PixelFiringsAsyncMock: PixelFiringAsync {
-    static var expectedFireError: Error?
-
-    static var lastParams: [String: String]?
-    static var lastPixel: Pixel.Event?
-    static var lastIncludedParams: [Pixel.QueryParameters]?
-    static func fire(pixel: Pixel.Event,
-                     withAdditionalParameters params: [String: String],
-                     includedParameters: [Pixel.QueryParameters]) async throws {
-        lastParams = params
-        lastPixel = pixel
-        lastIncludedParams = includedParameters
-
-        if let expectedFireError {
-            throw expectedFireError
-        }
-    }
-
-    static func tearDown() {
-        lastParams = nil
-        lastPixel = nil
-        lastIncludedParams = nil
-        expectedFireError = nil
-    }
-
-    private init() {}
 }
 
 extension AdServicesAttributionResponse {

--- a/DuckDuckGoTests/MockPixelFiring.swift
+++ b/DuckDuckGoTests/MockPixelFiring.swift
@@ -1,0 +1,69 @@
+//
+//  MockPixelFiring.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+
+final actor PixelFiringMock: PixelFiring, PixelFiringAsync {
+    static var expectedFireError: Error?
+
+    static var lastParams: [String: String]?
+    static var lastPixel: Pixel.Event?
+    static var lastIncludedParams: [Pixel.QueryParameters]?
+    
+    static func fire(pixel: Pixel.Event,
+                     withAdditionalParameters params: [String: String],
+                     includedParameters: [Pixel.QueryParameters]) async throws {
+        lastParams = params
+        lastPixel = pixel
+        lastIncludedParams = includedParameters
+
+        if let expectedFireError {
+            throw expectedFireError
+        }
+    }
+
+    static func fire(_ pixel: Pixel.Event,
+                     withAdditionalParameters params: [String: String],
+                     includedParameters: [Pixel.QueryParameters],
+                     onComplete: @escaping (Error?) -> Void) {
+        lastParams = params
+        lastPixel = pixel
+        lastIncludedParams = includedParameters
+
+        if let expectedFireError {
+            onComplete(expectedFireError)
+        }
+    }
+
+    static func fire(_ pixel: Pixel.Event,
+                     withAdditionalParameters params: [String: String]) {
+        lastParams = params
+        lastPixel = pixel
+    }
+
+    static func tearDown() {
+        lastParams = nil
+        lastPixel = nil
+        lastIncludedParams = nil
+        expectedFireError = nil
+    }
+
+    private init() {}
+}

--- a/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -35,7 +35,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-
+        PixelFiringMock.tearDown()
     }
 
     func testUpdatesOnNotification() {

--- a/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -1,0 +1,223 @@
+//
+//  NewTabPageMessagesModelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+import RemoteMessaging
+import XCTest
+
+@testable import DuckDuckGo
+
+final class NewTabPageMessagesModelTests: XCTestCase {
+
+    private var messagesConfiguration: HomePageMessagesConfigurationMock!
+    private var notificationCenter: NotificationCenter!
+
+
+    override func setUpWithError() throws {
+        messagesConfiguration = HomePageMessagesConfigurationMock(homeMessages: [])
+        notificationCenter = NotificationCenter()
+    }
+
+    override func tearDownWithError() throws {
+
+    }
+
+    func testUpdatesOnNotification() {
+        let sut = createSUT()
+
+        sut.load()
+
+        XCTAssertTrue(sut.homeMessageViewModels.isEmpty)
+
+        messagesConfiguration.homeMessages = [.placeholder]
+
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+                                object: nil)
+
+        XCTAssertEqual(sut.homeMessageViewModels.count, 1)
+    }
+
+    // MARK: Callbacks
+
+    func testCallsDismissOnClose() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        model.onDidClose(.close)
+
+        XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
+    }
+
+    func testCallsDismissOnAction() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        model.onDidClose(.action(isShare: false))
+
+        XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
+    }
+
+    func testCallsDismissOnPrimaryAction() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        model.onDidClose(.primaryAction(isShare: false))
+
+        XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
+    }
+
+    func testCallsDismissOnSecondaryAction() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        model.onDidClose(.secondaryAction(isShare: false))
+
+        XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
+    }
+
+    func testDoesNotCallDismissWhenSharing() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        model.onDidClose(.action(isShare: true))
+        model.onDidClose(.primaryAction(isShare: true))
+        model.onDidClose(.secondaryAction(isShare: true))
+
+        XCTAssertNil(messagesConfiguration.lastDismissedHomeMessage)
+    }
+
+    // MARK: Pixels
+
+    func testFiresPixelOnClose() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        model.onDidClose(.close)
+
+        XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessageDismissed)
+        XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
+    }
+
+    func testFiresPixelOnAction() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+        model.onDidClose(.action(isShare: false))
+
+        XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessageActionClicked)
+        XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
+    }
+
+    func testFiresPixelOnPrimaryAction() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+        model.onDidClose(.primaryAction(isShare: false))
+
+        XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessagePrimaryActionClicked)
+        XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
+    }
+
+    func testFiresPixelOnSecondaryAction() throws {
+        let sut = createSUT()
+        messagesConfiguration.homeMessages = [
+            .mockRemote(withType: .small(titleText: "", descriptionText: "")),
+        ]
+        sut.load()
+
+        let model = try XCTUnwrap(sut.homeMessageViewModels.first)
+        model.onDidClose(.secondaryAction(isShare: false))
+
+        XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessageSecondaryActionClicked)
+        XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
+    }
+
+    private func createSUT() -> NewTabPageMessagesModel {
+        NewTabPageMessagesModel(homePageMessagesConfiguration: messagesConfiguration,
+                                notificationCenter: notificationCenter,
+                                pixelFiring: PixelFiringMock.self)
+    }
+}
+
+private class HomePageMessagesConfigurationMock: HomePageMessagesConfiguration {
+    var homeMessages: [HomeMessage]
+    
+    init(homeMessages: [HomeMessage]) {
+        self.homeMessages = homeMessages
+    }
+
+    private(set) var lastAppearedHomeMessage: HomeMessage?
+    func didAppear(_ homeMessage: HomeMessage) {
+        lastAppearedHomeMessage = homeMessage
+    }
+
+    private(set) var lastDismissedHomeMessage: HomeMessage?
+    func dismissHomeMessage(_ homeMessage: HomeMessage) {
+        lastDismissedHomeMessage = homeMessage
+    }
+
+    private(set) var didRefresh: Bool = false
+    func refresh() {
+        didRefresh = true
+    }
+}
+
+private extension HomeMessage {
+    static func mockRemote(withType type: RemoteMessageModelType) -> Self {
+        HomeMessage.remoteMessage(remoteMessage: .init(id: "foo", content: type, matchingRules: [], exclusionRules: []))
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1206226850447395/1207703703130204/f
Tech Design URL:
CC:

**Description**:

Adds RemoteMessaging capability to new `NewTabPage` layout. 

`PixelFiring` protocol got reorganized and extended, allowing to abstract this functionality and make depending logic testable. So far it was used only in `AdAttributionPixelReporter`.

**Steps to test this PR**:
1. Change `RemoteMessagingClient.endpoint` value to `https://www.jsonblob.com/api/1257306235471781888`.
2. Restart app.
3. Make sure Internal User flag is set and NewTabPage sections are enabled in debug menu.
4. Test functionality of all 5 messages.
5. Check if proper pixels are fired on dismiss, appear, close and actions.
6. Verify if message does not appear twice after it's dismissed.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Device Testing**:

* [ ] iPhone 14 Pro
* [ ] iPad

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
