### PR TITLE
Increase testPixelDebouncePreventsFiringWithinInterval test timeout

### DIFF
--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -196,7 +196,7 @@ class PixelTests: XCTestCase {
             }, debounce: debounceInterval)
         }
 
-        wait(for: [firstFireExpectation, thirdFireExpectation], timeout: Double(debounceInterval + 2))
+        wait(for: [firstFireExpectation, thirdFireExpectation], timeout: Double(debounceInterval + 4))
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207981464168206/f

**Description**:
Increase timeout of testPixelDebouncePreventsFiringWithinInterval  in PixelTests.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
