### PR TITLE
fix ui tests broken by new onboarding and use shared setup flow

### DIFF
--- a/.maestro/ad_click_detection_flow_tests/01_yjs_heuristic_no_ad_domain_param_u3_param_included.yaml
+++ b/.maestro/ad_click_detection_flow_tests/01_yjs_heuristic_no_ad_domain_param_u3_param_included.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/02_mjs_heuristic_no_ad_domain_param_dsl_param_included.yaml
+++ b/.maestro/ad_click_detection_flow_tests/02_mjs_heuristic_no_ad_domain_param_dsl_param_included.yaml
@@ -5,15 +5,9 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
-
+    file: ../shared/setup.yaml
+    
 # Load Site
 - assertVisible:
     id: "searchEntry"

--- a/.maestro/ad_click_detection_flow_tests/03_yjs_heuristic_no_ad_domain_param_but_missing_u3_param.yaml
+++ b/.maestro/ad_click_detection_flow_tests/03_yjs_heuristic_no_ad_domain_param_but_missing_u3_param.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/04_mjs_heuristic_no_ad_domain_param_but_missing_dsl_param.yaml
+++ b/.maestro/ad_click_detection_flow_tests/04_mjs_heuristic_no_ad_domain_param_but_missing_dsl_param.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/05_yjs_heuristic_ad_domain_provided_but_empty_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/05_yjs_heuristic_ad_domain_provided_but_empty_u3_not_needed.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/06_mjs_heuristic_ad_domain_provided_but_empty_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/06_mjs_heuristic_ad_domain_provided_but_empty_dsl_not_needed.yaml
@@ -3,14 +3,10 @@ tags:
     - adClick
 
 ---
-- clearState
-- launchApp
+
+# Set up
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/07_yjs_bing-provided_ad_domain_provided_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/07_yjs_bing-provided_ad_domain_provided_u3_not_needed.yaml
@@ -3,14 +3,10 @@ tags:
     - adClick
 
 ---
-- clearState
-- launchApp
+
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/08_mjs_bing-provided_ad_domain_provided_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/08_mjs_bing-provided_ad_domain_provided_dsl_not_needed.yaml
@@ -3,14 +3,10 @@ tags:
     - adClick
 
 ---
-- clearState
-- launchApp
-- runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+
+# Set up 
+- runFlow:
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/09_yjs_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/09_yjs_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
@@ -4,14 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/10_mjs_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/10_mjs_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
@@ -4,14 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/11_yjs_bing-provided_ad_domain_provided_but_its_not_a_domain_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/11_yjs_bing-provided_ad_domain_provided_but_its_not_a_domain_u3_not_needed.yaml
@@ -4,14 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/12_mjs_bing-provided_ad_domain_provided_but_its_not_a_domain_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/12_mjs_bing-provided_ad_domain_provided_but_its_not_a_domain_dsl_not_needed.yaml
@@ -4,14 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/13_yjs_bing-provided_ad_domain_provided_but_its_a_subdomain_of_advertiser_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/13_yjs_bing-provided_ad_domain_provided_but_its_a_subdomain_of_advertiser_u3_not_needed.yaml
@@ -4,14 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/ad_click_detection_flow_tests/14_mjs_bing-provided_ad_domain_provided_but_its_a_subdomain_of_advertiser_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flow_tests/14_mjs_bing-provided_ad_domain_provided_but_its_a_subdomain_of_advertiser_dsl_not_needed.yaml
@@ -4,14 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/browser_features/opening_tabs.yaml
+++ b/.maestro/browser_features/opening_tabs.yaml
@@ -5,15 +5,9 @@ tags:
 
 ---
 
-# Set up
-- clearState
-- launchApp
-- runFlow:
-    when:
-      visible:
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/browser_features/search_bar.yaml
+++ b/.maestro/browser_features/search_bar.yaml
@@ -5,15 +5,9 @@ tags:
 
 ---
 
-# Set up
-- clearState
-- launchApp
-- runFlow:
-    when:
-      visible:
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/browser_features/swipe_tabs.yaml
+++ b/.maestro/browser_features/swipe_tabs.yaml
@@ -5,15 +5,9 @@ tags:
 
 ---
 
