### PR TITLE
Translate strings introduced in New Tab Page improvements

### DIFF
--- a/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/DuckDuckGo/bg.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Персонализирайте раздела Любими и функциите за достъп. Пренаредете елементите или скрийте някои от тях за по голяма яснота.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Показване, скриване и пренареждане на секции на страницата с нов раздел";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Страницата с нов раздел е... Нова!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "СЕКЦИИ";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "БЪРЗИ ВРЪЗКИ";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Персонализиране на страницата с нов раздел";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Чат с изкуствен интелект";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Отметки";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Изтеглени файлове";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Пароли";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Настройки";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "В който и да е сайт отворете менюто ••• и изберете **Добавяне към предпочитани**, за да го добавите към страницата с нов раздел.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/DuckDuckGo/cs.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Přizpůsob si oblíbené záložky a časté funkce. Přeskládej je nebo je skryj, ať je všechno přehledné.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Zobrazení, skrytí a změna pořadí oddílů na stránce nové karty";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Stránka nové karty je... úplně nová!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "ODDÍLY";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "ZKRATKY";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Přizpůsobení nové karty";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Záložky";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Stahování";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Hesla";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Nastavení";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Na libovolném webu otevři nabídku ••• a vyber **Přidat do oblíbených**. Web se ti přidá na stránku nové karty.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/da.lproj/Localizable.strings
+++ b/DuckDuckGo/da.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Tilpas dine favoritter og go-to-funktioner. Flyt rundt på ting, eller skjul dem for at holde det enkelt.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Vis, skjul og omarranger sektioner på den nye faneside";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Din nye faneside er... Ny!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SEKTIONER";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "GENVEJE";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Tilpas ny fane";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI-chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Bogmærker";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Downloads";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Adgangskoder";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Indstillinger";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "På et hvilket som helst websted skal du åbne menuen ••• og vælge **Tilføj favorit** for at føje den til din nye faneside.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/de.lproj/Localizable.strings
+++ b/DuckDuckGo/de.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Passe deine Favoriten und häufig genutzten Funktionen an. Ordne die Dinge neu an oder blende sie aus, um die Übersichtlichkeit zu wahren.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Abschnitte auf der neuen Tab-Seite anzeigen, ausblenden und neu anordnen";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Deine „Neuer Tab“-Seite ist ... neu!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "ABSCHNITTE";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Shortcuts";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Neuen Tab anpassen";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "KI-Chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Lesezeichen";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Downloads";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Passwörter";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Einstellungen";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Öffne auf einer beliebigen Site das Menü ••• und wähle **Favorit hinzufügen**, um sie zu deiner neuen Tab-Seite hinzuzufügen.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/el.lproj/Localizable.strings
+++ b/DuckDuckGo/el.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Προσαρμόστε τα Αγαπημένα και τις λειτουργίες μετάβασης. Αναδιατάξτε στοιχεία ή αποκρύψτε τα για να τη διατηρείτε καθαρή.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Εμφάνιση, απόκρυψη και αναδιάταξη ενοτήτων στη σελίδα της νέας καρτέλας";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Η σελίδα σας για τη Νέα καρτέλα είναι... Νέα!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "ΕΝΟΤΗΤΕΣ";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "ΣΥΝΤΟΜΕΥΣΕΙΣ";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Προσαρμογή νέας καρτέλας";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Συνομιλία με ΤΝ";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Σελιδοδείκτες";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Λήψεις";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Κωδικός πρόσβασης";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Ρυθμίσεις";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Σε οποιονδήποτε ιστότοπο, ανοίξτε το μενού ••• και επιλέξτε **Προσθήκη αγαπημένου** για προσθήκη στη σελίδα νέας καρτέλας σας.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/es.lproj/Localizable.strings
+++ b/DuckDuckGo/es.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Personaliza tus favoritos y funciones de acceso. Reordena los elementos o escóndelos para mantener el orden.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Mostrar, ocultar y reordenar las secciones de la página nueva pestaña";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Tu nueva pestaña es... ¡Novedad!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SECCIONES";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Accesos directos";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Personaliza la nueva pestaña";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Chat de IA";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Marcadores";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Descargas";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Contraseñas";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Ajustes";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "En cualquier sitio, abre el menú ••• y selecciona **Añadir favorito** para añadirlo a tu nueva pestaña.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/et.lproj/Localizable.strings
+++ b/DuckDuckGo/et.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Kohanda oma lemmikuid ja enim kasutatavaid funktsioone. Järjesta valikud ümber või peida need, et kõik oleks lihtsasti leitav.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Jaotiste kuvamine, peitmine ja järjestamine uuel vahelehel";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Sinu uue vahelehe leht on... Uus!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "JAOTISED";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "OTSETEED";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Uue vahekaardi kohandamine";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI vestlus";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Järjehoidjad";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Allalaadimised";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Paroolid";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Seaded";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Ava mis tahes saidil menüü ••• ja vali **Lisa lemmik**, et lisada see oma uue vahekaardi lehele.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/DuckDuckGo/fi.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Mukauta suosikkejasi ja muita usein käyttämiäsi ominaisuuksia. Luo uusi järjestys tai piilota kohteita pitääksesi selkeän ilmeen.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Näytä, piilota ja järjestä uuden välilehden osiot uudelleen";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Uusi välilehti -sivusi on... uusi!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "OSIOT";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "PIKAVALINNAT";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Mukauta uusi välilehti";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Tekoäly-chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Kirjanmerkit";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Lataukset";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Salasanat";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Asetukset";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Avaa missä tahansa sivustossa •••-valikko ja lisää se uudelle välilehtisivulle valitsemalla **Lisää suosikki**.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/DuckDuckGo/fr.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Personnalisez vos favoris et vos fonctionnalités préférées. Réorganisez les différents éléments ou masquez-les pour que tout reste en ordre.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Afficher, masquer et réorganiser les sections sur la nouvelle page d'onglet";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Votre nouvelle page d'onglet est… toute nouvelle !";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SECTIONS";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Raccourcis";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Personnaliser le nouvel onglet";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Chat IA";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Signets";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Téléchargements";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Mots de passe";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Paramètres";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Sur n'importe quel site, ouvrez le menu ••• et sélectionnez **Ajouter un favori** pour l'ajouter à votre nouvelle page d'onglet.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/DuckDuckGo/hr.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Prilagodi svoje favorite i najdraže značajke. Preuredi stvari ili ih sakrij kako bi sve bilo jasno.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Prikaži, sakrij i promijeni redoslijed odjeljaka na stranici nove kartice";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Tvoja stranica nove kartice je... nova!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SEKCIJE";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "PREČACI";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Prilagodi novu karticu";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI Chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Knjižne oznake";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Preuzimanja";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Lozinke";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Postavke";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Na bilo kojem web-mjestu otvori ••• izbornik i odaberi **Dodaj favorit** kako bi se on dodao na stranicu nove kartice.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/DuckDuckGo/hu.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Testre szabhatja a kedvenceket és a leggyakrabban használt funkciókat. Az áttekinthetőség érdekében átrendezheti az elemeket, vagy elrejtheti őket.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Részek megjelenítése, elrejtése és átrendezése az új lap oldalon";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Az új lap oldal… Új!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "RÉSZEK";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "GYORSPARANCSOK";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Új lap oldal testreszabása";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI-csevegés";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Könyvjelzők";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Letöltések";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Jelszavak";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Beállítások";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Nyisd meg a „•••” jelzésű menüt, és válaszd a **Kedvenc hozzáadása** lehetőséget, hogy hozzáadhasd azt az új laphoz.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/it.lproj/Localizable.strings
+++ b/DuckDuckGo/it.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Personalizza i tuoi Preferiti e le funzionalità principali. Riorganizza gli elementi o nascondili per mantenere tutto in ordine.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Mostra, nascondi e riordina le sezioni nella nuova scheda";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "La tua pagina Nuova scheda è... Nuova!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SEZIONI";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Scorciatoie";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Personalizza la pagina Nuova scheda";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Chat IA";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Segnalibri";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Download";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Password";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Impostazioni";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Su qualsiasi sito, apri il menu ••• e seleziona **Aggiungi preferito** per aggiungerlo alla nuova scheda.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/DuckDuckGo/lt.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Tinkinkite savo mėgstamiausius ir pagrindines funkcijas. Pertvarkykite elementus arba paslėpkite juos, kad užtikrintumėte tvarką.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Rodyti, slėpti ir pertvarkyti skiltis naujame skirtuko puslapyje";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Jūsų naujo skirtuko puslapis yra... Atnaujintas!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SKILTYS";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "ŠAUKINIAI";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Tinkinti naują skirtuką";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "DI pokalbis";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Žymės";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Atsisiuntimai";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Slaptažodžiai";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Nustatymai";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Bet kurioje interneto svetainėje atidarykite ••• meniu ir pasirinkite **Pridėti mėgstamą**, kad pridėtumėte naujame skirtuko puslapyje.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/DuckDuckGo/lv.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Pielāgo savu izlasi un bieži izmantotās funkcijas. Pārkārto elementus vai paslēp tos, lai lieki neaizņemtu vietu.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Rādīt, paslēpt un pārkārtot sadaļas jaunās cilnes lapā";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Tava jaunas cilnes lapa ir... atjaunota!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SADAĻAS";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "SAĪSNES";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Jaunas cilnes pielāgošana";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "MI čats";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Grāmatzīmes";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Lejupielādes";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Paroles";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Iestatījumi";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Jebkurā vietnē atver izvēlni ••• un izvēlies **Pievienot izlasei**, lai to pievienotu savai jaunas cilnes lapai.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/DuckDuckGo/nb.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Tilpass favorittene dine og de funksjonene du bruker mest. Endre på rekkefølgen av ting eller skjul dem for å holde orden.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Vis, skjul og endre rekkefølgen av delene på den nye fanesiden";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Den nye fanesiden din er … ny!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "DELER";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "SNARVEIER";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Tilpass ny fane";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "KI-chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Bokmerker";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Nedlastinger";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Passord";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Innstillinger";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Åpne menyen under de tre prikkene (•••) og velg **Legg til favoritt** for å legge den til ny fane-siden.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/DuckDuckGo/nl.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Pas je favorieten en go-to-functies aan. Herschik dingen of verberg ze om de tabbladpagina overzichtelijk te maken.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Secties op het nieuwe tabblad weergeven, verbergen en opnieuw ordenen";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Je nieuwe tabbladpagina is... Nieuw!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SECTIES";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Sneltoetsen";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Nieuwe tabbladpagina aanpassen";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI-chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Bladwijzers";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Downloads";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Wachtwoorden";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Instellingen";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Open op een willekeurige site het menu ••• en selecteer **Favoriet toevoegen** om deze toe te voegen aan je nieuwe tabbladpagina.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/DuckDuckGo/pl.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Dostosuj ulubione elementy i podręczne funkcje. Zmień kolejność opcji lub ukryj je, aby zachować porządek.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Pokazuj, ukrywaj i zmieniaj kolejność sekcji na stronie nowej karty";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Strona nowej karty ma nowy wygląd!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SEKCJE";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Skróty";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Dostosuj nową kartę";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Czat AI";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Zakładki";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Pobrane";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Hasła";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Ustawienia";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "W dowolnej witrynie otwórz menu ••• i wybierz **Dodaj ulubione**, aby dodać je do strony nowej karty.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/DuckDuckGo/pt.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Personaliza os teus Favoritos e as tuas funcionalidades de preferência. Reordena as coisas ou esconde-as para manter um aspeto limpo.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Mostrar, ocultar e reordenar secções na página do novo separador";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "A tua página Novo separador é... nova!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SECÇÕES";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Atalhos";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Personalizar novo separador";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Chat com IA";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Marcadores";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Transferências";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Palavras-passe";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Definições";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Em qualquer site, abre o menu ••• e seleciona **Adicionar favorito** para o adicionar à tua página de novo separador.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/DuckDuckGo/ro.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Personalizează-ți Favoritele și funcțiile predilecte. Reordonează lucrurile sau ascunde-le pentru a menține ordinea.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Afișează, ascunde și reordonează secțiunile din pagina noii file";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Pagina Filă nouă este... nouă!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "SECȚIUNI";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "SCURTĂTURI";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Personalizează noua filă";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Chat IA";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Semne de carte";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Descărcări";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Parole";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Setări";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Pe orice site, deschide meniul ••• și selectează **Adaugă la favorite** pentru a adăuga la pagina Filă nouă.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/DuckDuckGo/ru.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "К вашим услугам настройки «Избранного» и важнейших функций. Для поддержания порядка отдельные элементы можно переупорядочить или скрыть.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Показать, скрыть или изменить порядок разделов на странице новой вкладки";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Ваша страница новой вкладки... В новом виде!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "РАЗДЕЛЫ";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "Ярлыки";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Настройки страницы новой вкладки";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Чат с ИИ";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Закладки";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Загрузки";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Пароли";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Настройки";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Чтобы добавить сайт к странице новой вкладки, откройте меню ••• и выберите пункт **Добавить в избранное**.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/DuckDuckGo/sk.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Prispôsobenie obľúbených položiek a funkcií. Pre prehľadnosť zmeňte usporiadanie vecí alebo ich skryte.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Zobrazenie, skrytie a zmena poradia častí na novej stránke karty";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Vaša stránka Nová karta je... Nová!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "ČASTI";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "SKRATKY";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Prispôsobiť novú kartu";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI Chat";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Záložky";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Stiahnuté";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Heslo";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Nastavenia";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Na ľubovoľnej lokalite otvorte ponuku ••• a vybraním položky **Pridať obľúbené** ju pridajte na novú stránku karty.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/DuckDuckGo/sl.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Prilagodite zavihek Priljubljene in izbrane funkcije. Preuredite stvari ali jih skrijte, da boste imeli vse urejeno.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Prikaz, skrivanje in razvrščanje razdelkov na strani novega zavihka";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Vaša stran za nov zavihek je ... nova!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "RAZDELKI";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "BLIŽNJICE";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Prilagoditev strani novega zavihka";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Klepet z umetno inteligenco";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Zaznamki";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Prenosi";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Gesla";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Nastavitve";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Na katerem koli spletnem mestu odprite meni ••• in izberite **Dodaj priljubljene**, da ga dodate na stran novega zavihka.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/DuckDuckGo/sv.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Anpassa dina favoriter och funktioner. Ordna om saker och ting eller göm dem för att hålla layouten minimalistisk.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Visa, dölja och ändra ordning på avsnitt på den nya fliksidan";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Din nya fliksida är... ny!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "AVSNITT";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "GENVÄGAR";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Anpassa ny flik";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "AI-chatt";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Bokmärken";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "Nerladdningar";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Lösenord";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Inställningar";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Öppna menyn ••• på valfri webbplats och välj **Lägg till favorit** för att lägga till den på din nya fliksida.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";

