### PR TITLE
remove unused gating logic for history roll out

### DIFF
--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -26,7 +26,6 @@ extension FeatureName {
     // Define your feature e.g.:
     // public static let experimentalFeature = FeatureName(rawValue: "experimentalFeature")
 
-    public static let history = FeatureName(rawValue: "history")
 }
 
 public struct VariantIOS: Variant {
@@ -61,10 +60,6 @@ public struct VariantIOS: Variant {
         VariantIOS(name: "sc", weight: doNotAllocate, isIncluded: When.always, features: []),
         VariantIOS(name: "sd", weight: doNotAllocate, isIncluded: When.always, features: []),
         VariantIOS(name: "se", weight: doNotAllocate, isIncluded: When.always, features: []),
-
-        // This needs to stay until we finish rolling out history to all users...
-        // This ensures that users who previously had do not lose it.
-        VariantIOS(name: "md", weight: doNotAllocate, isIncluded: When.inEnglish, features: [.history]),
 
         returningUser
     ]

--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -32,7 +32,6 @@ public enum FeatureFlag: String {
     case incontextSignup
     case autoconsentOnByDefault
     case history
-    case historyRollout
     case newTabPageSections
     case duckPlayer
 }
@@ -62,8 +61,6 @@ extension FeatureFlag: FeatureFlagSourceProviding {
             return .remoteReleasable(.subfeature(AutoconsentSubfeature.onByDefault))
         case .history:
             return .remoteReleasable(.feature(.history))
-        case .historyRollout:
-            return .remoteReleasable(.subfeature(HistorySubFeature.onByDefault))
         case .newTabPageSections:
             return .internalOnly
         case .duckPlayer:

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -114,7 +114,7 @@ import WebKit
         }
     }
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         // SKAD4 support

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -237,10 +237,8 @@ import WebKit
         variantManager.assignVariantIfNeeded { _ in
             // MARK: perform first time launch logic here
             DaxDialogs.shared.primeForUse()
-            historyMessageManager.dismiss()
-        }
 
-        if variantManager.isSupported(feature: .history) {
+            // New users don't see the message
             historyMessageManager.dismiss()
         }
 
@@ -380,7 +378,6 @@ import WebKit
 
         switch HistoryManager.make(isAutocompleteEnabledByUser: settings.autocomplete,
                                    isRecentlyVisitedSitesEnabledByUser: settings.recentlyVisitedSites,
-                                   internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
                                    privacyConfigManager: ContentBlocking.shared.privacyConfigurationManager) {
 
         case .failure(let error):


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207766769947735/f
Tech Design URL:
CC:

**Description**:
Removes logic related to rolling out history which is now available to everyone.

**Steps to test this PR**:
1. Clean install of the app
2. Perform a search
3. Visit pages
4. Type in search bar and confirm history was stored
5. Use fire button
6. Confirm history was removed
7. Disable in settings 
8. Visit pages
9. Confirm history not added
10. Enable in settings
11. Visit pages
12. Confirm history was stored

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
