### PR TITLE
Contextual Onboarding Pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -146,6 +146,7 @@ public struct PixelParameters {
 
     // Privacy Dashboard
     public static let daysSinceInstall = "daysSinceInstall"
+    public static let fromOnboarding = "from_onboarding"
 }
 
 public struct PixelValues {

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -143,6 +143,9 @@ public struct PixelParameters {
 
     // Autofill
     public static let countBucket = "count_bucket"
+
+    // Privacy Dashboard
+    public static let daysSinceInstall = "daysSinceInstall"
 }
 
 public struct PixelValues {

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -161,7 +161,8 @@ extension Pixel {
         case daxDialogsFireEducationShownUnique
         case daxDialogsFireEducationConfirmedUnique
         case daxDialogsFireEducationCancelledUnique
-        case daxDialogsEndOfJourneyUnique
+        case daxDialogsEndOfJourneyTabUnique
+        case daxDialogsEndOfJourneyNewTabUnique
 
         case widgetsOnboardingCTAPressed
         case widgetsOnboardingDeclineOptionPressed
@@ -893,7 +894,8 @@ extension Pixel.Event {
         case .daxDialogsFireEducationShownUnique: return "m_dx_fe_s_unique"
         case .daxDialogsFireEducationConfirmedUnique: return "m_dx_fe_co_unique"
         case .daxDialogsFireEducationCancelledUnique: return "m_dx_fe_ca_unique"
-        case .daxDialogsEndOfJourneyUnique: return "m_dx_end_unique_unique"
+        case .daxDialogsEndOfJourneyTabUnique: return "m_dx_end_tab_unique"
+        case .daxDialogsEndOfJourneyNewTabUnique: return "m_dx_end_new_tab_unique"
 
         case .widgetsOnboardingCTAPressed: return "m_o_w_a"
         case .widgetsOnboardingDeclineOptionPressed: return "m_o_w_d"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -142,15 +142,9 @@ extension Pixel {
         case onboardingIntroShownUnique
         case onboardingIntroComparisonChartShownUnique
         case onboardingIntroChooseBrowserCTAPressed
-        case onboardingContextualSearchSayDuckUnique
-        case onboardingContextualSearchMightyDuckUnique
-        case onboardingContextualSearchWeatherUnique
-        case onboardingContextualSearchSurpriseMeUnique
+        case onboardingContextualSearchOptionTappedUnique
         case onboardingContextualSearchCustomUnique
-        case onboardingContextualSiteESPNUnique
-        case onboardingContextualSiteYahooUnique
-        case onboardingContextualSiteEbayUnique
-        case onboardingContextualSiteSurpriseMeUnique
+        case onboardingContextualSiteOptionTappedUnique
         case onboardingContextualSiteCustomUnique
         case onboardingContextualSecondSiteVisitUnique
 
@@ -876,17 +870,11 @@ extension Pixel.Event {
         case .onboardingIntroShownUnique: return "m_preonboarding_intro_shown_unique"
         case .onboardingIntroComparisonChartShownUnique: return "m_preonboarding_comparison_chart_shown_unique"
         case .onboardingIntroChooseBrowserCTAPressed: return "m_preonboarding_choose_browser_pressed"
-        case .onboardingContextualSearchSayDuckUnique: return "m_onboarding_search_say_duck_unique"
-        case .onboardingContextualSearchMightyDuckUnique: return "m_onboarding_search_mighty_duck_unique"
-        case .onboardingContextualSearchWeatherUnique: return "m_onboarding_search_weather_unique"
-        case .onboardingContextualSearchSurpriseMeUnique: return "m_onboarding_search_surprise_me_unique"
-        case .onboardingContextualSearchCustomUnique: return "m_onboarding_search_custom_unique"
-        case .onboardingContextualSiteESPNUnique: return "m_onboarding_visit_site_espn_unique"
-        case .onboardingContextualSiteYahooUnique: return "m_onboarding_visit_site_yahoo_unique"
-        case .onboardingContextualSiteEbayUnique: return "m_onboarding_visit_site_ebay_unique"
-        case .onboardingContextualSiteSurpriseMeUnique: return "m_onboarding_visit_site_surprise_me_unique"
-        case .onboardingContextualSiteCustomUnique: return "m_onboarding_visit_site_custom_unique"
+        case .onboardingContextualSearchOptionTappedUnique: return "m_onboarding_search_option_tapped_unique"
+        case .onboardingContextualSiteOptionTappedUnique: return "m_onboarding_visit_site_option_tapped_unique"
         case .onboardingContextualSecondSiteVisitUnique: return "m_second_sitevisit_unique"
+        case .onboardingContextualSearchCustomUnique: return "m_onboarding_search_custom_unique"
+        case .onboardingContextualSiteCustomUnique: return "m_onboarding_visit_site_custom_unique"
 
         case .daxDialogsSerp: return "m_dx_s"
         case .daxDialogsWithoutTrackers: return "m_dx_wo"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -142,6 +142,17 @@ extension Pixel {
         case onboardingIntroShownUnique
         case onboardingIntroComparisonChartShownUnique
         case onboardingIntroChooseBrowserCTAPressed
+        case onboardingContextualSearchSayDuckUnique
+        case onboardingContextualSearchMightyDuckUnique
+        case onboardingContextualSearchWeatherUnique
+        case onboardingContextualSearchSurpriseMeUnique
+        case onboardingContextualSearchCustomUnique
+        case onboardingContextualSiteESPNUnique
+        case onboardingContextualSiteYahooUnique
+        case onboardingContextualSiteEbayUnique
+        case onboardingContextualSiteSurpriseMeUnique
+        case onboardingContextualSiteCustomUnique
+        case onboardingContextualSecondSiteVisitUnique
 
         case daxDialogsSerp
         case daxDialogsWithoutTrackers
@@ -865,6 +876,17 @@ extension Pixel.Event {
         case .onboardingIntroShownUnique: return "m_preonboarding_intro_shown_unique"
         case .onboardingIntroComparisonChartShownUnique: return "m_preonboarding_comparison_chart_shown_unique"
         case .onboardingIntroChooseBrowserCTAPressed: return "m_preonboarding_choose_browser_pressed"
+        case .onboardingContextualSearchSayDuckUnique: return "m_onboarding_search_say_duck_unique"
+        case .onboardingContextualSearchMightyDuckUnique: return "m_onboarding_search_mighty_duck_unique"
+        case .onboardingContextualSearchWeatherUnique: return "m_onboarding_search_weather_unique"
+        case .onboardingContextualSearchSurpriseMeUnique: return "m_onboarding_search_surprise_me_unique"
+        case .onboardingContextualSearchCustomUnique: return "m_onboarding_search_custom_unique"
+        case .onboardingContextualSiteESPNUnique: return "m_onboarding_visit_site_espn_unique"
+        case .onboardingContextualSiteYahooUnique: return "m_onboarding_visit_site_yahoo_unique"
+        case .onboardingContextualSiteEbayUnique: return "m_onboarding_visit_site_ebay_unique"
+        case .onboardingContextualSiteSurpriseMeUnique: return "m_onboarding_visit_site_surprise_me_unique"
+        case .onboardingContextualSiteCustomUnique: return "m_onboarding_visit_site_custom_unique"
+        case .onboardingContextualSecondSiteVisitUnique: return "m_second_sitevisit_unique"
 
         case .daxDialogsSerp: return "m_dx_s"
         case .daxDialogsWithoutTrackers: return "m_dx_wo"

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -44,7 +44,8 @@ extension Pixel {
         case forgetAllDataCleared
         
         case privacyDashboardOpened
-        
+        case privacyDashboardFirstTimeOpenedUnique
+
         case dashboardProtectionAllowlistAdd
         case dashboardProtectionAllowlistRemove
         
@@ -147,18 +148,21 @@ extension Pixel {
         case onboardingContextualSiteOptionTappedUnique
         case onboardingContextualSiteCustomUnique
         case onboardingContextualSecondSiteVisitUnique
+        case onboardingContextualTrySearchUnique
+        case onboardingContextualTryVisitSiteUnique
 
-        case daxDialogsSerp
-        case daxDialogsWithoutTrackers
+        case daxDialogsSerpUnique
+        case daxDialogsWithoutTrackersUnique
         case daxDialogsWithoutTrackersFollowUp
-        case daxDialogsWithTrackers
-        case daxDialogsSiteIsMajor
-        case daxDialogsSiteOwnedByMajor
-        case daxDialogsHidden
-        case daxDialogsFireEducationShown
-        case daxDialogsFireEducationConfirmed
-        case daxDialogsFireEducationCancelled
-        
+        case daxDialogsWithTrackersUnique
+        case daxDialogsSiteIsMajorUnique
+        case daxDialogsSiteOwnedByMajorUnique
+        case daxDialogsHiddenUnique
+        case daxDialogsFireEducationShownUnique
+        case daxDialogsFireEducationConfirmedUnique
+        case daxDialogsFireEducationCancelledUnique
+        case daxDialogsEndOfJourneyUnique
+
         case widgetsOnboardingCTAPressed
         case widgetsOnboardingDeclineOptionPressed
         case widgetsOnboardingMovedToBackground
@@ -764,7 +768,8 @@ extension Pixel.Event {
         case .forgetAllDataCleared: return "mf_dc"
             
         case .privacyDashboardOpened: return "mp"
-            
+        case .privacyDashboardFirstTimeOpenedUnique: return "m_privacy_dashboard_first_time_used_unique"
+
         case .dashboardProtectionAllowlistAdd: return "mp_wla"
         case .dashboardProtectionAllowlistRemove: return "mp_wlr"
             
@@ -875,18 +880,21 @@ extension Pixel.Event {
         case .onboardingContextualSecondSiteVisitUnique: return "m_second_sitevisit_unique"
         case .onboardingContextualSearchCustomUnique: return "m_onboarding_search_custom_unique"
         case .onboardingContextualSiteCustomUnique: return "m_onboarding_visit_site_custom_unique"
-
-        case .daxDialogsSerp: return "m_dx_s"
-        case .daxDialogsWithoutTrackers: return "m_dx_wo"
+        case .onboardingContextualTrySearchUnique: return "m_dx_try_a_search_unique"
+        case .onboardingContextualTryVisitSiteUnique: return "m_dx_try_visit_site_unique"
+        
+        case .daxDialogsSerpUnique: return "m_dx_s_unique"
+        case .daxDialogsWithoutTrackersUnique: return "m_dx_wo_unique"
         case .daxDialogsWithoutTrackersFollowUp: return "m_dx_wof"
-        case .daxDialogsWithTrackers: return "m_dx_wt"
-        case .daxDialogsSiteIsMajor: return "m_dx_sm"
-        case .daxDialogsSiteOwnedByMajor: return "m_dx_so"
-        case .daxDialogsHidden: return "m_dx_h"
-        case .daxDialogsFireEducationShown: return "m_dx_fe_s"
-        case .daxDialogsFireEducationConfirmed: return "m_dx_fe_co"
-        case .daxDialogsFireEducationCancelled: return "m_dx_fe_ca"
-            
+        case .daxDialogsWithTrackersUnique: return "m_dx_wt_unique"
+        case .daxDialogsSiteIsMajorUnique: return "m_dx_sm_unique"
+        case .daxDialogsSiteOwnedByMajorUnique: return "m_dx_so_unique"
+        case .daxDialogsHiddenUnique: return "m_dx_h_unique"
+        case .daxDialogsFireEducationShownUnique: return "m_dx_fe_s_unique"
+        case .daxDialogsFireEducationConfirmedUnique: return "m_dx_fe_co_unique"
+        case .daxDialogsFireEducationCancelledUnique: return "m_dx_fe_ca_unique"
+        case .daxDialogsEndOfJourneyUnique: return "m_dx_end_unique_unique"
+
         case .widgetsOnboardingCTAPressed: return "m_o_w_a"
         case .widgetsOnboardingDeclineOptionPressed: return "m_o_w_d"
         case .widgetsOnboardingMovedToBackground: return "m_o_w_b"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -657,6 +657,7 @@
 		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
 		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
 		9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */; };
+		9F6933212C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
@@ -2370,6 +2371,7 @@
 		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
 		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
 		9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
+		9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHostingControllerMock.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
@@ -4470,6 +4472,7 @@
 				9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */,
 				9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */,
 				9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */,
+				9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -7489,6 +7492,7 @@
 				9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */,
 				9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */,
 				85D2187424BF25CD004373D2 /* FaviconsTests.swift in Sources */,
+				9F6933212C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift in Sources */,
 				9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */,
 				56D0602D2C383FD2003BAEB5 /* OnboardingSuggestedSearchesProviderTests.swift in Sources */,
 				85AD49EE2B6149110085D2D1 /* CookieStorageTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -656,6 +656,7 @@
 		9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */; };
 		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
 		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
+		9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
@@ -885,7 +886,6 @@
 		D668D92B2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */; };
 		D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */; };
 		D670E5BB2BB6A75300941A42 /* SubscriptionNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */; };
-		D670E5BD2BB6AA0000941A42 /* View+AppearModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D670E5BC2BB6AA0000941A42 /* View+AppearModifiers.swift */; };
 		D67969112BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */; };
 		D68A21442B7EC08500BB372E /* SubscriptionExternalLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68A21432B7EC08500BB372E /* SubscriptionExternalLinkView.swift */; };
 		D68A21462B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */; };
@@ -2369,6 +2369,7 @@
 		9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDaxFavouritesTests.swift; sourceTree = "<group>"; };
 		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
 		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
+		9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
@@ -2608,7 +2609,6 @@
 		D668D92A2B696840008E2FF2 /* IdentityTheftRestorationPagesFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityTheftRestorationPagesFeature.swift; sourceTree = "<group>"; };
 		D66F683C2BB333C100AE93E2 /* SubscriptionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerView.swift; sourceTree = "<group>"; };
 		D670E5BA2BB6A75200941A42 /* SubscriptionNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionNavigationCoordinator.swift; sourceTree = "<group>"; };
-		D670E5BC2BB6AA0000941A42 /* View+AppearModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AppearModifiers.swift"; sourceTree = "<group>"; };
 		D67969102BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewModel.swift; sourceTree = "<group>"; };
 		D68A21432B7EC08500BB372E /* SubscriptionExternalLinkView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExternalLinkView.swift; sourceTree = "<group>"; };
 		D68A21452B7EC16200BB372E /* SubscriptionExternalLinkViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionExternalLinkViewModel.swift; sourceTree = "<group>"; };
@@ -3066,6 +3066,7 @@
 				6FD3F80E2C3EF4F000DA5797 /* DeviceOrientationEnvironmentValue.swift */,
 				9FEA222D2C324ECD006B03BF /* ViewVisibility.swift */,
 				9FEA22282C2E38FA006B03BF /* AnimatableTypingText.swift */,
+				9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */,
 			);
 			name = SwiftUI;
 			sourceTree = "<group>";
@@ -4910,7 +4911,6 @@
 			children = (
 				F1FDC9342BF51E41006B1435 /* VPNSettings+Environment.swift */,
 				D664C7982B289AA000CBFA76 /* WKUserContentController+Handler.swift */,
-				D670E5BC2BB6AA0000941A42 /* View+AppearModifiers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7240,7 +7240,6 @@
 				984D035C24AE15CD0066CFB8 /* TabSwitcherSettings.swift in Sources */,
 				D6E83C562B21ECC1006C8AFB /* SettingsLegacyViewProvider.swift in Sources */,
 				98B31292218CCB8C00E54DE1 /* AppDependencyProvider.swift in Sources */,
-				D670E5BD2BB6AA0000941A42 /* View+AppearModifiers.swift in Sources */,
 				D6ACEA322BBD55BF008FADDF /* TabURLInterceptor.swift in Sources */,
 				C13F3F6A2B7F883A0083BE40 /* AuthConfirmationPromptViewController.swift in Sources */,
 				851624C72B96389D002D5CD7 /* HistoryDebugViewController.swift in Sources */,
@@ -7304,6 +7303,7 @@
 				CB84C7BD29A3EF530088A5B8 /* AppConfigurationURLProvider.swift in Sources */,
 				AA3D854723D9E88E00788410 /* AppIconSettingsCell.swift in Sources */,
 				316931D927BD22A80095F5ED /* DownloadActionMessageViewHelper.swift in Sources */,
+				9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */,
 				BDF8D0022C1B87F4003E3B27 /* NetworkProtectionDNSSettingsViewModel.swift in Sources */,
 				9838059F2228208E00385F1A /* PositiveFeedbackViewController.swift in Sources */,
 				8590CB67268A2E520089F6BF /* RootDebugViewController.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -655,6 +655,7 @@
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
 		9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */; };
 		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
+		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
@@ -2367,6 +2368,7 @@
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
 		9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDaxFavouritesTests.swift; sourceTree = "<group>"; };
 		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
