### PR TITLE
Alessandro/refresh dax dialog and ntp logo

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -51,6 +51,8 @@ public struct UserDefaultsWrapper<T> {
         case daxFireButtonEducationShownOrExpired = "com.duckduckgo.ios.daxfireButtonEducationShownOrExpired"
         case fireButtonPulseDateShown = "com.duckduckgo.ios.fireButtonPulseDateShown"
         case daxBrowsingFinalDialogShown = "com.duckduckgo.ios.daxOnboardingFinalDialogSeen"
+        case daxLastVisitedOnboardingWebsite = "com.duckduckgo.ios.daxOnboardingLastVisitedWebsite"
+        case daxLastShownContextualOnboardingDialogType = "com.duckduckgo.ios.daxLastShownContextualOnboardingDialogType"
 
         case notFoundCache = "com.duckduckgo.ios.favicons.notFoundCache"
         case faviconSizeNeedsMigration = "com.duckduckgo.ios.favicons.sizeNeedsMigration"

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -306,17 +306,17 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     private var fireButtonPulseTimer: Timer?
     private static let timeToFireButtonExpire: TimeInterval = 1 * 60 * 60
     
-    var lastVisitedOnboardingWebsiteURLPath: String? {
+    private var lastVisitedOnboardingWebsiteURLPath: String? {
         guard isNewOnboarding else { return nil }
         return settings.lastVisitedOnboardingWebsiteURLPath
     }
 
-    func saveLastVisitedOnboardingWebsite(url: URL?) {
+    private func saveLastVisitedOnboardingWebsite(url: URL?) {
         guard isNewOnboarding, let url = url else { return }
         settings.lastVisitedOnboardingWebsiteURLPath = url.absoluteString
     }
 
-    func removeLastVisitedOnboardingWebsite() {
+    private func removeLastVisitedOnboardingWebsite() {
         guard isNewOnboarding else { return }
         settings.lastVisitedOnboardingWebsiteURLPath = nil
     }
@@ -356,7 +356,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         case BrowsingSpec.SpecType.fire.rawValue:
             return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmed, type: .fire)
         case BrowsingSpec.SpecType.final.rawValue:
-            return BrowsingSpec.final
+            return nil
         default: return nil
         }
     }
@@ -493,7 +493,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
         if let spec {
             saveLastShownDaxDialog(specType: spec.type)
-            DaxDialogs.shared.saveLastVisitedOnboardingWebsite(url: privacyInfo.url)
+            saveLastVisitedOnboardingWebsite(url: privacyInfo.url)
         } else {
             removeLastVisitedOnboardingWebsite()
             removeLastShownDaxDialog()

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -671,10 +671,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             .replacingOccurrences(of: "+", with: " ")
             .replacingOccurrences(of: "%20", with: " ")
         
-        if normalizedQuery1 == normalizedQuery2 {
-            return true
-        }
-
-        return false
+        return normalizedQuery1 == normalizedQuery2
     }
 }

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -78,11 +78,15 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             settings.browsingWithTrackersShown = flag
         case .afterSearch:
             settings.browsingAfterSearchShown = flag
+        case .visitWebsite:
+            break
         case .withoutTrackers:
             settings.browsingWithoutTrackersShown = flag
         case .siteIsMajorTracker, .siteOwnedByMajorTracker:
             settings.browsingMajorTrackingSiteShown = flag
             settings.browsingWithoutTrackersShown = flag
+        case .fire:
+            settings.fireButtonEducationShownOrExpired = flag
         case .final:
             settings.browsingFinalDialogShown = flag
         }
@@ -93,11 +97,13 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
         enum SpecType: String {
             case afterSearch
+            case visitWebsite
             case withoutTrackers
             case siteIsMajorTracker
             case siteOwnedByMajorTracker
             case withOneTracker
             case withMultipleTrackers
+            case fire
             case final
         }
         // swiftlint:enable nesting
