### PR TITLE
fix bug not clearing ui properly on autoclear

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2445,11 +2445,11 @@ extension MainViewController: AutoClearWorker {
 
     @MainActor
     func autoClearDidFinishClearing(_: AutoClear, isLaunching: Bool) {
+        autoClearInProgress = false
         if autoClearShouldRefreshUIAfterClear && isLaunching == false {
             refreshUIAfterClear()
         }
 
-        autoClearInProgress = false
         autoClearShouldRefreshUIAfterClear = true
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207746141432859/f
Tech Design URL:
CC: @quanganhdo 

**Description**:
Fixes bug with autoclear + timer that leaves previous URL on screen and does not attach Home Screen properly

**Steps to test this PR**:
**Bug fix:**
1. Edit `AutoClear.swift` and set timer to clear after 5 seconds instead of 5 minutes in `shouldClearData`
2. Enable autoclear plus 5 minute timer in setting
3. Open a web page
4. Background the app (do not terminate)
5. Wait more than 5 seconds
6. Foreground the app
7. Data should be cleared and Home Screen should be attached and no URL visible in the bar

**Smoke test:**
1. Test regular auto clear after terminate
2. Test autoclear setting on and off
3. Test fire button