+		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
@@ -4466,6 +4468,7 @@
 			children = (
 				9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */,
 				9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */,
+				9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */,
 			);
 			name = Mocks;
 			sourceTree = "<group>";
@@ -7486,6 +7489,7 @@
 				9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */,
 				9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */,
 				85D2187424BF25CD004373D2 /* FaviconsTests.swift in Sources */,
+				9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */,
 				56D0602D2C383FD2003BAEB5 /* OnboardingSuggestedSearchesProviderTests.swift in Sources */,
 				85AD49EE2B6149110085D2D1 /* CookieStorageTests.swift in Sources */,
 				569437242BDD405400C0881B /* SyncBookmarksAdapterTests.swift in Sources */,

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -317,7 +317,8 @@ import WebKit
                                       privacyProDataReporter: privacyProDataReporter,
                                       variantManager: variantManager,
                                       contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager),
-                                      contextualOnboardingLogic: daxDialogs)
+                                      contextualOnboardingLogic: daxDialogs,
+                                      contextualOnboardingCustomSearchPixelReporting: OnboardingPixelReporter())
 
         main.loadViewIfNeeded()
         syncErrorHandler.alertPresenter = main

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -318,7 +318,7 @@ import WebKit
                                       variantManager: variantManager,
                                       contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager),
                                       contextualOnboardingLogic: daxDialogs,
-                                      contextualOnboardingCustomSearchPixelReporting: OnboardingPixelReporter())
+                                      contextualOnboardingPixelReporter: OnboardingPixelReporter())
 
         main.loadViewIfNeeded()
         syncErrorHandler.alertPresenter = main

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -123,6 +123,9 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
                                               pixelName: .daxDialogsSerpUnique,
                                               type: .afterSearch)
 
+        // Message and CTA empty on purpose as for this case we use only pixelName and type
+        static let visitWebsite = BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .onboardingContextualTryVisitSiteUnique, type: .visitWebsite)
+
         static let withoutTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithoutTrackers,
                                                   cta: UserText.daxDialogBrowsingWithoutTrackersCTA,
                                                   highlightAddressBar: false,
@@ -148,7 +151,10 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
                                                       highlightAddressBar: true,
                                                       pixelName: .daxDialogsWithTrackersUnique, type: .withMultipleTrackers)
 
-        static let final = BrowsingSpec(message: UserText.daxDialogHomeSubsequent, cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationShownUnique, type: .final)
+        // Message and CTA empty on purpose as for this case we use only pixelName and type
+        static let fire = BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationShownUnique, type: .fire)
+
+        static let final = BrowsingSpec(message: UserText.daxDialogHomeSubsequent, cta: "", highlightAddressBar: false, pixelName: .daxDialogsEndOfJourneyUnique, type: .final)
 
         let message: String
         let cta: String
@@ -373,7 +379,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         case BrowsingSpec.SpecType.afterSearch.rawValue:
             return BrowsingSpec.afterSearch
         case BrowsingSpec.SpecType.visitWebsite.rawValue:
-            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmedUnique, type: .visitWebsite)
+            return .visitWebsite
         case BrowsingSpec.SpecType.withoutTrackers.rawValue:
             return BrowsingSpec.withoutTrackers
         case BrowsingSpec.SpecType.siteIsMajorTracker.rawValue:
@@ -386,7 +392,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             guard let entityNames = blockedEntityNames(privacyInfo.trackerInfo) else { return nil }
             return trackersBlockedMessage(entityNames)
         case BrowsingSpec.SpecType.fire.rawValue:
-            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmedUnique, type: .fire)
+            return .fire
         case BrowsingSpec.SpecType.final.rawValue:
             return nil
         default: return nil

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -120,35 +120,35 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         static let afterSearch = BrowsingSpec(message: UserText.daxDialogBrowsingAfterSearch,
                                               cta: UserText.daxDialogBrowsingAfterSearchCTA,
                                               highlightAddressBar: false,
-                                              pixelName: .daxDialogsSerp,
+                                              pixelName: .daxDialogsSerpUnique,
                                               type: .afterSearch)
 
         static let withoutTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithoutTrackers,
                                                   cta: UserText.daxDialogBrowsingWithoutTrackersCTA,
                                                   highlightAddressBar: false,
-                                                  pixelName: .daxDialogsWithoutTrackers, type: .withoutTrackers)
-        
+                                                  pixelName: .daxDialogsWithoutTrackersUnique, type: .withoutTrackers)
+
         static let siteIsMajorTracker = BrowsingSpec(message: UserText.daxDialogBrowsingSiteIsMajorTracker,
                                                      cta: UserText.daxDialogBrowsingSiteIsMajorTrackerCTA,
                                                      highlightAddressBar: false,
-                                                     pixelName: .daxDialogsSiteIsMajor, type: .siteIsMajorTracker)
-        
+                                                     pixelName: .daxDialogsSiteIsMajorUnique, type: .siteIsMajorTracker)
+
         static let siteOwnedByMajorTracker = BrowsingSpec(message: UserText.daxDialogBrowsingSiteOwnedByMajorTracker,
                                                           cta: UserText.daxDialogBrowsingSiteOwnedByMajorTrackerCTA,
                                                           highlightAddressBar: false,
-                                                          pixelName: .daxDialogsSiteOwnedByMajor, type: .siteOwnedByMajorTracker)
-        
+                                                          pixelName: .daxDialogsSiteOwnedByMajorUnique, type: .siteOwnedByMajorTracker)
+
         static let withOneTracker = BrowsingSpec(message: UserText.daxDialogBrowsingWithOneTracker,
                                                  cta: UserText.daxDialogBrowsingWithOneTrackerCTA,
                                                  highlightAddressBar: true,
-                                                 pixelName: .daxDialogsWithTrackers, type: .withOneTracker)
-        
+                                                 pixelName: .daxDialogsWithTrackersUnique, type: .withOneTracker)
+
         static let withMultipleTrackers = BrowsingSpec(message: UserText.daxDialogBrowsingWithMultipleTrackers,
                                                       cta: UserText.daxDialogBrowsingWithMultipleTrackersCTA,
                                                       highlightAddressBar: true,
-                                                      pixelName: .daxDialogsWithTrackers, type: .withMultipleTrackers)
+                                                      pixelName: .daxDialogsWithTrackersUnique, type: .withMultipleTrackers)
 
-        static let final = BrowsingSpec(message: UserText.daxDialogHomeSubsequent, cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationShown, type: .final)
+        static let final = BrowsingSpec(message: UserText.daxDialogHomeSubsequent, cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationShownUnique, type: .final)
 
         let message: String
         let cta: String
@@ -180,10 +180,10 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
                                                          confirmAction: UserText.daxDialogFireButtonEducationConfirmAction,
                                                          cancelAction: UserText.daxDialogFireButtonEducationCancelAction,
                                                          isConfirmActionDestructive: true,
-                                                         displayedPixelName: .daxDialogsFireEducationShown,
-                                                         confirmActionPixelName: .daxDialogsFireEducationConfirmed,
-                                                         cancelActionPixelName: .daxDialogsFireEducationCancelled)
-        
+                                                         displayedPixelName: .daxDialogsFireEducationShownUnique,
+                                                         confirmActionPixelName: .daxDialogsFireEducationConfirmedUnique,
+                                                         cancelActionPixelName: .daxDialogsFireEducationCancelledUnique)
+
         let message: String
         let confirmAction: String
         let cancelAction: String
@@ -373,7 +373,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         case BrowsingSpec.SpecType.afterSearch.rawValue:
             return BrowsingSpec.afterSearch
         case BrowsingSpec.SpecType.visitWebsite.rawValue:
-            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmed, type: .visitWebsite)
+            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmedUnique, type: .visitWebsite)
         case BrowsingSpec.SpecType.withoutTrackers.rawValue:
             return BrowsingSpec.withoutTrackers
         case BrowsingSpec.SpecType.siteIsMajorTracker.rawValue:
@@ -386,7 +386,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             guard let entityNames = blockedEntityNames(privacyInfo.trackerInfo) else { return nil }
             return trackersBlockedMessage(entityNames)
         case BrowsingSpec.SpecType.fire.rawValue:
-            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmed, type: .fire)
+            return BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationConfirmedUnique, type: .fire)
         case BrowsingSpec.SpecType.final.rawValue:
             return nil
         default: return nil

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -154,7 +154,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         // Message and CTA empty on purpose as for this case we use only pixelName and type
         static let fire = BrowsingSpec(message: "", cta: "", highlightAddressBar: false, pixelName: .daxDialogsFireEducationShownUnique, type: .fire)
 
-        static let final = BrowsingSpec(message: UserText.daxDialogHomeSubsequent, cta: "", highlightAddressBar: false, pixelName: .daxDialogsEndOfJourneyUnique, type: .final)
+        static let final = BrowsingSpec(message: UserText.daxDialogHomeSubsequent, cta: "", highlightAddressBar: false, pixelName: .daxDialogsEndOfJourneyTabUnique, type: .final)
 
         let message: String
         let cta: String

