### PR TITLE
Fixes App Data Clearing State Status In Settings

### DIFF
--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -40,7 +40,7 @@ public class AppUserDefaults: AppSettings {
         public static let showsFullURLAddressSettingChanged = Notification.Name("com.duckduckgo.app.ShowsFullURLAddressSettingChanged")
         public static let autofillDebugScriptToggled = Notification.Name("com.duckduckgo.app.DidToggleAutofillDebugScript")
         public static let duckPlayerSettingsUpdated = Notification.Name("com.duckduckgo.app.DuckPlayerSettingsUpdated")
-        public static let appDataClearingUpdated = Notification.Name("com.duckduckgo.app.dataClearningUpdates")
+        public static let appDataClearingUpdated = Notification.Name("com.duckduckgo.app.dataClearingUpdates")
     }
 
     private let groupName: String

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -40,6 +40,7 @@ public class AppUserDefaults: AppSettings {
         public static let showsFullURLAddressSettingChanged = Notification.Name("com.duckduckgo.app.ShowsFullURLAddressSettingChanged")
         public static let autofillDebugScriptToggled = Notification.Name("com.duckduckgo.app.DidToggleAutofillDebugScript")
         public static let duckPlayerSettingsUpdated = Notification.Name("com.duckduckgo.app.DuckPlayerSettingsUpdated")
+        public static let appDataClearingUpdated = Notification.Name("com.duckduckgo.app.dataClearningUpdates")
     }
 
     private let groupName: String
@@ -154,6 +155,7 @@ public class AppUserDefaults: AppSettings {
         
         set {
             userDefaults?.setValue(newValue.rawValue, forKey: Keys.autoClearActionKey)
+            NotificationCenter.default.post(name: Notifications.appDataClearingUpdated, object: nil)
         }
         
     }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -60,6 +60,9 @@ final class SettingsViewModel: ObservableObject {
     private lazy var isPad = UIDevice.current.userInterfaceIdiom == .pad
     private var cancellables = Set<AnyCancellable>()
     
+    // App Data State Notification Observer
+    private var appDataClearingObserver: Any?
+    
     // Closures to interact with legacy view controllers through the container
     var onRequestPushLegacyView: ((UIViewController) -> Void)?
     var onRequestPresentLegacyView: ((UIViewController, _ modal: Bool) -> Void)?
@@ -345,6 +348,7 @@ final class SettingsViewModel: ObservableObject {
 
     deinit {
         subscriptionSignOutObserver = nil
+        appDataClearingObserver = nil
     }
 }
 // swiftlint:enable type_body_length
@@ -732,6 +736,15 @@ extension SettingsViewModel {
                 }
             }
         }
+        
+        // Observe App Data clearing state
+        appDataClearingObserver = NotificationCenter.default.addObserver(forName: AppUserDefaults.Notifications.appDataClearingUpdated,
+                                                                         object: nil,
+                                                                         queue: .main) { [weak self] _ in
+            guard let settings = self?.appSettings else { return }
+            self?.state.autoclearDataEnabled = (AutoClearSettingsModel(settings: settings) != nil)
+        }
+        
     }
     
     @available(iOS 15.0, *)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1207731330276486/f

**Description**:
Fixes an issue that caused the "Automatically Clear Data" state in settings to be out of sync. 

Fixed by observing Data Clearing updates. – (Eventually, this and all other parts of AppSettings should adopt Combine publishers instead of Notifications, but this does the trick today)

**Steps to test this PR**:
- Go to Settings > Data Clearing
- Observe on/off indicator for 'Automatically Clear Data'
- Click 'Automatically Clear Data' and toggle the setting ON or OFF
- Click the Back button
- Observe the on/off indicator and see that the copy doesn't accurately reflect the toggle state

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
