### PR TITLE
Contextual Onboarding - Disable Add Favorites flow for experiment group

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -653,6 +653,8 @@
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
+		9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */; };
+		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
@@ -2363,6 +2365,8 @@
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
+		9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDaxFavouritesTests.swift; sourceTree = "<group>"; };
+		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
@@ -4435,6 +4439,7 @@
 				9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */,
 				9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */,
 				9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */,
+				9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -5515,6 +5520,7 @@
 				9F23B8082C2BE9B700950875 /* MockURLOpener.swift */,
 				9FEA22332C3271DC006B03BF /* MockTimer.swift */,
 				9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */,
+				9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -7429,6 +7435,7 @@
 				8341D807212D5E8D000514C2 /* HashExtensionTest.swift in Sources */,
 				C1D21E2F293A599C006E5A05 /* AutofillLoginSessionTests.swift in Sources */,
 				85D2187924BF6B8B004373D2 /* FaviconSourcesProviderTests.swift in Sources */,
+				9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */,
 				983BD6B52B34760600AAC78E /* MockPrivacyConfiguration.swift in Sources */,
 				1E8146AD28C8ABF000D1AF63 /* TrackerAnimationLogicTests.swift in Sources */,
 				C1CDA31E2AFBF811006D1476 /* AutofillNeverPromptWebsitesManagerTests.swift in Sources */,
@@ -7477,6 +7484,7 @@
 				8521FDE6238D414B00A44CC3 /* FileStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,
 				9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */,
