### PR TITLE
Fix New Tab Page UI issues on iOS 15

### DIFF
--- a/DuckDuckGo/NewTabPageSettingsSectionItemView.swift
+++ b/DuckDuckGo/NewTabPageSettingsSectionItemView.swift
@@ -35,6 +35,7 @@ struct NewTabPageSettingsSectionItemView: View {
                     .foregroundStyle(Color(designSystemColor: .textPrimary))
                     .daxBodyRegular()
             })
+            .toggleStyle(SwitchToggleStyle(tint: Color(designSystemColor: .accent)))
 
             Divider()
         }

--- a/DuckDuckGo/NewTabPageSettingsSectionItemView.swift
+++ b/DuckDuckGo/NewTabPageSettingsSectionItemView.swift
@@ -38,6 +38,18 @@ struct NewTabPageSettingsSectionItemView: View {
 
             Divider()
         }
+        .applyListRowInsets()
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func applyListRowInsets() -> some View {
+        if #available(iOS 16, *) {
+            self
+        } else {
+            listRowInsets(EdgeInsets(top: 0, leading: -24, bottom: 0, trailing: 8))
+        }
     }
 }
 

--- a/DuckDuckGo/NewTabPageSettingsView.swift
+++ b/DuckDuckGo/NewTabPageSettingsView.swift
@@ -106,12 +106,12 @@ struct NewTabPageSettingsView: View {
             switch setting.item {
             case .favorites:
                 NewTabPageSettingsSectionItemView(title: "Favorites",
-                                              iconResource: .favorite24,
-                                              isEnabled: setting.isEnabled)
+                                                  iconResource: .favorite24,
+                                                  isEnabled: setting.isEnabled)
             case .shortcuts:
                 NewTabPageSettingsSectionItemView(title: "Shortcuts",
-                                              iconResource: .shortcut24,
-                                              isEnabled: setting.isEnabled)
+                                                  iconResource: .shortcut24,
+                                                  isEnabled: setting.isEnabled)
             }
         }.onMove(perform: { indices, newOffset in
             sectionsSettingsModel.moveItems(from: indices, to: newOffset)

--- a/DuckDuckGo/NewTabPageSettingsView.swift
+++ b/DuckDuckGo/NewTabPageSettingsView.swift
@@ -26,26 +26,22 @@ struct NewTabPageSettingsView: View {
     @ObservedObject var shortcutsSettingsModel: NewTabPageShortcutsSettingsModel
     @ObservedObject var sectionsSettingsModel: NewTabPageSectionsSettingsModel
 
-    // Arbitrary high value is required to acomodate for the content size
-    @State var listHeight: CGFloat = 5000
-
-    @State var firstSectionFrame: CGRect = .zero
-    @State var lastSectionFrame: CGRect = .zero
+    @State var listHeight: CGFloat = Metrics.initialListHeight
 
     var body: some View {
         mainView
-        .applyBackground()
-        .tintIfAvailable(Color(designSystemColor: .accent))
-        .navigationTitle(UserText.newTabPageSettingsTitle)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
-                Button(UserText.navigationTitleDone) {
-                    dismiss()
+            .applyBackground()
+            .tintIfAvailable(Color(designSystemColor: .accent))
+            .navigationTitle(UserText.newTabPageSettingsTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(UserText.navigationTitleDone) {
+                        dismiss()
+                    }
+                    .tint(Color(designSystemColor: .textPrimary))
                 }
-                .tint(Color(designSystemColor: .textPrimary))
             }
-        }
     }
 
     // MARK: Views
@@ -53,54 +49,55 @@ struct NewTabPageSettingsView: View {
     @ViewBuilder
     private var mainView: some View {
         if sectionsSettingsModel.enabledItems.contains(.shortcuts) {
-            ScrollView {
-                VStack {
-                    sectionsList(withFrameUpdates: true)
-                        .withoutScroll()
-                        .frame(height: listHeight)
-                    
-                    EditableShortcutsView(model: shortcutsSettingsModel)
-                        .padding(.horizontal, Metrics.horizontalPadding)
+            GeometryReader { geometry in
+                ScrollView {
+                    VStack {
+                        sectionsList(withFrameUpdates: true, geometry: geometry)
+                            .withoutScroll()
+                            .frame(height: listHeight)
+
+                        EditableShortcutsView(model: shortcutsSettingsModel)
+                            .padding(.horizontal, Metrics.horizontalPadding)
+                            .coordinateSpace(name: Constant.scrollCoordinateSpaceName)
+                    }
                 }
             }
-            .coordinateSpace(name: Constant.scrollCoordinateSpace)
         } else {
             sectionsList(withFrameUpdates: false)
         }
     }
 
     @ViewBuilder
-    private func sectionsList(withFrameUpdates: Bool) -> some View {
-        List {
-            Section {
-                sectionsSettingsContentView
-            } header: {
-                Text(UserText.newTabPageSettingsSectionsHeaderTitle)
-                    .if(withFrameUpdates) {
-                        $0.onFrameUpdate(in: Constant.scrollCoordinateSpace, using: FirstSectionFrameKey.self) { frame in
-                            self.firstSectionFrame = frame
-                            updateListHeight()
-                        }
-                    }
-            } footer: {
-                Text(UserText.newTabPageSettingsSectionsDescription)
-            }
-
-            if sectionsSettingsModel.enabledItems.contains(.shortcuts) {
+    private func sectionsList(withFrameUpdates: Bool, geometry: GeometryProxy? = nil) -> some View {
+            List {
                 Section {
+                    sectionsSettingsContentView
                 } header: {
-                    Text(UserText.newTabPageSettingsShortcutsHeaderTitle)
-                        .if(withFrameUpdates) {
-                            $0.onFrameUpdate(in: Constant.scrollCoordinateSpace, using: LastSectionFrameKey.self) { frame in
-                                self.lastSectionFrame = frame
-                                updateListHeight()
-                            }
-                        }
+                    Text(UserText.newTabPageSettingsSectionsHeaderTitle)
+                } footer: {
+                    Text(UserText.newTabPageSettingsSectionsDescription)
+                }
+
+                if sectionsSettingsModel.enabledItems.contains(.shortcuts) {
+                    Section {
+                    } header: {
+                        Text(UserText.newTabPageSettingsShortcutsHeaderTitle)
+                    } footer: {
+                        Rectangle().fill(.clear).frame(minHeight: 0.1)
+                    }
+                    .anchorPreference(key: ListBottomKey.self, value: .bottom, transform: { anchor in
+                        let y = geometry?[anchor].y ?? 0
+                        return y
+                    })
                 }
             }
-        }
-        .applyInsetGroupedListStyle()
-        .environment(\.editMode, .constant(.active))
+            .onPreferenceChange(ListBottomKey.self, perform: { position in
+                guard self.listHeight == Metrics.initialListHeight else { return }
+
+                self.listHeight = max(0, position)
+            })
+            .applyInsetGroupedListStyle()
+            .environment(\.editMode, .constant(.active))
     }
 
     @ViewBuilder
@@ -120,25 +117,26 @@ struct NewTabPageSettingsView: View {
             sectionsSettingsModel.moveItems(from: indices, to: newOffset)
         })
     }
-
-    // MARK: -
-
-    private func updateListHeight() {
-        guard firstSectionFrame != .zero, lastSectionFrame != .zero else { return }
-
-        let newHeight = lastSectionFrame.maxY - firstSectionFrame.minY + Metrics.defaultListTopPadding
-        self.listHeight = max(0, newHeight)
-    }
 }
 
 private struct Constant {
     static let scrollCoordinateSpaceName = "Scroll"
-    static let scrollCoordinateSpace = CoordinateSpace.named(scrollCoordinateSpaceName)
+}
+
+private extension CoordinateSpace {
+    static let scroll = CoordinateSpace.named(Constant.scrollCoordinateSpaceName)
 }
 
 private struct Metrics {
-    static let defaultListTopPadding = 24.0
     static let horizontalPadding = 16.0
+    static let initialListHeight = 5000.0
+}
+
+private struct ListBottomKey: PreferenceKey {
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+    static var defaultValue: CGFloat = Metrics.initialListHeight
 }
 
 #Preview {
@@ -148,18 +146,4 @@ private struct Metrics {
             sectionsSettingsModel: NewTabPageSectionsSettingsModel()
         )
     }
-}
-
-private struct FirstSectionFrameKey: PreferenceKey {
-    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
-        value = nextValue()
-    }
-    static var defaultValue: CGRect = .zero
-}
-
-private struct LastSectionFrameKey: PreferenceKey {
-    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
-        value = nextValue()
-    }
-    static var defaultValue: CGRect = .zero
 }

