### PR TITLE
Onboarding Contextual Tutorial Rendering

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -631,6 +631,8 @@
 		9F23B8092C2BE9B700950875 /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8082C2BE9B700950875 /* MockURLOpener.swift */; };
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AAE2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */; };
+		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
+		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
 		9F9EE4D42C37BB1300D4118E /* OnboardingView+Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */; };
@@ -2316,6 +2318,8 @@
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingBackgroundWrapper.swift; sourceTree = "<group>"; };
+		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
+		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewFactory.swift; sourceTree = "<group>"; };
 		9FB027112C2526DD009EA190 /* OnboardingView+IntroDialogContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+IntroDialogContent.swift"; sourceTree = "<group>"; };
@@ -4341,6 +4345,7 @@
 				564DE45D2C45218500D23241 /* OnboardingNavigationDelegateTests.swift */,
 				9F9EE4CB2C377D2400D4118E /* Mocks */,
 				9FE05CEF2C3642F900D9046B /* OnboardingPixelReporterTests.swift */,
+				9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -4357,6 +4362,7 @@
 			isa = PBXGroup;
 			children = (
 				9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */,
+				9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */,
 			);
 			path = ContextualOnboarding;
 			sourceTree = "<group>";
@@ -6797,6 +6803,7 @@
 				F1BE54581E69DE1000FCF649 /* TutorialSettings.swift in Sources */,
 				1EE52ABB28FB1D6300B750C1 /* UIImageExtension.swift in Sources */,
 				858650D12469BCDE00C36F8A /* DaxDialogs.swift in Sources */,
+				9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */,
 				310D091B2799F54900DC0060 /* DownloadManager.swift in Sources */,
 				98D98A7425ED88D100D8E3DF /* BrowsingMenuEntryViewCell.swift in Sources */,
 				F1564F032B7B915F00D454A6 /* AppDelegate+SKAD4.swift in Sources */,
@@ -7302,6 +7309,7 @@
 				C1CDA31E2AFBF811006D1476 /* AutofillNeverPromptWebsitesManagerTests.swift in Sources */,
 				B6AD9E3A28D456820019CDE9 /* PrivacyConfigurationManagerMock.swift in Sources */,
 				F189AED71F18F6DE001EBAE1 /* TabTests.swift in Sources */,
+				9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */,
 				F13B4BFB1F18E3D900814661 /* TabsModelPersistenceExtensionTests.swift in Sources */,
 				CB48D3372B90DF2000631D8B /* UserBehaviorMonitorTests.swift in Sources */,
 				8528AE7E212EF5FF00D0BD74 /* AppRatingPromptTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -629,6 +629,7 @@
 		9F23B8032C2BCD0000950875 /* DaxDialogStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8022C2BCD0000950875 /* DaxDialogStyles.swift */; };
 		9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */; };
 		9F23B8092C2BE9B700950875 /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8082C2BE9B700950875 /* MockURLOpener.swift */; };
+		9F5E5AAE2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
 		9F9EE4D42C37BB1300D4118E /* OnboardingView+Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */; };
@@ -2312,6 +2313,7 @@
 		9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8082C2BE9B700950875 /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
+		9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingBackgroundWrapper.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewFactory.swift; sourceTree = "<group>"; };
 		9FB027112C2526DD009EA190 /* OnboardingView+IntroDialogContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+IntroDialogContent.swift"; sourceTree = "<group>"; };
@@ -3484,6 +3486,7 @@
 				56D060232C35918D003BAEB5 /* ContextualOnboardingList.swift */,
 				56D060252C359D2E003BAEB5 /* ContextualOnboardingDialogs.swift */,
 				564DE4522C3ED1B700D23241 /* NewTabDaxDialogFactory.swift */,
+				9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */,
 			);
 			path = ContextualDaxDialogs;
 			sourceTree = "<group>";
@@ -6797,6 +6800,7 @@
 				C1D21E2D293A5965006E5A05 /* AutofillLoginSession.swift in Sources */,
 				4B53648A26718D0E001AA041 /* EmailWaitlist.swift in Sources */,
 				D63677F52BBDB1C300605BA5 /* DaxLogoNavbarTitle.swift in Sources */,