+				9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */,
 				85D2187424BF25CD004373D2 /* FaviconsTests.swift in Sources */,
 				56D0602D2C383FD2003BAEB5 /* OnboardingSuggestedSearchesProviderTests.swift in Sources */,
 				85AD49EE2B6149110085D2D1 /* CookieStorageTests.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -687,6 +687,11 @@ import WebKit
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         os_log("App launched with url %s", log: .lifecycleLog, type: .debug, url.absoluteString)
 
+        // If showing the onboarding intro ignore deeplinks
+        guard mainViewController?.needsToShowOnboardingIntro() == false else {
+            return false
+        }
+
         if handleEmailSignUpDeepLink(url) {
             return true
         }

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -43,6 +43,9 @@ protocol ContextualOnboardingLogic {
     func setFireEducationMessageSeen()
     func setFinalOnboardingDialogSeen()
     func setPrivacyButtonPulseSeen()
+
+    func canEnableAddFavoriteFlow() -> Bool // Temporary during Contextual Onboarding Experiment
+    func enableAddFavoriteFlow()
 }
 
 extension ContentBlockerRulesManager: EntityProviding {
@@ -297,7 +300,13 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         settings.isDismissed = false
     }
 
+    func canEnableAddFavoriteFlow() -> Bool {
+        !isNewOnboarding
+    }
+
     func enableAddFavoriteFlow() {
+        guard canEnableAddFavoriteFlow() else { return }
+
         nextHomeScreenMessageOverride = .addFavorite
         // Progress to next home screen message, but don't re-show the second dax dialog if it's already been shown
         settings.homeScreenMessagesSeen = max(settings.homeScreenMessagesSeen, 1)

--- a/DuckDuckGo/HomeViewController+DaxDialogs.swift
+++ b/DuckDuckGo/HomeViewController+DaxDialogs.swift
@@ -80,7 +80,8 @@ extension HomeViewController {
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
         if didFinishNTPOnboarding {
-            delegate?.home(self, didRequestHideLogo: false)
+            // If there are favorites to show hide the Dax logo
+            delegate?.home(self, didRequestHideLogo: hasFavoritesToShow)
         }
     }
 }

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -84,6 +84,10 @@ class HomeViewController: UIViewController, NewTabPage {
 
     let privacyProDataReporter: PrivacyProDataReporting
 
+    var hasFavoritesToShow: Bool {
+        !favoritesViewModel.favorites.isEmpty
+    }
+
     static func loadFromStoryboard(
         homePageDependecies: HomePageDependencies
     ) -> HomeViewController {

--- a/DuckDuckGo/TutorialSettings.swift
+++ b/DuckDuckGo/TutorialSettings.swift
@@ -20,14 +20,14 @@
 import Foundation
 import Core
 
-protocol TutorialSettings {
+protocol TutorialSettings: AnyObject {
 
     var lastVersionSeen: Int { get }
     var hasSeenOnboarding: Bool { get set }
 
 }
 
-struct DefaultTutorialSettings: TutorialSettings {
+final class DefaultTutorialSettings: TutorialSettings {
 
     private struct Constants {
         // Set the build number of the last build that didn't force them to appear to force them to appear.

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -889,6 +889,48 @@ final class DaxDialog: XCTestCase {
         XCTAssertEqual(result, .final)
     }
 
+    func testWhenExperimentGroup_AndCanEnableAddFavoritesFlowIsCalled_ThenReturnFalse() {
+        // GIVEN
+        let sut = makeExperimentSUT(settings: InMemoryDaxDialogsSettings())
+
+        // WHEN
+        let result = sut.canEnableAddFavoriteFlow()
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenControlGroup_AndCanEnableAddFavoritesFlowIsCalled_ThenReturnTrue() {
+        // WHEN
+        let result = onboarding.canEnableAddFavoriteFlow()
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenControlGroup_AndEnableAddFavoritesFlowIsCalled_ThenIsAddFavoriteFlowIsTrue() {
+        // GIVEN
+        XCTAssertFalse(onboarding.isAddFavoriteFlow)
+
+        // WHEN
+        onboarding.enableAddFavoriteFlow()
+
+        // THEN
+        XCTAssertTrue(onboarding.isAddFavoriteFlow)
+    }
+
+    func testWhenExperimentGroup_AndEnableAddFavoritesFlowIsCalled_ThenIsAddFavoriteFlowIsFalse() {
+        // GIVEN
+        let sut = makeExperimentSUT(settings: InMemoryDaxDialogsSettings())
+        XCTAssertFalse(sut.isAddFavoriteFlow)
+
+        // WHEN
+        sut.enableAddFavoriteFlow()
+
+        // THEN
+        XCTAssertFalse(sut.isAddFavoriteFlow)
+    }
+
     private func detectedTrackerFrom(_ url: URL, pageUrl: String) -> DetectedRequest {
         let entity = entityProvider.entity(forHost: url.host!)
         return DetectedRequest(url: url.absoluteString,

--- a/DuckDuckGoTests/DaxDialogsNewTabTests.swift
+++ b/DuckDuckGoTests/DaxDialogsNewTabTests.swift
@@ -38,6 +38,7 @@ final class DaxDialogsNewTabTests: XCTestCase {
     }
 
     func testIfIsAddFavoriteFlow_OnNextHomeScreenMessageNew_ReturnsAddFavorite() {
+        XCTExpectFailure("Add Favrite flow, is currenty disabled for new onboarding. Remove failure expectation once we support it.")
         // GIVEN
         daxDialogs.enableAddFavoriteFlow()
 

--- a/DuckDuckGoTests/MockTutorialSettings.swift
+++ b/DuckDuckGoTests/MockTutorialSettings.swift
@@ -1,0 +1,30 @@
+//
+//  MockTutorialSettings.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo
+
+class MockTutorialSettings: TutorialSettings {
+    var lastVersionSeen: Int { 0 }
+    var hasSeenOnboarding: Bool
+
+    init(hasSeenOnboarding: Bool) {
+        self.hasSeenOnboarding = hasSeenOnboarding
+    }
+}

--- a/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
+++ b/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
@@ -1,0 +1,170 @@
+//
+//  OnboardingDaxFavouritesTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Persistence
+import Bookmarks
+import DDGSync
+import History
+import BrowserServicesKit
+import RemoteMessaging
+import Configuration
+import Core
+@testable import DuckDuckGo
+
+final class OnboardingDaxFavouritesTests: XCTestCase {
+    private var sut: MainViewController!
+    private var tutorialSettingsMock: MockTutorialSettings!
+    private var contextualOnboardingLogicMock: ContextualOnboardingLogicMock!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let db = CoreDataDatabase.bookmarksMock
+        let bookmarkDatabaseCleaner = BookmarkDatabaseCleaner(bookmarkDatabase: db, errorEvents: nil)
+        let dataProviders = SyncDataProviders(
+            bookmarksDatabase: db,
+            secureVaultFactory: AutofillSecureVaultFactory,
+            secureVaultErrorReporter: SecureVaultReporter(),
+            settingHandlers: [],
+            favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
+            syncErrorHandler: SyncErrorHandler()
+        )
+
+        let remoteMessagingClient = RemoteMessagingClient(
+            bookmarksDatabase: db,
+            appSettings: AppSettingsMock(),
+            internalUserDecider: DefaultInternalUserDecider(),
+            configurationStore: MockConfigurationStoring(),
+            database: db,
+            errorEvents: nil,
+            remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProviding(),
+            duckPlayerStorage: MockDuckPlayerStorage()
+        )
+        let homePageConfiguration = HomePageConfiguration(remoteMessagingClient: remoteMessagingClient, privacyProDataReporter: MockPrivacyProDataReporter())
+        let tabsModel = TabsModel(desktop: true)
+        tutorialSettingsMock = MockTutorialSettings(hasSeenOnboarding: false)
+        contextualOnboardingLogicMock = ContextualOnboardingLogicMock()
+        sut = MainViewController(
+            bookmarksDatabase: db,
+            bookmarksDatabaseCleaner: bookmarkDatabaseCleaner,
+            historyManager: MockHistoryManager(historyCoordinator: MockHistoryCoordinator(), isEnabledByUser: true, historyFeatureEnabled: true),
+            homePageConfiguration: homePageConfiguration,
+            syncService: MockDDGSyncing(authState: .active, isSyncInProgress: false),
+            syncDataProviders: dataProviders,
+            appSettings: AppSettingsMock(),
+            previewsSource: TabPreviewsSource(),
+            tabsModel: tabsModel,
+            syncPausedStateManager: CapturingSyncPausedStateManager(),
+            privacyProDataReporter: MockPrivacyProDataReporter(),
+            variantManager: MockVariantManager(),
+            contextualOnboardingPresenter: ContextualOnboardingPresenterMock(),
+            contextualOnboardingLogic: contextualOnboardingLogicMock,
+            tutorialSettings: tutorialSettingsMock
+        )
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        window.rootViewController?.present(sut, animated: false, completion: nil)
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testWhenMakeOnboardingSeenIsCalled_ThenSetHasSeenOnboardingTrue() {
+        // GIVEN
+        XCTAssertFalse(tutorialSettingsMock.hasSeenOnboarding)
+
+        // WHEN
+        tutorialSettingsMock.hasSeenOnboarding = true
+
+        // THEN
+        XCTAssertTrue(tutorialSettingsMock.hasSeenOnboarding)
+    }
+
+    func testWhenHasSeenOnboardingIntroIsCalled_AndHasSeenOnboardingSettingIsTrue_ThenReturnFalse() throws {
+        // GIVEN
+        tutorialSettingsMock.hasSeenOnboarding = true
+
+        // WHEN
+        let result = sut.needsToShowOnboardingIntro()
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenHasSeenOnboardingIntroIsCalled_AndHasSeenOnboardingIsFalse_ThenReturnTrue() throws {
+        // GIVEN
+        tutorialSettingsMock.hasSeenOnboarding = false
+
+        // WHEN
+        let result = sut.needsToShowOnboardingIntro()
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenAddFavouriteIsCalled_ThenItShouldAskContextualOnboardingLogicIfAddFavoriteFlowCanStart() {
+        // GIVEN
+        XCTAssertFalse(contextualOnboardingLogicMock.didCallCanEnableAddFavoriteFlow)
+
+        // WHEN
+        sut.startAddFavoriteFlow()
+
+        // THEN
+        XCTAssertTrue(contextualOnboardingLogicMock.didCallCanEnableAddFavoriteFlow)
+    }
+
+    func testWhenAddFavouriteIsCalled_AndCanStartAddFavouriteFlow_ThenItShouldEnableAddFavouriteFlowOnContextualOnboardingLogic() {
+        // GIVEN
+        contextualOnboardingLogicMock.canStartFavoriteFlow = true
+        XCTAssertFalse(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
+
+        // WHEN
+        sut.startAddFavoriteFlow()
+
+        // THEN
+        XCTAssertTrue(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
+    }
+
+    func testWhenAddFavouriteIsCalled_AndCannotStartAddFavouriteFlow_ThenItShouldNotEnableAddFavouriteFlowOnContextualOnboardingLogic() {
+        // GIVEN
+        contextualOnboardingLogicMock.canStartFavoriteFlow = false
+        XCTAssertFalse(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
+
+        // WHEN
+        sut.startAddFavoriteFlow()
+
+        // THEN
+        XCTAssertFalse(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
+    }
+
+    func testWhenAddFavouriteIsCalled_AndCannotStartAddFavouriteFlow_ThenOpenANewTab() {
+        // GIVEN
+        contextualOnboardingLogicMock.canStartFavoriteFlow = false
+        XCTAssertEqual(sut.tabManager.model.tabs.count, 1)
+
+        // WHEN
+        sut.startAddFavoriteFlow()
+
+        // THEN
+        XCTAssertEqual(sut.tabManager.model.tabs.count, 2)
+    }
+}

--- a/DuckDuckGoTests/Subscription/PrivacyProDataReporterTests.swift
+++ b/DuckDuckGoTests/Subscription/PrivacyProDataReporterTests.swift
@@ -172,15 +172,6 @@ final class PrivacyProDataReporterTests: XCTestCase {
     }
 }
 
-struct MockTutorialSettings: TutorialSettings {
-    var lastVersionSeen: Int { 0 }
-    var hasSeenOnboarding: Bool
-
-    init(hasSeenOnboarding: Bool) {
-        self.hasSeenOnboarding = hasSeenOnboarding
-    }
-}
-
 class MockEmailStorage: EmailManagerStorage {
     private let username: String?
     private let token: String?

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -184,6 +184,10 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
     private(set) var didCallSetFireEducationMessageSeen = false
     private(set) var didCallsetFinalOnboardingDialogSeen = false
     private(set) var didCallsetsetSearchMessageSeen = false
+    private(set) var didCallCanEnableAddFavoriteFlow = false
+    private(set) var didCallEnableAddFavoriteFlow = false
+
+    var canStartFavoriteFlow = false
 
     var isShowingFireDialog: Bool = false
     var shouldShowPrivacyButtonPulse: Bool = false
@@ -205,4 +209,13 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
 
     }
 
+    func canEnableAddFavoriteFlow() -> Bool {
+        didCallCanEnableAddFavoriteFlow = true
+        return canStartFavoriteFlow
+    }
+
+    func enableAddFavoriteFlow() {
+        didCallEnableAddFavoriteFlow = true
+    }
+    
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207937793719014/f

**Description**:
This PR addresses:

1. [Brindy’s comment](https://github.com/duckduckgo/iOS/pull/3160#pullrequestreview-2207374692). When the experiment group users tap the Favorites widget, we want to disable the Add Favourites flow.

2. An issue where the favorites list and Dax Logo would overlap when the users finished the contextual onboarding.

3. An edge-case that exists in the current App. If the users deep link into the App via a widget, e.g. the search widget, while they are in the Onboarding Intro the flow would break (Screenshot Attached).
 
![IMG_97FB7556EF52-1](https://github.com/user-attachments/assets/3760c3c1-d301-4be7-acf7-6e2b7ca43487)

**Steps to test this PR**:
Prerequisites for all scenarios:  
1. Add `return VariantIOS(name: "mb", weight: 1, isIncluded: VariantIOS.When.always, features: [.newOnboardingIntro])` in `DefaultVariantManager` at line 145.
2. Add  `newInstallCompletion(self)` in `DefaultVariantManager` at line 128.
3. Delete the App.

**SCENARIO 1 - Disable Add Favorite flow - Experiment Group**
Prerequisites:
1. Make sure you have no favorites
2. Add the “Search and Favorites widget” after installing the App.
Steps:
1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip".
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Now or at any subsequent step of the flow:
6. Go to the Springboard and tap on the "Add favorites" section of the widget
**Expected Result:** The flow should open a new tab and show the expected dax onboarding dialog. It should not show the below screenshot.
![dax-add-favorites-flow](https://github.com/user-attachments/assets/32faf7a3-26ea-4dd9-aa3a-cb5262bbac86)

**SCENARIO 2 - Remove Overlapping of Favorites and Dax Logo**
1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Choose your browser” or “Skip".
4. Go Back to DuckDuckGo App.
5. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
6. Tap on one of the searches. E.g. “local weather”.
8. Tap on the "Got it!” button.
9. The Dax dialogue should update and suggest to the user a list of websites to try.
10. Tap on one of the websites. E.g. “ebay.com”.
12. The Dax dialogue should now inform the user of the trackers that have been blocked. 
11. Open the `…` menu and tap `Add Favorite`. 
17. Tap the “Got It!” Button.
18. The Fire dialog should be visible on screen.
19. Tap the “Fire” button.
21. Tap “Close Tabs and Clear Data”.
22. The new tab page should have a Dax dialogue titled “You’ve got this”.
23. Tap on the “High Five!” button.
24. The Dax dialogue on the new tab page should be dismissed.
**Expected Result:** The favorites should show on the home page and NO dax logo should be visible.

**SCENARIO 3 - Deeplink when Onboarding Intro is visible** 
Prerequisites:
1. Add the “Search and Favorites widget” after installing the App.

Steps:
1. Launch App and wait for Onboarding intro first screen to appear.
2. Background the App.
3. Tap on the DuckDuckGo Search widget
**Expected Result:** The App should open and be on the same screen it was left off.

**NOTE**
If `#3` requires a deeper discussion as we’re preventing deeplinks during the onboarding intro I can address it later on and go through ship review. It’s a rare edge case.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
