### PR TITLE
Open keyboard on New Tab Page based on Settings

### DIFF
--- a/DuckDuckGo/HomeCollectionView.swift
+++ b/DuckDuckGo/HomeCollectionView.swift
@@ -150,10 +150,6 @@ class HomeCollectionView: UICollectionView {
         menuController.showMenu(from: self, rect: menuView.frame)
     }
     
-    func omniBarCancelPressed() {
-        renderers.omniBarCancelPressed()
-    }
-    
     func openedAsNewTab(allowingKeyboard: Bool) {
         renderers.openedAsNewTab(allowingKeyboard: allowingKeyboard)
     }

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -216,10 +216,6 @@ class HomeViewController: UIViewController, NewTabPage {
         collectionView.reloadData()
     }
     
-    func omniBarCancelPressed() {
-        collectionView.omniBarCancelPressed()
-    }
-    
     func openedAsNewTab(allowingKeyboard: Bool) {
         collectionView.openedAsNewTab(allowingKeyboard: allowingKeyboard)
         if !variantManager.isSupported(feature: .newOnboardingIntro) {

--- a/DuckDuckGo/HomeViewSectionRenderers.swift
+++ b/DuckDuckGo/HomeViewSectionRenderers.swift
@@ -38,8 +38,6 @@ protocol HomeViewSectionRenderer: AnyObject {
     
     func remove(from controller: HomeViewController)
     
-    func omniBarCancelPressed()
-    
     func openedAsNewTab(allowingKeyboard: Bool)
 
     func launchNewSearch()
@@ -134,12 +132,6 @@ class HomeViewSectionRenderers: NSObject,
     
     func rendererFor(section: Int) -> HomeViewSectionRenderer {
         return renderers[section]
-    }
-    
-    func omniBarCancelPressed() {
-        renderers.forEach { renderer in
-            renderer.omniBarCancelPressed()
-        }
     }
     
     func openedAsNewTab(allowingKeyboard: Bool) {

--- a/DuckDuckGo/HomeViewSectionRenderersExtension.swift
+++ b/DuckDuckGo/HomeViewSectionRenderersExtension.swift
@@ -26,8 +26,6 @@ extension HomeViewSectionRenderer {
 
     func remove(from controller: HomeViewController) { }
 
-    func omniBarCancelPressed() { }
-
     func openedAsNewTab(allowingKeyboard: Bool) { }
 
     func menuItemsFor(itemAt: Int) -> [UIMenuItem]? {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -771,6 +771,7 @@ class MainViewController: UIViewController {
 
             controller.delegate = self
             controller.shortcutsDelegate = self
+            controller.chromeDelegate = self
 
             newTabPageViewController = controller
             addToContentContainer(controller: controller)

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1851,7 +1851,6 @@ extension MainViewController: OmniBarDelegate {
         dismissOmniBar()
         omniBar.cancel()
         hideSuggestionTray()
-        homeController?.omniBarCancelPressed()
         self.showMenuHighlighterIfNeeded()
     }
 

--- a/DuckDuckGo/NavigationSearchHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/NavigationSearchHomeViewSectionRenderer.swift
@@ -48,7 +48,7 @@ class NavigationSearchHomeViewSectionRenderer: HomeViewSectionRenderer {
     func openedAsNewTab(allowingKeyboard: Bool) {
         guard allowingKeyboard && KeyboardSettings().onNewTab else { return }
         // The omnibar is inside a collection view so this needs to chance to do its thing
-        //  which might also be async.  Not great.
+        //  which might also be async. Not great.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.launchNewSearch()
         }

--- a/DuckDuckGo/NewTabPage.swift
+++ b/DuckDuckGo/NewTabPage.swift
@@ -26,7 +26,6 @@ protocol NewTabPage: UIViewController {
 
     func launchNewSearch()
     func openedAsNewTab(allowingKeyboard: Bool)
-    func omniBarCancelPressed()
 
     func dismiss()
 

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -119,11 +119,17 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
     weak var shortcutsDelegate: NewTabPageControllerShortcutsDelegate?
 
     func launchNewSearch() {
-
+        chromeDelegate?.omniBar.becomeFirstResponder()
     }
 
     func openedAsNewTab(allowingKeyboard: Bool) {
+        guard allowingKeyboard && KeyboardSettings().onNewTab else { return }
 
+        // The omnibar is inside a collection view so this needs a chance to do its thing
+        // which might also be async. Not great.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.launchNewSearch()
+        }
     }
 
     func dismiss() {

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -126,10 +126,6 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
 
     }
 
-    func omniBarCancelPressed() {
-
-    }
-
     func dismiss() {
 
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207840822110802/f
Tech Design URL:
CC:

**Description**:

When opening New Tab Page keyboard needs to open according to setting in General → Keyboard → New Tab.

**Steps to test this PR**:
1. Enable New Tab Page sections in Debug menu
2. Enable General → Keyboard → New Tab
3. Open New Tab, search field should start editing automatically
4. Disable General → Keyboard → New Tab
5. Open New Tab, no editing should take place

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