--- a/DuckDuckGo/ShortcutAccessoryView.swift
+++ b/DuckDuckGo/ShortcutAccessoryView.swift
@@ -22,6 +22,7 @@ import SwiftUI
 struct ShortcutAccessoryView: View {
 
     let accessoryType: ShortcutAccessoryType
+    let expectedSize: CGSize
 
     var body: some View {
         Circle()
@@ -32,6 +33,13 @@ struct ShortcutAccessoryView: View {
                     .aspectRatio(contentMode: .fit)
             }
             .shadow(color: .shade(0.15), radius: 1, y: 1)
+            .frame(width: expectedSize.width, height: expectedSize.height)
+    }
+}
+
+extension ShortcutAccessoryView {
+    init(accessoryType: ShortcutAccessoryType) {
+        self.init(accessoryType: accessoryType, expectedSize: CGSize(width: 24, height: 24))
     }
 }
 

--- a/DuckDuckGo/ShortcutItemView.swift
+++ b/DuckDuckGo/ShortcutItemView.swift
@@ -27,13 +27,13 @@ struct ShortcutItemView: View {
     var body: some View {
         VStack(spacing: 6) {
             ShortcutIconView(shortcut: shortcut)
-            .overlay(alignment: .topTrailing) {
-                if let accessoryType {
-                    ShortcutAccessoryView(accessoryType: accessoryType)
-                        .frame(width: Constant.accessorySize)
-                        .offset(Constant.accessoryOffset)
+                .overlay(alignment: .topTrailing) {
+                    if let accessoryType {
+                        ShortcutAccessoryView(accessoryType: accessoryType)
+                            .alignedForOverlay(edgeSize: Constant.accessorySize)
+                    }
                 }
-            }
+
             Text(shortcut.name)
                 .font(Font.system(size: 12))
                 .lineLimit(2)
@@ -45,7 +45,6 @@ struct ShortcutItemView: View {
 
     private enum Constant {
         static let accessorySize = 24.0
-        static let accessoryOffset = CGSize(width: 6, height: -6)
     }
 }
 
@@ -95,6 +94,21 @@ private extension NewTabPageShortcut {
             return .downloadsColor32
         case .settings:
             return .settingsColor32
+        }
+    }
+}
+
+private extension ShortcutAccessoryView {
+    @ViewBuilder func alignedForOverlay(edgeSize: CGFloat) -> some View {
+        let offset = CGSize(width: edgeSize/4.0, height: -edgeSize/4.0)
+        let size = CGSize(width: edgeSize, height: edgeSize)
+        
+        if #available(iOS 16, *) {
+            frame(width: edgeSize)
+                .offset(offset)
+        } else {
+            frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            .offset(offset)
         }
     }
 }

--- a/DuckDuckGo/ViewExtension.swift
+++ b/DuckDuckGo/ViewExtension.swift
@@ -35,16 +35,13 @@ extension View {
 }
 
 extension View {
-    /// Disables scroll in a backwards-compatible way. 
-    ///
-    /// Keep in mind fallback version may have unforeseen consequences.
-    /// Verify if it does not break anything else for you.
+    /// Disables scroll if allowed by system version
     @ViewBuilder
-    func withoutScroll() -> some View {
+    func withoutScroll(_ isScrollDisabled: Bool = true) -> some View {
         if #available(iOS 16, *) {
-            scrollDisabled(true)
+            scrollDisabled(isScrollDisabled)
         } else {
-            gesture(DragGesture(minimumDistance: 0, coordinateSpace: .local), including: .gesture)
+            self
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207977496450588/f
Tech Design URL:
CC:

**Description**:

This PR fixes a bunch of UI issues I've found while running the app on iOS 15, namely:
* Alignment of editing accessory was out of place, because of differences in sizing inside an overlay (https://github.com/duckduckgo/iOS/pull/3198/commits/c298f22784fa6d58d95bc9c2e0a4f7a16ba414f3).
* List height was not calculated properly with previous approach. I used anchorPreferences which seems to be more reliable at converting into another coordinate space. (https://github.com/duckduckgo/iOS/pull/3198/commits/29387e7bf39ab324e4cbfab163edb76d189679f4)
* Leading insets on editable list were weirdly big. (https://github.com/duckduckgo/iOS/pull/3198/commits/2ee12806de5d4e02a8d4f1a047dab7b9f8c7a07a)
* Tint color was not applied for switch in NTP settings view. (https://github.com/duckduckgo/iOS/pull/3198/commits/66c5888a84a7f4beb6c7df66c7e5dc1d813ff62e)
* Adding a gesture to disable scroll had a side effect of disabling all editing interactions. Decided to leave the scroll enabled for iOS 15, since I haven't found any other solution that works reliably inside `NavigationView`. (https://github.com/duckduckgo/iOS/pull/3198/commits/53dc2558a23df820ed6f33f051227cc4d5573e42)

**Steps to test this PR**:
1. Verify issues mentioned in the description are not present on iOS 15
2. Check UI looks properly on iOS 16+

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
