### PR TITLE
add autoclear tests

### DIFF
--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -1,0 +1,75 @@
+# backgrounding.yaml
+appId: com.duckduckgo.mobile.ios
+tags:
+    - release
+
+---
+
+# Set up 
+- clearState
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    arguments: 
+       "autoclear-ui-test": true
+
+- runFlow: 
+    file: ../shared/onboarding.yaml
+
+# Enable autoclear
+
+- tapOn: "Settings"
+- assertVisible: "Default Browser"
+- scrollUntilVisible:
+    centerElement: true
+    element:
+      text: "Data Clearing"
+- assertVisible: "Data Clearing"
+- tapOn: "Data Clearing"
+- assertVisible: "Off"
+- assertVisible: "Automatically Clear Data"
+- tapOn: "Automatically Clear Data"
+- assertVisible: 
+    id: "AutoclearEnabledToggle"
+- tapOn: 
+    id: "AutoclearEnabledToggle"
+- assertVisible: "App Exit, Inactive for 5 Minutes"
+- tapOn: "App Exit, Inactive for 5 Minutes"
+- tapOn: "Data Clearing" # Uses the name of the previous page
+- tapOn: "Settings"
+- tapOn: "Done"
+
+# Load Site
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site"
+- pressKey: Enter
+
+# Manage onboarding
+- runFlow:
+    file: ../shared/onboarding_browsing.yaml
+
+# Load a new tab
+- longPressOn: "Tab Switcher"
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://example.com"
+- pressKey: Enter
+
+# Go home and hover there a bit
+- pressKey: Home
+
+- repeat:
+    times: 3
+    commands:
+      - swipe:  
+          start: 50%, 50%
+          end: 10%, 50%
+      - swipe:  
+          start: 10%, 50%
+          end: 50%, 50%
+
+- tapOn: "DuckDuckGo"

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -73,3 +73,11 @@ tags:
           end: 50%, 50%
 
 - tapOn: "DuckDuckGo"
+
+- assertNotVisible: "https://example.com/"
+- assertVisible: "Search or enter address"
+- tapOn: "Tab Switcher"
+- assertNotVisible: "Example Domain"
+- assertVisible: "1 Private Tab"
+
+

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -1,4 +1,4 @@
-# backgrounding.yaml
+# autoclear.yaml
 appId: com.duckduckgo.mobile.ios
 tags:
     - release

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -43,12 +43,22 @@ tags:
     id: "searchEntry"
 - tapOn: 
     id: "searchEntry"
-- inputText: "https://privacy-test-pages.site"
+- inputText: "https://privacy-test-pages.site/features/local-storage.html"
 - pressKey: Enter
 
 # Manage onboarding
 - runFlow:
     file: ../shared/onboarding_browsing.yaml
+
+# Add a cookie
+- assertVisible: "Storage Counter: undefined"
+- assertVisible: "Cookie Counter:"
+- assertNotVisible: "Cookie Counter: 1"
+- assertNotVisible: "Storage Counter: 1"
+- assertVisible: "Manual Increment"
+- tapOn: "Manual Increment"
+- assertVisible: "Cookie Counter: 1"
+- assertVisible: "Storage Counter: 1"
 
 # Load a new tab
 - longPressOn: "Tab Switcher"
@@ -79,5 +89,14 @@ tags:
 - tapOn: "Tab Switcher"
 - assertNotVisible: "Example Domain"
 - assertVisible: "1 Private Tab"
+- tapOn: "Done"
 
-
+# Load Site
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site/features/local-storage.html"
+- pressKey: Enter
+- assertVisible: "Storage Counter: undefined"
+- assertVisible: "Cookie Counter:"

--- a/.maestro/release_tests/backgrounding.yaml
+++ b/.maestro/release_tests/backgrounding.yaml
@@ -8,6 +8,9 @@ tags:
 # Set up 
 - clearState
 - launchApp
+    - arguments:
+        autoclear-ui-test: true 
+
 - runFlow: 
     file: ../shared/onboarding.yaml
 

--- a/.maestro/release_tests/backgrounding.yaml
+++ b/.maestro/release_tests/backgrounding.yaml
@@ -8,8 +8,6 @@ tags:
 # Set up 
 - clearState
 - launchApp
-    - arguments:
-        autoclear-ui-test: true 
 
 - runFlow: 
     file: ../shared/onboarding.yaml

