### PR TITLE
Show shortcuts for enabled features only

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		6F9FFE302C57B34800A238BE /* NewTabPageSectionsSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9FFE2F2C57B34800A238BE /* NewTabPageSectionsSettingsModel.swift */; };
 		6FA3438F2C3D3BC300470677 /* Favorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA3438E2C3D3BC300470677 /* Favorite.swift */; };
 		6FA343922C3D3C3B00470677 /* FavoriteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA343912C3D3C3B00470677 /* FavoriteIconView.swift */; };
+		6FABAA692C6116FD003762EC /* NewTabPageShortcutsSettingsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FABAA682C6116FD003762EC /* NewTabPageShortcutsSettingsStorageTests.swift */; };
 		6FB1FE9E2C24D41D0075B68B /* NewTabPageSectionsDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB1FE9D2C24D41D0075B68B /* NewTabPageSectionsDebugView.swift */; };
 		6FB1FEA22C256ACD0075B68B /* NewTabPageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB1FEA12C256ACD0075B68B /* NewTabPageManager.swift */; };
 		6FB2A67A2C2C5BAE004D20C8 /* FavoriteEmptyStateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A6792C2C5BAE004D20C8 /* FavoriteEmptyStateItem.swift */; };
@@ -672,9 +673,9 @@
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
+		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
 		9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */; };
 		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
-		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
 		9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */; };
 		9F6933212C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
@@ -1504,6 +1505,7 @@
 		6F9FFE2F2C57B34800A238BE /* NewTabPageSectionsSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSectionsSettingsModel.swift; sourceTree = "<group>"; };
 		6FA3438E2C3D3BC300470677 /* Favorite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Favorite.swift; sourceTree = "<group>"; };
 		6FA343912C3D3C3B00470677 /* FavoriteIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteIconView.swift; sourceTree = "<group>"; };
+		6FABAA682C6116FD003762EC /* NewTabPageShortcutsSettingsStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageShortcutsSettingsStorageTests.swift; sourceTree = "<group>"; };
 		6FB030C7234331B400A10DB9 /* Configuration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Configuration.xcconfig; path = Configuration/Configuration.xcconfig; sourceTree = "<group>"; };
 		6FB1FE9D2C24D41D0075B68B /* NewTabPageSectionsDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSectionsDebugView.swift; sourceTree = "<group>"; };
 		6FB1FEA12C256ACD0075B68B /* NewTabPageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageManager.swift; sourceTree = "<group>"; };
@@ -2404,9 +2406,9 @@
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
+		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
 		9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDaxFavouritesTests.swift; sourceTree = "<group>"; };
 		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
-		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
 		9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
 		9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHostingControllerMock.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
@@ -3618,6 +3620,7 @@
 				6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */,
 				6FD0C4202C5BF774000561C9 /* NewTabPageModelTests.swift */,
 				564DE4562C4150E600D23241 /* HomeViewControllerDaxDialogTests.swift */,
+				6FABAA682C6116FD003762EC /* NewTabPageShortcutsSettingsStorageTests.swift */,
 			);
 			name = NewTabPage;
 			sourceTree = "<group>";
@@ -7549,6 +7552,7 @@
 				C1CDA31E2AFBF811006D1476 /* AutofillNeverPromptWebsitesManagerTests.swift in Sources */,
 				B6AD9E3A28D456820019CDE9 /* PrivacyConfigurationManagerMock.swift in Sources */,
 				F189AED71F18F6DE001EBAE1 /* TabTests.swift in Sources */,
+				6FABAA692C6116FD003762EC /* NewTabPageShortcutsSettingsStorageTests.swift in Sources */,
 				9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */,
 				9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */,
 				F13B4BFB1F18E3D900814661 /* TabsModelPersistenceExtensionTests.swift in Sources */,

--- a/DuckDuckGo/NewTabPageShortcutsSettingsModel.swift
+++ b/DuckDuckGo/NewTabPageShortcutsSettingsModel.swift
@@ -18,11 +18,20 @@
 //
 
 import Foundation
