### PR TITLE
Onboarding fix iPad landscape gradient

### DIFF
--- a/DuckDuckGo/OnboardingExperiment/OnboardingBackground.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingBackground.swift
@@ -22,14 +22,10 @@ import SwiftUI
 struct OnboardingBackground: View {
 
     var body: some View {
-        ZStack {
-            Gradient()
-
-            Image(.daxOnboardingBackground)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        }
-        .ignoresSafeArea()
+        Image(.daxOnboardingBackground)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .background(Gradient())
     }
 }
 
@@ -74,10 +70,9 @@ private extension OnboardingBackground {
         private func gradient(colorStops: [SwiftUI.Gradient.Stop]) -> some View {
             LinearGradient(
                 stops: colorStops,
-                startPoint: UnitPoint(x: 0, y: 0.5),
-                endPoint: UnitPoint(x: 1, y: 0.5)
+                startPoint: UnitPoint(x: 0.5, y: 0),
+                endPoint: UnitPoint(x: 0.5, y: 1)
             )
-            .rotationEffect(Angle(degrees: 90))
         }
 
     }

--- a/DuckDuckGo/OnboardingExperiment/OnboardingBackground.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingBackground.swift
@@ -25,7 +25,10 @@ struct OnboardingBackground: View {
         Image(.daxOnboardingBackground)
             .resizable()
             .aspectRatio(contentMode: .fill)
-            .background(Gradient())
+            .background(
+                Gradient()
+                    .ignoresSafeArea()
+            )
     }
 }
 

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -46,11 +46,7 @@ struct OnboardingView: View {
     }
 
     private func backgroundWrapped(view: some View) -> some View {
-        view
-            .background(
-                OnboardingBackground()
-                    .ignoresSafeArea()
-            )
+        view.background(OnboardingBackground())
     }
 
     private func mainView(state: ViewState.Intro) -> some View {

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -46,14 +46,11 @@ struct OnboardingView: View {
     }
 
     private func backgroundWrapped(view: some View) -> some View {
-        GeometryReader { proxy in
-            ZStack {
+        view
+            .background(
                 OnboardingBackground()
-                    .frame(width: proxy.size.width, height: proxy.size.height)
-
-                view
-            }
-        }
+                    .ignoresSafeArea()
+            )
     }
 
     private func mainView(state: ViewState.Intro) -> some View {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207585462837403/f
CC: @SabrinaTardio 

**Description**:

I found an issue with the rendering of the iPad background in landscape (I'm pretty sure I’ve tested it previously 🤔).
Interestingly, the gradient didn't extend to the edges of the screen no matter it was in a ZStack. I tried to use a Geometry reader but had no luck and that’s when I noticed that `width` and `height` were flipped for the view.
 
I noticed the issue disappeared when I removed `.rotationEffect(Angle(degrees: 90))` from the Gradient. There is no need to rotate the gradient (thanks Figma 😓 ). Indeed, we can achieve the same effect by adjusting the x and y of the start and end points without rotating the gradient.

I’ve also simplified the view hierarchy by removing ZStack and Geometry Reader and just using `.background()` modifiers

**BEFORE FIX**
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-02 at 12 59 44](https://github.com/duckduckgo/iOS/assets/1089358/e5ffdb53-24bc-4841-9732-ed29f937597c)

**AFTER FIX**
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-02 at 12 57 00](https://github.com/duckduckgo/iOS/assets/1089358/5ee00afa-c5e8-403e-a702-aaed4680dd7c)

**Steps to test this PR**:
1. Smoke test SwiftUI OnboardingView previews in different screen sizes and iPad portrait/landscape

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 14
* [ ] iOS 15
* [ ] iOS 16

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
