### PR TITLE
Fix issue when cancelling a download

### DIFF
--- a/DuckDuckGo/DownloadsList.swift
+++ b/DuckDuckGo/DownloadsList.swift
@@ -24,9 +24,8 @@ struct DownloadsList: View {
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject var viewModel: DownloadsListViewModel
     @State var editMode: EditMode = .inactive
-    
-    @State private var isCancelDownloadAlertPresented: Bool = false
-    
+    @State private var selectedRowModelToCancel: OngoingDownloadRowViewModel? = nil
+
     var body: some View {
         NavigationView {
             listOrEmptyState
@@ -34,6 +33,9 @@ struct DownloadsList: View {
                 .navigationBarItems(trailing: doneButton)
         }
         .navigationViewStyle(.stack)
+        .alert(item: $selectedRowModelToCancel) { rowModel in
+            makeCancelDownloadAlert(for: rowModel)
+        }
     }
     
     private var doneButton: some View {
@@ -171,8 +173,7 @@ struct DownloadsList: View {
     private func row(for rowModel: DownloadsListRowViewModel) -> some View {
         if let rowModel = rowModel as? OngoingDownloadRowViewModel {
             OngoingDownloadRow(rowModel: rowModel,
-                               cancelButtonAction: { self.isCancelDownloadAlertPresented = true })
-                .alert(isPresented: $isCancelDownloadAlertPresented) { makeCancelDownloadAlert(for: rowModel) }
+                               cancelButtonAction: { self.selectedRowModelToCancel = rowModel })
                 .deleteDisabled(true)
         } else if let rowModel = rowModel as? CompleteDownloadRowViewModel {
             CompleteDownloadRow(rowModel: rowModel,

--- a/DuckDuckGo/DownloadsList.swift
+++ b/DuckDuckGo/DownloadsList.swift
@@ -24,7 +24,7 @@ struct DownloadsList: View {
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject var viewModel: DownloadsListViewModel
     @State var editMode: EditMode = .inactive
-    @State private var selectedRowModelToCancel: OngoingDownloadRowViewModel? = nil
+    @State private var selectedRowModelToCancel: OngoingDownloadRowViewModel?
 
     var body: some View {
         NavigationView {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207722065639812/f

**Description**:
Fix issue where the wrong item was being cancelled in the download list

**Steps to test this PR**:
1. Open https://www.thinkbroadband.com/download
2. Select multiple items to download
3. Cancel the downloads and check if the correct ones in the list are being removed
4. To make it easier, you can also change the line [here](https://github.com/duckduckgo/iOS/blob/b33782933a33c959d01e9cdfc096ae93aeae014c/DuckDuckGo/DownloadsList.swift#L206) to something like `Text("\(UserText.cancelDownloadAlertDescription) \(row.id)")` so you can see what item is being selected

