### PR TITLE
Hide all connection details when the VPN isn’t connected

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -40,7 +40,7 @@ struct NetworkProtectionStatusView: View {
             toggle()
             locationDetails()
 
-            if statusModel.shouldShowConnectionDetails {
+            if statusModel.isNetPEnabled && statusModel.shouldShowConnectionDetails && statusModel.ipAddress != nil {
                 connectionDetails()
             }
 
@@ -178,8 +178,8 @@ struct NetworkProtectionStatusView: View {
 
             NetworkProtectionThroughputItemView(
                 title: UserText.vpnDataVolume,
-                downloadSpeed: statusModel.downloadTotal,
-                uploadSpeed: statusModel.uploadTotal
+                downloadSpeed: statusModel.downloadTotal ?? NetworkProtectionStatusViewModel.Constants.defaultDownloadVolume,
+                uploadSpeed: statusModel.uploadTotal ?? NetworkProtectionStatusViewModel.Constants.defaultUploadVolume
             )
         } header: {
             Text(UserText.netPStatusViewConnectionDetails).foregroundColor(.init(designSystemColor: .textSecondary))


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1199333091098016/1207750283125995/f
Tech Design URL:
CC:

**Description**:

This PR fixes an issue with the VPN showing connection details for the last connection, even after disconnecting.

See https://github.com/duckduckgo/BrowserServicesKit/pull/858/files for where the issue was introduced - rather than modify that code, I'm adding checks on the iOS VPN UI side to ensure we only show the status row when appropriate.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open the VPN UI, make sure that no connection details are showing
2. Disconnect the VPN, make sure that IP address and throughout disappear
3. Reconnect the VPN, make sure that connection details reappear and look accurate
4.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