+				9F5E5AAE2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift in Sources */,
 				8524CC98246D66E100E59D45 /* String+Markdown.swift in Sources */,
 				CBEFB9142AE0844700DEDE7B /* CriticalAlerts.swift in Sources */,
 				986B16C425E92DF0007D23E8 /* BrowsingMenuViewController.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -629,6 +629,7 @@
 		9F23B8032C2BCD0000950875 /* DaxDialogStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8022C2BCD0000950875 /* DaxDialogStyles.swift */; };
 		9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */; };
 		9F23B8092C2BE9B700950875 /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8082C2BE9B700950875 /* MockURLOpener.swift */; };
+		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AAE2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
@@ -2313,6 +2314,7 @@
 		9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8082C2BE9B700950875 /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
+		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAD2C3E44DC00165F54 /* ContextualOnboardingBackgroundWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingBackgroundWrapper.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewFactory.swift; sourceTree = "<group>"; };
@@ -4351,6 +4353,14 @@
 			name = Mocks;
 			sourceTree = "<group>";
 		};
+		9F5E5AAA2C3D0FAA00165F54 /* ContextualOnboarding */ = {
+			isa = PBXGroup;
+			children = (
+				9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */,
+			);
+			path = ContextualOnboarding;
+			sourceTree = "<group>";
+		};
 		9FB027102C2526A8009EA190 /* DaxDialogs */ = {
 			isa = PBXGroup;
 			children = (
@@ -4403,6 +4413,7 @@
 				9FB027172C26BC0F009EA190 /* BrowsersComparison */,
 				9FB027102C2526A8009EA190 /* DaxDialogs */,
 				9F23B7FF2C2BABE000950875 /* OnboardingIntro */,
+				9F5E5AAA2C3D0FAA00165F54 /* ContextualOnboarding */,
 				9F23B8002C2BC94400950875 /* OnboardingBackground.swift */,
 			);
 			path = OnboardingExperiment;
@@ -6849,6 +6860,7 @@
 				F114C55B1E66EB020018F95F /* NibLoading.swift in Sources */,
 				D6BFCB612B7525160051FF81 /* SubscriptionPIRViewModel.swift in Sources */,
 				D668D9252B693778008E2FF2 /* SubscriptionITPView.swift in Sources */,
+				9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */,
 				C10CB5F32A1A5BDF0048E503 /* AutofillViews.swift in Sources */,
 				6FE127382C20492500EB5724 /* NewTabPage.swift in Sources */,
 				982E5630222C3D5B008D861B /* FeedbackPickerViewController.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -319,7 +319,8 @@ import WebKit
                                       previewsSource: previewsSource,
                                       tabsModel: tabsModel,
                                       syncPausedStateManager: syncErrorHandler,
-                                      variantManager: variantManager)
+                                      variantManager: variantManager,
+                                      contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager))
 
         main.loadViewIfNeeded()
         syncErrorHandler.alertPresenter = main

--- a/DuckDuckGo/Base.lproj/Tab.storyboard
+++ b/DuckDuckGo/Base.lproj/Tab.storyboard
@@ -28,11 +28,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3yc-Gh-Vqe">
-                                <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <edgeInsets key="layoutMargins" top="-50" left="0.0" bottom="0.0" right="0.0"/>
-                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wfg-yB-zj4">
+                                <rect key="frame" x="0.0" y="20" width="768" height="1004"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3yc-Gh-Vqe">
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="1004"/>
+                                        <edgeInsets key="layoutMargins" top="-50" left="0.0" bottom="0.0" right="0.0"/>
+                                    </view>
+                                </subviews>
+                            </stackView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gSI-9K-1Ti" userLabel="Alert Container View">
                                 <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                                 <connections>
@@ -119,11 +123,15 @@
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="centerY" secondItem="t0t-53-xVf" secondAttribute="centerY" id="3qe-NM-ikO"/>
                             <constraint firstItem="gSI-9K-1Ti" firstAttribute="leading" secondItem="Sgm-Wo-lho" secondAttribute="leading" id="4ZJ-81-h64"/>
                             <constraint firstItem="gSI-9K-1Ti" firstAttribute="top" secondItem="Sgm-Wo-lho" secondAttribute="top" id="9Fd-Ru-MPw"/>
+                            <constraint firstItem="Wfg-yB-zj4" firstAttribute="leading" secondItem="t0t-53-xVf" secondAttribute="leading" id="DLc-Mq-QSc"/>
                             <constraint firstItem="t0t-53-xVf" firstAttribute="top" secondItem="ypz-s2-KJB" secondAttribute="top" constant="80" id="Hdu-Wc-sCB"/>
                             <constraint firstAttribute="trailing" secondItem="gSI-9K-1Ti" secondAttribute="trailing" id="WIt-GE-l23"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="width" secondItem="Sgm-Wo-lho" secondAttribute="width" id="WgD-oO-Ds7"/>
+                            <constraint firstItem="Wfg-yB-zj4" firstAttribute="top" secondItem="t0t-53-xVf" secondAttribute="top" id="atL-ZI-N6g"/>
                             <constraint firstAttribute="trailing" secondItem="ypz-s2-KJB" secondAttribute="trailing" id="bXU-Fx-c7D"/>
+                            <constraint firstItem="t0t-53-xVf" firstAttribute="trailing" secondItem="Wfg-yB-zj4" secondAttribute="trailing" id="bpw-ay-E03"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="centerX" secondItem="t0t-53-xVf" secondAttribute="centerX" id="oFL-Ft-NQV"/>
+                            <constraint firstItem="t0t-53-xVf" firstAttribute="bottom" secondItem="Wfg-yB-zj4" secondAttribute="bottom" id="reE-gN-ecB"/>
                             <constraint firstAttribute="bottom" secondItem="gSI-9K-1Ti" secondAttribute="bottom" id="t3k-1K-dv4"/>
                             <constraint firstItem="ypz-s2-KJB" firstAttribute="leading" secondItem="Sgm-Wo-lho" secondAttribute="leading" id="ugB-DM-Oye"/>
                         </constraints>
@@ -133,6 +141,7 @@
                     </view>
                     <nil key="simulatedStatusBarMetrics"/>
                     <connections>
+                        <outlet property="containerStackView" destination="Wfg-yB-zj4" id="TDY-ap-WRj"/>
                         <outlet property="error" destination="Kd4-Oi-JP2" id="zBn-cG-pfQ"/>
                         <outlet property="errorHeader" destination="6P7-7R-riV" id="IkB-Tc-Eat"/>
                         <outlet property="errorInfoImage" destination="TUO-E3-s7Q" id="ngN-8S-PwR"/>
@@ -153,7 +162,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1181.5999999999999" y="445.72713643178412"/>
+            <point key="canvasLocation" x="1181.25" y="445.31249999999994"/>
         </scene>
         <!--PrivacyDashboard-->
         <scene sceneID="L6K-iW-ae0">

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -774,18 +774,27 @@ class MainViewController: UIViewController {
     }
 
     @IBAction func onFirePressed() {
-        Pixel.fire(pixel: .forgetAllPressedBrowsing)
-        wakeLazyFireButtonAnimator()
-        
-        if let spec = DaxDialogs.shared.fireButtonEducationMessage() {
-            segueToActionSheetDaxDialogWithSpec(spec)
-        } else {
+
+        func showClearDataAlert() {
             let alert = ForgetDataAlert.buildAlert(forgetTabsAndDataHandler: { [weak self] in
                 self?.forgetAllWithAnimation {}
             })
             self.present(controller: alert, fromView: self.viewCoordinator.toolbar)
         }
 
+        Pixel.fire(pixel: .forgetAllPressedBrowsing)
+        wakeLazyFireButtonAnimator()
+
+        if DefaultVariantManager().isSupported(feature: .newOnboardingIntro) {
+            showClearDataAlert()
+        } else {
+            if let spec = DaxDialogs.shared.fireButtonEducationMessage() {
+                segueToActionSheetDaxDialogWithSpec(spec)
+            } else {
+               showClearDataAlert()
+            }
+        }
+        
         performCancel()
     }
     

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -183,7 +183,8 @@ class MainViewController: UIViewController {
         previewsSource: TabPreviewsSource,
         tabsModel: TabsModel,
         syncPausedStateManager: any SyncPausedStateManaging,
-        variantManager: VariantManager
+        variantManager: VariantManager,
+        contextualOnboardingPresenter: ContextualOnboardingPresenting
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner
@@ -201,7 +202,8 @@ class MainViewController: UIViewController {
                                      previewsSource: previewsSource,
                                      bookmarksDatabase: bookmarksDatabase,
                                      historyManager: historyManager,
-                                     syncService: syncService)
+                                     syncService: syncService,
+                                     contextualOnboardingPresenter: contextualOnboardingPresenter)
         self.syncPausedStateManager = syncPausedStateManager
         self.homeTabManager = NewTabPageManager()
         self.variantManager = variantManager

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingBackgroundWrapper.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingBackgroundWrapper.swift
@@ -1,0 +1,44 @@
+//
+//  ContextualOnboardingBackgroundWrapper.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+struct ContextualOnboardingBackgroundWrapper<Content: View>: View {
+    private let content: Content
+
+    init(_ content: Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        content
+            .padding()
+            .background(OnboardingBackground())
+    }
+}
+
+#Preview {
+    ContextualOnboardingBackgroundWrapper(
+        ContextualDaxDialog(
+            message: .init(string: "Hello World!!!"),
+            cta: "OK!",
+            action: {}
+        )
+    )
+}

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -1,0 +1,49 @@
+//
+//  ContextualDaxDialogsFactory.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+protocol ContextualDaxDialogsFactory {
+    func makeView(for spec: DaxDialogs.BrowsingSpec, onActionTapped: (() -> Void)?) -> UIViewController
+}
+
+extension ContextualDaxDialogsFactory {
+    func makeView(for spec: DaxDialogs.BrowsingSpec) -> UIViewController {
+        self.makeView(for: spec, onActionTapped: nil)
+    }
+}
+
+// TODO: This will be replaced with the factory that returns the Contextual Dax Dialogs for the new contextual flow
+final class ExistingLogicContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
+
+    func makeView(for spec: DaxDialogs.BrowsingSpec, onActionTapped: (() -> Void)?) -> UIViewController {
+        let contextualDialog = ContextualDaxDialog(
+            message: spec.message.attributedStringFromMarkdown(color: ThemeManager.shared.currentTheme.daxDialogTextColor),
+            cta: spec.cta,
+            action: onActionTapped
+        )
+
+        let hostingController = UIHostingController(rootView: ContextualOnboardingBackgroundWrapper(contextualDialog))
+        if #available(iOS 16.0, *) {
+            hostingController.sizingOptions = [.intrinsicContentSize]
+        }
+
+        return hostingController
+    }
+}

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
@@ -52,12 +52,7 @@ private extension ContextualOnboardingPresenter {
         vc.performSegue(withIdentifier: "DaxDialog", sender: spec)
     }
 
-    func presentExperimentContextualOnboarding(
-        for spec: DaxDialogs.BrowsingSpec,
-        in vc: TabViewControllerType,
-        onCompletion: (() -> Void)? = nil,
-        onDismiss: (() -> Void)? = nil
-    ) {
+    func presentExperimentContextualOnboarding(for spec: DaxDialogs.BrowsingSpec, in vc: TabViewControllerType) {
 
         func animate(daxController: UIViewController, visible isVisible: Bool, onCompletion: ((Bool) -> Void)? = nil) {
             daxController.view.isHidden = !isVisible

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
@@ -1,0 +1,136 @@
+//
+//  ContextualOnboardingPresenter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+import Core
+
+protocol ContextualOnboardingPresenting {
+    func presentContextualOnboarding(for spec: DaxDialogs.BrowsingSpec, in vc: TabViewControllerType)
+}
+
+final class ContextualOnboardingPresenter: ContextualOnboardingPresenting {
+    private let variantManager: VariantManager
+    private let daxDialogsFactory: ContextualDaxDialogsFactory
+
+    init(variantManager: VariantManager, daxDialogsFactory: ContextualDaxDialogsFactory = ExistingLogicContextualDaxDialogsFactory()) {
+        self.variantManager = variantManager
+        self.daxDialogsFactory = daxDialogsFactory
+    }
+
+    func presentContextualOnboarding(for spec: DaxDialogs.BrowsingSpec, in vc: TabViewControllerType) {
+        if variantManager.isSupported(feature: .newOnboardingIntro) {
+            presentExperimentContextualOnboarding(for: spec, in: vc)
+        } else {
+            presentControlContextualOnboarding(for: spec, in: vc)
+        }
+    }
+
+}
+
+// MARK: - Private
+
+private extension ContextualOnboardingPresenter {
+
+    func presentControlContextualOnboarding(for spec: DaxDialogs.BrowsingSpec, in vc: TabViewControllerType) {
+        vc.performSegue(withIdentifier: "DaxDialog", sender: spec)
+    }
+
+    func presentExperimentContextualOnboarding(
+        for spec: DaxDialogs.BrowsingSpec,
+        in vc: TabViewControllerType,
+        onCompletion: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) {
+
+        func animate(daxController: UIViewController, visible isVisible: Bool, onCompletion: ((Bool) -> Void)? = nil) {
+            daxController.view.isHidden = !isVisible
+            UIView.animate(
+                withDuration: 0.3,
+                animations: {
+                    daxController.view.alpha = isVisible ? 1 : 0
+                    daxController.parent?.view.layoutIfNeeded()
+                },
+                completion: onCompletion
+            )
+        }
+
+        // Before presenting a new dialog, remove any existing ones.
+        vc.daxDialogsStackView.arrangedSubviews.filter({ $0 != vc.webViewContainerView }).forEach {
+            vc.daxDialogsStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+
+        // Ask the Dax Dialogs Factory for a view for the given spec
+        let controller = daxDialogsFactory.makeView(for: spec) { [weak vc] in
+            guard let vc, let daxController = vc.daxContextualOnboardingController else { return }
+
+            // Collapse stack view and remove dax controller
+            animate(daxController: daxController, visible: false) { _ in
+                vc.daxDialogsStackView.removeArrangedSubview(daxController.view)
+                vc.removeChild(daxController)
+            }
+        }
+        controller.view.isHidden = true
+        controller.view.alpha = 0
+
+        vc.insertChild(controller, in: vc.daxDialogsStackView, at: 0)
+        vc.daxContextualOnboardingController = controller
+
+        animate(daxController: controller, visible: true)
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension UIViewController {
+
+    func insertChild(_ childController: UIViewController, in stackView: UIStackView, at index: Int) {
+        addChild(childController)
+        stackView.insertArrangedSubview(childController.view, at: index)
+        childController.didMove(toParent: self)
+    }
+
+    func removeChild(_ childController: UIViewController) {
+        childController.willMove(toParent: nil)
+        childController.view.removeFromSuperview()
+        childController.removeFromParent()
+    }
+
+}
+
+// MARK: - TabViewControllerType
+
+protocol TabViewControllerType: UIViewController {
+    var daxDialogsStackView: UIStackView { get }
+    var webViewContainerView: UIView { get }
+    var daxContextualOnboardingController: UIViewController? { get set }
+}
+
+extension TabViewController: TabViewControllerType {
+
+    var daxDialogsStackView: UIStackView {
+        containerStackView
+    }
+
+    var webViewContainerView: UIView {
+        webViewContainer
+    }
+}

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -35,6 +35,7 @@ class TabManager {
     private let historyManager: HistoryManaging
     private let syncService: DDGSyncing
     private var previewsSource: TabPreviewsSource
+    private let contextualOnboardingPresenter: ContextualOnboardingPresenting
 
     weak var delegate: TabDelegate?
 
@@ -46,12 +47,14 @@ class TabManager {
          previewsSource: TabPreviewsSource,
          bookmarksDatabase: CoreDataDatabase,
          historyManager: HistoryManaging,
-         syncService: DDGSyncing) {
+         syncService: DDGSyncing,
+         contextualOnboardingPresenter: ContextualOnboardingPresenting) {
         self.model = model
         self.previewsSource = previewsSource
         self.bookmarksDatabase = bookmarksDatabase
         self.historyManager = historyManager
         self.syncService = syncService
+        self.contextualOnboardingPresenter = contextualOnboardingPresenter
 
         registerForNotifications()
     }
@@ -68,7 +71,8 @@ class TabManager {
         let controller = TabViewController.loadFromStoryboard(model: tab,
                                                               bookmarksDatabase: bookmarksDatabase,
                                                               historyManager: historyManager,
-                                                              syncService: syncService)
+                                                              syncService: syncService,
+                                                              contextualOnboardingPresenter: contextualOnboardingPresenter)
         controller.applyInheritedAttribution(inheritedAttribution)
         controller.attachWebView(configuration: configuration,
                                  andLoadRequest: url == nil ? nil : URLRequest.userInitiated(url!),
@@ -140,7 +144,8 @@ class TabManager {
         let controller = TabViewController.loadFromStoryboard(model: tab,
                                                               bookmarksDatabase: bookmarksDatabase,
                                                               historyManager: historyManager,
-                                                              syncService: syncService)
+                                                              syncService: syncService,
+                                                              contextualOnboardingPresenter: contextualOnboardingPresenter)
         controller.attachWebView(configuration: configCopy,
                                  andLoadRequest: request,
                                  consumeCookies: !model.hasActiveTabs,

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -105,7 +105,8 @@ extension TabViewController {
         let tabController = TabViewController.loadFromStoryboard(model: tab,
                                                                  bookmarksDatabase: bookmarksDatabase,
                                                                  historyManager: historyManager,
-                                                                 syncService: syncService)
+                                                                 syncService: syncService,
+                                                                 contextualOnboardingPresenter: contextualOnboardingPresenter)
         tabController.isLinkPreview = true
         let configuration = WKWebViewConfiguration.nonPersistent()
         tabController.attachWebView(configuration: configuration, andLoadRequest: URLRequest.userInitiated(url), consumeCookies: false)

--- a/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
@@ -1,0 +1,93 @@
+//
+//  ContextualOnboardingPresenterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import SwiftUI
+@testable import DuckDuckGo
+
+final class ContextualOnboardingPresenterTests: XCTestCase {
+
+    func testWhenPresentContextualOnboardingAndVariantDoesNotSupportOnboardingIntroThenOldContextualOnboardingIsPresented() throws {
+        // GIVEN
+        var variantManagerMock = MockVariantManager()
+        variantManagerMock.isSupportedBlock = { feature in
+            feature != .newOnboardingIntro
+        }
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock)
+        let parent = TabViewControllerMock()
+        XCTAssertFalse(parent.didCallPerformSegue)
+        XCTAssertNil(parent.capturedSegueIdentifier)
+        XCTAssertNil(parent.capturedSender)
+
+        // WHEN
+        sut.presentContextualOnboarding(for: .afterSearch, in: parent)
+
+        // THEN
+        XCTAssertTrue(parent.didCallPerformSegue)
+        XCTAssertEqual(parent.capturedSegueIdentifier, "DaxDialog")
+        let sender = try XCTUnwrap(parent.capturedSender as? DaxDialogs.BrowsingSpec)
+        XCTAssertEqual(sender, DaxDialogs.BrowsingSpec.afterSearch)
+    }
+
+    func testWhenPresentContextualOnboardingAndVariantSupportsNewOnboardingIntroThenThenNewContextualOnboardingIsPresented() {
+        // GIVEN
+        var variantManagerMock = MockVariantManager()
+        variantManagerMock.isSupportedBlock = { feature in
+            feature == .newOnboardingIntro
+        }
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock)
+        let parent = TabViewControllerMock()
+        XCTAssertFalse(parent.didCallAddChild)
+        XCTAssertNil(parent.capturedChild)
+
+        // WHEN
+        sut.presentContextualOnboarding(for: .afterSearch, in: parent)
+
+        // THEN
+        XCTAssertTrue(parent.didCallAddChild)
+        XCTAssertNotNil(parent.capturedChild)
+        XCTAssertTrue(parent.capturedChild is UIHostingController<ContextualOnboardingBackgroundWrapper<ContextualDaxDialog>>)
+    }
+
+}
+
+final class TabViewControllerMock: UIViewController, TabViewControllerType {
+    var daxDialogsStackView: UIStackView = UIStackView()
+    var webViewContainerView: UIView  = UIView()
+    var daxContextualOnboardingController: UIViewController?
+
+    private(set) var didCallPerformSegue = false
+    private(set) var capturedSegueIdentifier: String?
+    private(set) var capturedSender: Any?
+
+    private(set) var didCallAddChild = false
+    private(set) var capturedChild: UIViewController?
+
+    override func performSegue(withIdentifier identifier: String, sender: Any?) {
+        didCallPerformSegue = true
+        capturedSegueIdentifier = identifier
+        capturedSender = sender
+    }
+
+    override func addChild(_ childController: UIViewController) {
+        didCallAddChild = true
+        capturedChild = childController
+    }
+
+}

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -68,7 +68,8 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             previewsSource: TabPreviewsSource(),
             tabsModel: tabsModel,
             syncPausedStateManager: CapturingSyncPausedStateManager(),
-            variantManager: MockVariantManager())
+            variantManager: MockVariantManager(),
+            contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: DefaultVariantManager()))
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207701578629995/f
CC: @SabrinaTardio 

**Description**:

This PR changes the rendering of the onboarding contextual messages based on the cohorts.

For cohort `ma` show the Old onboarding overlays
For cohort `mb` show the new Dax Contextual Dialogs.

I created a `ContextualOnboardingPresenter` and a `ContextualDaxDialogsFactory`. 

The `ContextualDaxDialogsFactory` responsibility is to create specific contextual dialogs based on the BrowsingSpec. In this PR, only one type is created. In the next PRs different types will be returned.

The presenter is in charge of: 
- Perform the DaxDialog segue and show the messages as full-screen overlay if the cohort is `ma`
- Ask the `ContextualDaxDialogsFactory` for the correct dialog, add it as a child and render it as part of the Tab screen. 

**Video**

https://github.com/duckduckgo/iOS/assets/1089358/3bfb3955-cb8d-4454-b541-eb5ba0ad29d9

**Steps to test this PR**:

**SCENARIO 1 - Old Onboarding**
Prerequisites: Delete DuckDuckGo App from Simulator.

1. DuckDuckGo Scheme -> Run -> Arguments -> Environment Variables -> VARIANT -> `ma`
2. Add temporary `newInstallCompletion(self)` at line 141 in `DefaultVariantManager`
3. Launch the App.
4. Complete the Onboarding Intro.
5. The New Tab Page should show the old Dax Dialog.
6. Follow the instructions and input a website (e.g. “facebook.com”) into the address bar.
**Expected Result:** An overlay informing the user about the trackers blocked should appear on top of the screen.
8. Dismiss the overlay.
9. Tap the fire Button.
**Expected Result:** The action sheet to clear the data should appear on the screen along with an overlay informing the user about the fire button.

**SCENARIO 2 - New Onboarding**
Prerequisites: Delete DuckDuckGo App from Simulator.

1. DuckDuckGo Scheme -> Run -> Arguments -> Environment Variables -> VARIANT -> `mb`
2. Add temporary `newInstallCompletion(self)` at line 141 in `DefaultVariantManager`
3. Launch the App
4. Complete the Onboarding Intro.
5. The New Tab Page should show the old Dax Dialog.
6. Follow the instructions and input a website (e.g. “facebook.com”) into the address bar.
**Expected Result:** The Web page should shift down and the Dax Contextual Dialog should appear on the screen.
7. Tap the action button of the Dax Contextual Dialog. 
**Expected Result:** The Dax Contextual Dialog should disappear and the web page shift up.
8. Tap the fire Button.
**Expected Result:** The action sheet to clear the data should appear on screen but it should not show any overlay.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
