### PR TITLE
restore CrashLogMessageExtractor with disabled __cxa_throw swapper

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10206,7 +10206,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 176.1.1;
+				version = "176.1.1-1";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "a3e62d6c295063f757ef7dc2f96b6a57a503f0f5",
-        "version" : "176.1.1"
+        "revision" : "7325384a51085d470607427e4555acc3d0fba1a6",
+        "version" : "176.1.1-1"
       }
     },
     {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -100,6 +100,12 @@ import WebKit
 
     override init() {
         super.init()
+
+        if !didCrashDuringCrashHandlersSetUp {
+            didCrashDuringCrashHandlersSetUp = true
+            CrashLogMessageExtractor.setUp(swapCxaThrow: false)
+            didCrashDuringCrashHandlersSetUp = false
+        }
     }
 
     // swiftlint:disable:next function_body_length


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207878606354585/f
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/909
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3011

**Description**:
- restore CrashLogMessageExtractor for unhandled NSException, cpp termination handler
- Added `swapCxaThrow: false` parameter to `CrashLogMessageExtractor.setUp` to allow disabling `__cxa_throw` swapping

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. run, detach debugger
2. simulate c++ crash
3. run from debugger
4. validate uploaded reports is generated (without the exception stack trace)
5. Simulate NSException and validate the stack trace is there

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