--- a/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/DuckDuckGo/tr.lproj/Localizable.strings
@@ -1710,9 +1710,37 @@
 
 /* Information message about New Tab Page redesign */
 "new.tab.page.intro.message.body" = "Favorilerinizi ve düzenli olarak kullandığınız özellikleri kendinize göre ayarlayın. Temiz tutmak için öğeleri yeniden sıralayın veya gizleyin.";
+/* Footer of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.description" = "Yeni sekme sayfasında bölümleri göster, gizle ve yeniden sırala";
 
 /* Title of information message about New Tab Page redesign */
 "new.tab.page.intro.message.title" = "Yeni Sekme Sayfanız... Yeni!";
+/* Header title of the group allowing for setting up new tab page sections */
+"new.tab.page.settings.sections.header.title" = "BÖLÜMLER";
+
+/* Header title of the shortcuts in New Tab Page preferences. */
+"new.tab.page.settings.shortcuts.header.title" = "KISAYOLLAR";
+
+/* Title of New Tab Page preferences page. */
+"new.tab.page.settings.title" = "Yeni Sekme Sayfasını Özelleştirin";
+
+/* Shortcut title leading to AI Chat */
+"new.tab.page.shortcut.ai.chat" = "Yapay Zeka Sohbeti";
+
+/* Shortcut title leading to Bookmarks */
+"new.tab.page.shortcut.bookmarks" = "Yer İmleri";
+
+/* Shortcut title leading to Downloads */
+"new.tab.page.shortcut.downloads" = "İndirilenler";
+
+/* Shortcut title leading to Passwords */
+"new.tab.page.shortcut.passwords" = "Şifreler";
+
+/* Shortcut title leading to app settings */
+"new.tab.page.shortcut.settings" = "Ayarlar";
+
+/* Text shown on the favorites info tooltip */
+"new.tab.page.tooltip.body" = "Herhangi bir sitedeyken, ••• menüsünü açın ve siteyi yeni sekme sayfanıza eklemek için **Favori Ekle**'yi seçin.";
 
 /* Do not translate - stringsdict entry */
 "number.of.tabs" = "number.of.tabs";


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1207955482856155/f
Tech Design URL:
CC:

**Description**:

Translations for Improvements to the New Tab Page.

**Steps to test this PR**:
1. Verify all New Tab Page strings (`new.tab.page.*` keys) have translations.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