-# Set up
-- clearState
-- launchApp
-- runFlow:
-    when:
-      visible:
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/data_clearing_tests/01_fire_proofing.yml
+++ b/.maestro/data_clearing_tests/01_fire_proofing.yml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/data_clearing_tests/02_duckduckgo_settings.yml
+++ b/.maestro/data_clearing_tests/02_duckduckgo_settings.yml
@@ -5,15 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearKeychain
-- clearState
-- launchApp
-- runFlow:
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+- runFlow: 
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/01_single-site_single-tab_session.yaml
+++ b/.maestro/privacy_tests/01_single-site_single-tab_session.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/02_single-site_new_tab_session.yaml
+++ b/.maestro/privacy_tests/02_single-site_new_tab_session.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/03_single-site_new-tab_session_variant_two.yaml
+++ b/.maestro/privacy_tests/03_single-site_new-tab_session_variant_two.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/04_single-site_multi-tab_session.yaml
+++ b/.maestro/privacy_tests/04_single-site_multi-tab_session.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/05_multi-site_single-tab_session.yaml
+++ b/.maestro/privacy_tests/05_multi-site_single-tab_session.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/06_multi-tab.yaml
+++ b/.maestro/privacy_tests/06_multi-tab.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/07_browser_restart_mid-session.yaml
+++ b/.maestro/privacy_tests/07_browser_restart_mid-session.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/08_navigation_with_back_forward.yaml
+++ b/.maestro/privacy_tests/08_navigation_with_back_forward.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/privacy_tests/09_navigation_with_refresh.yaml
+++ b/.maestro/privacy_tests/09_navigation_with_refresh.yaml
@@ -5,14 +5,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -12,7 +12,6 @@ tags:
     clearKeychain: true
     arguments: 
        "autoclear-ui-test": true
-       "VARIANT": "ru"
 
 - runFlow: 
     file: ../shared/onboarding.yaml

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -5,7 +5,7 @@ tags:
 
 ---
 
-# Set up 
+# Set up  - custom setup
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
     clearState: true

--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -6,11 +6,13 @@ tags:
 ---
 
 # Set up 
-- clearState
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
     arguments: 
        "autoclear-ui-test": true
+       "VARIANT": "ru"
 
 - runFlow: 
     file: ../shared/onboarding.yaml

--- a/.maestro/release_tests/backgrounding.yaml
+++ b/.maestro/release_tests/backgrounding.yaml
@@ -6,11 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
-
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/bookmarks-multi.yaml
+++ b/.maestro/release_tests/bookmarks-multi.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/bookmarks.yaml
+++ b/.maestro/release_tests/bookmarks.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/browsing.yaml
+++ b/.maestro/release_tests/browsing.yaml
@@ -6,15 +6,9 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
-
+    file: ../shared/setup.yaml
+   
 # Load Site
 - assertVisible:
     id: "searchEntry"

--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/emailprotection.yaml
+++ b/.maestro/release_tests/emailprotection.yaml
@@ -4,15 +4,9 @@ tags:
 
 ---
 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
-
+    file: ../shared/setup.yaml
+    
 - tapOn: Settings
 # Handling two different flows because of the current experiment
 # TODO: Remove the unused flow when the experiment is completed.

--- a/.maestro/release_tests/favorites.yaml
+++ b/.maestro/release_tests/favorites.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/firebutton.yaml
+++ b/.maestro/release_tests/firebutton.yaml
@@ -6,12 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- clearKeychain
-- launchApp
-
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/password-authentication.yaml
+++ b/.maestro/release_tests/password-authentication.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Validate passcode requested when accessing passwords for the first time
 - tapOn: "Settings"

--- a/.maestro/release_tests/password-autofill.yaml
+++ b/.maestro/release_tests/password-autofill.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Capture login credentials
 - assertVisible:

--- a/.maestro/release_tests/password-management.yaml
+++ b/.maestro/release_tests/password-management.yaml
@@ -6,10 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Validate passcode requested when accessing passwords for the first time
 - tapOn: "Settings"

--- a/.maestro/release_tests/tabs.yaml
+++ b/.maestro/release_tests/tabs.yaml
@@ -6,14 +6,8 @@ tags:
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/release_tests/widgets.yaml
+++ b/.maestro/release_tests/widgets.yaml
@@ -8,10 +8,8 @@ appId: com.duckduckgo.mobile.ios
 ---
 
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load a website
 - assertVisible:

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -2,15 +2,10 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - securityTest
 ---
+
 # Set up 
-- clearState
-- launchApp
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Load Site
 - assertVisible:

--- a/.maestro/shared/onboarding.yaml
+++ b/.maestro/shared/onboarding.yaml
@@ -9,6 +9,8 @@ appId: com.duckduckgo.mobile.ios
 - tapOn:
     text: "Let’s Do It!"
     index: 0
-- assertVisible: "Make DuckDuckGo your default browser."
+
+# Disabled while UI testing is happening
+# - assertVisible: "Make DuckDuckGo your default browser."
 - tapOn:
     text: "Skip"

