### PR TITLE
ensure only one history database context

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -279,9 +279,7 @@ import WebKit
             }
 
         let previewsSource = TabPreviewsSource()
-        let historyManager = makeHistoryManager(AppDependencyProvider.shared.appSettings,
-                                                AppDependencyProvider.shared.internalUserDecider,
-                                                ContentBlocking.shared.privacyConfigurationManager)
+        let historyManager = makeHistoryManager()
         let tabsModel = prepareTabsModel(previewsSource: previewsSource)
 
         let main = MainViewController(bookmarksDatabase: bookmarksDatabase,
@@ -346,6 +344,29 @@ import WebKit
         return true
     }
 
+    private func makeHistoryManager() -> HistoryManaging {
+
+        let settings = AppDependencyProvider.shared.appSettings
+
+        switch HistoryManager.make(isAutocompleteEnabledByUser: settings.autocomplete,
+                                   isRecentlyVisitedSitesEnabledByUser: settings.recentlyVisitedSites,
+                                   internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
+                                   privacyConfigManager: ContentBlocking.shared.privacyConfigurationManager) {
+
+        case .failure(let error):
+            Pixel.fire(pixel: .historyStoreLoadFailed, error: error)
+            if error.isDiskFull {
+                self.presentInsufficientDiskSpaceAlert()
+            } else {
+                self.presentPreemptiveCrashAlert()
+            }
+            return NullHistoryManager()
+
+        case .success(let historyManager):
+            return historyManager
+        }
+    }
+
     private func prepareTabsModel(previewsSource: TabPreviewsSource = TabPreviewsSource(),
                                   appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
                                   isDesktop: Bool = UIDevice.current.userInterfaceIdiom == .pad) -> TabsModel {
@@ -365,39 +386,6 @@ import WebKit
             }
         }
         return tabsModel
