### PR TITLE
ensure new data clearing api is being used

### DIFF
--- a/Core/WKWebViewConfigurationExtension.swift
+++ b/Core/WKWebViewConfigurationExtension.swift
@@ -56,21 +56,29 @@ extension WKWebViewConfiguration {
 
 }
 
-public class DataStoreIdManager {
+public protocol DataStoreIdManaging {
+
+    var id: UUID? { get }
+    var hasId: Bool { get }
+    func allocateNewContainerId()
+
+}
+
+public class DataStoreIdManager: DataStoreIdManaging {
 
     public static let shared = DataStoreIdManager()
 
     @UserDefaultsWrapper(key: .webContainerId, defaultValue: nil)
     private var containerId: String?
 
-    var id: UUID? {
+    public var id: UUID? {
         if let containerId {
             return UUID(uuidString: containerId)
         }
         return nil
     }
 
-    var hasId: Bool {
+    public var hasId: Bool {
         return containerId != nil
     }
 

--- a/Core/WebCacheManager.swift
+++ b/Core/WebCacheManager.swift
@@ -78,7 +78,7 @@ public class WebCacheManager {
 
     public func clear(cookieStorage: CookieStorage = CookieStorage(),
                       logins: PreserveLogins = PreserveLogins.shared,
-                      dataStoreIdManager: DataStoreIdManager = .shared) async {
+                      dataStoreIdManager: DataStoreIdManaging = DataStoreIdManager.shared) async {
 
         var cookiesToUpdate = [HTTPCookie]()
         if #available(iOS 17, *), dataStoreIdManager.hasId {
@@ -87,6 +87,10 @@ public class WebCacheManager {
 
         // Perform legacy clearing to migrate to new container
         cookiesToUpdate += await legacyDataClearing() ?? []
+
+        if #available(iOS 17, *) {
+            dataStoreIdManager.allocateNewContainerId()
+        }
 
         cookieStorage.updateCookies(cookiesToUpdate, keepingPreservedLogins: logins)
     }
@@ -106,7 +110,7 @@ extension WebCacheManager {
     }
 
     @available(iOS 17, *)
-    private func containerBasedClearing(storeIdManager: DataStoreIdManager) async -> [HTTPCookie]? {
+    private func containerBasedClearing(storeIdManager: DataStoreIdManaging) async -> [HTTPCookie]? {
         guard let containerId = storeIdManager.id else { return [] }
         var dataStore: WKWebsiteDataStore? = WKWebsiteDataStore(forIdentifier: containerId)
         let cookies = await dataStore?.httpCookieStore.allCookies()
@@ -118,7 +122,6 @@ extension WebCacheManager {
         }
         await checkForLeftBehindDataStores()
 
-        storeIdManager.allocateNewContainerId()
         return cookies
     }
 

--- a/DuckDuckGoTests/FireButtonReferenceTests.swift
+++ b/DuckDuckGoTests/FireButtonReferenceTests.swift
@@ -61,12 +61,9 @@ final class FireButtonReferenceTests: XCTestCase {
         }
                     
         let cookieStorage = CookieStorage()
-        
-        let idManager = DataStoreIdManager()
-        
+
         for test in referenceTests {
             let cookie = try XCTUnwrap(cookie(for: test))
-            XCTAssertFalse(idManager.hasId)
 
             let warmup = DataStoreWarmup()
             await warmup.ensureReady(applicationState: .unknown)
@@ -77,8 +74,8 @@ final class FireButtonReferenceTests: XCTestCase {
             // Pretend the webview was loaded and the cookies were previously consumed
             cookieStorage.isConsumed = true
             
-            await WebCacheManager.shared.clear(cookieStorage: cookieStorage, logins: preservedLogins, dataStoreIdManager: idManager)
-            
+            await WebCacheManager.shared.clear(cookieStorage: cookieStorage, logins: preservedLogins, dataStoreIdManager: NullDataStoreIdManager())
+
             let testCookie = cookieStorage.cookies.filter { $0.name == test.cookieName }.first
 
             if test.expectCookieRemoved {
@@ -159,4 +156,12 @@ private struct Test: Codable {
     let name, cookieDomain, cookieName: String
     let expectCookieRemoved: Bool
     let exceptPlatforms: [String]
+}
+
+private struct NullDataStoreIdManager: DataStoreIdManaging {
+
+    var id: UUID? { return nil }
+    var hasId: Bool { return false }
+    func allocateNewContainerId() { }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207976962313197/f
Tech Design URL: 
CC: @bwaresiak 

**Description**:
Ensure allocation of container id after clearing if on iOS 17 and fix relevant tests.

**Steps to test this PR**:
1. Clean app - browse some sites, use the fire button.  Container id should be nil when data clearing function is called
2. Browse some sites and use the fire button.  Container id should NOT be nil when data clearing function is called
3. Browse some sites and use the fire button.  Container id should NOT be nil when data clearing function is called and should be different from old one
4. Ensure tests all pass
