### PR TITLE
If no App Store subscriptions option are available return empty options object

### DIFF
--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -205,7 +205,7 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
         } else {
             os_log("Failed to obtain subscription options", log: .subscription, type: .error)
             setTransactionError(.failedToGetSubscriptionOptions)
-            return nil
+            return SubscriptionOptions.empty
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1207934463147478/f

**Description**:
In case no App Store subscription objects are available we should return a proper SubscriptionOptions.empty object.

**Steps to test this PR**:
Mock no subscription products available in the App Store (change app identifier or fix `DefaultStorePurchaseManager`  `subscriptionOptions()` to return nil)
1. Open Settings -> Debug -> Subscription -> I Have a Subscription
2. Sing in to active staging subscription via OTP
3. Click "Done" on the success page
4. Ensure that subscription "Welcome" page is loaded

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
