### PR TITLE
new pixel and parameter for monitoring clearing of data stores

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -535,7 +535,8 @@ extension Pixel {
         case debugCannotClearObservationsDatabase
         case debugWebsiteDataStoresNotClearedMultiple
         case debugWebsiteDataStoresNotClearedOne
-        
+        case debugWebsiteDataStoresCleared
+
         case debugBookmarksMigratedMoreThanOnce
         
         // Return user measurement
@@ -1243,7 +1244,8 @@ extension Pixel.Event {
         case .debugCannotClearObservationsDatabase: return "m_d_cannot_clear_observations_database"
         case .debugWebsiteDataStoresNotClearedMultiple: return "m_d_wkwebsitedatastoresnotcleared_multiple"
         case .debugWebsiteDataStoresNotClearedOne: return "m_d_wkwebsitedatastoresnotcleared_one"
-            
+        case .debugWebsiteDataStoresCleared: return "m_d_wkwebsitedatastorescleared"
+
             // MARK: Ad Attribution
             
         case .adAttributionGlobalAttributedRulesDoNotExist: return "m_attribution_global_attributed_rules_do_not_exist"

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -96,9 +96,9 @@ public class WebCacheManager {
 extension WebCacheManager {
 
     @available(iOS 17, *)
-    private func checkForLeftBehindDataStores(leftOversCount: Int) async {
+    private func checkForLeftBehindDataStores(previousLeftOversCount: Int) async {
         let params = [
-            "left_overs_count": "\(leftOversCount)"
+            "left_overs_count": "\(previousLeftOversCount)"
         ]
 
         let ids = await WKWebsiteDataStore.allDataStoreIdentifiers
@@ -106,7 +106,7 @@ extension WebCacheManager {
             Pixel.fire(pixel: .debugWebsiteDataStoresNotClearedMultiple, withAdditionalParameters: params)
         } else if ids.count > 0 {
             Pixel.fire(pixel: .debugWebsiteDataStoresNotClearedOne, withAdditionalParameters: params)
-        } else if leftOversCount > 0 {
+        } else if previousLeftOversCount > 0 {
             Pixel.fire(pixel: .debugWebsiteDataStoresCleared, withAdditionalParameters: params)
         }
     }
@@ -119,11 +119,11 @@ extension WebCacheManager {
         dataStore = nil
 
         let uuids = await WKWebsiteDataStore.allDataStoreIdentifiers
-        let count = max(0, uuids.count - 1) // -1 because there should be a current store
+        let previousLeftOversCount = max(0, uuids.count - 1) // -1 because there should be a current store
         for uuid in uuids {
             try? await WKWebsiteDataStore.remove(forIdentifier: uuid)
         }
-        await checkForLeftBehindDataStores(leftOversCount: count)
+        await checkForLeftBehindDataStores(previousLeftOversCount: previousLeftOversCount)
 
         storeIdManager.allocateNewContainerId()
         return cookies


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207974821438701/f
Tech Design URL:
CC:

**Description**:
Adds new pixel fired if there were previous left overs but we have cleared all containers.  Also adds a parameter to show last left over count.

**Steps to test this PR**:
1. Browse some sites
2. Use the fire button
3. Check data was cleared.  
4. If datastores pixel is fired check it has left_over_count parameter