--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -3,7 +3,10 @@ appId: com.duckduckgo.mobile.ios
 
 ---
 
-# If you need more arguments, copy this whole thing into your test
+# If you need more arguments, copy these two commands directly into your test
+# * See release_tests/autoclear.yaml for an example
+
+# Launch the app with `ru` variant to ensure that no experiment variant is used
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
     clearState: true
@@ -11,5 +14,6 @@ appId: com.duckduckgo.mobile.ios
     arguments: 
        "VARIANT": "ru"
 
+# Get past onboarding screens
 - runFlow:
     file: onboarding.yaml

--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -6,7 +6,6 @@ appId: com.duckduckgo.mobile.ios
 # If you need more arguments, copy these two commands directly into your test
 # * See release_tests/autoclear.yaml for an example
 
-# Launch the app with `ru` variant to ensure that no experiment variant is used
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
     clearState: true

--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -1,10 +1,15 @@
+# setup.yaml
 appId: com.duckduckgo.mobile.ios
 
 ---
 
-# Set up 
-- clearState
-- clearKeychain
-- launchApp
-- runFlow: 
+# If you need more arguments, copy this whole thing into your test
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments: 
+       "VARIANT": "ru"
+
+- runFlow:
     file: onboarding.yaml

--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -11,8 +11,6 @@ appId: com.duckduckgo.mobile.ios
     appId: "com.duckduckgo.mobile.ios"
     clearState: true
     clearKeychain: true
-    arguments: 
-       "VARIANT": "ru"
 
 # Get past onboarding screens
 - runFlow:

--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -1,0 +1,10 @@
+appId: com.duckduckgo.mobile.ios
+
+---
+
+# Set up 
+- clearState
+- clearKeychain
+- launchApp
+- runFlow: 
+    file: onboarding.yaml

--- a/.maestro/sync_tests/01_create_account.yaml
+++ b/.maestro/sync_tests/01_create_account.yaml
@@ -5,17 +5,9 @@ name: 01_create_account
 
 ---
 
-# Clear and launch
-- clearState
-- launchApp
-
-# Run onboarding Flow
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Set Internal User
 - tapOn: Settings

--- a/.maestro/sync_tests/02_login_account.yaml
+++ b/.maestro/sync_tests/02_login_account.yaml
@@ -5,17 +5,9 @@ name: 02_login_account
 
 ---
 
-# Clear and launch
-- clearState
-- launchApp
-
-# Run onboarding Flow
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 #  Copy Recovery Code
 - tapOn: Settings

--- a/.maestro/sync_tests/03_recover_account.yaml
+++ b/.maestro/sync_tests/03_recover_account.yaml
@@ -5,17 +5,9 @@ name: 03_recover_account
 
 ---
 
-# Clear and launch
-- clearState
-- launchApp
-
-# Run onboarding Flow
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Set Internal User
 - tapOn: Settings

--- a/.maestro/sync_tests/04_sync_data_setup.yaml
+++ b/.maestro/sync_tests/04_sync_data_setup.yaml
@@ -5,17 +5,9 @@ name: 04_sync_data_setup
 
 ---
 
-# Clear and launch
-- clearState
-- launchApp
-
-# Run onboarding Flow
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Add local favorite and bookmark
 - runFlow:

--- a/.maestro/sync_tests/05_sync_data_check.yaml
+++ b/.maestro/sync_tests/05_sync_data_check.yaml
@@ -8,17 +8,10 @@ name: 05_sync_data_check
 #            and it will fail if 04 is not executed before. 
 #            The test is split in two different flow to accomodate 
 #            for Maestro CI max execution time. 
-# Clear and launch
-- clearState
-- launchApp
 
-# Run onboarding Flow
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 #  Copy Recovery Code
 - tapOn: Settings

--- a/.maestro/sync_tests/06_delete_account.yaml
+++ b/.maestro/sync_tests/06_delete_account.yaml
@@ -4,17 +4,9 @@ tags:
 name: 06_delete_account
 ---
 
-# Clear and launch
-- clearState
-- launchApp
-
-# Run onboarding Flow
+# Set up 
 - runFlow: 
-    when: 
-      visible: 
-        text: "Let’s Do It!"
-        index: 0
-    file: ../shared/onboarding.yaml
+    file: ../shared/setup.yaml
 
 # Set Internal User
 - tapOn: Settings

