### PR TITLE
Contextual Onboarding - Show final dialog

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -50,6 +50,7 @@ public struct UserDefaultsWrapper<T> {
         case daxBrowsingOwnedByMajorTrackingSiteShown = "com.duckduckgo.ios.daxOnboardingBrowsingOwnedByMajorTrackingSiteShown"
         case daxFireButtonEducationShownOrExpired = "com.duckduckgo.ios.daxfireButtonEducationShownOrExpired"
         case fireButtonPulseDateShown = "com.duckduckgo.ios.fireButtonPulseDateShown"
+        case daxBrowsingFinalDialogShown = "com.duckduckgo.ios.daxOnboardingFinalDialogSeen"
 
         case notFoundCache = "com.duckduckgo.ios.favicons.notFoundCache"
         case faviconSizeNeedsMigration = "com.duckduckgo.ios.favicons.sizeNeedsMigration"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -633,6 +633,8 @@
 		9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */; };
 		9F4CC51B2C48C0C7006A96EB /* MockTabDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51A2C48C0C7006A96EB /* MockTabDelegate.swift */; };
 		9F4CC51D2C48D240006A96EB /* CoreDataDatabaseTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51C2C48D240006A96EB /* CoreDataDatabaseTestUtilities.swift */; };
+		9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */; };
+		9F4CC5242C4A4F0D006A96EB /* SwiftUITestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */; };
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
@@ -2322,6 +2324,8 @@
 		9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerDaxDialogTests.swift; sourceTree = "<group>"; };
 		9F4CC51A2C48C0C7006A96EB /* MockTabDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabDelegate.swift; sourceTree = "<group>"; };
 		9F4CC51C2C48D240006A96EB /* CoreDataDatabaseTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataDatabaseTestUtilities.swift; sourceTree = "<group>"; };
+		9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactoryTests.swift; sourceTree = "<group>"; };
+		9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITestUtilities.swift; sourceTree = "<group>"; };
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
@@ -4352,6 +4356,7 @@
 				9FE05CEF2C3642F900D9046B /* OnboardingPixelReporterTests.swift */,
 				9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */,
 				9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */,
+				9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -5114,6 +5119,7 @@
 				85449F0023FEAF3000512AAF /* UserDefaultsExtension.swift */,
 				31B1FA86286EFC5C00CA3C1C /* XCTestCaseExtension.swift */,
 				EE7917902A83DE93008DFF28 /* CombineTestUtilities.swift */,
+				9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */,
 			);
 			name = TestUtils;
 			sourceTree = "<group>";
@@ -6833,6 +6839,7 @@
 				988AC355257E47C100793C64 /* RequeryLogic.swift in Sources */,
 				6FB2A67A2C2C5BAE004D20C8 /* FavoriteEmptyStateItem.swift in Sources */,
 				6FBF0F8B2BD7C0A900136CF0 /* AllProtectedCell.swift in Sources */,
+				9F4CC5242C4A4F0D006A96EB /* SwiftUITestUtilities.swift in Sources */,
 				1E4F4A5A297193DE00625985 /* MainViewController+CookiesManaged.swift in Sources */,
 				8586A10D24CBA7070049720E /* FindInPageActivity.swift in Sources */,
 				9FB0271D2C293619009EA190 /* OnboardingIntroViewModel.swift in Sources */,
@@ -7358,6 +7365,7 @@
 				C14E2F7729DE14EA002AC515 /* AutofillInterfaceUsernameTruncatorTests.swift in Sources */,
 				564DE45A2C450BE600D23241 /* DaxDialogsNewTabTests.swift in Sources */,
 				C174CE602BD6A6CE00AED2EA /* MockDDGSyncing.swift in Sources */,
