### PR TITLE
Onboarding Intro experiment setup

### DIFF
--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -27,6 +27,8 @@ extension FeatureName {
     // public static let experimentalFeature = FeatureName(rawValue: "experimentalFeature")
 
     public static let history = FeatureName(rawValue: "history")
+
+    public static let newOnboardingIntro = FeatureName(rawValue: "newOnboardingIntro")
 }
 
 public struct VariantIOS: Variant {
@@ -65,6 +67,9 @@ public struct VariantIOS: Variant {
         // This needs to stay until we finish rolling out history to all users...
         // This ensures that users who previously had do not lose it.
         VariantIOS(name: "md", weight: doNotAllocate, isIncluded: When.inEnglish, features: [.history]),
+
+        VariantIOS(name: "ma", weight: 1, isIncluded: When.always, features: []),
+        VariantIOS(name: "mb", weight: 1, isIncluded: When.always, features: [.newOnboardingIntro]),
 
         returningUser
     ]

--- a/DuckDuckGo/MainViewController+Segues.swift
+++ b/DuckDuckGo/MainViewController+Segues.swift
@@ -32,8 +32,8 @@ extension MainViewController {
         os_log(#function, log: .generalLog, type: .debug)
         hideAllHighlightsIfNeeded()
 
-        let controller: Onboarding?
-        
+        var controller: (Onboarding & UIViewController)?
+
         if DefaultVariantManager().isSupported(feature: .newOnboardingIntro) {
             controller = OnboardingIntroViewController()
         } else {
@@ -43,8 +43,8 @@ extension MainViewController {
             })
         }
         
+        controller?.delegate = self
         guard let controller else { return assertionFailure() }
-        controller.delegate = self
         controller.modalPresentationStyle = .overFullScreen
         present(controller, animated: false)
     }

--- a/DuckDuckGo/MainViewController+Segues.swift
+++ b/DuckDuckGo/MainViewController+Segues.swift
@@ -31,13 +31,19 @@ extension MainViewController {
     func segueToDaxOnboarding() {
         os_log(#function, log: .generalLog, type: .debug)
         hideAllHighlightsIfNeeded()
-        let storyboard = UIStoryboard(name: "DaxOnboarding", bundle: nil)
-        guard let controller = storyboard.instantiateInitialViewController(creator: { coder in
-            DaxOnboardingViewController(coder: coder)
-        }) else {
-            assertionFailure()
-            return
+
+        let controller: Onboarding?
+        
+        if DefaultVariantManager().isSupported(feature: .newOnboardingIntro) {
+            controller = OnboardingIntroViewController()
+        } else {
+            let storyboard = UIStoryboard(name: "DaxOnboarding", bundle: nil)
+            controller = storyboard.instantiateInitialViewController(creator: { coder in
+                DaxOnboardingViewController(coder: coder)
+            })
         }
+        
+        guard let controller else { return assertionFailure() }
         controller.delegate = self
         controller.modalPresentationStyle = .overFullScreen
         present(controller, animated: false)

--- a/DuckDuckGo/Onboarding.swift
+++ b/DuckDuckGo/Onboarding.swift
@@ -21,7 +21,7 @@ import Foundation
 import Core
 import UserNotifications
 
-protocol Onboarding: UIViewController {
+protocol Onboarding {
     
     var delegate: OnboardingDelegate? { get set }
     

--- a/DuckDuckGo/Onboarding.swift
+++ b/DuckDuckGo/Onboarding.swift
@@ -21,7 +21,7 @@ import Foundation
 import Core
 import UserNotifications
 
-protocol Onboarding {
+protocol Onboarding: UIViewController {
     
     var delegate: OnboardingDelegate? { get set }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207723831937951/f
CC: @SabrinaTardio 

**Description**:

This PR is to setup the experiment variants and to show a different onboarding intro based on the variant.

**Steps to test this PR**:

**Scenario 1 - Old Onboarding**
<img width="337" alt="Screenshot 2024-07-03 at 7 30 03 PM" src="https://github.com/duckduckgo/iOS/assets/1089358/c6fe437e-bd38-4878-b193-41a5a8dd160f">

1. Setup the variant by using `Edit Scheme` -> `Arguments` -> `Environment Variables` as per attached image.
2. Launch the App
**Expected Result:** The old onboarding should be presented to the user.

**Scenario 2 - New Onboarding**
<img width="272" alt="Screenshot 2024-07-03 at 7 29 50 PM" src="https://github.com/duckduckgo/iOS/assets/1089358/617b7acb-d629-41f4-b871-f27be916dc91">

1. Setup the variant by using `Edit Scheme` -> `Arguments` -> `Environment Variables` as per attached image.
2. Launch the App
**Expected Result:** The new onboarding should be presented to the user.

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