--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -91,7 +91,7 @@ public protocol VariantRNG {
 public class DefaultVariantManager: VariantManager {
 
     public var currentVariant: Variant? {
-        let variantName = ProcessInfo.variantName
+        let variantName = ProcessInfo.variantName ?? storage.variant
         return variants.first(where: { $0.name == variantName })
     }
 

--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -182,13 +182,12 @@ public class Arc4RandomUniformVariantRNG: VariantRNG {
 extension ProcessInfo {
 
     static var variantName: String? {
-        guard let variantArg = ProcessInfo().arguments.first(where: {
-            $0.starts(with: "VARIANT=")
+        let p = ProcessInfo()
+        guard let variantArgIndex = p.arguments.firstIndex(where: {
+            $0.starts(with: "VARIANT")
         }) else { return nil }
-
-        let components = variantArg.components(separatedBy: "=")
-        guard components.count == 2 else { return nil }
-        return components[1]
+        guard p.arguments.count > variantArgIndex + 1 else { return nil }
+        return p.arguments[variantArgIndex + 1]
     }
 
 }

--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -91,7 +91,7 @@ public protocol VariantRNG {
 public class DefaultVariantManager: VariantManager {
 
     public var currentVariant: Variant? {
-        let variantName = ProcessInfo.processInfo.environment["VARIANT", default: storage.variant ?? "" ]
+        let variantName = ProcessInfo.variantName
         return variants.first(where: { $0.name == variantName })
     }
 
@@ -175,6 +175,20 @@ public class Arc4RandomUniformVariantRNG: VariantRNG {
     public func nextInt(upperBound: Int) -> Int {
         // swiftlint:disable:next legacy_random
         return Int(arc4random_uniform(UInt32(upperBound)))
+    }
+
+}
+
+extension ProcessInfo {
+
+    static var variantName: String? {
+        guard let variantArg = ProcessInfo().arguments.first(where: {
+            $0.starts(with: "VARIANT=")
+        }) else { return nil }
+
+        let components = variantArg.components(separatedBy: "=")
+        guard components.count == 2 else { return nil }
+        return components[1]
     }
 
 }

--- a/Core/DefaultVariantManager.swift
+++ b/Core/DefaultVariantManager.swift
@@ -91,7 +91,7 @@ public protocol VariantRNG {
 public class DefaultVariantManager: VariantManager {
 
     public var currentVariant: Variant? {
-        let variantName = ProcessInfo.variantName ?? storage.variant
+        let variantName = ProcessInfo.processInfo.environment["VARIANT", default: storage.variant ?? "" ]
         return variants.first(where: { $0.name == variantName })
     }
 
@@ -175,19 +175,6 @@ public class Arc4RandomUniformVariantRNG: VariantRNG {
     public func nextInt(upperBound: Int) -> Int {
         // swiftlint:disable:next legacy_random
         return Int(arc4random_uniform(UInt32(upperBound)))
-    }
-
-}
-
-extension ProcessInfo {
-
-    static var variantName: String? {
-        let p = ProcessInfo()
-        guard let variantArgIndex = p.arguments.firstIndex(where: {
-            $0.starts(with: "VARIANT")
-        }) else { return nil }
-        guard p.arguments.count > variantArgIndex + 1 else { return nil }
-        return p.arguments[variantArgIndex + 1]
     }
 
 }

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -114,10 +114,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "VARIANT ma"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>
@@ -130,6 +126,11 @@
          <EnvironmentVariable
             key = "ONBOARDING"
             value = "true"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "VARIANT"
+            value = "ma"
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -114,6 +114,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "VARIANT=ru"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>
@@ -123,11 +127,6 @@
          </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "VARIANT"
-            value = "md"
-            isEnabled = "NO">
-         </EnvironmentVariable>
          <EnvironmentVariable
             key = "ONBOARDING"
             value = "true"

--- a/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
+++ b/DuckDuckGo.xcodeproj/xcshareddata/xcschemes/DuckDuckGo.xcscheme
@@ -114,8 +114,8 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "VARIANT=ru"
-            isEnabled = "YES">
+            argument = "VARIANT ma"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207808692245660/f
Tech Design URL:
CC:

**Description**:

Also: https://app.asana.com/0/392891325557410/1207809241818381/f

Fixes UI test breakage by skipping assertion for title of onboarding screen.

**Steps to test this PR**:
1. Confirm E2E tests pass: https://github.com/duckduckgo/iOS/actions/runs/9974333207
3. Confirm Sync tests pass: https://github.com/duckduckgo/iOS/actions/runs/9974343415
5. Run the `.maestro/setup_ui_tests.sh` script.
6. Run some of the UI tests using the `.maestro/run_ui_tests.sh` script.  Should consistently pass.
