### PR TITLE
Properly compare actual value of the entitlement check

### DIFF
--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -727,7 +727,7 @@ extension SettingsViewModel {
             let entitlementsToCheck: [Entitlement.ProductName] = [.networkProtection, .dataBrokerProtection, .identityTheftRestoration]
 
             for entitlement in entitlementsToCheck {
-                if case .success = await subscriptionManager.accountManager.hasEntitlement(forProductName: entitlement) {
+                if case .success(true) = await subscriptionManager.accountManager.hasEntitlement(forProductName: entitlement) {
                     currentEntitlements.append(entitlement)
                 }
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1207839252973142/f

**Description**:
When building available entitlements list for the settings the entitlement check API should read actual result value instead of only validating if the call succeeded. The entitlement check returns Swift Result type wrapping boolean in the success case.

**Steps to test this PR**:
1. Prepare account having subscription that is missing some of the entitlements
2. Activate the subscription on the device
3. Open settings
4. Only feature for respective entitlements should be present

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