+import BrowserServicesKit
 
 typealias NewTabPageShortcutsSettingsModel = NewTabPageSettingsModel<NewTabPageShortcut, NewTabPageShortcutsSettingsStorage>
 
 extension NewTabPageShortcutsSettingsModel {
-    convenience init(storage: NewTabPageShortcutsSettingsStorage = NewTabPageShortcutsSettingsStorage()) {
-        self.init(settingsStorage: storage)
+    convenience init(storage: NewTabPageShortcutsSettingsStorage = NewTabPageShortcutsSettingsStorage(),
+                     featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
+        self.init(settingsStorage: storage) { shortcut in
+            switch shortcut {
+            case .aiChat, .bookmarks, .downloads, .settings:
+                return true
+            case .passwords:
+                return featureFlagger.isFeatureOn(.autofillAccessCredentialManagement)
+            }
+        }
     }
 }

--- a/DuckDuckGoTests/NewTabPageShortcutsSettingsStorageTests.swift
+++ b/DuckDuckGoTests/NewTabPageShortcutsSettingsStorageTests.swift
@@ -1,0 +1,121 @@
+//
+//  NewTabPageShortcutsSettingsStorageTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class NewTabPageSettingsModelTests: XCTestCase {
+
+    private let storage = StorageMock(itemsOrder: SettingsItemMock.allCases)
+
+    func testFiltersSettingsUsingProvidedFilter() {
+        let sut = createSUT { item in
+            item != .two
+        }
+
+        XCTAssertFalse(sut.enabledItems.contains(.two))
+    }
+
+    func testMovingReordersFullSet() {
+        let sut = createSUT { item in
+            item != .two
+        }
+
+        sut.moveItems(from: IndexSet(integer: 0), to: 1)
+
+        XCTAssertEqual(storage.itemsOrder, [.two, .one, .three])
+    }
+
+    func testMovingItemToEndWhenNoFilter() {
+        let sut = createSUT()
+
+        sut.moveItems(from: IndexSet(integer: 0), to: 3)
+
+        XCTAssertEqual(storage.itemsOrder, [.two, .three, .one])
+    }
+
+    func testMovingItemToEndWhenFiltered() {
+        let sut = createSUT { item in
+            item != .two
+        }
+
+        sut.moveItems(from: IndexSet(integer: 0), to: 2)
+
+        XCTAssertEqual(storage.itemsOrder, [.two, .three, .one])
+    }
+
+    func testMovingToStartWhenFiltered() {
+        let sut = createSUT { item in
+            item != .one
+        }
+
+        sut.moveItems(from: IndexSet(integer: 1), to: 0)
+
+        XCTAssertEqual(storage.itemsOrder, [.one, .three, .two])
+    }
+
+    func testItemsSettingsAreFiltered() {
+        let sut = createSUT { item in
+            item != .one
+        }
+
+        XCTAssertEqual(sut.itemsSettings.map(\.item), [.two, .three])
+    }
+
+    func testEnabledItemsAreFiltered() {
+        let sut = createSUT { item in
+            item != .one
+        }
+
+        XCTAssertEqual(sut.enabledItems, [.two, .three])
+    }
+
+    private func createSUT(filter: @escaping (SettingsItemMock) -> Bool = { _ in true }) -> NewTabPageSettingsModel<SettingsItemMock, StorageMock> {
+        NewTabPageSettingsModel(settingsStorage: storage, visibilityFilter: filter)
+    }
+}
+
+private final class StorageMock: NewTabPageSettingsStorage {
+    var itemsOrder: [SettingsItemMock]
+
+    init(itemsOrder: [SettingsItemMock]) {
+        self.itemsOrder = itemsOrder
+    }
+
+    func isEnabled(_ item: SettingsItemMock) -> Bool {
+        return true
+    }
+
+    func setItem(_ item: SettingsItemMock, enabled: Bool) {
+
+    }
+
+    func moveItems(_ fromOffsets: IndexSet, toOffset: Int) {
+        itemsOrder.move(fromOffsets: fromOffsets, toOffset: toOffset)
+    }
+
+    func save() {
+    }
+}
+
+private enum SettingsItemMock: CaseIterable, NewTabPageSettingsStorageItem {
+    case one
+    case two
+    case three
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207977496450580/f
Tech Design URL:
CC:

**Description**:

Some features are available conditionally. These should not be visible on NTP and in settings.

**Steps to test this PR**:
1. Enable New Tab Page sections in Debug menu.
2. Reorder shortcuts and enable/disable as you see fit.
3. Change shortcuts visibility in `NewTabPageShortcutsSettingsModel.swift`
4. Make sure only allowed shortcuts are visible.
5. Reorder and enable/disable once again.
6. Verify the order and settings are preserved.
7. Re-enable all shortcuts in `NewTabPageShortcutsSettingsModel.swift`.
8. Verify all shortcuts are visible.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
