### PR TITLE
tentatively fix content blocking UI test

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -75,7 +75,7 @@ jobs:
           --header "Accept: application/json" \
           --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
           --header "Content-Type: application/json" \
-          --data ' { "data": { "name": "GH Workflow Failure - End to end tests (${{ vars.GITHUB_REF_NAME }})", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'
+          --data ' { "data": { "name": "GH Workflow Failure - End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'
 
     - name: Upload logs when workflow failed
       uses: actions/upload-artifact@v4

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -75,7 +75,7 @@ jobs:
           --header "Accept: application/json" \
           --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
           --header "Content-Type: application/json" \
-          --data ' { "data": { "name": "GH Workflow Failure - End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'
+          --data ' { "data": { "name": "GH Workflow Failure - End to end tests (${{ vars.GITHUB_REF_NAME }})", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'
 
     - name: Upload logs when workflow failed
       uses: actions/upload-artifact@v4

--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -45,13 +45,13 @@ tags:
 - tapOn: "Don't Send"
 
 - tapOn: "Refresh Page"
+- extendedWaitUntil: 
+    notVisible: "Nonsense text that won't exist"
+    timeout: 2000
+
 - assertVisible: "1 major tracker loaded via script src"
 
 - tapOn: 
     id: PrivacyIcon
-- extendedWaitUntil: 
-    visible: "Protections are OFF for this site"
-    timeout: 10000
-
-
+- assertVisible: "Protections are OFF for this site"
 

--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -49,4 +49,9 @@ tags:
 
 - tapOn: 
     id: PrivacyIcon
-- assertVisible: "Protections are OFF for this site"
+- extendedWaitUntil: 
+    visible: "Protections are OFF for this site"
+    timeout: 10000
+
+
+

--- a/.maestro/setup_ui_tests.sh
+++ b/.maestro/setup_ui_tests.sh
@@ -18,8 +18,8 @@ check_maestro() {
     local known_version="1.36.0"
 
     if command -v $command_name > /dev/null 2>&1; then
-      local version_output=$($command_name -v 2>&1)
-      
+      local version_output=$($command_name -v 2>&1 | tail -n 1)
+
       local command_version=$(echo $version_output | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
       if [[ $command_version == $known_version ]]; then


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/392891325557410/1207863848732212/f
Tech Design URL:
CC:

**Description**:
Tries to fix flakey UI test by adding some wait time.  Otherwise it's not really clear what the problem is.  As the dashboard just seems to appear and then immediately disappear.

**Steps to test this PR**:
1. Check this flow passes https://github.com/duckduckgo/iOS/actions/runs/10080371461
2. Run flow locally using `run_ui_test release/content_blocking.yaml`
3. Optionally run all the end to end flows with `run_ui_test release/`