+				9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */,
 				8521FDE6238D414B00A44CC3 /* FileStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,
 				9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -230,13 +230,14 @@ import WebKit
         
         let variantManager = DefaultVariantManager()
         let historyMessageManager = HistoryMessageManager()
+        let daxDialogs = DaxDialogs.shared
 
         // assign it here, because "did become active" is already too late and "viewWillAppear"
         // has already been called on the HomeViewController so won't show the home row CTA
         AtbAndVariantCleanup.cleanup()
         variantManager.assignVariantIfNeeded { _ in
             // MARK: perform first time launch logic here
-            DaxDialogs.shared.primeForUse()
+            daxDialogs.primeForUse()
 
             // New users don't see the message
             historyMessageManager.dismiss()
@@ -320,7 +321,8 @@ import WebKit
                                       tabsModel: tabsModel,
                                       syncPausedStateManager: syncErrorHandler,
                                       variantManager: variantManager,
-                                      contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager))
+                                      contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager),
+                                      contextualOnboardingLogic: daxDialogs)
 
         main.loadViewIfNeeded()
         syncErrorHandler.alertPresenter = main

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -36,6 +36,10 @@ protocol NewTabDialogSpecProvider {
     func dismiss()
 }
 
+protocol ContextualOnboardingLogic {
+    func setFireEducationMessageSeen()
+}
+
 extension ContentBlockerRulesManager: EntityProviding {
     
     func entity(forHost host: String) -> Entity? {
@@ -44,7 +48,7 @@ extension ContentBlockerRulesManager: EntityProviding {
     
 }
 
-final class DaxDialogs: NewTabDialogSpecProvider {
+final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     
     struct MajorTrackers {
         

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -436,7 +436,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             return .subsequent
         }
 
-        if firstBrowsingMessageSeen && !finalDaxDialogSeen  {
+        if firstBrowsingMessageSeen && !finalDaxDialogSeen {
             // Ensure we don't show the final dialog again in context when the user sees it and vice-versa.
             settings.browsingFinalDialogShown = true
             return .final

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -74,7 +74,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         switch spec.type {
         case .withMultipleTrackers, .withOneTracker:
             settings.browsingWithTrackersShown = flag
-        case .afterSearch, .afterSearchWithWebsitesFollowUp:
+        case .afterSearch:
             settings.browsingAfterSearchShown = flag
         case .withoutTrackers:
             settings.browsingWithoutTrackersShown = flag
@@ -91,7 +91,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
         enum SpecType {
             case afterSearch
-            case afterSearchWithWebsitesFollowUp
             case withoutTrackers
             case siteIsMajorTracker
             case siteOwnedByMajorTracker
@@ -101,20 +100,11 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         }
         // swiftlint:enable nesting
 
-        private static func afterSearch(followUpWithWebsiteSearch: Bool) -> BrowsingSpec {
-            let specType = followUpWithWebsiteSearch ? SpecType.afterSearchWithWebsitesFollowUp : SpecType.afterSearch
-            return BrowsingSpec(
-                message: UserText.daxDialogBrowsingAfterSearch,
-                cta: UserText.daxDialogBrowsingAfterSearchCTA,
-                highlightAddressBar: false,
-                pixelName: .daxDialogsSerp,
-                type: specType
-            )
-        }
-
-        static let afterSearch = afterSearch(followUpWithWebsiteSearch: false)
-
-        static let afterSearchWithWebsitesFollowUp = afterSearch(followUpWithWebsiteSearch: true)
+        static let afterSearch = BrowsingSpec(message: UserText.daxDialogBrowsingAfterSearch,
+                                              cta: UserText.daxDialogBrowsingAfterSearchCTA,
+                                              highlightAddressBar: false,
+                                              pixelName: .daxDialogsSerp,
+                                              type: .afterSearch)
 
         static let withoutTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithoutTrackers,
                                                   cta: UserText.daxDialogBrowsingWithoutTrackersCTA,
@@ -377,13 +367,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         }
 
         if privacyInfo.url.isDuckDuckGoSearch {
-            // If user already visited a site, show after search dialog but don't follow up by suggesting to visit a site.
-            // Otherwise show after search dialog and follow up by suggesting to visit a site.
-            if nonDDGBrowsingMessageSeen {
-                return searchMessage()
-            } else {
-                return searchMessageWithWebsitesFollowUp()
-            }
+            return searchMessage()
         }
 
         // won't be shown if owned by major tracker message has already been shown
@@ -492,12 +476,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         guard !settings.browsingAfterSearchShown else { return nil }
         settings.browsingAfterSearchShown = true
         return BrowsingSpec.afterSearch
-    }
-
-    private func searchMessageWithWebsitesFollowUp() -> BrowsingSpec? {
-        guard !settings.browsingAfterSearchShown else { return nil }
-        settings.browsingAfterSearchShown = true
-        return BrowsingSpec.afterSearchWithWebsitesFollowUp
     }
 
     private func finalMessage() -> BrowsingSpec? {

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -452,7 +452,9 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             return .subsequent
         }
 
-        if firstBrowsingMessageSeen {
+        if firstBrowsingMessageSeen && !finalDaxDialogSeen  {
+            // Ensure we don't show the final dialog again in context when the user sees it and vice-versa.
+            settings.browsingFinalDialogShown = true
             return .final
         }
 

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -146,7 +146,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
         let message: String
         let cta: String
-        let highlightAddressBar: Bool
+        fileprivate(set) var highlightAddressBar: Bool
         let pixelName: Pixel.Event
         let type: SpecType
         
@@ -507,21 +507,27 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     private func trackersBlockedMessage(_ entitiesBlocked: [String]) -> BrowsingSpec? {
         guard !settings.browsingWithTrackersShown else { return nil }
 
+        var spec: BrowsingSpec?
         switch entitiesBlocked.count {
 
         case 0:
-            return nil
-            
+            spec = nil
+
         case 1:
             settings.browsingWithTrackersShown = true
-            return BrowsingSpec.withOneTracker.format(args: entitiesBlocked[0])
-            
+            spec = BrowsingSpec.withOneTracker.format(args: entitiesBlocked[0])
+
         default:
             settings.browsingWithTrackersShown = true
-            return BrowsingSpec.withMultipleTrackers.format(args: entitiesBlocked.count - 2,
+            spec = BrowsingSpec.withMultipleTrackers.format(args: entitiesBlocked.count - 2,
                                                            entitiesBlocked[0],
                                                            entitiesBlocked[1])
         }
+        // New Contextual onboarding doesn't highlight the address bar. This checks prevents to cancel the lottie animation.
+        if isNewOnboarding {
+            spec?.highlightAddressBar = false
+        }
+        return spec
     }
  
     private func blockedEntityNames(_ trackerInfo: TrackerInfo) -> [String]? {

--- a/DuckDuckGo/DaxDialogsSettings.swift
+++ b/DuckDuckGo/DaxDialogsSettings.swift
@@ -37,6 +37,8 @@ protocol DaxDialogsSettings {
     
     var fireButtonPulseDateShown: Date? { get set }
 
+    var browsingFinalDialogShown: Bool { get set }
+
 }
 
 class DefaultDaxDialogsSettings: DaxDialogsSettings {
@@ -65,6 +67,9 @@ class DefaultDaxDialogsSettings: DaxDialogsSettings {
     @UserDefaultsWrapper(key: .fireButtonPulseDateShown, defaultValue: nil)
     var fireButtonPulseDateShown: Date?
     
+    @UserDefaultsWrapper(key: .daxBrowsingFinalDialogShown, defaultValue: false)
+    var browsingFinalDialogShown: Bool
+
 }
 
 class InMemoryDaxDialogsSettings: DaxDialogsSettings {
@@ -85,4 +90,6 @@ class InMemoryDaxDialogsSettings: DaxDialogsSettings {
     
     var fireButtonPulseDateShown: Date?
     
+    var browsingFinalDialogShown = false
+
 }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -184,7 +184,8 @@ class MainViewController: UIViewController {
         tabsModel: TabsModel,
         syncPausedStateManager: any SyncPausedStateManaging,
         variantManager: VariantManager,
-        contextualOnboardingPresenter: ContextualOnboardingPresenting
+        contextualOnboardingPresenter: ContextualOnboardingPresenting,
+        contextualOnboardingLogic: ContextualOnboardingLogic
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner
@@ -203,7 +204,8 @@ class MainViewController: UIViewController {
                                      bookmarksDatabase: bookmarksDatabase,
                                      historyManager: historyManager,
                                      syncService: syncService,
-                                     contextualOnboardingPresenter: contextualOnboardingPresenter)
+                                     contextualOnboardingPresenter: contextualOnboardingPresenter,
+                                     contextualOnboardingLogic: contextualOnboardingLogic)
         self.syncPausedStateManager = syncPausedStateManager
         self.homeTabManager = NewTabPageManager()
         self.variantManager = variantManager

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -130,6 +130,7 @@ struct OnboardingTrackersDoneDialog: View {
 
     @State private var showNextScreen: Bool = false
 
+    let shouldFollowUp: Bool
     let message: NSAttributedString
     let blockedTrackersCTAAction: () -> Void
 
@@ -141,9 +142,11 @@ struct OnboardingTrackersDoneDialog: View {
                         OnboardingFireButtonDialogContent()
                     } else {
                         ContextualDaxDialogContent(message: message, cta: cta) {
-                            withAnimation {
-                                showNextScreen = true
-                                blockedTrackersCTAAction()
+                            blockedTrackersCTAAction()
+                            if shouldFollowUp {
+                                withAnimation {
+                                    showNextScreen = true
+                                }
                             }
                         }
                     }
@@ -212,6 +215,7 @@ struct OnboardingFinalDialog: View {
 
 #Preview("Trackers Dialog") {
     OnboardingTrackersDoneDialog(
+        shouldFollowUp: true,
         message: NSAttributedString(string: """
             Heads up! Instagram.com is owned by Facebook.\n\n
             Facebook’s trackers lurk on about 40% of top websites 😱 but don’t worry!\n\n

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -37,7 +37,7 @@ typealias ContextualOnboardingDelegate = OnboardingNavigationDelegate & Contextu
 // MARK: - Contextual Dialogs Factory
 
 protocol ContextualDaxDialogsFactory {
-    func makeView(for spec: DaxDialogs.BrowsingSpec, delegate: ContextualOnboardingDelegate) -> UIViewController
+    func makeView(for spec: DaxDialogs.BrowsingSpec, delegate: ContextualOnboardingDelegate) -> UIHostingController<AnyView>
 }
 
 final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
@@ -47,7 +47,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         self.contextualOnboardingSettings = contextualOnboardingSettings
     }
 
-    func makeView(for spec: DaxDialogs.BrowsingSpec, delegate: ContextualOnboardingDelegate) -> UIViewController {
+    func makeView(for spec: DaxDialogs.BrowsingSpec, delegate: ContextualOnboardingDelegate) -> UIHostingController<AnyView> {
         let rootView: AnyView
         switch spec.type {
         case .afterSearch:
@@ -59,7 +59,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         }
 
         let viewWithBackground = rootView.withOnboardingBackground()
-        let hostingController = UIHostingController(rootView: viewWithBackground)
+        let hostingController = UIHostingController(rootView: AnyView(viewWithBackground))
         if #available(iOS 16.0, *) {
             hostingController.sizingOptions = [.intrinsicContentSize]
         }

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -41,16 +41,19 @@ protocol ContextualDaxDialogsFactory {
 }
 
 final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
+    private let contextualOnboardingSettings: ContextualOnboardingSettings
+
+    init(contextualOnboardingSettings: ContextualOnboardingSettings = DefaultDaxDialogsSettings()) {
+        self.contextualOnboardingSettings = contextualOnboardingSettings
+    }
 
     func makeView(for spec: DaxDialogs.BrowsingSpec, delegate: ContextualOnboardingDelegate) -> UIViewController {
         let rootView: AnyView
         switch spec.type {
         case .afterSearch:
-            rootView = AnyView(afterSearchDialog(shouldFollowUpToWebsiteSearch: false, delegate: delegate))
-        case .afterSearchWithWebsitesFollowUp:
-            rootView = AnyView(afterSearchDialog(shouldFollowUpToWebsiteSearch: true, delegate: delegate))
+            rootView = AnyView(afterSearchDialog(shouldFollowUpToWebsiteSearch: !contextualOnboardingSettings.userHasSeenTrackersDialog, delegate: delegate))
         case .siteIsMajorTracker, .siteOwnedByMajorTracker, .withMultipleTrackers, .withOneTracker, .withoutTrackers:
-            rootView = AnyView(withTrackersDialog(for: spec, delegate: delegate))
+            rootView = AnyView(withTrackersDialog(for: spec, shouldFollowUpToFireDialog: !contextualOnboardingSettings.userHasSeenFireDialog, delegate: delegate))
         case .final:
             rootView = AnyView(endOfJourneyDialog(delegate: delegate))
         }
@@ -71,10 +74,15 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         return OnboardingFirstSearchDoneDialog(shouldFollowUp: shouldFollowUpToWebsiteSearch, viewModel: viewModel, gotItAction: gotItAction)
     }
 
-    private func withTrackersDialog(for spec: DaxDialogs.BrowsingSpec, delegate: ContextualOnboardingDelegate) -> some View {
+    private func withTrackersDialog(for spec: DaxDialogs.BrowsingSpec, shouldFollowUpToFireDialog: Bool, delegate: ContextualOnboardingDelegate) -> some View {
         let attributedMessage = spec.message.attributedStringFromMarkdown(color: ThemeManager.shared.currentTheme.daxDialogTextColor)
-        return OnboardingTrackersDoneDialog(message: attributedMessage, blockedTrackersCTAAction: { [weak delegate] in
-            delegate?.didAcknowledgeContextualOnboardingTrackersDialog()
+        return OnboardingTrackersDoneDialog(shouldFollowUp: shouldFollowUpToFireDialog, message: attributedMessage, blockedTrackersCTAAction: { [weak self, weak delegate] in
+            // If the user has not seen the fire dialog yet proceed to the fire dialog, otherwise dismiss the dialog.
+            if self?.contextualOnboardingSettings.userHasSeenFireDialog == true {
+                delegate?.didTapDismissContextualOnboardingAction()
+            } else {
+                delegate?.didAcknowledgeContextualOnboardingTrackersDialog()
+            }
         })
         .onAppear { [weak delegate] in
             delegate?.didShowContextualOnboardingTrackersDialog()
@@ -97,6 +105,27 @@ private extension View {
         self
             .padding()
             .background(OnboardingBackground())
+    }
+
+}
+
+// MARK: - Contextual Onboarding Settings
+
+protocol ContextualOnboardingSettings {
+    var userHasSeenTrackersDialog: Bool { get }
+    var userHasSeenFireDialog: Bool { get }
+}
+
+extension DefaultDaxDialogsSettings: ContextualOnboardingSettings {
+    
+    var userHasSeenTrackersDialog: Bool {
+        browsingWithTrackersShown ||
+        browsingWithoutTrackersShown ||
+        browsingMajorTrackingSiteShown
+    }
+    
+    var userHasSeenFireDialog: Bool {
+        fireButtonEducationShownOrExpired
     }
 
 }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -36,6 +36,7 @@ class TabManager {
     private let syncService: DDGSyncing
     private var previewsSource: TabPreviewsSource
     private let contextualOnboardingPresenter: ContextualOnboardingPresenting
+    private let contextualOnboardingLogic: ContextualOnboardingLogic
 
     weak var delegate: TabDelegate?
 
@@ -48,14 +49,15 @@ class TabManager {
          bookmarksDatabase: CoreDataDatabase,
          historyManager: HistoryManaging,
          syncService: DDGSyncing,
-         contextualOnboardingPresenter: ContextualOnboardingPresenting) {
+         contextualOnboardingPresenter: ContextualOnboardingPresenting,
+         contextualOnboardingLogic: ContextualOnboardingLogic) {
         self.model = model
         self.previewsSource = previewsSource
         self.bookmarksDatabase = bookmarksDatabase
         self.historyManager = historyManager
         self.syncService = syncService
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
-
+        self.contextualOnboardingLogic = contextualOnboardingLogic
         registerForNotifications()
     }
 
@@ -72,7 +74,8 @@ class TabManager {
                                                               bookmarksDatabase: bookmarksDatabase,
                                                               historyManager: historyManager,
                                                               syncService: syncService,
-                                                              contextualOnboardingPresenter: contextualOnboardingPresenter)
+                                                              contextualOnboardingPresenter: contextualOnboardingPresenter,
+                                                              contextualOnboardingLogic: contextualOnboardingLogic)
         controller.applyInheritedAttribution(inheritedAttribution)
         controller.attachWebView(configuration: configuration,
                                  andLoadRequest: url == nil ? nil : URLRequest.userInitiated(url!),
@@ -145,7 +148,8 @@ class TabManager {
                                                               bookmarksDatabase: bookmarksDatabase,
                                                               historyManager: historyManager,
                                                               syncService: syncService,
-                                                              contextualOnboardingPresenter: contextualOnboardingPresenter)
+                                                              contextualOnboardingPresenter: contextualOnboardingPresenter,
+                                                              contextualOnboardingLogic: contextualOnboardingLogic)
         controller.attachWebView(configuration: configCopy,
                                  andLoadRequest: request,
                                  consumeCookies: !model.hasActiveTabs,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2853,6 +2853,7 @@ extension TabViewController: OnboardingNavigationDelegate {
 extension TabViewController: ContextualOnboardingEventDelegate {
 
     func didAcknowledgeContextualOnboardingTrackersDialog() {
+        DaxDialogs.shared.setFireEducationMessageSeen()
         delegate?.tabDidRequestFireButtonPulse(tab: self)
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -296,7 +296,8 @@ class TabViewController: UIViewController {
                                    bookmarksDatabase: CoreDataDatabase,
                                    historyManager: HistoryManaging,
                                    syncService: DDGSyncing,
-                                   contextualOnboardingPresenter: ContextualOnboardingPresenting) -> TabViewController {
+                                   contextualOnboardingPresenter: ContextualOnboardingPresenting,
+                                   contextualOnboardingLogic: ContextualOnboardingLogic) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
             TabViewController(coder: coder,
@@ -305,7 +306,8 @@ class TabViewController: UIViewController {
                               bookmarksDatabase: bookmarksDatabase,
                               historyManager: historyManager,
                               syncService: syncService,
-                              contextualOnboardingPresenter: contextualOnboardingPresenter)
+                              contextualOnboardingPresenter: contextualOnboardingPresenter,
+                              contextualOnboardingLogic: contextualOnboardingLogic)
         })
         return controller
     }
@@ -321,6 +323,7 @@ class TabViewController: UIViewController {
     var youtubeNavigationHandler: DuckNavigationHandling?
 
     let contextualOnboardingPresenter: ContextualOnboardingPresenting
+    let contextualOnboardingLogic: ContextualOnboardingLogic
 
     required init?(coder aDecoder: NSCoder,
                    tabModel: Tab,
@@ -328,7 +331,8 @@ class TabViewController: UIViewController {
                    bookmarksDatabase: CoreDataDatabase,
                    historyManager: HistoryManaging,
                    syncService: DDGSyncing,
-                   contextualOnboardingPresenter: ContextualOnboardingPresenting) {
+                   contextualOnboardingPresenter: ContextualOnboardingPresenting,
+                   contextualOnboardingLogic: ContextualOnboardingLogic) {
         self.tabModel = tabModel
         self.appSettings = appSettings
         self.bookmarksDatabase = bookmarksDatabase
@@ -336,6 +340,7 @@ class TabViewController: UIViewController {
         self.historyCapture = HistoryCapture(historyManager: historyManager)
         self.syncService = syncService
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
+        self.contextualOnboardingLogic = contextualOnboardingLogic
         super.init(coder: aDecoder)
     }
 
@@ -2853,7 +2858,8 @@ extension TabViewController: OnboardingNavigationDelegate {
 extension TabViewController: ContextualOnboardingEventDelegate {
 
     func didAcknowledgeContextualOnboardingTrackersDialog() {
-        DaxDialogs.shared.setFireEducationMessageSeen()
+        // Store when Fire contextual dialog is shown to decide if final dialog needs to be shown.
+        contextualOnboardingLogic.setFireEducationMessageSeen()
         delegate?.tabDidRequestFireButtonPulse(tab: self)
     }
 

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -106,7 +106,8 @@ extension TabViewController {
                                                                  bookmarksDatabase: bookmarksDatabase,
                                                                  historyManager: historyManager,
                                                                  syncService: syncService,
-                                                                 contextualOnboardingPresenter: contextualOnboardingPresenter)
+                                                                 contextualOnboardingPresenter: contextualOnboardingPresenter,
+                                                                 contextualOnboardingLogic: contextualOnboardingLogic)
         tabController.isLinkPreview = true
         let configuration = WKWebViewConfiguration.nonPersistent()
         tabController.attachWebView(configuration: configuration, andLoadRequest: URLRequest.userInitiated(url), consumeCookies: false)

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -1,0 +1,198 @@
+//
+//  ContextualDaxDialogsFactoryTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import SwiftUI
+@testable import DuckDuckGo
+
+final class ContextualDaxDialogsFactoryTests: XCTestCase {
+    private var sut: ExperimentContextualDaxDialogsFactory!
+    private var delegate: ContextualOnboardingDelegateMock!
+    private var settingsMock: ContextualOnboardingSettingsMock!
+
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        delegate = ContextualOnboardingDelegateMock()
+        settingsMock = ContextualOnboardingSettingsMock()
+        sut = ExperimentContextualDaxDialogsFactory(contextualOnboardingSettings: settingsMock)
+    }
+
+    override func tearDownWithError() throws {
+        delegate = nil
+        settingsMock = nil
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - After Search
+
+    func testWhenMakeViewForAfterSearchSpecThenCreatesOnboardingFirstSearchDoneDialog() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.afterSearch
+
+        // WHEN
+        let result = sut.makeView(for: spec, delegate: delegate)
+
+        // THEN
+        let view = try XCTUnwrap(find(OnboardingFirstSearchDoneDialog.self, in: result))
+        XCTAssertTrue(view.viewModel.delegate === delegate)
+    }
+
+    func test_WhenMakeViewForAfterSearchSpec_AndActionIsTapped_AndTrackersDialogHasShown_ThenDidTapDismissContextualOnboardingActionIsCalledOnDelegate() throws {
+        // GIVEN
+        settingsMock.userHasSeenTrackersDialog = true
+        let spec = DaxDialogs.BrowsingSpec.afterSearch
+        let result = sut.makeView(for: spec, delegate: delegate)
+        let view = try XCTUnwrap(find(OnboardingFirstSearchDoneDialog.self, in: result))
+        XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+
+        // WHEN
+        view.gotItAction()
+
+        // THEN
+        XCTAssertTrue(delegate.didCallDidTapDismissContextualOnboardingAction)
+    }
+
+    func test_WhenMakeViewForAfterSearchSpec_AndActionIsTapped_AndTrackersDialogHasNotShown_ThenDidTapDismissContextualOnboardingActionIsCalledOnDelegate() throws {
+        // GIVEN
+        settingsMock.userHasSeenTrackersDialog = false
+        let spec = DaxDialogs.BrowsingSpec.afterSearch
+        let result = sut.makeView(for: spec, delegate: delegate)
+        let view = try XCTUnwrap(find(OnboardingFirstSearchDoneDialog.self, in: result))
+        XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+
+        // WHEN
+        view.gotItAction()
+
+        // THEN
+        XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+    }
+
+    // MARK: - Trackers
+
+    func test_WhenMakeViewForTrackerSpec_ThenReturnViewOnboardingTrackersDoneDialog() throws {
+        // GIVEN
+        try [DaxDialogs.BrowsingSpec.siteIsMajorTracker, .siteOwnedByMajorTracker, .withMultipleTrackers, .withoutTrackers, .withoutTrackers].forEach { spec in
+            // WHEN
+            let result = sut.makeView(for: spec, delegate: delegate)
+
+            // THEN
+            let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: result))
+            XCTAssertNotNil(view)
+        }
+    }
+
+    func test_WhenMakeViewForTrackerSpec_AndFireDialogHasNotShown_ThenActionCallsDidAcknowledgeContextualOnboardingTrackersDialog() throws {
+        try [DaxDialogs.BrowsingSpec.siteIsMajorTracker, .siteOwnedByMajorTracker, .withMultipleTrackers, .withoutTrackers, .withoutTrackers].forEach { spec in
+            // GIVEN
+            delegate = ContextualOnboardingDelegateMock()
+            settingsMock.userHasSeenFireDialog = false
+            let result = sut.makeView(for: spec, delegate: delegate)
+            let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: result))
+            XCTAssertFalse(delegate.didCallDidAcknowledgeContextualOnboardingTrackersDialog)
+
+            // WHEN
+            view.blockedTrackersCTAAction()
+
+            // THEN
+            XCTAssertTrue(delegate.didCallDidAcknowledgeContextualOnboardingTrackersDialog)
+        }
+    }
+
+    func test_WhenMakeViewForTrackerSpec_AndFireDialogHasShown_ThenActionCallsDidTapDismissContextualOnboardingAction() throws {
+        try [DaxDialogs.BrowsingSpec.siteIsMajorTracker, .siteOwnedByMajorTracker, .withMultipleTrackers, .withoutTrackers, .withoutTrackers].forEach { spec in
+            // GIVEN
+            delegate = ContextualOnboardingDelegateMock()
+            settingsMock.userHasSeenFireDialog = true
+            let result = sut.makeView(for: spec, delegate: delegate)
+            let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: result))
+            XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+
+            // WHEN
+            view.blockedTrackersCTAAction()
+
+            // THEN
+            XCTAssertTrue(delegate.didCallDidTapDismissContextualOnboardingAction)
+        }
+    }
+
+    // MARK: - Final
+
+    func test_WhenMakeViewForFinalSpec_ThenReturnViewOnboardingFinalDialog() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+
+        // WHEN
+        let result = sut.makeView(for: spec, delegate: delegate)
+
+        // THEN
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: result))
+        XCTAssertNotNil(view)
+    }
+
+    func test_WhenCallActionOnOnboardingFinalDialog_ThenDidTapDismissContextualOnboardingActionOnDelegateIsCalled() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        let result = sut.makeView(for: spec, delegate: delegate)
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: result))
+        XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+
+        // WHEN
+        view.highFiveAction()
+
+        // THEN
+        XCTAssertTrue(delegate.didCallDidTapDismissContextualOnboardingAction)
+    }
+}
+
+final class ContextualOnboardingSettingsMock: ContextualOnboardingSettings {
+    var userHasSeenTrackersDialog: Bool = false
+    var userHasSeenFireDialog: Bool = false
+}
+
+
+final class ContextualOnboardingDelegateMock: ContextualOnboardingDelegate {
+    private(set) var didCallDidShowContextualOnboardingTrackersDialog = false
+    private(set) var didCallDidAcknowledgeContextualOnboardingTrackersDialog = false
+    private(set) var didCallDidTapDismissContextualOnboardingAction = false
+    private(set) var didCallSearchForQuery = false
+    private(set) var didCallNavigateToURL = false
+
+    func didShowContextualOnboardingTrackersDialog() {
+        didCallDidShowContextualOnboardingTrackersDialog = true
+    }
+    
+    func didAcknowledgeContextualOnboardingTrackersDialog() {
+        didCallDidAcknowledgeContextualOnboardingTrackersDialog = true
+    }
+    
+    func didTapDismissContextualOnboardingAction() {
+        didCallDidTapDismissContextualOnboardingAction = true
+    }
+    
+    func searchFor(_ query: String) {
+        didCallSearchForQuery = true
+    }
+    
+    func navigateTo(url: URL) {
+        didCallNavigateToURL = true
+    }
+
+}

--- a/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -104,16 +104,4 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         XCTAssertEqual(addFavoriteDialog?.message.string, homeDialog.message)
     }
 
-    private func find<T: View>(_ type: T.Type, in root: Any) -> T? {
-        let mirror = Mirror(reflecting: root)
-        for child in mirror.children {
-            if let view = child.value as? T {
-                return view
-            }
-            if let found = find(type, in: child.value) {
-                return found
-            }
-        }
-        return nil
-    }
 }

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -131,44 +131,6 @@ final class DaxDialog: XCTestCase {
         
     }
 
-    func testWhenExperimentAndBrowsingSpecIsWithOneTrackerThenHighlightAddressBarIsFalse() throws {
-        // GIVEN
-        mockVariantManager.isSupportedReturns = true
-        let sut = makeExperimentSUT(settings: InMemoryDaxDialogsSettings())
-        let privacyInfo = makePrivacyInfo(url: URLs.example)
-        let detectedTracker = detectedTrackerFrom(URLs.google, pageUrl: URLs.example.absoluteString)
-        privacyInfo.trackerInfo.addDetectedTracker(detectedTracker, onPageWithURL: URLs.example)
-
-        // WHEN
-        let result = try XCTUnwrap(sut.nextBrowsingMessageIfShouldShow(for: privacyInfo))
-
-        // THEN
-        XCTAssertEqual(result.type, .withOneTracker)
-        XCTAssertFalse(result.highlightAddressBar)
-    }
-
-    func testWhenExperimentAndBrowsingSpecIsWithMultipleTrackerThenHighlightAddressBarIsFalse() throws {
-        // GIVEN
-        mockVariantManager.isSupportedReturns = true
-        let sut = makeExperimentSUT(settings: InMemoryDaxDialogsSettings())
-        let privacyInfo = makePrivacyInfo(url: URLs.example)
-        [URLs.google, URLs.amazon].forEach { tracker in
-            let detectedTracker = detectedTrackerFrom(tracker, pageUrl: URLs.example.absoluteString)
-            privacyInfo.trackerInfo.addDetectedTracker(detectedTracker, onPageWithURL: URLs.example)
-        }
-
-        // WHEN
-        let result = try XCTUnwrap(sut.nextBrowsingMessageIfShouldShow(for: privacyInfo))
-
-        // THEN
-        XCTAssertEqual(result.type, .withMultipleTrackers)
-        XCTAssertFalse(result.highlightAddressBar)
-    }
-
-    func testWhenExperimentAndBrowsingSpecIsWithMultipleTrackersThenHighlightAddressBarIsFalse() {
-
-    }
-
     func testWhenTrackersShownThenFireEducationShown() {
         let privacyInfo = makePrivacyInfo(url: URLs.example)
         privacyInfo.trackerInfo.addDetectedTracker(detectedTrackerFrom(URLs.google, pageUrl: URLs.example.absoluteString),
@@ -343,6 +305,40 @@ final class DaxDialog: XCTestCase {
     }
 
     // MARK: - Experiment
+
+    func testWhenExperimentAndBrowsingSpecIsWithOneTrackerThenHighlightAddressBarIsFalse() throws {
+        // GIVEN
+        mockVariantManager.isSupportedReturns = true
+        let sut = makeExperimentSUT(settings: InMemoryDaxDialogsSettings())
+        let privacyInfo = makePrivacyInfo(url: URLs.example)
+        let detectedTracker = detectedTrackerFrom(URLs.google, pageUrl: URLs.example.absoluteString)
+        privacyInfo.trackerInfo.addDetectedTracker(detectedTracker, onPageWithURL: URLs.example)
+
+        // WHEN
+        let result = try XCTUnwrap(sut.nextBrowsingMessageIfShouldShow(for: privacyInfo))
+
+        // THEN
+        XCTAssertEqual(result.type, .withOneTracker)
+        XCTAssertFalse(result.highlightAddressBar)
+    }
+
+    func testWhenExperimentAndBrowsingSpecIsWithMultipleTrackerThenHighlightAddressBarIsFalse() throws {
+        // GIVEN
+        mockVariantManager.isSupportedReturns = true
+        let sut = makeExperimentSUT(settings: InMemoryDaxDialogsSettings())
+        let privacyInfo = makePrivacyInfo(url: URLs.example)
+        [URLs.google, URLs.amazon].forEach { tracker in
+            let detectedTracker = detectedTrackerFrom(tracker, pageUrl: URLs.example.absoluteString)
+            privacyInfo.trackerInfo.addDetectedTracker(detectedTracker, onPageWithURL: URLs.example)
+        }
+
+        // WHEN
+        let result = try XCTUnwrap(sut.nextBrowsingMessageIfShouldShow(for: privacyInfo))
+
+        // THEN
+        XCTAssertEqual(result.type, .withMultipleTrackers)
+        XCTAssertFalse(result.highlightAddressBar)
+    }
 
     func testWhenExperimentGroupAndURLIsDuckDuckGoSearchAndSearchDialogHasNotBeenSeenThenReturnSpecTypeAfterSearch() {
         // GIVEN

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -361,20 +361,6 @@ final class DaxDialog: XCTestCase {
         }
     }
 
-    func testWhenExperimentGroupAndURLIsDuckDuckGoSearchAndHasNotVisitedWebsiteThenSpecTypeSearchWithWebsiteFollowUpIsReturned() throws {
-        // GIVEN
-        let isExperiment = true
-        let settings = InMemoryDaxDialogsSettings()
-        let mockVariantManager = MockVariantManager(isSupportedReturns: isExperiment)
-        let sut = DaxDialogs(settings: settings, entityProviding: entityProvider, variantManager: mockVariantManager)
-
-        // WHEN
-        let result = try XCTUnwrap(sut.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: URLs.ddg)))
-
-        // THEN
-        XCTAssertEqual(result.type, .afterSearchWithWebsitesFollowUp)
-    }
-
     func testWhenExperimentGroup_AndFireButtonSeen_AndFinalDialogNotSeen_AndSearchDone_ThenFinalBrowsingSpecIsReturned() throws {
         // GIVEN
         let settings = InMemoryDaxDialogsSettings()

--- a/DuckDuckGoTests/DaxDialogsNewTabTests.swift
+++ b/DuckDuckGoTests/DaxDialogsNewTabTests.swift
@@ -120,4 +120,6 @@ class MockDaxDialogsSettings: DaxDialogsSettings {
     var fireButtonEducationShownOrExpired: Bool = false
 
     var fireButtonPulseDateShown: Date?
+
+    var browsingFinalDialogShown: Bool = false
 }

--- a/DuckDuckGoTests/DaxDialogsNewTabTests.swift
+++ b/DuckDuckGoTests/DaxDialogsNewTabTests.swift
@@ -47,7 +47,7 @@ final class DaxDialogsNewTabTests: XCTestCase {
         XCTAssertEqual(homeScreenMessage, .addFavorite)
     }
 
-    func testIfBrowsingAfterSearchNotShown_OnNextHomeScreenMessageNew_ReturnsAddFavorite() {
+    func testIfBrowsingAfterSearchNotShown_OnNextHomeScreenMessageNew_ReturnsInitial() {
         // WHEN
         let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
 
@@ -55,7 +55,7 @@ final class DaxDialogsNewTabTests: XCTestCase {
         XCTAssertEqual(homeScreenMessage, .initial)
     }
 
-    func testIfBrowsingAfterSearchShown_OnNextHomeScreenMessageNew_ReturnsAddFavorite() {
+    func testIfBrowsingAfterSearchShown_OnNextHomeScreenMessageNew_ReturnsSubsequent() {
         // GIVEN
         settings.browsingAfterSearchShown = true
 
@@ -66,40 +66,85 @@ final class DaxDialogsNewTabTests: XCTestCase {
         XCTAssertEqual(homeScreenMessage, .subsequent)
     }
 
-    func testIfBrowsingAfterSearchShown_andBrowsingMajorTrackingSiteShown_OnNextHomeScreenMessageNew_ReturnsAddFavorite() {
+    func testIfBrowsingAfterSearchShown_andBrowsingMajorTrackingSiteShown_OnNextHomeScreenMessageNew_ReturnsFinal() {
         // GIVEN
         settings.browsingAfterSearchShown = true
         settings.browsingMajorTrackingSiteShown = true
+        XCTAssertFalse(settings.browsingFinalDialogShown)
 
         // WHEN
         let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
 
         // THEN
         XCTAssertEqual(homeScreenMessage, .final)
+        XCTAssertTrue(settings.browsingFinalDialogShown)
     }
 
-    func testIfBrowsingAfterSearchShown_andBrowsingWithTrackersShown_OnNextHomeScreenMessageNew_ReturnsAddFavorite() {
+    func testIfBrowsingAfterSearchShown_andBrowsingWithTrackersShown_OnNextHomeScreenMessageNew_ReturnsFinal() {
         // GIVEN
         settings.browsingAfterSearchShown = true
         settings.browsingWithTrackersShown = true
+        XCTAssertFalse(settings.browsingFinalDialogShown)
 
         // WHEN
         let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
 
         // THEN
         XCTAssertEqual(homeScreenMessage, .final)
+        XCTAssertTrue(settings.browsingFinalDialogShown)
     }
 
-    func testIfBrowsingAfterSearchShown_andBrowsingWithoutTrackersShown_OnNextHomeScreenMessageNew_ReturnsAddFavorite() {
+    func testIfBrowsingAfterSearchShown_andBrowsingWithoutTrackersShown_OnNextHomeScreenMessageNew_ReturnsFinal() {
         // GIVEN
         settings.browsingAfterSearchShown = true
         settings.browsingWithoutTrackersShown = true
+        XCTAssertFalse(settings.browsingFinalDialogShown)
 
         // WHEN
         let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
 
         // THEN
         XCTAssertEqual(homeScreenMessage, .final)
+        XCTAssertTrue(settings.browsingFinalDialogShown)
+    }
+
+    func testIfBrowsingAfterSearchShown_andBrowsingMajorTrackingSiteShown_andFinalDialogAlreadyShown_OnNextHomeScreenMessageNew_ReturnsNil() {
+        // GIVEN
+        settings.browsingAfterSearchShown = true
+        settings.browsingMajorTrackingSiteShown = true
+        settings.browsingFinalDialogShown = true
+
+        // WHEN
+        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
+
+        // THEN
+        XCTAssertNil(homeScreenMessage)
+    }
+
+    func testIfBrowsingAfterSearchShown_andBrowsingWithTrackersShown_andFinalDialogAlreadyShown_OnNextHomeScreenMessageNew_ReturnsNil() {
+        // GIVEN
+        settings.browsingAfterSearchShown = true
+        settings.browsingWithTrackersShown = true
+        settings.browsingFinalDialogShown = true
+
+        // WHEN
+        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
+
+        // THEN
+        XCTAssertNil(homeScreenMessage)
+    }
+
+    func testIfBrowsingAfterSearchShown_andBrowsingWithoutTrackersShown_andFinalDialogAlreadyShown_OnNextHomeScreenMessageNew_ReturnsNil() {
+        // GIVEN
+        settings.browsingAfterSearchShown = true
+        settings.browsingWithoutTrackersShown = true
+        settings.browsingFinalDialogShown = true
+
+        // WHEN
+        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
+
+        // THEN
+        XCTAssertNil(homeScreenMessage)
     }
 
 }

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -111,14 +111,18 @@ final class MockTabDelegate: TabDelegate {
 
 extension TabViewController {
 
-    static func fake(contextualOnboardingPresenter: ContextualOnboardingPresenting = ContextualOnboardingPresenterMock()) -> TabViewController {
+    static func fake(
+        contextualOnboardingPresenter: ContextualOnboardingPresenting = ContextualOnboardingPresenterMock(),
+        contextualOnboardingLogic: ContextualOnboardingLogic = ContextualOnboardingLogicMock()
+    ) -> TabViewController {
         let tab = TabViewController.loadFromStoryboard(
             model: .init(link: Link(title: nil, url: .ddg)),
             appSettings: AppSettingsMock(),
             bookmarksDatabase: CoreDataDatabase.bookmarksMock,
             historyManager: MockHistoryManager(historyCoordinator: MockHistoryCoordinator(), isEnabledByUser: true, historyFeatureEnabled: true),
             syncService: MockDDGSyncing(authState: .active, isSyncInProgress: false),
-            contextualOnboardingPresenter: contextualOnboardingPresenter
+            contextualOnboardingPresenter: contextualOnboardingPresenter,
+            contextualOnboardingLogic: contextualOnboardingLogic
         )
         tab.attachWebView(configuration: .nonPersistent(), andLoadRequest: nil, consumeCookies: false)
         return tab

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -67,7 +67,8 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             tabsModel: tabsModel,
             syncPausedStateManager: CapturingSyncPausedStateManager(),
             variantManager: MockVariantManager(),
-            contextualOnboardingPresenter: ContextualOnboardingPresenterMock())
+            contextualOnboardingPresenter: ContextualOnboardingPresenterMock(),
+            contextualOnboardingLogic: ContextualOnboardingLogicMock())
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()

--- a/DuckDuckGoTests/SwiftUITestUtilities.swift
+++ b/DuckDuckGoTests/SwiftUITestUtilities.swift
@@ -1,0 +1,40 @@
+//
+//  SwiftUITestUtilities.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+/// Recursively searches for a SwiftUI view of type `T` within the given root object.
+///
+/// - Parameters:
+///   - type: The type of view to search for.
+///   - root: The root object to start searching from.
+/// - Returns: An optional view of type `T`, or `nil` if no such view is found.
+func find<T: View>(_ type: T.Type, in root: Any) -> T? {
+    let mirror = Mirror(reflecting: root)
+    for child in mirror.children {
+        if let view = child.value as? T {
+            return view
+        }
+        if let found = find(type, in: child.value) {
+            return found
+        }
+    }
+    return nil
+}
+

--- a/DuckDuckGoTests/SwiftUITestUtilities.swift
+++ b/DuckDuckGoTests/SwiftUITestUtilities.swift
@@ -37,4 +37,3 @@ func find<T: View>(_ type: T.Type, in root: Any) -> T? {
     }
     return nil
 }
-

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -26,18 +26,21 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
     private var sut: TabViewController!
     private var delegateMock: MockTabDelegate!
     private var onboardingPresenterMock: ContextualOnboardingPresenterMock!
+    private var onboardingLogicMock: ContextualOnboardingLogicMock!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         delegateMock = MockTabDelegate()
         onboardingPresenterMock = ContextualOnboardingPresenterMock()
-        sut = .fake(contextualOnboardingPresenter: onboardingPresenterMock)
+        onboardingLogicMock = ContextualOnboardingLogicMock()
+        sut = .fake(contextualOnboardingPresenter: onboardingPresenterMock, contextualOnboardingLogic: onboardingLogicMock)
         sut.delegate = delegateMock
     }
 
     override func tearDownWithError() throws {
         delegateMock = nil
         onboardingPresenterMock = nil
+        onboardingLogicMock = nil
         sut = nil
         try super.tearDownWithError()
     }
@@ -100,6 +103,26 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(onboardingPresenterMock.didCallDismissContextualOnboardingIfNeeded)
+    }
+
+    func testWhenDidAcknowledgedTrackersDialogIsCalledThenSetFireEducationMessageSeenIsCalledOnLogic() {
+        // GIVEN
+        XCTAssertFalse(onboardingLogicMock.didCallSetFireEducationMessageSeen)
+
+        // WHEN
+        sut.didAcknowledgeContextualOnboardingTrackersDialog()
+
+        // THEN
+        XCTAssertTrue(onboardingLogicMock.didCallSetFireEducationMessageSeen)
+    }
+
+}
+
+final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
+    private(set) var didCallSetFireEducationMessageSeen = false
+
+    func setFireEducationMessageSeen() {
+        didCallSetFireEducationMessageSeen = true
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207701571713573/f

**Description**:

1. Show in context final dialog
2. Set flag when final dialog is shown by NTP and use the flag to decide if we should show the final dialog in NTP.
3. Ensure Fire Dialog is not show multiple times.
4. Make Tracker dialogs have more priority than final dialog

**Steps to test this PR**:

**SCENARIO 1 - Show contextual final dialog**
1. Launch new onboarding 
2. When anonymous searches appear, navigate to a website, eg. repubblica.it
3. When the blocked tracker dialog appear, tap the CTA. The fire dialog appears.
4. Open a new website with same type of trackers of first website, eg. kayosports.com.au
**Expecter Result: Final Dialog should be shown to the user**
5. Tap CTA
6. Final dialog should be dismissed.

**SCENARIO 2 - Tracker Dialogs greater priority than final dialog & fire dialog not showing multiple times**
1. Launch new onboarding 
2. When anonymous searches appear, navigate to a website, eg. repubblica.it
3. When the blocked tracker dialog appear, tap the CTA. The fire dialog appears.
4. Open facebook website.
**Expecter Result:** Facebook tracker dialog should show instead of final**
5. Tap CTA
**Expecter Result:** Tracker dialog should be dismissed.
6. Refresh page
**Expecter Result:** Final dialog should be shown.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
