### PR TITLE
Update Sync error pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -559,6 +559,9 @@ extension Pixel {
         case syncBookmarksTooManyRequestsDaily
         case syncCredentialsTooManyRequestsDaily
         case syncSettingsTooManyRequestsDaily
+        case syncBookmarksValidationErrorDaily
+        case syncCredentialsValidationErrorDaily
+        case syncSettingsValidationErrorDaily
 
         case syncSentUnauthenticatedRequest
         case syncMetadataCouldNotLoadDatabase
@@ -1260,6 +1263,9 @@ extension Pixel.Event {
         case .syncBookmarksTooManyRequestsDaily: return "m_sync_bookmarks_too_many_requests_daily"
         case .syncCredentialsTooManyRequestsDaily: return "m_sync_credentials_too_many_requests_daily"
         case .syncSettingsTooManyRequestsDaily: return "m_sync_settings_too_many_requests_daily"
+        case .syncBookmarksValidationErrorDaily: return "m_sync_bookmarks_validation_error_daily"
+        case .syncCredentialsValidationErrorDaily: return "m_sync_credentials_validation_error_daily"
+        case .syncSettingsValidationErrorDaily: return "m_sync_settings_validation_error_daily"
 
         case .syncSentUnauthenticatedRequest: return "m_d_sync_sent_unauthenticated_request"
         case .syncMetadataCouldNotLoadDatabase: return "m_d_sync_metadata_could_not_load_database"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -552,11 +552,14 @@ extension Pixel {
         case syncFailedToMigrate
         case syncFailedToLoadAccount
         case syncFailedToSetupEngine
-        case syncBookmarksCountLimitExceededDaily
-        case syncCredentialsCountLimitExceededDaily
+        case syncBookmarksObjectLimitExceededDaily
+        case syncCredentialsObjectLimitExceededDaily
         case syncBookmarksRequestSizeLimitExceededDaily
         case syncCredentialsRequestSizeLimitExceededDaily
-        
+        case syncBookmarksTooManyRequestsDaily
+        case syncCredentialsTooManyRequestsDaily
+        case syncSettingsTooManyRequestsDaily
+
         case syncSentUnauthenticatedRequest
         case syncMetadataCouldNotLoadDatabase
         case syncBookmarksFailed
@@ -1250,11 +1253,14 @@ extension Pixel.Event {
         case .syncFailedToMigrate: return "m_d_sync_failed_to_migrate"
         case .syncFailedToLoadAccount: return "m_d_sync_failed_to_load_account"
         case .syncFailedToSetupEngine: return "m_d_sync_failed_to_setup_engine"
-        case .syncBookmarksCountLimitExceededDaily: return "m_d_sync_bookmarks_count_limit_exceeded_daily"
-        case .syncCredentialsCountLimitExceededDaily: return "m_d_sync_credentials_count_limit_exceeded_daily"
-        case .syncBookmarksRequestSizeLimitExceededDaily: return "m_d_sync_bookmarks_request_size_limit_exceeded_daily"
-        case .syncCredentialsRequestSizeLimitExceededDaily: return "m_d_sync_credentials_request_size_limit_exceeded_daily"
-            
+        case .syncBookmarksObjectLimitExceededDaily: return "m_sync_bookmarks_object_limit_exceeded_daily"
+        case .syncCredentialsObjectLimitExceededDaily: return "m_sync_credentials_object_limit_exceeded_daily"
+        case .syncBookmarksRequestSizeLimitExceededDaily: return "m_sync_bookmarks_request_size_limit_exceeded_daily"
+        case .syncCredentialsRequestSizeLimitExceededDaily: return "m_sync_credentials_request_size_limit_exceeded_daily"
+        case .syncBookmarksTooManyRequestsDaily: return "m_sync_bookmarks_too_many_requests_daily"
+        case .syncCredentialsTooManyRequestsDaily: return "m_sync_credentials_too_many_requests_daily"
+        case .syncSettingsTooManyRequestsDaily: return "m_sync_settings_too_many_requests_daily"
+
         case .syncSentUnauthenticatedRequest: return "m_d_sync_sent_unauthenticated_request"
         case .syncMetadataCouldNotLoadDatabase: return "m_d_sync_metadata_could_not_load_database"
         case .syncBookmarksFailed: return "m_d_sync_bookmarks_failed"

--- a/Core/SyncErrorHandler.swift
+++ b/Core/SyncErrorHandler.swift
@@ -208,6 +208,7 @@ extension SyncErrorHandler {
             case .settings:
                 break
             }
+            DailyPixel.fire(pixel: modelType.badRequestPixel)
         case .unexpectedStatusCode(401):
             syncIsPaused(errorType: .invalidLoginCredentials)
         case .unexpectedStatusCode(418), .unexpectedStatusCode(429):
@@ -315,6 +316,17 @@ extension SyncErrorHandler {
                     .syncCredentialsTooManyRequestsDaily
             case .settings:
                     .syncSettingsTooManyRequestsDaily
+            }
+        }
+
+        var badRequestPixel: Pixel.Event {
+            switch self {
+            case .bookmarks:
+                    .syncBookmarksValidationErrorDaily
+            case .credentials:
+                    .syncCredentialsValidationErrorDaily
+            case .settings:
+                    .syncSettingsValidationErrorDaily
             }
         }
     }

--- a/Core/SyncErrorHandler.swift
+++ b/Core/SyncErrorHandler.swift
@@ -212,6 +212,7 @@ extension SyncErrorHandler {
             syncIsPaused(errorType: .invalidLoginCredentials)
         case .unexpectedStatusCode(418), .unexpectedStatusCode(429):
             syncIsPaused(errorType: .tooManyRequests)
+            DailyPixel.fire(pixel: modelType.tooManyRequestsPixel)
         default:
             break
         }
@@ -223,11 +224,11 @@ extension SyncErrorHandler {
         case .bookmarksCountLimitExceeded:
             currentSyncBookmarksPausedError = errorType.rawValue
             self.isSyncBookmarksPaused = true
-            DailyPixel.fire(pixel: .syncBookmarksCountLimitExceededDaily)
+            DailyPixel.fire(pixel: .syncBookmarksObjectLimitExceededDaily)
         case .credentialsCountLimitExceeded:
             currentSyncCredentialsPausedError = errorType.rawValue
             self.isSyncCredentialsPaused = true
-            DailyPixel.fire(pixel: .syncCredentialsCountLimitExceededDaily)
+            DailyPixel.fire(pixel: .syncCredentialsObjectLimitExceededDaily)
         case .bookmarksRequestSizeLimitExceeded:
             currentSyncBookmarksPausedError = errorType.rawValue
             self.isSyncBookmarksPaused = true
@@ -303,6 +304,17 @@ extension SyncErrorHandler {
                     .syncCredentialsPatchCompressionFailed
             case .settings:
                     .syncSettingsPatchCompressionFailed
+            }
+        }
+
+        var tooManyRequestsPixel: Pixel.Event {
+            switch self {
+            case .bookmarks:
+                    .syncBookmarksTooManyRequestsDaily
+            case .credentials:
+                    .syncCredentialsTooManyRequestsDaily
+            case .settings:
+                    .syncSettingsTooManyRequestsDaily
             }
         }
     }


### PR DESCRIPTION

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201621708115095/1207559244852258/f

**Description**:
Rename count limit exceeded as object limit exceeded and add "Too Many Requests" pixels.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
Since this change doesn't modify any logic related to processing errors, it's enough that you verify that pixel names are correct. The simplest is to add this snippet of code at the bottom of AppDelegate's applicationDidFinishLaunching:
```swift
Pixel.fire(pixel: .syncBookmarksObjectLimitExceededDaily)
Pixel.fire(pixel: .syncCredentialsObjectLimitExceededDaily)
Pixel.fire(pixel: .syncBookmarksRequestSizeLimitExceededDaily)
Pixel.fire(pixel: .syncCredentialsRequestSizeLimitExceededDaily)
Pixel.fire(pixel: .syncBookmarksTooManyRequestsDaily)
Pixel.fire(pixel: .syncCredentialsTooManyRequestsDaily)
Pixel.fire(pixel: .syncSettingsTooManyRequestsDaily)
```
Then run the app and check the log. Compare output with what's expected in the Asana task.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