-    }
-
-    private func makeHistoryManager(_ appSettings: AppSettings,
-                                    _ internalUserDecider: InternalUserDecider,
-                                    _ privacyConfigManager: PrivacyConfigurationManaging) -> HistoryManager {
-
-        let db = HistoryDatabase.make()
-        var loadError: Error?
-        db.loadStore { _, error in
-            loadError = error
-        }
-
-        if let loadError {
-            Pixel.fire(pixel: .historyStoreLoadFailed, error: loadError)
-            if loadError.isDiskFull {
-                self.presentInsufficientDiskSpaceAlert()
-            } else {
-                self.presentPreemptiveCrashAlert()
-            }
-        }
-
-        let historyManager = HistoryManager(privacyConfigManager: privacyConfigManager,
-                                            variantManager: DefaultVariantManager(),
-                                            database: db,
-                                            internalUserDecider: internalUserDecider,
-                                            isEnabledByUser: appSettings.recentlyVisitedSites)
-
-        // Ensure we don't do this if the history is disabled in privacy confg
-        guard historyManager.isHistoryFeatureEnabled() else { return historyManager }
-        historyManager.loadStore(onCleanFinished: {
-            // Do future migrations after clean has finished.  See macOS for an example.
-        })
-        return historyManager
     }
 
     private func presentPreemptiveCrashAlert() {

--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -40,7 +40,7 @@ class AutocompleteViewController: UIHostingController<AutocompleteView> {
     weak var delegate: AutocompleteViewControllerDelegate?
     weak var presentationDelegate: AutocompleteViewControllerPresentationDelegate?
 
-    private let historyManager: HistoryManager
+    private let historyManager: HistoryManaging
     var historyCoordinator: HistoryCoordinating {
         historyManager.historyCoordinator
     }
@@ -63,7 +63,7 @@ class AutocompleteViewController: UIHostingController<AutocompleteView> {
 
     private var historyMessageManager: HistoryMessageManager
 
-    init(historyManager: HistoryManager,
+    init(historyManager: HistoryManaging,
          bookmarksDatabase: CoreDataDatabase,
          appSettings: AppSettings,
          historyMessageManager: HistoryMessageManager = HistoryMessageManager()) {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -170,13 +170,13 @@ class MainViewController: UIViewController {
         fatalError("Use init?(code:")
     }
     
-    var historyManager: HistoryManager
+    var historyManager: HistoryManaging
     var viewCoordinator: MainViewCoordinator!
 
     init(
         bookmarksDatabase: CoreDataDatabase,
         bookmarksDatabaseCleaner: BookmarkDatabaseCleaner,
-        historyManager: HistoryManager,
+        historyManager: HistoryManaging,
         syncService: DDGSyncing,
         syncDataProviders: SyncDataProviders,
         appSettings: AppSettings,

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -164,7 +164,6 @@ final class SettingsViewModel: ObservableObject {
             set: {
                 self.appSettings.autocomplete = $0
                 self.state.autocomplete = $0
-
                 self.clearHistoryIfNeeded()
                 self.updateRecentlyVisitedSitesVisibility()
                 

--- a/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/DuckDuckGo/SuggestionTrayViewController.swift
@@ -49,7 +49,7 @@ class SuggestionTrayViewController: UIViewController {
     private var willRemoveAutocomplete = false
     private let bookmarksDatabase: CoreDataDatabase
     private let favoritesModel: FavoritesListInteracting
-    private let historyManager: HistoryManager
+    private let historyManager: HistoryManaging
 
     var selectedSuggestion: Suggestion? {
         autocompleteController?.selectedSuggestion
@@ -79,7 +79,7 @@ class SuggestionTrayViewController: UIViewController {
         }
     }
     
-    required init?(coder: NSCoder, favoritesViewModel: FavoritesListInteracting, bookmarksDatabase: CoreDataDatabase, historyManager: HistoryManager) {
+    required init?(coder: NSCoder, favoritesViewModel: FavoritesListInteracting, bookmarksDatabase: CoreDataDatabase, historyManager: HistoryManaging) {
         self.favoritesModel = favoritesViewModel
         self.bookmarksDatabase = bookmarksDatabase
         self.historyManager = historyManager

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -32,7 +32,7 @@ class TabManager {
     private var tabControllerCache = [TabViewController]()
 
     private let bookmarksDatabase: CoreDataDatabase
-    private let historyManager: HistoryManager
+    private let historyManager: HistoryManaging
     private let syncService: DDGSyncing
     private var previewsSource: TabPreviewsSource
 
@@ -45,7 +45,7 @@ class TabManager {
     init(model: TabsModel,
          previewsSource: TabPreviewsSource,
          bookmarksDatabase: CoreDataDatabase,
-         historyManager: HistoryManager,
+         historyManager: HistoryManaging,
          syncService: DDGSyncing) {
         self.model = model
         self.previewsSource = previewsSource

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -298,7 +298,7 @@ class TabViewController: UIViewController {
     static func loadFromStoryboard(model: Tab,
                                    appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
                                    bookmarksDatabase: CoreDataDatabase,
-                                   historyManager: HistoryManager,
+                                   historyManager: HistoryManaging,
                                    syncService: DDGSyncing) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
@@ -316,7 +316,7 @@ class TabViewController: UIViewController {
         (webView.configuration.userContentController as? UserContentController)!
     }
 
-    let historyManager: HistoryManager
+    let historyManager: HistoryManaging
     let historyCapture: HistoryCapture
     
     var duckPlayer: DuckPlayerProtocol = DuckPlayer()
@@ -326,7 +326,7 @@ class TabViewController: UIViewController {
                    tabModel: Tab,
                    appSettings: AppSettings,
                    bookmarksDatabase: CoreDataDatabase,
-                   historyManager: HistoryManager,
+                   historyManager: HistoryManaging,
                    syncService: DDGSyncing) {
         self.tabModel = tabModel
         self.appSettings = appSettings

--- a/DuckDuckGoTests/HistoryCaptureTests.swift
+++ b/DuckDuckGoTests/HistoryCaptureTests.swift
@@ -79,7 +79,10 @@ final class HistoryCaptureTests: XCTestCase {
     }
 
     func makeCapture() -> HistoryCapture {
-        return HistoryCapture(historyManager: MockHistoryManager(historyCoordinator: mockHistoryCoordinator, isEnabledByUser: true, historyFeatureEnabled: true))
+        let mock = MockHistoryManager(historyCoordinator: mockHistoryCoordinator,
+                                      isEnabledByUser: true,
+                                      historyFeatureEnabled: true)
+        return HistoryCapture(historyManager: mock)
     }
 
 }

--- a/DuckDuckGoTests/HistoryCaptureTests.swift
+++ b/DuckDuckGoTests/HistoryCaptureTests.swift
@@ -79,7 +79,7 @@ final class HistoryCaptureTests: XCTestCase {
     }
 
     func makeCapture() -> HistoryCapture {
-        return HistoryCapture(historyManager: MockHistoryManager(historyCoordinator: mockHistoryCoordinator))
+        return HistoryCapture(historyManager: MockHistoryManager(historyCoordinator: mockHistoryCoordinator, isEnabledByUser: true, historyFeatureEnabled: true))
     }
 
 }
@@ -107,11 +107,20 @@ private extension URL {
 class MockHistoryManager: HistoryManaging {
 
     let historyCoordinator: HistoryCoordinating
+    var isEnabledByUser: Bool
+    var historyFeatureEnabled: Bool
 
-    init(historyCoordinator: HistoryCoordinating) {
+    init(historyCoordinator: HistoryCoordinating, isEnabledByUser: Bool, historyFeatureEnabled: Bool) {
         self.historyCoordinator = historyCoordinator
+        self.historyFeatureEnabled = historyFeatureEnabled
+        self.isEnabledByUser = isEnabledByUser
     }
 
-    func loadStore(onCleanFinished: @escaping () -> Void) throws {
+    func isHistoryFeatureEnabled() -> Bool {
+        return historyFeatureEnabled
     }
-}
+
+    func removeAllHistory() async {
+    }
+
+ }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207755453158856/f
Tech Design URL:
CC:

**Description**:
Ensures there's only 1 database context for the history store to avoid having merge conflicts.

**Steps to test this PR**:

***Fire button:***
1. Make sure feature is enabled
2. Visit some sites and generate history
3. Check history appears
4. Use the fire button
5. Check history has been deleted

***Settings:***
2. Visit some sites and generate history.
3. Disable the autocomplete setting
4. Check history not visible and visit different sites
6. Enable the autocomplete setting
7. Check previous history not visible
8. Repeat but by turning off the recently visited sites setting

***Autoclear:***
1. Turn on autoclear and set timer to 5 seconds in the code 
2. Visit some sites
3. Background the app and trigger autoclear 
4. Check sites not in history
5. Visit more sites
6. Kill the app
7. Check sites not in history