--- a/DuckDuckGo/FullscreenDaxDialogViewController.swift
+++ b/DuckDuckGo/FullscreenDaxDialogViewController.swift
@@ -137,7 +137,7 @@ extension TabViewController: FullscreenDaxDialogDelegate {
                                            preferredStyle: isPad ? .alert : .actionSheet)
 
         alertController.addAction(title: UserText.daxDialogHideButton, style: .default) {
-            Pixel.fire(pixel: .daxDialogsHidden, withAdditionalParameters: [ "c": DefaultDaxDialogsSettings().browsingDialogsSeenCount ])
+            Pixel.fire(pixel: .daxDialogsHiddenUnique, withAdditionalParameters: [ "c": DefaultDaxDialogsSettings().browsingDialogsSeenCount ])
             DaxDialogs.shared.dismiss()
         }
         alertController.addAction(title: UserText.daxDialogHideCancel, style: .cancel) {

--- a/DuckDuckGo/HomeViewController+DaxDialogs.swift
+++ b/DuckDuckGo/HomeViewController+DaxDialogs.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import UIKit
+import Core
 import SwiftUI
 
 extension HomeViewController {
@@ -34,6 +35,10 @@ extension HomeViewController {
         daxDialogViewController.loadViewIfNeeded()
         daxDialogViewController.message = spec.message
         daxDialogViewController.accessibleMessage = spec.accessibilityLabel
+
+        if spec == .initial {
+            UniquePixel.fire(pixel: .onboardingContextualTryVisitSiteUnique, includedParameters: [.appVersion, .atb])
+        }
 
         view.addGestureRecognizer(daxDialogViewController.tapToCompleteGestureRecognizer)
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1726,9 +1726,11 @@ extension MainViewController: OmniBarDelegate {
         fireOnboardingCustomSearchPixelIfNeeded(query: query)
     }
 
-    func onPrivacyIconPressed() {
+    func onPrivacyIconPressed(isHighlighted: Bool) {
         guard !isSERPPresented else { return }
 
+        // Track first tap of privacy icon button
+        contextualOnboardingPixelReporter.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: isHighlighted)
         // Dismiss privacy icon animation when showing privacy dashboard
         dismissPrivacyDashboardButtonPulse()
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -103,6 +103,7 @@ class MainViewController: UIViewController {
     private let variantManager: VariantManager
     private let tutorialSettings: TutorialSettings
     private let contextualOnboardingLogic: ContextualOnboardingLogic
+    private let contextualOnboardingPixelReporting: OnboardingCustomSearchPixelReporting
 
     @UserDefaultsWrapper(key: .syncDidShowSyncPausedByFeatureFlagAlert, defaultValue: false)
     private var syncDidShowSyncPausedByFeatureFlagAlert: Bool
@@ -184,6 +185,7 @@ class MainViewController: UIViewController {
         variantManager: VariantManager,
         contextualOnboardingPresenter: ContextualOnboardingPresenting,
         contextualOnboardingLogic: ContextualOnboardingLogic,
+        contextualOnboardingCustomSearchPixelReporting: OnboardingCustomSearchPixelReporting
         tutorialSettings: TutorialSettings = DefaultTutorialSettings()
     ) {
         self.bookmarksDatabase = bookmarksDatabase
@@ -212,6 +214,7 @@ class MainViewController: UIViewController {
         self.variantManager = variantManager
         self.tutorialSettings = tutorialSettings
         self.contextualOnboardingLogic = contextualOnboardingLogic
+        self.contextualOnboardingPixelReporting = contextualOnboardingCustomSearchPixelReporting
 
         super.init(nibName: nil, bundle: nil)
         
@@ -1288,6 +1291,14 @@ class MainViewController: UIViewController {
         }
     }
 
+    func fireOnboardingCustomSearchPixelIfNeeded(query: String) {
+        if contextualOnboardingLogic.isShowingSearchSuggestions {
+            contextualOnboardingPixelReporting.trackCustomSearch()
+        } else if contextualOnboardingLogic.isShowingSitesSuggestions {
+            contextualOnboardingPixelReporting.trackCustomSite()
+        }
+    }
+
     func animateBackgroundTab() {
         showBars()
         tabSwitcherButton.incrementAnimated()
@@ -1709,6 +1720,7 @@ extension MainViewController: OmniBarDelegate {
         loadQuery(query)
         hideSuggestionTray()
         showHomeRowReminder()
+        fireOnboardingCustomSearchPixelIfNeeded(query: query)
     }
 
     func onPrivacyIconPressed() {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -187,7 +187,7 @@ class MainViewController: UIViewController {
         contextualOnboardingPresenter: ContextualOnboardingPresenting,
         contextualOnboardingLogic: ContextualOnboardingLogic,
         contextualOnboardingPixelReporter: OnboardingCustomInteractionPixelReporting,
-        tutorialSettings: TutorialSettings = DefaultTutorialSettings()
+        tutorialSettings: TutorialSettings = DefaultTutorialSettings(),
         statisticsStore: StatisticsStore = StatisticsUserDefaults()
     ) {
         self.bookmarksDatabase = bookmarksDatabase

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -103,7 +103,8 @@ class MainViewController: UIViewController {
     private let variantManager: VariantManager
     private let tutorialSettings: TutorialSettings
     private let contextualOnboardingLogic: ContextualOnboardingLogic
-    private let contextualOnboardingPixelReporting: OnboardingCustomSearchPixelReporting
+    private let contextualOnboardingPixelReporter: OnboardingCustomInteractionPixelReporting
+    private let statisticsStore: StatisticsStore
 
     @UserDefaultsWrapper(key: .syncDidShowSyncPausedByFeatureFlagAlert, defaultValue: false)
     private var syncDidShowSyncPausedByFeatureFlagAlert: Bool
@@ -185,8 +186,9 @@ class MainViewController: UIViewController {
         variantManager: VariantManager,
         contextualOnboardingPresenter: ContextualOnboardingPresenting,
         contextualOnboardingLogic: ContextualOnboardingLogic,
-        contextualOnboardingCustomSearchPixelReporting: OnboardingCustomSearchPixelReporting
+        contextualOnboardingPixelReporter: OnboardingCustomInteractionPixelReporting,
         tutorialSettings: TutorialSettings = DefaultTutorialSettings()
+        statisticsStore: StatisticsStore = StatisticsUserDefaults()
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner
@@ -214,7 +216,8 @@ class MainViewController: UIViewController {
         self.variantManager = variantManager
         self.tutorialSettings = tutorialSettings
         self.contextualOnboardingLogic = contextualOnboardingLogic
-        self.contextualOnboardingPixelReporting = contextualOnboardingCustomSearchPixelReporting
+        self.contextualOnboardingPixelReporter = contextualOnboardingPixelReporter
+        self.statisticsStore = statisticsStore
 
         super.init(nibName: nil, bundle: nil)
         
@@ -1293,9 +1296,9 @@ class MainViewController: UIViewController {
 
     func fireOnboardingCustomSearchPixelIfNeeded(query: String) {
         if contextualOnboardingLogic.isShowingSearchSuggestions {
-            contextualOnboardingPixelReporting.trackCustomSearch()
+            contextualOnboardingPixelReporter.trackCustomSearch()
         } else if contextualOnboardingLogic.isShowingSitesSuggestions {
-            contextualOnboardingPixelReporting.trackCustomSite()
+            contextualOnboardingPixelReporter.trackCustomSite()
         }
     }
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1730,7 +1730,9 @@ extension MainViewController: OmniBarDelegate {
         guard !isSERPPresented else { return }
 
         // Track first tap of privacy icon button
-        contextualOnboardingPixelReporter.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: isHighlighted)
+        if isHighlighted {
+            contextualOnboardingPixelReporter.trackPrivacyDashboardOpenedForFirstTime()
+        }
         // Dismiss privacy icon animation when showing privacy dashboard
         dismissPrivacyDashboardButtonPulse()
 

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -466,7 +466,8 @@ class OmniBar: UIView {
     }
 
     @IBAction func onPrivacyIconPressed(_ sender: Any) {
-        omniDelegate?.onPrivacyIconPressed()
+        let isPrivacyIconHighlighted = privacyIconContextualOnboardingAnimator.isPrivacyIconHighlighted(privacyInfoContainer.privacyIcon)
+        omniDelegate?.onPrivacyIconPressed(isHighlighted: isPrivacyIconHighlighted)
     }
 
     @IBAction func onMenuButtonPressed(_ sender: UIButton) {

--- a/DuckDuckGo/OmniBarDelegate.swift
+++ b/DuckDuckGo/OmniBarDelegate.swift
@@ -35,7 +35,7 @@ protocol OmniBarDelegate: AnyObject {
     
     func onEditingEnd() -> OmniBarEditingEndResult
 
-    func onPrivacyIconPressed()
+    func onPrivacyIconPressed(isHighlighted: Bool)
     
     func onMenuPressed()
 
@@ -82,8 +82,8 @@ extension OmniBarDelegate {
         
     }
     
-    func onPrivacyIconPressed() {
-        
+    func onPrivacyIconPressed(isHighlighted: Bool) {
+
     }
     
     func onMenuPressed() {

--- a/DuckDuckGo/OnFirstAppearViewModifier.swift
+++ b/DuckDuckGo/OnFirstAppearViewModifier.swift
@@ -1,5 +1,5 @@
 //
-//  View+AppearModifiers.swift
+//  OnFirstAppear.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -19,15 +19,29 @@
 
 import SwiftUI
 
+/// A view modifier that executes a specified action only once when the view first appears.
+///
+/// Use this modifier to perform an action the first time the view becomes visible on the screen.
+/// The action will not be executed again if the view reappears or is recreated.
+///
+/// Example:
+/// ```swift
+/// Text("Hello, World!")
+///     .modifier(OnFirstAppearModifier {
+///         print("The view has appeared for the first time.")
+///     })
+/// ```
+///
+/// - Parameter onFirstAppearAction: A closure to be executed the first time the view appears.
 public struct OnFirstAppearModifier: ViewModifier {
 
     private let onFirstAppearAction: () -> Void
     @State private var hasAppeared = false
-    
+
     public init(_ onFirstAppearAction: @escaping () -> Void) {
         self.onFirstAppearAction = onFirstAppearAction
     }
-    
+
     public func body(content: Content) -> some View {
         content
             .onAppear {
@@ -39,9 +53,13 @@ public struct OnFirstAppearModifier: ViewModifier {
 }
 
 extension View {
-        
+
+    /// Adds an action to perform that is executed only the first time before this view appears.
+    ///
+    /// - Parameter action: A closure to be executed the first time the view appears.
+    /// - Returns: A view that will execute `action` only once when it appears.
     func onFirstAppear(_ onFirstAppearAction: @escaping () -> Void ) -> some View {
         return modifier(OnFirstAppearModifier(onFirstAppearAction))
     }
-    
+
 }

--- a/DuckDuckGo/OnFirstAppearViewModifier.swift
+++ b/DuckDuckGo/OnFirstAppearViewModifier.swift
@@ -1,5 +1,5 @@
 //
-//  OnFirstAppear.swift
+//  OnFirstAppearViewModifier.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -33,7 +33,7 @@ import SwiftUI
 /// ```
 ///
 /// - Parameter onFirstAppearAction: A closure to be executed the first time the view appears.
-public struct OnFirstAppearModifier: ViewModifier {
+public struct OnFirstAppearViewModifier: ViewModifier {
 
     private let onFirstAppearAction: () -> Void
     @State private var hasAppeared = false
@@ -59,7 +59,7 @@ extension View {
     /// - Parameter action: A closure to be executed the first time the view appears.
     /// - Returns: A view that will execute `action` only once when it appears.
     func onFirstAppear(_ onFirstAppearAction: @escaping () -> Void ) -> some View {
-        return modifier(OnFirstAppearModifier(onFirstAppearAction))
+        return modifier(OnFirstAppearViewModifier(onFirstAppearAction))
     }
 
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -100,7 +100,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         .onboardingContextualBackgroundStyle()
         .onFirstAppear { [weak self] in
             self?.contextualOnboardingLogic.setFinalOnboardingDialogSeen()
-            self?.onboardingPixelReporter.trackScreenImpression(event: .daxDialogsEndOfJourneyUnique)
+            self?.onboardingPixelReporter.trackScreenImpression(event: .daxDialogsEndOfJourneyNewTabUnique)
         }
     }
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
@@ -27,12 +27,16 @@ protocol OnboardingNavigationDelegate: AnyObject {
 struct OnboardingSearchSuggestionsViewModel {
     let suggestedSearchesProvider: OnboardingSuggestionsItemsProviding
     weak var delegate: OnboardingNavigationDelegate?
+    private let pixelReporter: OnboardingSearchSuggestionsPixelReporting
 
     init(
         suggestedSearchesProvider: OnboardingSuggestionsItemsProviding = OnboardingSuggestedSearchesProvider(),
-        delegate: OnboardingNavigationDelegate? = nil) {
+        delegate: OnboardingNavigationDelegate? = nil,
+        pixelReporter: OnboardingSearchSuggestionsPixelReporting = OnboardingPixelReporter()
+    ) {
         self.suggestedSearchesProvider = suggestedSearchesProvider
         self.delegate = delegate
+        self.pixelReporter = pixelReporter
     }
 
     var itemsList: [ContextualOnboardingListItem] {
@@ -40,22 +44,44 @@ struct OnboardingSearchSuggestionsViewModel {
     }
 
     func listItemPressed(_ item: ContextualOnboardingListItem) {
+        firePixel(for: item)
         delegate?.searchFor(item.title)
+    }
+
+    // Temporary pixels, they will be removed.
+    // This avoid refactoring `OnboardingSuggestedSearchesProvider` and `ContextualOnboardingListItem` when removing the pixels
+    // This is covered by tests
+    private func firePixel(for item: ContextualOnboardingListItem) {
+        guard let index = itemsList.firstIndex(of: item) else { return }
+        switch index {
+        case 0:
+            pixelReporter.trackSearchSuggestionSayDuck()
+        case 1:
+            pixelReporter.trackSearchSuggestionMightyDuck()
+        case 2:
+            pixelReporter.trackSearchSuggestionWeather()
+        case 3:
+            pixelReporter.trackSearchSuggestionSurpriseMe()
+        default: break
+        }
     }
 }
 
 struct OnboardingSiteSuggestionsViewModel {
     let suggestedSitesProvider: OnboardingSuggestionsItemsProviding
     weak var delegate: OnboardingNavigationDelegate?
+    private let pixelReporter: OnboardingSiteSuggestionsPixelReporting
 
     init(
         title: String,
         suggestedSitesProvider: OnboardingSuggestionsItemsProviding = OnboardingSuggestedSitesProvider(),
         delegate: OnboardingNavigationDelegate? = nil
+        pixelReporter: OnboardingSiteSuggestionsPixelReporting = OnboardingPixelReporter()
     ) {
         self.title = title
         self.suggestedSitesProvider = suggestedSitesProvider
         self.delegate = delegate
+        self.pixelReporter = pixelReporter
     }
 
     let title: String
@@ -66,6 +92,26 @@ struct OnboardingSiteSuggestionsViewModel {
 
     func listItemPressed(_ item: ContextualOnboardingListItem) {
         guard let url = URL(string: item.title) else { return }
+        firePixel(for: item)
         delegate?.navigateTo(url: url)
     }
+
+    // Temporary pixels, they will be removed.
+    // This avoid refactoring `OnboardingSuggestedSitesProvider` and `ContextualOnboardingListItem` when removing the pixels
+    // This is covered by tests
+    private func firePixel(for item: ContextualOnboardingListItem) {
+        guard let index = itemsList.firstIndex(of: item) else { return }
+        switch index {
+        case 0:
+            pixelReporter.trackSiteSuggestionESPN()
+        case 1:
+            pixelReporter.trackSiteSuggestionYahoo()
+        case 2:
+            pixelReporter.trackSiteSuggestionEbay()
+        case 3:
+            pixelReporter.trackSiteSuggestionSurpriseMe()
+        default: break
+        }
+    }
+
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
@@ -44,26 +44,8 @@ struct OnboardingSearchSuggestionsViewModel {
     }
 
     func listItemPressed(_ item: ContextualOnboardingListItem) {
-        firePixel(for: item)
+        pixelReporter.trackSearchSuggetionOptionTapped()
         delegate?.searchFor(item.title)
-    }
-
-    // Temporary pixels, they will be removed.
-    // This avoid refactoring `OnboardingSuggestedSearchesProvider` and `ContextualOnboardingListItem` when removing the pixels
-    // This is covered by tests
-    private func firePixel(for item: ContextualOnboardingListItem) {
-        guard let index = itemsList.firstIndex(of: item) else { return }
-        switch index {
-        case 0:
-            pixelReporter.trackSearchSuggestionSayDuck()
-        case 1:
-            pixelReporter.trackSearchSuggestionMightyDuck()
-        case 2:
-            pixelReporter.trackSearchSuggestionWeather()
-        case 3:
-            pixelReporter.trackSearchSuggestionSurpriseMe()
-        default: break
-        }
     }
 }
 
@@ -75,7 +57,7 @@ struct OnboardingSiteSuggestionsViewModel {
     init(
         title: String,
         suggestedSitesProvider: OnboardingSuggestionsItemsProviding = OnboardingSuggestedSitesProvider(),
-        delegate: OnboardingNavigationDelegate? = nil
+        delegate: OnboardingNavigationDelegate? = nil,
         pixelReporter: OnboardingSiteSuggestionsPixelReporting = OnboardingPixelReporter()
     ) {
         self.title = title
@@ -92,26 +74,7 @@ struct OnboardingSiteSuggestionsViewModel {
 
     func listItemPressed(_ item: ContextualOnboardingListItem) {
         guard let url = URL(string: item.title) else { return }
-        firePixel(for: item)
+        pixelReporter.trackSiteSuggetionOptionTapped()
         delegate?.navigateTo(url: url)
     }
-
-    // Temporary pixels, they will be removed.
-    // This avoid refactoring `OnboardingSuggestedSitesProvider` and `ContextualOnboardingListItem` when removing the pixels
-    // This is covered by tests
-    private func firePixel(for item: ContextualOnboardingListItem) {
-        guard let index = itemsList.firstIndex(of: item) else { return }
-        switch index {
-        case 0:
-            pixelReporter.trackSiteSuggestionESPN()
-        case 1:
-            pixelReporter.trackSiteSuggestionYahoo()
-        case 2:
-            pixelReporter.trackSiteSuggestionEbay()
-        case 3:
-            pixelReporter.trackSiteSuggestionSurpriseMe()
-        default: break
-        }
-    }
-
 }

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -80,15 +80,19 @@ final class OnboardingPixelReporter {
     private let pixel: OnboardingPixelFiring.Type
     private let uniquePixel: OnboardingPixelFiring.Type
     private let daysSinceInstallProvider: DaysSinceInstallProviding
+    private let userDefaults: UserDefaults
+    private let siteVisitedUserDefaultsKey = "com.duckduckgo.ios.site-visited"
 
     init(
         pixel: OnboardingPixelFiring.Type = Pixel.self,
         uniquePixel: OnboardingPixelFiring.Type = UniquePixel.self,
-        daysSinceInstallProvider: DaysSinceInstallProviding = DaysSinceInstallProvider()
+        daysSinceInstallProvider: DaysSinceInstallProviding = DaysSinceInstallProvider(),
+        userDefaults: UserDefaults = UserDefaults.standard
     ) {
         self.pixel = pixel
         self.uniquePixel = uniquePixel
         self.daysSinceInstallProvider = daysSinceInstallProvider
+        self.userDefaults = userDefaults
     }
 
     private func fire(event: Pixel.Event, unique: Bool, additionalParameters: [String: String] = [:]) {
@@ -175,7 +179,11 @@ extension OnboardingPixelReporter: OnboardingCustomSearchPixelReporting {
     }
     
     func trackSecondSiteVisit() {
-        fire(event: .onboardingContextualSecondSiteVisitUnique, unique: true)
+        if userDefaults.bool(forKey: siteVisitedUserDefaultsKey) {
+            fire(event: .onboardingContextualSecondSiteVisitUnique, unique: true)
+        } else {
+            userDefaults.set(true, forKey: siteVisitedUserDefaultsKey)
+        }
     }
 
 }

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -68,6 +68,10 @@ protocol OnboardingPrivacyDashboardPixelReporting {
     func trackPrivacyDashboardOpen()
 }
 
+protocol OnboardingScreenImpressionReporting {
+    func trackScreenImpression(event: Pixel.Event)
+}
+
 // MARK: - Implementation
 
 final class OnboardingPixelReporter {
@@ -165,6 +169,16 @@ extension OnboardingPixelReporter: OnboardingPrivacyDashboardPixelReporting {
     func trackPrivacyDashboardOpen() {
         guard let daysSinceInstall = daysSinceInstallProvider.daysSinceInstall else { return }
         fire(event: .privacyDashboardOpened, unique: true, additionalParameters: ["daysSinceInstall": String(daysSinceInstall)])
+    }
+
+}
+
+// MARK: - OnboardingPixelReporter + Screen Impression
+
+extension OnboardingPixelReporter: OnboardingScreenImpressionReporting {
+    
+    func trackScreenImpression(event: Pixel.Event) {
+        fire(event: event, unique: true)
     }
 
 }

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -51,17 +51,11 @@ protocol OnboardingIntroPixelReporting: OnboardingIntroImpressionReporting {
 }
 
 protocol OnboardingSearchSuggestionsPixelReporting {
-    func trackSearchSuggestionSayDuck()
-    func trackSearchSuggestionMightyDuck()
-    func trackSearchSuggestionWeather()
-    func trackSearchSuggestionSurpriseMe()
+    func trackSearchSuggetionOptionTapped()
 }
 
 protocol OnboardingSiteSuggestionsPixelReporting {
-    func trackSiteSuggestionESPN()
-    func trackSiteSuggestionYahoo()
-    func trackSiteSuggestionEbay()
-    func trackSiteSuggestionSurpriseMe()
+    func trackSiteSuggetionOptionTapped()
 }
 
 protocol OnboardingCustomSearchPixelReporting {
@@ -127,41 +121,17 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
 // MARK: - OnboardingPixelReporter + List
 
 extension OnboardingPixelReporter: OnboardingSearchSuggestionsPixelReporting {
-   
-    func trackSearchSuggestionSayDuck() {
-        fire(event: .onboardingContextualSearchSayDuckUnique, unique: true)
-    }
     
-    func trackSearchSuggestionMightyDuck() {
-        fire(event: .onboardingContextualSearchMightyDuckUnique, unique: true)
-    }
-    
-    func trackSearchSuggestionWeather() {
-        fire(event: .onboardingContextualSearchWeatherUnique, unique: true)
-    }
-    
-    func trackSearchSuggestionSurpriseMe() {
-        fire(event: .onboardingContextualSearchSurpriseMeUnique, unique: true)
+    func trackSearchSuggetionOptionTapped() {
+        fire(event: .onboardingContextualSearchOptionTappedUnique, unique: true)
     }
 
 }
 
 extension OnboardingPixelReporter: OnboardingSiteSuggestionsPixelReporting {
     
-    func trackSiteSuggestionESPN() {
-        fire(event: .onboardingContextualSiteESPNUnique, unique: true)
-    }
-    
-    func trackSiteSuggestionYahoo() {
-        fire(event: .onboardingContextualSiteYahooUnique, unique: true)
-    }
-    
-    func trackSiteSuggestionEbay() {
-        fire(event: .onboardingContextualSiteEbayUnique, unique: true)
-    }
-    
-    func trackSiteSuggestionSurpriseMe() {
-        fire(event: .onboardingContextualSiteSurpriseMeUnique, unique: true)
+    func trackSiteSuggetionOptionTapped() {
+        fire(event: .onboardingContextualSiteOptionTappedUnique, unique: true)
     }
 
 }

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -62,7 +62,7 @@ protocol OnboardingCustomInteractionPixelReporting {
     func trackCustomSearch()
     func trackCustomSite()
     func trackSecondSiteVisit()
-    func trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: Bool)
+    func trackPrivacyDashboardOpenedForFirstTime()
 }
 
 protocol OnboardingScreenImpressionReporting {
@@ -96,12 +96,11 @@ final class OnboardingPixelReporter {
         self.userDefaults = userDefaults
     }
 
-    private func fire(event: Pixel.Event, unique: Bool, additionalParameters: [String: String] = [:]) {
-        let parameters: [Pixel.QueryParameters] = [.appVersion, .atb]
+    private func fire(event: Pixel.Event, unique: Bool, additionalParameters: [String: String] = [:], includedParameters: [Pixel.QueryParameters] = [.appVersion, .atb]) {
         if unique {
-            uniquePixel.fire(pixel: event, withAdditionalParameters: additionalParameters, includedParameters: parameters)
+            uniquePixel.fire(pixel: event, withAdditionalParameters: additionalParameters, includedParameters: includedParameters)
         } else {
-            pixel.fire(pixel: event, withAdditionalParameters: additionalParameters, includedParameters: parameters)
+            pixel.fire(pixel: event, withAdditionalParameters: additionalParameters, includedParameters: includedParameters)
         }
     }
 
@@ -163,13 +162,13 @@ extension OnboardingPixelReporter: OnboardingCustomInteractionPixelReporting {
         }
     }
 
-    func trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: Bool) {
+    func trackPrivacyDashboardOpenedForFirstTime() {
         let daysSinceInstall = statisticsStore.installDate.flatMap { calendar.numberOfDaysBetween($0, and: dateProvider()) }
         let additionalParameters = [
-            PixelParameters.fromOnboarding: String(fromOnboarding),
+            PixelParameters.fromOnboarding: "true",
             PixelParameters.daysSinceInstall: String(daysSinceInstall ?? 0)
         ]
-        fire(event: .privacyDashboardFirstTimeOpenedUnique, unique: true, additionalParameters: additionalParameters)
+        fire(event: .privacyDashboardFirstTimeOpenedUnique, unique: true, additionalParameters: additionalParameters, includedParameters: [.appVersion])
     }
 
 }

--- a/DuckDuckGo/PrivacyIconContextualOnboardingAnimator.swift
+++ b/DuckDuckGo/PrivacyIconContextualOnboardingAnimator.swift
@@ -27,9 +27,12 @@ final class PrivacyIconContextualOnboardingAnimator {
     }
 
     func dismissPrivacyIconAnimation(_ view: PrivacyIconView) {
-        if ViewHighlighter.highlightedViews.contains(where: { $0.view == view }) {
+        if isPrivacyIconHighlighted(view) {
             ViewHighlighter.hideAll()
         }
     }
 
+    func isPrivacyIconHighlighted(_ view: PrivacyIconView) -> Bool {
+        ViewHighlighter.highlightedViews.contains(where: { $0.view == view })
+    }
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -297,7 +297,8 @@ class TabViewController: UIViewController {
                                    duckPlayer: DuckPlayerProtocol,
                                    privacyProDataReporter: PrivacyProDataReporting,
                                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
-                                   contextualOnboardingLogic: ContextualOnboardingLogic) -> TabViewController {
+                                   contextualOnboardingLogic: ContextualOnboardingLogic,
+                                   daysSinceInstallProvider: DaysSinceInstallProviding = DaysSinceInstallProvider()) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
             TabViewController(coder: coder,
@@ -309,7 +310,9 @@ class TabViewController: UIViewController {
                               duckPlayer: duckPlayer,
                               privacyProDataReporter: privacyProDataReporter,
                               contextualOnboardingPresenter: contextualOnboardingPresenter,
-                              contextualOnboardingLogic: contextualOnboardingLogic)
+                              contextualOnboardingLogic: contextualOnboardingLogic,
+                              daysSinceInstallProvider: daysSinceInstallProvider
+            )
         })
         return controller
     }
@@ -325,6 +328,7 @@ class TabViewController: UIViewController {
 
     let contextualOnboardingPresenter: ContextualOnboardingPresenting
     let contextualOnboardingLogic: ContextualOnboardingLogic
+    let daysSinceInstallProvider: DaysSinceInstallProviding
 
     required init?(coder aDecoder: NSCoder,
                    tabModel: Tab,
@@ -335,7 +339,8 @@ class TabViewController: UIViewController {
                    duckPlayer: DuckPlayerProtocol,
                    privacyProDataReporter: PrivacyProDataReporting,
                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
-                   contextualOnboardingLogic: ContextualOnboardingLogic) {
+                   contextualOnboardingLogic: ContextualOnboardingLogic,
+                   daysSinceInstallProvider: DaysSinceInstallProviding) {
         self.tabModel = tabModel
         self.appSettings = appSettings
         self.bookmarksDatabase = bookmarksDatabase
@@ -347,6 +352,7 @@ class TabViewController: UIViewController {
         self.privacyProDataReporter = privacyProDataReporter
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
         self.contextualOnboardingLogic = contextualOnboardingLogic
+        self.daysSinceInstallProvider = daysSinceInstallProvider
         super.init(coder: aDecoder)
     }
 
@@ -922,7 +928,13 @@ class TabViewController: UIViewController {
     }
 
     func showPrivacyDashboard() {
-        Pixel.fire(pixel: .privacyDashboardOpened)
+        func firePrivacyDashboardOpenPixel() {
+            let additionalParameters = daysSinceInstallProvider.daysSinceInstall
+                .flatMap { [PixelParameters.daysSinceInstall: String($0)] } ?? [:]
+            UniquePixel.fire(pixel: .privacyDashboardOpened, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion, .atb])
+        }
+
+        firePrivacyDashboardOpenPixel()
         performSegue(withIdentifier: "PrivacyDashboard", sender: self)
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -298,8 +298,7 @@ class TabViewController: UIViewController {
                                    privacyProDataReporter: PrivacyProDataReporting,
                                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                                    contextualOnboardingLogic: ContextualOnboardingLogic,
-                                   onboardingPixelReporter: OnboardingPixelReporter = OnboardingPixelReporter(),
-                                   daysSinceInstallProvider: DaysSinceInstallProviding = DaysSinceInstallProvider()) -> TabViewController {
+                                   onboardingPixelReporter: OnboardingPixelReporter = OnboardingPixelReporter()) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
             TabViewController(coder: coder,
@@ -312,8 +311,7 @@ class TabViewController: UIViewController {
                               privacyProDataReporter: privacyProDataReporter,
                               contextualOnboardingPresenter: contextualOnboardingPresenter,
                               contextualOnboardingLogic: contextualOnboardingLogic,
-                              onboardingPixelReporter: onboardingPixelReporter,
-                              daysSinceInstallProvider: daysSinceInstallProvider
+                              onboardingPixelReporter: onboardingPixelReporter
             )
         })
         return controller
@@ -330,7 +328,6 @@ class TabViewController: UIViewController {
 
     let contextualOnboardingPresenter: ContextualOnboardingPresenting
     let contextualOnboardingLogic: ContextualOnboardingLogic
-    let daysSinceInstallProvider: DaysSinceInstallProviding
     let onboardingPixelReporter: OnboardingPixelReporter
 
     required init?(coder aDecoder: NSCoder,
@@ -343,8 +340,7 @@ class TabViewController: UIViewController {
                    privacyProDataReporter: PrivacyProDataReporting,
                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                    contextualOnboardingLogic: ContextualOnboardingLogic,
-                   onboardingPixelReporter: OnboardingPixelReporter,
-                   daysSinceInstallProvider: DaysSinceInstallProviding) {
+                   onboardingPixelReporter: OnboardingPixelReporter) {
         self.tabModel = tabModel
         self.appSettings = appSettings
         self.bookmarksDatabase = bookmarksDatabase
@@ -357,7 +353,6 @@ class TabViewController: UIViewController {
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
         self.contextualOnboardingLogic = contextualOnboardingLogic
         self.onboardingPixelReporter = onboardingPixelReporter
-        self.daysSinceInstallProvider = daysSinceInstallProvider
         super.init(coder: aDecoder)
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -298,6 +298,7 @@ class TabViewController: UIViewController {
                                    privacyProDataReporter: PrivacyProDataReporting,
                                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                                    contextualOnboardingLogic: ContextualOnboardingLogic,
+                                   onboardingPixelReporter: OnboardingPixelReporter = OnboardingPixelReporter(),
                                    daysSinceInstallProvider: DaysSinceInstallProviding = DaysSinceInstallProvider()) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
@@ -311,6 +312,7 @@ class TabViewController: UIViewController {
                               privacyProDataReporter: privacyProDataReporter,
                               contextualOnboardingPresenter: contextualOnboardingPresenter,
                               contextualOnboardingLogic: contextualOnboardingLogic,
+                              onboardingPixelReporter: onboardingPixelReporter,
                               daysSinceInstallProvider: daysSinceInstallProvider
             )
         })
@@ -329,6 +331,7 @@ class TabViewController: UIViewController {
     let contextualOnboardingPresenter: ContextualOnboardingPresenting
     let contextualOnboardingLogic: ContextualOnboardingLogic
     let daysSinceInstallProvider: DaysSinceInstallProviding
+    let onboardingPixelReporter: OnboardingPixelReporter
 
     required init?(coder aDecoder: NSCoder,
                    tabModel: Tab,
@@ -340,6 +343,7 @@ class TabViewController: UIViewController {
                    privacyProDataReporter: PrivacyProDataReporting,
                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                    contextualOnboardingLogic: ContextualOnboardingLogic,
+                   onboardingPixelReporter: OnboardingPixelReporter,
                    daysSinceInstallProvider: DaysSinceInstallProviding) {
         self.tabModel = tabModel
         self.appSettings = appSettings
@@ -352,6 +356,7 @@ class TabViewController: UIViewController {
         self.privacyProDataReporter = privacyProDataReporter
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
         self.contextualOnboardingLogic = contextualOnboardingLogic
+        self.onboardingPixelReporter = onboardingPixelReporter
         self.daysSinceInstallProvider = daysSinceInstallProvider
         super.init(coder: aDecoder)
     }
@@ -1321,7 +1326,8 @@ extension TabViewController: WKNavigationDelegate {
         onWebpageDidFinishLoading()
         instrumentation.didLoadURL()
         checkLoginDetectionAfterNavigation()
-        
+        onboardingPixelReporter.trackSecondSiteVisit()
+
         // definitely finished with any potential login cycle by this point, so don't try and handle it any more
         detectedLoginURL = nil
         updatePreview()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -928,13 +928,7 @@ class TabViewController: UIViewController {
     }
 
     func showPrivacyDashboard() {
-        func firePrivacyDashboardOpenPixel() {
-            let additionalParameters = daysSinceInstallProvider.daysSinceInstall
-                .flatMap { [PixelParameters.daysSinceInstall: String($0)] } ?? [:]
-            UniquePixel.fire(pixel: .privacyDashboardOpened, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion, .atb])
-        }
-
-        firePrivacyDashboardOpenPixel()
+        Pixel.fire(pixel: .privacyDashboardOpened)
         performSegue(withIdentifier: "PrivacyDashboard", sender: self)
     }
 

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -19,24 +19,36 @@
 
 import XCTest
 import SwiftUI
+import Core
 @testable import DuckDuckGo
 
 final class ContextualDaxDialogsFactoryTests: XCTestCase {
     private var sut: ExperimentContextualDaxDialogsFactory!
     private var delegate: ContextualOnboardingDelegateMock!
     private var settingsMock: ContextualOnboardingSettingsMock!
-
+    private var pixelReporterMock: OnboardingPixelReporterMock!
+    private var window: UIWindow!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         delegate = ContextualOnboardingDelegateMock()
         settingsMock = ContextualOnboardingSettingsMock()
-        sut = ExperimentContextualDaxDialogsFactory(contextualOnboardingSettings: settingsMock, contextualOnboardingLogic: ContextualOnboardingLogicMock())
+        pixelReporterMock = OnboardingPixelReporterMock()
+        sut = ExperimentContextualDaxDialogsFactory(
+            contextualOnboardingLogic: ContextualOnboardingLogicMock(),
+            contextualOnboardingSettings: settingsMock,
+            contextualOnboardingPixelReporter: pixelReporterMock
+        )
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window.makeKeyAndVisible()
     }
 
     override func tearDownWithError() throws {
+        window.isHidden = true
+        window = nil
         delegate = nil
         settingsMock = nil
+        pixelReporterMock = nil
         sut = nil
         try super.tearDownWithError()
     }
@@ -167,7 +179,6 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         XCTAssertNotNil(view)
     }
 
-
     // MARK: - Final
 
     func test_WhenMakeViewForFinalSpec_ThenReturnViewOnboardingFinalDialog() throws {
@@ -195,6 +206,143 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         // THEN
         XCTAssertTrue(delegate.didCallDidTapDismissContextualOnboardingAction)
     }
+
+    // MARK: - Pixels
+
+    func testWhenViewForAfterSearchSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.afterSearch
+        let expectedPixel = Pixel.Event.daxDialogsSerpUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForVisitSiteSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.visitWebsite
+        let expectedPixel = Pixel.Event.onboardingContextualTryVisitSiteUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForWithoutTrackersSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.withoutTrackers
+        let expectedPixel = Pixel.Event.daxDialogsWithoutTrackersUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForWithOneTrackerSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.withOneTracker
+        let expectedPixel = Pixel.Event.daxDialogsWithTrackersUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForWithTrackersSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.withMultipleTrackers
+        let expectedPixel = Pixel.Event.daxDialogsWithTrackersUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForSiteIsMajorTrackerSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.siteIsMajorTracker
+        let expectedPixel = Pixel.Event.daxDialogsSiteIsMajorUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForSiteIsOwnedByMajorTrackerSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.siteOwnedByMajorTracker
+        let expectedPixel = Pixel.Event.daxDialogsSiteOwnedByMajorUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForFireSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.fire
+        let expectedPixel = Pixel.Event.daxDialogsFireEducationShownUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenViewForFinalSpecAppearsThenExpectedPixelFires() {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        let expectedPixel = Pixel.Event.daxDialogsEndOfJourneyUnique
+        // TEST
+        testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
+    }
+
+    func testWhenAfterSearchCTAIsTappedAndTryVisitWebsiteDialogThenExpectedPixelFires() throws {
+        try [DaxDialogs.BrowsingSpec.siteIsMajorTracker, .siteOwnedByMajorTracker, .withMultipleTrackers, .withoutTrackers, .withoutTrackers].forEach { spec in
+            // GIVEN
+            settingsMock.userHasSeenFireDialog = false
+            pixelReporterMock = OnboardingPixelReporterMock()
+            sut = ExperimentContextualDaxDialogsFactory(
+                contextualOnboardingLogic: ContextualOnboardingLogicMock(),
+                contextualOnboardingSettings: settingsMock,
+                contextualOnboardingPixelReporter: pixelReporterMock
+            )
+            let result = sut.makeView(for: spec, delegate: delegate, onSizeUpdate: {})
+            let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: result))
+            XCTAssertFalse(pixelReporterMock.didCallTrackScreenImpressionCalled)
+            XCTAssertNil(pixelReporterMock.capturedScreenImpression)
+
+            // WHEN
+            view.blockedTrackersCTAAction()
+
+            // THEN
+            XCTAssertTrue(pixelReporterMock.didCallTrackScreenImpressionCalled)
+            XCTAssertEqual(pixelReporterMock.capturedScreenImpression, .daxDialogsFireEducationShownUnique)
+        }
+    }
+
+    func testWhenTrackersDialogCTAIsTappedAndFireDialogThenExpectedPixelFires() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.afterSearch
+        let result = sut.makeView(for: spec, delegate: delegate, onSizeUpdate: {})
+        let view = try XCTUnwrap(find(OnboardingFirstSearchDoneDialog.self, in: result))
+        XCTAssertFalse(pixelReporterMock.didCallTrackScreenImpressionCalled)
+        XCTAssertNil(pixelReporterMock.capturedScreenImpression)
+
+        // WHEN
+        view.gotItAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackScreenImpressionCalled)
+        XCTAssertEqual(pixelReporterMock.capturedScreenImpression, .onboardingContextualTryVisitSiteUnique)
+    }
+}
+
+extension ContextualDaxDialogsFactoryTests {
+
+    func testDialogDefinedBy(spec: DaxDialogs.BrowsingSpec, firesEvent event: Pixel.Event) {
+        // GIVEN
+        let expectation = self.expectation(description: #function)
+        XCTAssertFalse(pixelReporterMock.didCallTrackScreenImpressionCalled)
+        XCTAssertNil(pixelReporterMock.capturedScreenImpression)
+
+        // WHEN
+        let view = sut.makeView(for: spec, delegate: ContextualOnboardingDelegateMock(), onSizeUpdate: {}).rootView
+        let host = OnboardingHostingControllerMock(rootView: AnyView(view))
+        host.onAppearExpectation = expectation
+        window.rootViewController = host
+        XCTAssertNotNil(host.view)
+
+        // THEN
+        waitForExpectations(timeout: 2.0)
+        XCTAssertTrue(pixelReporterMock.didCallTrackScreenImpressionCalled)
+        XCTAssertEqual(pixelReporterMock.capturedScreenImpression, event)
+    }
+
 }
 
 final class ContextualOnboardingSettingsMock: ContextualOnboardingSettings {

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -276,7 +276,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
     func testWhenViewForFinalSpecAppearsThenExpectedPixelFires() {
         // GIVEN
         let spec = DaxDialogs.BrowsingSpec.final
-        let expectedPixel = Pixel.Event.daxDialogsEndOfJourneyUnique
+        let expectedPixel = Pixel.Event.daxDialogsEndOfJourneyTabUnique
         // TEST
         testDialogDefinedBy(spec: spec, firesEvent: expectedPixel)
     }

--- a/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -142,7 +142,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
     func testWhenOnboardingFinalDialogAppearForTheFirstTime_ThenSendFireExpectedPixel() {
         // GIVEN
         let spec = DaxDialogs.HomeScreenSpec.final
-        let pixelEvent = Pixel.Event.daxDialogsEndOfJourneyUnique
+        let pixelEvent = Pixel.Event.daxDialogsEndOfJourneyNewTabUnique
         // TEST
         testDialogDefinedBy(spec: spec, firesEvent: pixelEvent)
     }

--- a/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -49,6 +49,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         mockDelegate = nil
         onDismissCalled = nil
         contextualOnboardingLogicMock = nil
+        pixelReporterMock = nil
         super.tearDown()
     }
 
@@ -158,7 +159,7 @@ private extension ContextualOnboardingNewTabDialogFactoryTests {
 
         // WHEN
         let view = factory.createDaxDialog(for: spec, onDismiss: {})
-        let host = UIHostingControllerMock(rootView: AnyView(view))
+        let host = OnboardingHostingControllerMock(rootView: AnyView(view))
         host.onAppearExpectation = expectation
         window.rootViewController = host
         XCTAssertNotNil(host.view)
@@ -167,17 +168,6 @@ private extension ContextualOnboardingNewTabDialogFactoryTests {
         waitForExpectations(timeout: 2.0)
         XCTAssertTrue(pixelReporterMock.didCallTrackScreenImpressionCalled)
         XCTAssertEqual(pixelReporterMock.capturedScreenImpression, event)
-    }
-
-}
-
-private final class UIHostingControllerMock: UIHostingController<AnyView> {
-
-    var onAppearExpectation: XCTestExpectation?
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        onAppearExpectation?.fulfill()
     }
 
 }

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -115,7 +115,8 @@ extension TabViewController {
 
     static func fake(
         contextualOnboardingPresenter: ContextualOnboardingPresenting = ContextualOnboardingPresenterMock(),
-        contextualOnboardingLogic: ContextualOnboardingLogic = ContextualOnboardingLogicMock()
+        contextualOnboardingLogic: ContextualOnboardingLogic = ContextualOnboardingLogicMock(),
+        contextualOnboardingPixelReporter: OnboardingCustomInteractionPixelReporting = OnboardingPixelReporterMock()
     ) -> TabViewController {
         let tab = TabViewController.loadFromStoryboard(
             model: .init(link: Link(title: nil, url: .ddg)),
@@ -126,7 +127,8 @@ extension TabViewController {
             duckPlayer: MockDuckPlayer(settings: MockDuckPlayerSettings(privacyConfigManager: PrivacyConfigurationManagerMock())),
             privacyProDataReporter: MockPrivacyProDataReporter(),
             contextualOnboardingPresenter: contextualOnboardingPresenter,
-            contextualOnboardingLogic: contextualOnboardingLogic
+            contextualOnboardingLogic: contextualOnboardingLogic,
+            onboardingPixelReporter: contextualOnboardingPixelReporter
         )
         tab.attachWebView(configuration: .nonPersistent(), andLoadRequest: nil, consumeCookies: false)
         return tab

--- a/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
+++ b/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
@@ -75,6 +75,7 @@ final class OnboardingDaxFavouritesTests: XCTestCase {
             variantManager: MockVariantManager(),
             contextualOnboardingPresenter: ContextualOnboardingPresenterMock(),
             contextualOnboardingLogic: contextualOnboardingLogicMock,
+            contextualOnboardingPixelReporter: OnboardingPixelReporterMock(),
             tutorialSettings: tutorialSettingsMock
         )
         let window = UIWindow(frame: UIScreen.main.bounds)

--- a/DuckDuckGoTests/OnboardingHostingControllerMock.swift
+++ b/DuckDuckGoTests/OnboardingHostingControllerMock.swift
@@ -1,0 +1,32 @@
+//
+//  OnboardingHostingControllerMock.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import XCTest
+
+final class OnboardingHostingControllerMock: UIHostingController<AnyView> {
+
+    var onAppearExpectation: XCTestExpectation?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        onAppearExpectation?.fulfill()
+    }
+
+}

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -71,7 +71,8 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             privacyProDataReporter: MockPrivacyProDataReporter(),
             variantManager: MockVariantManager(),
             contextualOnboardingPresenter: ContextualOnboardingPresenterMock(),
-            contextualOnboardingLogic: ContextualOnboardingLogicMock())
+            contextualOnboardingLogic: ContextualOnboardingLogicMock(),
+            contextualOnboardingCustomSearchPixelReporting: OnboardingPixelReporterMock())
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -155,32 +155,28 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
 
     // MARK: Pixel
 
-    func testWhenPrivacyBarIconIsPressed_AndPrivacyIconIsHighlighted_ThenFireFirstTimePrivacyDashboardUsedPixel_AndFromOnboardingIsTrue() {
+    func testWhenPrivacyBarIconIsPressed_AndPrivacyIconIsHighlighted_ThenFireFirstTimePrivacyDashboardUsedPixel() {
         // GIVEN
         let isHighlighted = true
         XCTAssertFalse(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
-        XCTAssertNil(onboardingPixelReporter.capturedFromOnboarding)
 
         // WHEN
         mainVC.onPrivacyIconPressed(isHighlighted: isHighlighted)
 
         // THEN
         XCTAssertTrue(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
-        XCTAssertEqual(onboardingPixelReporter.capturedFromOnboarding, true)
     }
 
-    func testWhenPrivacyBarIconIsPressed_AndPrivacyIconIsNotHighlighted_ThenFireFirstTimePrivacyDashboardUsedPixel_AndFromOnboardingIsFalse() {
+    func testWhenPrivacyBarIconIsPressed_AndPrivacyIconIsNotHighlighted_ThenDoNotFireFirstTimePrivacyDashboardUsedPixel() {
         // GIVEN
         let isHighlighted = false
         XCTAssertFalse(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
-        XCTAssertNil(onboardingPixelReporter.capturedFromOnboarding)
 
         // WHEN
         mainVC.onPrivacyIconPressed(isHighlighted: isHighlighted)
 
         // THEN
-        XCTAssertTrue(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
-        XCTAssertEqual(onboardingPixelReporter.capturedFromOnboarding, false)
+        XCTAssertFalse(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
     }
 
 }

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -72,7 +72,7 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             variantManager: MockVariantManager(),
             contextualOnboardingPresenter: ContextualOnboardingPresenterMock(),
             contextualOnboardingLogic: ContextualOnboardingLogicMock(),
-            contextualOnboardingCustomSearchPixelReporting: OnboardingPixelReporterMock())
+            contextualOnboardingPixelReporter: OnboardingPixelReporterMock())
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -32,6 +32,7 @@ import Combine
 final class OnboardingNavigationDelegateTests: XCTestCase {
 
     var mainVC: MainViewController!
+    var onboardingPixelReporter: OnboardingPixelReporterMock!
 
     override func setUp() {
         let db = CoreDataDatabase.bookmarksMock
@@ -57,6 +58,7 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
         )
         let homePageConfiguration = HomePageConfiguration(remoteMessagingClient: remoteMessagingClient, privacyProDataReporter: MockPrivacyProDataReporter())
         let tabsModel = TabsModel(desktop: true)
+        onboardingPixelReporter = OnboardingPixelReporterMock()
         mainVC = MainViewController(
             bookmarksDatabase: db,
             bookmarksDatabaseCleaner: bookmarkDatabaseCleaner,
@@ -72,7 +74,7 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             variantManager: MockVariantManager(),
             contextualOnboardingPresenter: ContextualOnboardingPresenterMock(),
             contextualOnboardingLogic: ContextualOnboardingLogicMock(),
-            contextualOnboardingPixelReporter: OnboardingPixelReporterMock())
+            contextualOnboardingPixelReporter: onboardingPixelReporter)
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
@@ -149,6 +151,36 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
     func assertExpected(url: URL) {
         XCTAssertNotNil(mainVC.currentTab?.url)
         XCTAssertEqual(mainVC.currentTab?.url, url)
+    }
+
+    // MARK: Pixel
+
+    func testWhenPrivacyBarIconIsPressed_AndPrivacyIconIsHighlighted_ThenFireFirstTimePrivacyDashboardUsedPixel_AndFromOnboardingIsTrue() {
+        // GIVEN
+        let isHighlighted = true
+        XCTAssertFalse(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
+        XCTAssertNil(onboardingPixelReporter.capturedFromOnboarding)
+
+        // WHEN
+        mainVC.onPrivacyIconPressed(isHighlighted: isHighlighted)
+
+        // THEN
+        XCTAssertTrue(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
+        XCTAssertEqual(onboardingPixelReporter.capturedFromOnboarding, true)
+    }
+
+    func testWhenPrivacyBarIconIsPressed_AndPrivacyIconIsNotHighlighted_ThenFireFirstTimePrivacyDashboardUsedPixel_AndFromOnboardingIsFalse() {
+        // GIVEN
+        let isHighlighted = false
+        XCTAssertFalse(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
+        XCTAssertNil(onboardingPixelReporter.capturedFromOnboarding)
+
+        // WHEN
+        mainVC.onPrivacyIconPressed(isHighlighted: isHighlighted)
+
+        // THEN
+        XCTAssertTrue(onboardingPixelReporter.didCallTrackPrivacyDashboardOpenedForFirstTime)
+        XCTAssertEqual(onboardingPixelReporter.capturedFromOnboarding, false)
     }
 
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -26,7 +26,7 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     private(set) var didCallTrackSiteOptionTapped = false
     private(set) var didCallTrackCustomSearch = false
     private(set) var didCallTrackCustomSite = false
-    private(set) var didCallSecondSiteVisit = false {
+    private(set) var didCallTrackSecondSiteVisit = false {
         didSet {
             secondSiteVisitCounter += 1
         }
@@ -54,7 +54,7 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     }
 
     func trackSecondSiteVisit() {
-        didCallSecondSiteVisit = true
+        didCallTrackSecondSiteVisit = true
     }
 
     func trackScreenImpression(event: Pixel.Event) {

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -35,7 +35,6 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     private(set) var didCallTrackScreenImpressionCalled = false
     private(set) var capturedScreenImpression: Pixel.Event?
     private(set) var didCallTrackPrivacyDashboardOpenedForFirstTime = false
-    private(set) var capturedFromOnboarding: Bool?
 
     func trackSiteSuggetionOptionTapped() {
         didCallTrackSiteOptionTapped = true
@@ -62,8 +61,7 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
         capturedScreenImpression = event
     }
 
-    func trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: Bool) {
+    func trackPrivacyDashboardOpenedForFirstTime() {
         didCallTrackPrivacyDashboardOpenedForFirstTime = true
-        capturedFromOnboarding = fromOnboarding
     }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -1,0 +1,56 @@
+//
+//  OnboardingPixelReporterMock.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo
+
+final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomSearchPixelReporting {
+
+    private(set) var didCallTrackSearchOptionTapped = false
+    private(set) var didCallTrackSiteOptionTapped = false
+    private(set) var didCallTrackCustomSearch = false
+    private(set) var didCallTrackCustomSite = false
+    private(set) var didCallSecondSiteVisit = false {
+        didSet {
+            secondSiteVisitCounter += 1
+        }
+    }
+    private(set) var secondSiteVisitCounter = 0
+
+    func trackSiteSuggetionOptionTapped() {
+        didCallTrackSiteOptionTapped = true
+    }
+
+    func trackSearchSuggetionOptionTapped() {
+        didCallTrackSearchOptionTapped = true
+    }
+
+    func trackCustomSearch() {
+        didCallTrackCustomSearch = true
+    }
+
+    func trackCustomSite() {
+        didCallTrackCustomSite = true
+    }
+
+    func trackSecondSiteVisit() {
+        didCallSecondSiteVisit = true
+    }
+
+}

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -34,7 +34,7 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     private(set) var secondSiteVisitCounter = 0
     private(set) var didCallTrackScreenImpressionCalled = false
     private(set) var capturedScreenImpression: Pixel.Event?
-    private(set) var didCallPrivacyDashboardOpenedForFirstTime = false
+    private(set) var didCallTrackPrivacyDashboardOpenedForFirstTime = false
     private(set) var capturedFromOnboarding: Bool?
 
     func trackSiteSuggetionOptionTapped() {
@@ -63,7 +63,7 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     }
 
     func trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: Bool) {
-        didCallPrivacyDashboardOpenedForFirstTime = true
+        didCallTrackPrivacyDashboardOpenedForFirstTime = true
         capturedFromOnboarding = fromOnboarding
     }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -18,10 +18,10 @@
 //
 
 import Foundation
+import Core
 @testable import DuckDuckGo
 
-final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomSearchPixelReporting {
-
+final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomSearchPixelReporting, OnboardingScreenImpressionReporting {
     private(set) var didCallTrackSearchOptionTapped = false
     private(set) var didCallTrackSiteOptionTapped = false
     private(set) var didCallTrackCustomSearch = false
@@ -32,6 +32,8 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
         }
     }
     private(set) var secondSiteVisitCounter = 0
+    private(set) var didCallTrackScreenImpressionCalled = false
+    private(set) var capturedScreenImpression: Pixel.Event?
 
     func trackSiteSuggetionOptionTapped() {
         didCallTrackSiteOptionTapped = true
@@ -53,4 +55,8 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
         didCallSecondSiteVisit = true
     }
 
+    func trackScreenImpression(event: Pixel.Event) {
+        didCallTrackScreenImpressionCalled = true
+        capturedScreenImpression = event
+    }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -21,7 +21,7 @@ import Foundation
 import Core
 @testable import DuckDuckGo
 
-final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomSearchPixelReporting, OnboardingScreenImpressionReporting {
+final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingScreenImpressionReporting {
     private(set) var didCallTrackSearchOptionTapped = false
     private(set) var didCallTrackSiteOptionTapped = false
     private(set) var didCallTrackCustomSearch = false
@@ -34,6 +34,8 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     private(set) var secondSiteVisitCounter = 0
     private(set) var didCallTrackScreenImpressionCalled = false
     private(set) var capturedScreenImpression: Pixel.Event?
+    private(set) var didCallPrivacyDashboardOpenedForFirstTime = false
+    private(set) var capturedFromOnboarding: Bool?
 
     func trackSiteSuggetionOptionTapped() {
         didCallTrackSiteOptionTapped = true
@@ -58,5 +60,10 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     func trackScreenImpression(event: Pixel.Event) {
         didCallTrackScreenImpressionCalled = true
         capturedScreenImpression = event
+    }
+
+    func trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: Bool) {
+        didCallPrivacyDashboardOpenedForFirstTime = true
+        capturedFromOnboarding = fromOnboarding
     }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -234,35 +234,24 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
 
         // WHEN
-        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: true)
+        sut.trackPrivacyDashboardOpenedForFirstTime()
 
         // THEN
         XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
         XCTAssertEqual(expectedPixel.name, "m_privacy_dashboard_first_time_used_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion])
     }
 
-    func testWhenTrackPrivacyDashboardOpenedForFirstTimeAndFromOnboardingFalseThenParameterIsSetToFalse() {
+    func testWhenTrackPrivacyDashboardOpenedForFirstTimeThenFromOnboardingParameterIsSetToTrue() {
         // GIVEN
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
 
         // WHEN
-        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: true)
+        sut.trackPrivacyDashboardOpenedForFirstTime()
 
         // THEN
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams["from_onboarding"], "true")
-    }
-
-    func testWhenTrackPrivacyDashboardOpenedForFirstTimeAndFromOnboardingTrueThenParameterIsSetToTrue() {
-        // GIVEN
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-
-        // WHEN
-        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: false)
-
-        // THEN
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams["from_onboarding"], "false")
     }
 
     func testWhenTrackPrivacyDashboardOpenedForFirstTimeThenDaysSinceInstallParameterIsSet() {
@@ -273,7 +262,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
 
         // WHEN
-        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: false)
+        sut.trackPrivacyDashboardOpenedForFirstTime()
 
         // THEN
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams["daysSinceInstall"], "3")

--- a/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -93,4 +93,157 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
     }
 
+    // MARK: - List
+
+    func testWhenTrackSearchSuggestionSayDuckThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSearchSayDuckUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSearchSuggestionSayDuck()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_say_duck_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+    
+    func testWhenTrackSearchSuggestionMightyDuckThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSearchMightyDuckUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSearchSuggestionMightyDuck()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_mighty_duck_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSearchSuggestionWeatherThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSearchWeatherUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSearchSuggestionWeather()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_weather_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSearchSuggestionSurpriseMeThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSearchSurpriseMeUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSearchSuggestionSurpriseMe()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_surprise_me_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSiteSuggestionESPNThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSiteESPNUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSiteSuggestionESPN()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_espn_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSiteSuggestionYahooThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSiteYahooUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSiteSuggestionYahoo()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_yahoo_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSiteSuggestionEbayThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSiteEbayUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSiteSuggestionEbay()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_ebay_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSiteSuggestionSurpriseMeThenExpectedEventIsCalled() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSiteSurpriseMeUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSiteSuggestionSurpriseMe()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_surprise_me_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -95,155 +95,42 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     // MARK: - List
 
-    func testWhenTrackSearchSuggestionSayDuckThenExpectedEventIsCalled() {
+    func testWhenTrackSearchSuggestionOptionTappedThenExpectedEventIsCalled() {
         // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSearchSayDuckUnique
+        let expectedPixel = Pixel.Event.onboardingContextualSearchOptionTappedUnique
         XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
         XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
 
         // WHEN
-        sut.trackSearchSuggestionSayDuck()
+        sut.trackSearchSuggetionOptionTapped()
 
         // THEN
         XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_say_duck_unique")
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_option_tapped_unique")
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
     }
-    
-    func testWhenTrackSearchSuggestionMightyDuckThenExpectedEventIsCalled() {
+
+    func testWhenTrackSiteSuggestionThenExpectedEventIsCalled() {
         // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSearchMightyDuckUnique
+        let expectedPixel = Pixel.Event.onboardingContextualSiteOptionTappedUnique
         XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
         XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
 
         // WHEN
-        sut.trackSearchSuggestionMightyDuck()
+        sut.trackSiteSuggetionOptionTapped()
 
         // THEN
         XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_mighty_duck_unique")
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_option_tapped_unique")
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
     }
 
-    func testWhenTrackSearchSuggestionWeatherThenExpectedEventIsCalled() {
-        // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSearchWeatherUnique
-        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
-
-        // WHEN
-        sut.trackSearchSuggestionWeather()
-
-        // THEN
-        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_weather_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
-    }
-
-    func testWhenTrackSearchSuggestionSurpriseMeThenExpectedEventIsCalled() {
-        // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSearchSurpriseMeUnique
-        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
-
-        // WHEN
-        sut.trackSearchSuggestionSurpriseMe()
-
-        // THEN
-        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_surprise_me_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
-    }
-
-    func testWhenTrackSiteSuggestionESPNThenExpectedEventIsCalled() {
-        // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSiteESPNUnique
-        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
-
-        // WHEN
-        sut.trackSiteSuggestionESPN()
-
-        // THEN
-        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_espn_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
-    }
-
-    func testWhenTrackSiteSuggestionYahooThenExpectedEventIsCalled() {
-        // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSiteYahooUnique
-        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
-
-        // WHEN
-        sut.trackSiteSuggestionYahoo()
-
-        // THEN
-        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_yahoo_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
-    }
-
-    func testWhenTrackSiteSuggestionEbayThenExpectedEventIsCalled() {
-        // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSiteEbayUnique
-        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
-
-        // WHEN
-        sut.trackSiteSuggestionEbay()
-
-        // THEN
-        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_ebay_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
-    }
-
-    func testWhenTrackSiteSuggestionSurpriseMeThenExpectedEventIsCalled() {
-        // GIVEN
-        let expectedPixel = Pixel.Event.onboardingContextualSiteSurpriseMeUnique
-        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
-
-        // WHEN
-        sut.trackSiteSuggestionSurpriseMe()
-
-        // THEN
-        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
-        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_surprise_me_unique")
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
-        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
-    }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -22,16 +22,29 @@ import Core
 @testable import DuckDuckGo
 
 final class OnboardingPixelReporterTests: XCTestCase {
+    private static let suiteName = "testing_onboarding_pixel_store"
     private var sut: OnboardingPixelReporter!
+    private var statisticsStoreMock: MockStatisticsStore!
+    private var now: Date!
+    private var userDefaultsMock: UserDefaults!
 
     override func setUpWithError() throws {
-        sut = OnboardingPixelReporter(pixel: OnboardingPixelFireMock.self, uniquePixel: OnboardingUniquePixelFireMock.self)
+        statisticsStoreMock = MockStatisticsStore()
+        now = Date()
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        userDefaultsMock = UserDefaults(suiteName: Self.suiteName)
+        sut = OnboardingPixelReporter(pixel: OnboardingPixelFireMock.self, uniquePixel: OnboardingUniquePixelFireMock.self, statisticsStore: statisticsStoreMock, calendar: calendar, dateProvider: { self.now }, userDefaults: userDefaultsMock)
         try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
         OnboardingPixelFireMock.tearDown()
         OnboardingUniquePixelFireMock.tearDown()
+        statisticsStoreMock = nil
+        now = nil
+        userDefaultsMock.removePersistentDomain(forName: Self.suiteName)
+        userDefaultsMock = nil
         sut = nil
         try super.tearDownWithError()
     }
@@ -95,7 +108,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     // MARK: - List
 
-    func testWhenTrackSearchSuggestionOptionTappedThenExpectedEventIsCalled() {
+    func testWhenTrackSearchSuggestionOptionTappedThenSearchOptionTappedFires() {
         // GIVEN
         let expectedPixel = Pixel.Event.onboardingContextualSearchOptionTappedUnique
         XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
@@ -114,7 +127,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
     }
 
-    func testWhenTrackSiteSuggestionThenExpectedEventIsCalled() {
+    func testWhenTrackSiteSuggestionThenSiteOptionsTappedFires() {
         // GIVEN
         let expectedPixel = Pixel.Event.onboardingContextualSiteOptionTappedUnique
         XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
@@ -133,4 +146,155 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
     }
 
+    // MARK: - Custom Interactions
+
+    func testWhenTrackCustomSearchIsCalledThenSearchCustomFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSearchCustomUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackCustomSearch()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_search_custom_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackCustomSiteIsCalledThenSiteCustomFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingContextualSiteCustomUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackCustomSite()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_onboarding_visit_site_custom_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackSecondVisitIsCalledAndStoreDoesNotContainPixelThenPixelIsNotFired() {
+        // GIVEN
+        XCTAssertNil(userDefaultsMock.value(forKey: "com.duckduckgo.ios.site-visited"))
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSecondSiteVisit()
+
+        // THEN
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+    }
+
+    func testWhenTrackSecondVisitIsCalledThenFiresOnlyOnSecondTime() {
+        // GIVEN
+        let key = "com.duckduckgo.ios.site-visited"
+        userDefaultsMock.set(true, forKey: key)
+        XCTAssertTrue(userDefaultsMock.bool(forKey: key))
+        let expectedPixel = Pixel.Event.onboardingContextualSecondSiteVisitUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackSecondSiteVisit()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_second_sitevisit_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackPrivacyDashboardOpenedForFirstTimeThenPrivacyDashboardFirstTimeOpenedPixelFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.privacyDashboardFirstTimeOpenedUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: true)
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_privacy_dashboard_first_time_used_unique")
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackPrivacyDashboardOpenedForFirstTimeAndFromOnboardingFalseThenParameterIsSetToFalse() {
+        // GIVEN
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+
+        // WHEN
+        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: true)
+
+        // THEN
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams["from_onboarding"], "true")
+    }
+
+    func testWhenTrackPrivacyDashboardOpenedForFirstTimeAndFromOnboardingTrueThenParameterIsSetToTrue() {
+        // GIVEN
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+
+        // WHEN
+        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: false)
+
+        // THEN
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams["from_onboarding"], "false")
+    }
+
+    func testWhenTrackPrivacyDashboardOpenedForFirstTimeThenDaysSinceInstallParameterIsSet() {
+        // GIVEN
+        let installDate = Date(timeIntervalSince1970: 1722348000) // 30th July 2024 GMT
+        now = Date(timeIntervalSince1970: 1722607200) // 1st August 2024 GMT
+        statisticsStoreMock.installDate = installDate
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams, [:])
+
+        // WHEN
+        sut.trackPrivacyDashboardOpenedForFirstTime(fromOnboarding: false)
+
+        // THEN
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedParams["daysSinceInstall"], "3")
+    }
+
+    // MARK: - Screen Impressions
+
+    func testWhenTrackScreenImpressionIsCalledThenPixelFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.daxDialogsSerpUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackScreenImpression(event: expectedPixel)
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, expectedPixel.name)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
 }

--- a/DuckDuckGoTests/OnboardingSuggestionsViewModelsTests.swift
+++ b/DuckDuckGoTests/OnboardingSuggestionsViewModelsTests.swift
@@ -26,12 +26,12 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
     var navigationDelegate: CapturingOnboardingNavigationDelegate!
     var searchSuggestionsVM: OnboardingSearchSuggestionsViewModel!
     var siteSuggestionsVM: OnboardingSiteSuggestionsViewModel!
-    var pixelReporterMock: OnboardingSuggestionsPixelReporterMock!
+    var pixelReporterMock: OnboardingPixelReporterMock!
 
     override func setUp() {
         suggestionsProvider = MockOnboardingSuggestionsProvider()
         navigationDelegate = CapturingOnboardingNavigationDelegate()
-        pixelReporterMock = OnboardingSuggestionsPixelReporterMock()
+        pixelReporterMock = OnboardingPixelReporterMock()
         searchSuggestionsVM = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestionsProvider, delegate: navigationDelegate, pixelReporter: pixelReporterMock)
         siteSuggestionsVM = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestionsProvider, delegate: navigationDelegate, pixelReporter: pixelReporterMock)
     }
@@ -108,10 +108,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
             ContextualOnboardingListItem.surprise(title: "Surprise"),
         ]
         suggestionsProvider.list = searches
-        XCTAssertFalse(pixelReporterMock.didCallTrackSearchSayDuck)
-        XCTAssertFalse(pixelReporterMock.didCallTrackSearchMightyDuck)
-        XCTAssertFalse(pixelReporterMock.didCallTrackSearchWeather)
-        XCTAssertFalse(pixelReporterMock.didCallTrackSearchSurpriseMe)
+        XCTAssertFalse(pixelReporterMock.didCallTrackSearchOptionTapped)
 
         // WHEN
         searches.forEach { searchItem in
@@ -119,10 +116,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         }
 
         // THEN
-        XCTAssertTrue(pixelReporterMock.didCallTrackSearchSayDuck)
-        XCTAssertTrue(pixelReporterMock.didCallTrackSearchMightyDuck)
-        XCTAssertTrue(pixelReporterMock.didCallTrackSearchWeather)
-        XCTAssertTrue(pixelReporterMock.didCallTrackSearchSurpriseMe)
+        XCTAssertTrue(pixelReporterMock.didCallTrackSearchOptionTapped)
     }
 
     func testWhenSiteSuggestionsTapped_ThenPixelReporterIsCalled() {
@@ -134,10 +128,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
             ContextualOnboardingListItem.surprise(title: "Surprise"),
         ]
         suggestionsProvider.list = searches
-        XCTAssertFalse(pixelReporterMock.didCallTrackSiteESPN)
-        XCTAssertFalse(pixelReporterMock.didCallTrackSiteYahoo)
-        XCTAssertFalse(pixelReporterMock.didCallTrackSiteEbay)
-        XCTAssertFalse(pixelReporterMock.didCallTrackSiteSurpriseMe)
+        XCTAssertFalse(pixelReporterMock.didCallTrackSiteOptionTapped)
 
         // WHEN
         searches.forEach { searchItem in
@@ -145,10 +136,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         }
 
         // THEN
-        XCTAssertTrue(pixelReporterMock.didCallTrackSiteESPN)
-        XCTAssertTrue(pixelReporterMock.didCallTrackSiteYahoo)
-        XCTAssertTrue(pixelReporterMock.didCallTrackSiteEbay)
-        XCTAssertTrue(pixelReporterMock.didCallTrackSiteSurpriseMe)
+        XCTAssertTrue(pixelReporterMock.didCallTrackSiteOptionTapped)
     }
 
 }
@@ -168,49 +156,4 @@ class CapturingOnboardingNavigationDelegate: OnboardingNavigationDelegate {
     func navigateTo(url: URL) {
         urlToNavigateTo = url
     }
-}
-
-final class OnboardingSuggestionsPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting {
-    private(set) var didCallTrackSearchSayDuck = false
-    private(set) var didCallTrackSearchMightyDuck = false
-    private(set) var didCallTrackSearchWeather = false
-    private(set) var didCallTrackSearchSurpriseMe = false
-
-    private(set) var didCallTrackSiteESPN = false
-    private(set) var didCallTrackSiteYahoo = false
-    private(set) var didCallTrackSiteEbay = false
-    private(set) var didCallTrackSiteSurpriseMe = false
-
-    func trackSearchSuggestionSayDuck() {
-        didCallTrackSearchSayDuck = true
-    }
-
-    func trackSearchSuggestionMightyDuck() {
-        didCallTrackSearchMightyDuck = true
-    }
-
-    func trackSearchSuggestionWeather() {
-        didCallTrackSearchWeather = true
-    }
-
-    func trackSearchSuggestionSurpriseMe() {
-        didCallTrackSearchSurpriseMe = true
-    }
-
-    func trackSiteSuggestionESPN() {
-        didCallTrackSiteESPN = true
-    }
-    
-    func trackSiteSuggestionYahoo() {
-        didCallTrackSiteYahoo = true
-    }
-    
-    func trackSiteSuggestionEbay() {
-        didCallTrackSiteEbay = true
-    }
-    
-    func trackSiteSuggestionSurpriseMe() {
-        didCallTrackSiteSurpriseMe = true
-    }
-
 }

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -179,7 +179,6 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
 }
 
 final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
-    
     var expectation: XCTestExpectation?
     private(set) var didCallSetFireEducationMessageSeen = false
     private(set) var didCallsetFinalOnboardingDialogSeen = false
@@ -191,6 +190,8 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
 
     var isShowingFireDialog: Bool = false
     var shouldShowPrivacyButtonPulse: Bool = false
+    var isShowingSearchSuggestions: Bool = false
+    var isShowingSitesSuggestions: Bool = false
 
     func setFireEducationMessageSeen() {
         didCallSetFireEducationMessageSeen = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207569383033366/f

**Description**:

Adds Pixels for Contextual Onboarding.

**Note**
You may wonder why we renamed pixels with `_unique`. Since SwiftUI can redraw the view multiple times and because the user can interact with the browser, e.g. refresh the page, I’ve renamed the pixels `_unique` so I can take advantage of the UniquePixel class. ODRI is across the change as per [comment](https://app.asana.com/0/0/1207860980308144/1207881498389336/f).

**Steps to test this PR**:

Prerequisites:
1. Add return VariantIOS(name: "mb", weight: 1, isIncluded: VariantIOS.When.always, features: [.newOnboardingIntro]) in `DefaultVariantManager` at line 145.
2. Add  `newInstallCompletion(self)` in `DefaultVariantManager` at line 128.
3. Delete the App.

SCENARIO 1 - Linear Flow

1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip”.
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Ensure that `m_dx_try_a_search_unique` is fired in console log.
6. Tap on one of the searches. E.g. “local weather”.
7. Ensure that `m_onboarding_search_option_tapped_unique` is fired in the console log.
8. A Dax dialogue informing the user about the DDG search should appear.
9. Ensure that `m_dx_s_unique` is fired in the console log
10. Tap on the "Got it!” button.
12. The Dax dialogue should update and suggest to the user a list of websites to try.
13. Ensure that `m_dx_try_visit_site_unique` is fired in the console log.
14. Tap on one of the websites “ebay.com”.
15. Ensure that `m_onboarding_visit_site_option_tapped_unique` is fired in the console log.
16. The Dax dialogue should inform the user that multiple trackers have been blocked. The Privacy Dashboard icon should be highlighted.
17. Ensure that `m_dx_wt_unique` is fired in the console log.
18. Tap on the privacy icon button.
19. Ensure that `m_privacy_dashboard_first_time_used_unique` is fired in the console log. If the app is just installed `daysSinceInstall` parameter should be 0. If the privacy icon was highlighted `from_onboarding` parameter should be true.
20. Ensure also that existing pixel `mp` is fired.
21. The privacy dashboard should be presented on the screen.
22. Tap the “Done” button on the Privacy Dashboard to dismiss the Privacy Dashboard. 
23. The Privacy Dashboard icon should not be highlighted anymore.
24. Tap the “Got It!” Button.
25. The Dax dialogue should update and educate the user on the Fire Button. The Fire Button should show the pulse animation.
26. Ensure that `m_dx_fe_s_unique` is fired in the console log.
27. Tap the “Fire” button.
28. The Dax dialog should dismiss and the fire button should stop the pulse animation.
29. Tap “Close Tabs and Clear Data”.
30. The new tab page should have a Dax dialogue titled “You’ve got this”.
31. Ensure that `m_dx_end_new_tab_unique` is fired in the console log.
32. Enter a URL in the address bar and press enter.
33. Ensure that `m_second_sitevisit_unique` is fired in the console log.

Scenario 2 - Custom Searches

1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip”.
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Instead of tapping one of the suggested searches, input' flying duck' in the address bar and press enter.
6. Ensure that `m_onboarding_search_custom_unique` is fired in the console log.
7. Tap on the "Got it!” button.
8. The Dax dialogue should update and suggest to the user a list of websites to try.
9. Instead of tapping one of the suggested searches, input `www.facebook.com` and press enter.
10. Ensure that `m_onboarding_visit_site_custom_unique` is fired.
11. Ensure that `m_dx_sm_unique` is fired.
12. Visit another website
13. Ensure that `m_second_sitevisit_unique` is fired in the console log.

Scenario 3 - Site Owned by Major Trackers
1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip”.
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Tap `whatsapp.com` in the address bar.
6. A dialog explaining that FB owns whatsapp should appear.
7. Ensure that `m_dx_so_unique` is fired in the console log.

Scenario 4 - Site is Major Tracker
1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip”.
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Tap `facebook.com` in the address bar.
6. A dialog explaining that we can’t protect the users from FB should appear. 
7. Ensure that `m_dx_sm_unique` is fired in the console log.

Scenario 4 - Site with no Trackers
1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip”.
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Tap `duckduckgo.com` in the address bar.
6. The Pesky trackers dialog should appear
7. Ensure that `m_dx_wo_unique` is fired in the console log.

Scenario 5 - Final Dialog from Contextual Dax 
1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on “Skip”.
4. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
5. Tap on one of the searches. E.g. “local weather”.
6. A Dax dialogue informing the user about the DDG search should appear.
7. Tap on the "Got it!” button.
12. The Dax dialogue should update and suggest to the user a list of websites to try.
13. Tap on one of the websites “ebay.com”.
14. The Dax dialogue should inform the user that multiple trackers have been blocked. The Privacy Dashboard icon should be highlighted.
15. Tap the “Got It!” Button.
25. The Dax dialogue should update and educate the user on the Fire Button. The Fire Button should show the pulse animation.
26. Navigate to another website, eg. `www.repubblica.it`
27. End of Journey dialog “You’ve got this” should appear.
28. Ensure that `m_dx_end_tab_unique` pixel fires in the console log.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