--- a/.maestro/run_ui_tests.sh
+++ b/.maestro/run_ui_tests.sh
@@ -40,6 +40,7 @@ run_flow() {
 
 	echo "⏲️ Starting flow $( basename $flow)"
 
+	export MAESTRO_DRIVER_STARTUP_TIMEOUT=60000
 	maestro --udid=$device_uuid test $flow
 	if [ $? -ne 0 ]; then
 		log_message $run_log "❌ FAIL: $flow"

--- a/.maestro/run_ui_tests.sh
+++ b/.maestro/run_ui_tests.sh
@@ -26,9 +26,6 @@ run_flow() {
 	local flow=$2
 
 	echo "ℹ️ Deleting app in simulator $device_uuid"
-	
-	# Ignore result of this for now. The only error hopefully is that there was nothing to terminate
-	xcrun simctl terminate $device_uuid $app_bundle 2> /dev/null
 
 	xcrun simctl uninstall $device_uuid $app_bundle
 	if [ $? -ne 0 ]; then
@@ -79,16 +76,8 @@ echo "ℹ️ Running UI tests for $1"
 device_uuid=$(cat $device_uuid_path)
 echo "ℹ️ using device $device_uuid"
 
-killall Simulator
-
-xcrun simctl shutdown $device_uuid
-xcrun simctl boot $device_uuid
-if [ $? -ne 0 ]; then
-    echo "‼️ Unable to boot simulator"
-    exit 1
-fi
-
-open -a Simulator
+# Simulator should already be up and running from running the setup script
+#  re-run the setup script with `--skip-build` to set up again 
 
 echo "ℹ️ creating run log in $run_log"
 if [ -f $run_log ]; then

--- a/.maestro/setup_ui_tests.sh
+++ b/.maestro/setup_ui_tests.sh
@@ -112,6 +112,20 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+echo "ℹ️ Setting device locale to en_US"
+
+xcrun simctl spawn $device_uuid defaults write "Apple Global Domain" AppleLanguages -array en
+if [ $? -ne 0 ]; then
+    echo "‼️ Unable to set preferred language"
+    exit 1
+fi
+
+xcrun simctl spawn $device_uuid defaults write "Apple Global Domain" AppleLocale -string en_US
+if [ $? -ne 0 ]; then
+    echo "‼️ Unable to set region"
+    exit 1
+fi
+
 open -a Simulator
 
 xcrun simctl install booted $app_location

--- a/.maestro/setup_ui_tests.sh
+++ b/.maestro/setup_ui_tests.sh
@@ -40,10 +40,11 @@ check_maestro() {
 }
 
 build_app() {
-
-    if [ -d "$derived_data_path" ]; then
+    if [ -d "$derived_data_path" ] && [ "$1" -eq "0" ]; then
         echo "⚠️ Removing previously created $derived_data_path"
         rm -rf $derived_data_path
+    else
+        echo "ℹ️ Not cleaning derived data at $derived_data_path"
     fi
 
     echo "⏲️ Building the app"
@@ -78,6 +79,8 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --skip-build) 
             skip_build=1 ;;
+        --rebuild) 
+            rebuild=1 ;;
         *)
     esac
     shift
@@ -86,7 +89,7 @@ done
 if [ -n "$skip_build" ]; then
     echo "Skipping build"
 else
-    build_app
+    build_app $rebuild
 fi
 
 echo "ℹ️ Closing all simulators"

--- a/DuckDuckGo/AutoClear.swift
+++ b/DuckDuckGo/AutoClear.swift
@@ -73,6 +73,10 @@ class AutoClear {
     private func shouldClearData(elapsedTime: TimeInterval) -> Bool {
         guard let settings = AutoClearSettingsModel(settings: appSettings) else { return false }
 
+        if ProcessInfo.processInfo.arguments.contains("autoclear-ui-test") {
+            return elapsedTime > 5
+        }
+
         switch settings.timing {
         case .termination:
             return false

--- a/DuckDuckGo/Base.lproj/Settings.storyboard
+++ b/DuckDuckGo/Base.lproj/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -205,6 +205,7 @@
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cdQ-74-TuJ">
                                                     <rect key="frame" x="305" y="6.6666666666666679" width="51" height="31.000000000000004"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="AutoclearEnabledToggle"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="4sD-XX-siI"/>
                                                     </constraints>


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/392891325557410/1207203028528350/f
Tech Design URL:
CC: @loremattei 

**Description**:
Adds UI tests for autoclearing.

Tweaked storyboard to give the toggle an accessibility ID.

**Steps to test this PR**:
1. Check End to End tests have passed: https://github.com/duckduckgo/iOS/actions/runs/9842231721
1. `cd` into `.maestro` in the project
1. Run `./setup_ui_tests.sh`
2. Run `run_ui_tests.sh release_tests/autoclear.yaml`
3. Run `run_ui_tests.sh release_tests/backgrounding.yaml`