@@ -334,6 +340,8 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         switch dialogType {
         case BrowsingSpec.SpecType.afterSearch.rawValue:
             return BrowsingSpec.afterSearch
+        case BrowsingSpec.SpecType.visitWebsite.rawValue:
+            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmed, type: .visitWebsite)
         case BrowsingSpec.SpecType.withoutTrackers.rawValue:
             return BrowsingSpec.withoutTrackers
         case BrowsingSpec.SpecType.siteIsMajorTracker.rawValue:
@@ -345,6 +353,8 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         case BrowsingSpec.SpecType.withOneTracker.rawValue, BrowsingSpec.SpecType.withMultipleTrackers.rawValue:
             guard let entityNames = blockedEntityNames(privacyInfo.trackerInfo) else { return nil }
             return trackersBlockedMessage(entityNames)
+        case BrowsingSpec.SpecType.fire.rawValue:
+            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmed, type: .fire)
         case BrowsingSpec.SpecType.final.rawValue:
             return BrowsingSpec.final
         default: return nil
@@ -379,13 +389,13 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
     func setSearchMessageSeen() {
         guard isNewOnboarding else { return }
-        removeLastShownDaxDialog()
+        saveLastShownDaxDialog(specType: .visitWebsite)
     }
 
     func setFireEducationMessageSeen() {
         guard isNewOnboarding else { return }
         settings.fireButtonEducationShownOrExpired = true
-        removeLastShownDaxDialog()
+        saveLastShownDaxDialog(specType: .fire)
     }
 
     func setFinalOnboardingDialogSeen() {

--- a/DuckDuckGo/DaxDialogsSettings.swift
+++ b/DuckDuckGo/DaxDialogsSettings.swift
@@ -39,6 +39,10 @@ protocol DaxDialogsSettings {
 
     var browsingFinalDialogShown: Bool { get set }
 
+    var lastVisitedOnboardingWebsiteURLPath: String? { get set }
+
+    var lastShownContextualOnboardingDialogType: String? { get set }
+
 }
 
 class DefaultDaxDialogsSettings: DaxDialogsSettings {
@@ -70,6 +74,12 @@ class DefaultDaxDialogsSettings: DaxDialogsSettings {
     @UserDefaultsWrapper(key: .daxBrowsingFinalDialogShown, defaultValue: false)
     var browsingFinalDialogShown: Bool
 
+    @UserDefaultsWrapper(key: .daxLastVisitedOnboardingWebsite, defaultValue: nil)
+    var lastVisitedOnboardingWebsiteURLPath: String?
+
+    @UserDefaultsWrapper(key: .daxLastShownContextualOnboardingDialogType, defaultValue: nil)
+    var lastShownContextualOnboardingDialogType: String?
+
 }
 
 class InMemoryDaxDialogsSettings: DaxDialogsSettings {
@@ -91,5 +101,9 @@ class InMemoryDaxDialogsSettings: DaxDialogsSettings {
     var fireButtonPulseDateShown: Date?
     
     var browsingFinalDialogShown = false
+
+    var lastVisitedOnboardingWebsiteURLPath: String?
+
+    var lastShownContextualOnboardingDialogType: String?
 
 }

--- a/DuckDuckGo/HomeViewController+DaxDialogs.swift
+++ b/DuckDuckGo/HomeViewController+DaxDialogs.swift
@@ -52,10 +52,10 @@ extension HomeViewController {
     }
 
     func showNextDaxDialogNew(dialogProvider: NewTabDialogSpecProvider, factory: any NewTabDaxDialogProvider) {
-        dismissHostingController()
+        dismissHostingController(didFinishNTPOnboarding: false)
         let onDismiss = {
             dialogProvider.dismiss()
-            self.dismissHostingController()
+            self.dismissHostingController(didFinishNTPOnboarding: true)
         }
         guard let spec = dialogProvider.nextHomeScreenMessageNew() else { return }
         let daxDialogView = AnyView(factory.createDaxDialog(for: spec, onDismiss: onDismiss))
@@ -75,10 +75,12 @@ extension HomeViewController {
         configureCollectionView()
     }
 
-    private func dismissHostingController() {
+    private func dismissHostingController(didFinishNTPOnboarding: Bool) {
         hostingController?.willMove(toParent: nil)
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
-        delegate?.home(self, didRequestHideLogo: false)
+        if didFinishNTPOnboarding {
+            delegate?.home(self, didRequestHideLogo: false)
+        }
     }
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -120,6 +120,19 @@ struct OnboardingFirstSearchDoneDialog: View {
     }
 }
 
+struct OnboardingFireDialog: View {
+   
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            DaxDialogView(logoPosition: .left) {
+                VStack {
+                    OnboardingFireButtonDialogContent()
+                }
+            }
+        }
+    }
+}
+
 struct OnboardingTrackersDoneDialog: View {
     let cta = UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingGotItButton
 

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -106,20 +106,15 @@ struct OnboardingFirstSearchDoneDialog: View {
                         OnboardingTryVisitingSiteDialogContent(viewModel: viewModel)
                     } else {
                         ContextualDaxDialogContent(message: message, cta: cta) {
-                            buttonAction()
+                            gotItAction()
+                            withAnimation {
+                                if shouldFollowUp {
+                                    showNextScreen = true
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
-    }
-
-    private func buttonAction() {
-        withAnimation {
-            if shouldFollowUp {
-                showNextScreen = true
-            } else {
-                gotItAction()
             }
         }
     }

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -53,8 +53,12 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         switch spec.type {
         case .afterSearch:
             rootView = AnyView(afterSearchDialog(shouldFollowUpToWebsiteSearch: !contextualOnboardingSettings.userHasSeenTrackersDialog, delegate: delegate))
+        case .visitWebsite:
+            rootView = AnyView(tryVisitingSiteDialog(delegate: delegate))
         case .siteIsMajorTracker, .siteOwnedByMajorTracker, .withMultipleTrackers, .withOneTracker, .withoutTrackers:
             rootView = AnyView(withTrackersDialog(for: spec, shouldFollowUpToFireDialog: !contextualOnboardingSettings.userHasSeenFireDialog, delegate: delegate))
+        case .fire:
+            rootView = AnyView(OnboardingFireDialog())
         case .final:
             rootView = AnyView(endOfJourneyDialog(delegate: delegate))
         }
@@ -81,6 +85,11 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
             }
         }
         return OnboardingFirstSearchDoneDialog(shouldFollowUp: shouldFollowUpToWebsiteSearch, viewModel: viewModel, gotItAction: gotItAction)
+    }
+
+    private func tryVisitingSiteDialog(delegate: ContextualOnboardingDelegate) -> some View {
+        let viewModel = OnboardingSiteSuggestionsViewModel(delegate: delegate)
+        return OnboardingTryVisitingSiteDialog(logoPosition: .left, viewModel: viewModel)
     }
 
     private func withTrackersDialog(for spec: DaxDialogs.BrowsingSpec, shouldFollowUpToFireDialog: Bool, delegate: ContextualOnboardingDelegate) -> some View {

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -23,6 +23,7 @@ import SwiftUI
 
 /// A delegate to inform about specific events happening during the contextual onboarding.
 protocol ContextualOnboardingEventDelegate: AnyObject {
+    func didAcknowledgeContextualOnboardingSearch()
     /// Inform the delegate that a dialog for blocked trackers have been shown to the user.
     func didShowContextualOnboardingTrackersDialog()
     /// Inform the delegate that the user did acknowledge the dialog for blocked trackers.
@@ -70,7 +71,15 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     private func afterSearchDialog(shouldFollowUpToWebsiteSearch: Bool, delegate: ContextualOnboardingDelegate) -> some View {
         let viewModel = OnboardingSiteSuggestionsViewModel(delegate: delegate)
         // If should not show websites search after searching inform the delegate that the user dimissed the dialog, otherwise let the dialog handle it.
-        let gotItAction: () -> Void = if shouldFollowUpToWebsiteSearch { {} } else { { [weak delegate] in delegate?.didTapDismissContextualOnboardingAction() } }
+        let gotItAction: () -> Void = if shouldFollowUpToWebsiteSearch {
+            { [weak delegate] in
+                delegate?.didAcknowledgeContextualOnboardingSearch()
+            }
+        } else {
+            { [weak delegate] in
+                delegate?.didTapDismissContextualOnboardingAction()
+            }
+        }
         return OnboardingFirstSearchDoneDialog(shouldFollowUp: shouldFollowUpToWebsiteSearch, viewModel: viewModel, gotItAction: gotItAction)
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1374,8 +1374,7 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
 
-        guard let spec = daxBrowsingSpec(for: privacyInfo) else {
-            DaxDialogs.shared.removeLastVisitedOnboardingWebsite()
+        guard let spec = DaxDialogs.shared.nextBrowsingMessageIfShouldShow(for: privacyInfo) else {
 
             // Dismiss Contextual onboarding if there's no message to show.
             contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
@@ -1408,8 +1407,7 @@ extension TabViewController: WKNavigationDelegate {
             self.chromeDelegate?.omniBar.resignFirstResponder()
             self.chromeDelegate?.setBarsHidden(false, animated: true)
 
-            // Save the last onboarding website visited to show Dax if the user kills the App and restart during the onboarding.
-            DaxDialogs.shared.saveLastVisitedOnboardingWebsite(url: daxDialogSourceURL)
+
             // Present the contextual onboarding
             contextualOnboardingPresenter.presentContextualOnboarding(for: spec, in: self)
 
@@ -1419,25 +1417,6 @@ extension TabViewController: WKNavigationDelegate {
             }
         }
     }
-
-    private func daxBrowsingSpec(for privacyInfo: PrivacyInfo) -> DaxDialogs.BrowsingSpec? {
-        // If old onboarding re-use existing behaviour
-        guard DefaultVariantManager().isSupported(feature: .newOnboardingIntro) else {
-            return DaxDialogs.shared.nextBrowsingMessageIfShouldShow(for: privacyInfo)
-        }
-
-        // If new onboarding...
-        let spec: DaxDialogs.BrowsingSpec?
-        // If the user refreshed the web page or restarted the App while onboarding show last Dax that was shown. Otherwise compute next dialog to show.
-        if let lastVisitedOnboardingWebsitePath = DaxDialogs.shared.lastVisitedOnboardingWebsiteURLPath, lastVisitedOnboardingWebsitePath == url?.absoluteString {
-            spec = DaxDialogs.shared.lastShownDaxDialog(privacyInfo: privacyInfo)
-        } else {
-            spec = DaxDialogs.shared.nextBrowsingMessageIfShouldShow(for: privacyInfo)
-        }
-
-        return spec
-    }
-
 
     private func scheduleTrackerNetworksAnimation(collapsing: Bool) {
         let trackersWorkItem = DispatchWorkItem {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1373,7 +1373,6 @@ extension TabViewController: WKNavigationDelegate {
             scheduleTrackerNetworksAnimation(collapsing: true)
             return
         }
-
         guard let spec = DaxDialogs.shared.nextBrowsingMessageIfShouldShow(for: privacyInfo) else {
 
             // Dismiss Contextual onboarding if there's no message to show.
@@ -1406,7 +1405,6 @@ extension TabViewController: WKNavigationDelegate {
 
             self.chromeDelegate?.omniBar.resignFirstResponder()
             self.chromeDelegate?.setBarsHidden(false, animated: true)
-
 
             // Present the contextual onboarding
             contextualOnboardingPresenter.presentContextualOnboarding(for: spec, in: self)

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -68,6 +68,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(delegate.didCallDidTapDismissContextualOnboardingAction)
+        XCTAssertFalse(delegate.didCallDidAcknowledgeContextualOnboardingSearch)
     }
 
     func test_WhenMakeViewForAfterSearchSpec_AndActionIsTapped_AndTrackersDialogHasNotShown_ThenDidTapDismissContextualOnboardingActionIsCalledOnDelegate() throws {
@@ -83,6 +84,26 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
 
         // THEN
         XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+        XCTAssertTrue(delegate.didCallDidAcknowledgeContextualOnboardingSearch)
+    }
+
+    // MARK: - Visit Website
+
+    func test_WhenMakeViewForVisitWebsiteSpec_AndActionIsTapped_AndTrackersDialogHasShown_ThenNavigateToActionIsCalledOnDelegate() throws {
+        // GIVEN
+        settingsMock.userHasSeenTrackersDialog = true
+        let spec = DaxDialogs.BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .onboardingIntroShownUnique, type: .visitWebsite)
+        let result = sut.makeView(for: spec, delegate: delegate)
+        let view = try XCTUnwrap(find(OnboardingTryVisitingSiteDialog.self, in: result))
+        XCTAssertFalse(delegate.didCallDidTapDismissContextualOnboardingAction)
+
+        // WHEN
+        let urlString = "some.site"
+        view.viewModel.listItemPressed(ContextualOnboardingListItem.site(title: urlString))
+
+        // THEN
+        XCTAssertTrue(delegate.didCallNavigateToURL)
+        XCTAssertEqual(delegate.urlToNavigateTo, URL(string: urlString))
     }
 
     // MARK: - Trackers
@@ -133,6 +154,20 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         }
     }
 
+    // MARK: - Fire
+    func test_WhenMakeViewFire_ThenReturnViewOnboardingFireDialog() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .onboardingIntroShownUnique, type: .fire)
+
+        // WHEN
+        let result = sut.makeView(for: spec, delegate: delegate)
+
+        // THEN
+        let view = try XCTUnwrap(find(OnboardingFireDialog.self, in: result))
+        XCTAssertNotNil(view)
+    }
+
+
     // MARK: - Final
 
     func test_WhenMakeViewForFinalSpec_ThenReturnViewOnboardingFinalDialog() throws {
@@ -174,6 +209,8 @@ final class ContextualOnboardingDelegateMock: ContextualOnboardingDelegate {
     private(set) var didCallDidTapDismissContextualOnboardingAction = false
     private(set) var didCallSearchForQuery = false
     private(set) var didCallNavigateToURL = false
+    private(set) var didCallDidAcknowledgeContextualOnboardingSearch = false
+    private(set) var urlToNavigateTo: URL?
 
     func didShowContextualOnboardingTrackersDialog() {
         didCallDidShowContextualOnboardingTrackersDialog = true
@@ -193,10 +230,11 @@ final class ContextualOnboardingDelegateMock: ContextualOnboardingDelegate {
     
     func navigateTo(url: URL) {
         didCallNavigateToURL = true
+        urlToNavigateTo = url
     }
 
     func didAcknowledgeContextualOnboardingSearch() {
-        
+        didCallDidAcknowledgeContextualOnboardingSearch = true
     }
 
 }

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -195,4 +195,8 @@ final class ContextualOnboardingDelegateMock: ContextualOnboardingDelegate {
         didCallNavigateToURL = true
     }
 
+    func didAcknowledgeContextualOnboardingSearch() {
+        
+    }
+
 }

--- a/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
@@ -64,6 +64,43 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         XCTAssertNotNil(parent.capturedChild)
     }
 
+    func testWhenPresentContextualOnboardingForFireEducational_andBarAtTheTop_TheMessageHandPointsInTheRightDirection() throws {
+        // GIVEN
+        var variantManagerMock = MockVariantManager()
+        variantManagerMock.isSupportedBlock = { feature in
+            feature == .newOnboardingIntro
+        }
+        let appSettings = AppSettingsMock()
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, appSettings: appSettings)
+        let parent = TabViewControllerMock()
+
+        // WHEN
+        sut.presentContextualOnboarding(for: .withOneTracker, in: parent)
+        let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: parent))
+
+        // THEN
+        XCTAssertTrue(view.message.string.contains("☝️"))
+    }
+
+    func testWhenPresentContextualOnboardingForFireEducational_andBarAtTheBottom_TheMessageHandPointsInTheRightDirection() throws {
+        // GIVEN
+        var variantManagerMock = MockVariantManager()
+        variantManagerMock.isSupportedBlock = { feature in
+            feature == .newOnboardingIntro
+        }
+        let appSettings = AppSettingsMock()
+        appSettings.currentAddressBarPosition = .bottom
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, appSettings: appSettings)
+        let parent = TabViewControllerMock()
+
+        // WHEN
+        sut.presentContextualOnboarding(for: .withOneTracker, in: parent)
+        let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: parent))
+
+        // THEN
+        XCTAssertTrue(view.message.string.contains("👇"))
+    }
+
     func testWhenDismissContextualOnboardingAndVariantSupportsNewOnboardingIntroThenContextualOnboardingIsDismissed() {
         // GIVEN
         let expectation = self.expectation(description: #function)

--- a/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
@@ -115,6 +115,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
 }
 
 final class TabViewControllerMock: UIViewController, TabViewOnboardingDelegate {
+    
     var daxDialogsStackView: UIStackView = UIStackView()
     var webViewContainerView: UIView  = UIView()
     var daxContextualOnboardingController: UIViewController?
@@ -166,6 +167,10 @@ final class TabViewControllerMock: UIViewController, TabViewOnboardingDelegate {
     func navigateTo(url: URL) {
         didCallNavigateToURL = true
         capturedURL = url
+    }
+
+    func didAcknowledgeContextualOnboardingSearch() {
+        
     }
 
 }

--- a/DuckDuckGoTests/DaxDialogsNewTabTests.swift
+++ b/DuckDuckGoTests/DaxDialogsNewTabTests.swift
@@ -164,6 +164,10 @@ final class DaxDialogsNewTabTests: XCTestCase {
 }
 
 class MockDaxDialogsSettings: DaxDialogsSettings {
+    var lastVisitedOnboardingWebsiteURLPath: String?
+    
+    var lastShownContextualOnboardingDialogType: String?
+    
     var isDismissed: Bool = false
 
     var homeScreenMessagesSeen: Int = 0

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -32,7 +32,6 @@ final class MockTabDelegate: TabDelegate {
     private(set) var didRequestLoadURLCalled = false
     private(set) var capturedURL: URL?
     private(set) var didRequestFireButtonPulseCalled = false
-    private(set) var didRequestPrivacyDashboardButtonPulseCalled = false
     private(set) var tabDidRequestPrivacyDashboardButtonPulseCalled = false
     private(set) var privacyDashboardAnimated: Bool?
 

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -33,6 +33,8 @@ final class MockTabDelegate: TabDelegate {
     private(set) var capturedURL: URL?
     private(set) var didRequestFireButtonPulseCalled = false
     private(set) var didRequestPrivacyDashboardButtonPulseCalled = false
+    private(set) var tabDidRequestPrivacyDashboardButtonPulseCalled = false
+    private(set) var privacyDashboardAnimated: Bool?
 
 
     func tabWillRequestNewTab(_ tab: DuckDuckGo.TabViewController) -> UIKeyModifierFlags? { nil }
@@ -82,7 +84,8 @@ final class MockTabDelegate: TabDelegate {
     }
 
     func tabDidRequestPrivacyDashboardButtonPulse(tab: DuckDuckGo.TabViewController, animated: Bool) {
-        didRequestPrivacyDashboardButtonPulseCalled = true
+        tabDidRequestPrivacyDashboardButtonPulseCalled = true
+        privacyDashboardAnimated = animated
     }
 
     func tabDidRequestSearchBarRect(tab: DuckDuckGo.TabViewController) -> CGRect { .zero }

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -116,6 +116,30 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
         XCTAssertTrue(onboardingLogicMock.didCallSetFireEducationMessageSeen)
     }
 
+    func testWhenDidAcknowledgeContextualOnboardingSearchIsCalledThenSetSearchMessageSeenOnLogic() {
+        // GIVEN
+        XCTAssertFalse(onboardingLogicMock.didCallsetsetSearchMessageSeen)
+
+        // WHEN
+        sut.didAcknowledgeContextualOnboardingSearch()
+
+        // THEN
+        XCTAssertTrue(onboardingLogicMock.didCallsetsetSearchMessageSeen)
+    }
+
+    func testWhenDidShowContextualOnboardingTrackersDialog_ShieldIconAnimationActivated() {
+        // GIVEN
+        XCTAssertFalse(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)
+        XCTAssertNil(delegateMock.privacyDashboardAnimated)
+
+        // WHEN
+        sut.didShowContextualOnboardingTrackersDialog()
+
+        // THEN
+        XCTAssertTrue(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)
+        XCTAssertTrue(delegateMock.privacyDashboardAnimated ?? false)
+    }
+
     func testOnPrivacyDashboardShown_ShieldIconAnimationRemoved() {
         // GIVEN
         XCTAssertFalse(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -116,12 +116,27 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
         XCTAssertTrue(onboardingLogicMock.didCallSetFireEducationMessageSeen)
     }
 
+    func testOnPrivacyDashboardShown_ShieldIconAnimationRemoved() {
+        // GIVEN
+        XCTAssertFalse(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)
+        XCTAssertNil(delegateMock.privacyDashboardAnimated)
+
+        // WHEN
+        sut.showPrivacyDashboard()
+
+        // THEN
+        XCTAssertTrue(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)
+        XCTAssertFalse(delegateMock.privacyDashboardAnimated ?? true)
+    }
+
 }
 
 final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
+    
     var expectation: XCTestExpectation?
     private(set) var didCallSetFireEducationMessageSeen = false
     private(set) var didCallsetFinalOnboardingDialogSeen = false
+    private(set) var didCallsetsetSearchMessageSeen = false
 
     func setFireEducationMessageSeen() {
         didCallSetFireEducationMessageSeen = true
@@ -130,6 +145,10 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
     func setFinalOnboardingDialogSeen() {
         didCallsetFinalOnboardingDialogSeen = true
         expectation?.fulfill()
+    }
+
+    func setSearchMessageSeen() {
+        didCallsetsetSearchMessageSeen = true
     }
 
 }

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -74,13 +74,13 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
 
     func testWhenDidShowTrackersDialogIsCalledThenTabDidRequestPrivacyDashboardButtonPulseIsCalledOnDelegate() {
         // GIVEN
-        XCTAssertFalse(delegateMock.didRequestPrivacyDashboardButtonPulseCalled)
+        XCTAssertFalse(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)
 
         // WHEN
         sut.didShowContextualOnboardingTrackersDialog()
 
         // THEN
-        XCTAssertTrue(delegateMock.didRequestPrivacyDashboardButtonPulseCalled)
+        XCTAssertTrue(delegateMock.tabDidRequestPrivacyDashboardButtonPulseCalled)
     }
 
     func testWhenDidAcknowledgeTrackersDialogIsCalledThenTabDidRequestFireButtonPulseIsCalledOnDelegate() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207874379831572/f

**Description**:

Implements logic for showing the same dialog on refresh and restore the dax dialog when the app re-launch.

**Steps to test this PR**:
1.
2.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
