### PR TITLE
Show improved Dax onboarding on New Tab Page

### DIFF
--- a/DuckDuckGo/HomeViewController+DaxDialogs.swift
+++ b/DuckDuckGo/HomeViewController+DaxDialogs.swift
@@ -67,16 +67,17 @@ extension HomeViewController {
         hostingController = UIHostingController(rootView: daxDialogView)
         guard let hostingController else { return }
         hostingController.view.backgroundColor = .clear
+        addChild(hostingController)
         view.addSubview(hostingController.view)
-        hostingController.didMove(toParent: self)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        hideLogo()
         NSLayoutConstraint.activate([
             hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
             hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+        hostingController.didMove(toParent: self)
+        hideLogo()
         configureCollectionView()
     }
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -765,13 +765,17 @@ class MainViewController: UIViewController {
             fatalError("No tab model")
         }
 
+        let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, contextualOnboardingLogic: DaxDialogs.shared)
         if homeTabManager.isNewTabPageSectionsEnabled {
             let controller = NewTabPageViewController(tab: tabModel,
                                                       interactionModel: favoritesViewModel,
                                                       syncService: syncService,
                                                       syncBookmarksAdapter: syncDataProviders.bookmarksAdapter,
                                                       homePageMessagesConfiguration: homePageConfiguration,
-                                                      privacyProDataReporting: privacyProDataReporter)
+                                                      privacyProDataReporting: privacyProDataReporter,
+                                                      variantManager: variantManager,
+                                                      newTabDialogFactory: newTabDaxDialogFactory,
+                                                      newTabDialogTypeProvider: DaxDialogs.shared)
 
             controller.delegate = self
             controller.shortcutsDelegate = self
@@ -782,7 +786,6 @@ class MainViewController: UIViewController {
             viewCoordinator.logoContainer.isHidden = true
             adjustNewTabPageSafeAreaInsets(for: appSettings.currentAddressBarPosition)
         } else {
-            let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, contextualOnboardingLogic: DaxDialogs.shared)
             let homePageDependencies = HomePageDependencies(homePageConfiguration: homePageConfiguration,
                                                             model: tabModel,
                                                             favoritesViewModel: favoritesViewModel,

--- a/DuckDuckGo/NewTabPageModel.swift
+++ b/DuckDuckGo/NewTabPageModel.swift
@@ -22,6 +22,7 @@ import Foundation
 final class NewTabPageModel: ObservableObject {
 
     @Published private(set) var isIntroMessageVisible: Bool
+    @Published private(set) var isOnboarding: Bool
 
     private let appSettings: AppSettings
 
@@ -29,6 +30,7 @@ final class NewTabPageModel: ObservableObject {
         self.appSettings = appSettings
         
         isIntroMessageVisible = appSettings.newTabPageIntroMessageEnabled ?? false
+        isOnboarding = false
     }
 
     func increaseIntroMessageCounter() {
@@ -41,5 +43,13 @@ final class NewTabPageModel: ObservableObject {
     func dismissIntroMessage() {
         appSettings.newTabPageIntroMessageEnabled = false
         isIntroMessageVisible = false
+    }
+
+    func startOnboarding() {
+        isOnboarding = true
+    }
+
+    func finishOnboarding() {
+        isOnboarding = false
     }
 }

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -115,7 +115,7 @@ struct NewTabPageView<FavoritesModelType: FavoritesModel>: View {
         !shortcutsSettingsModel.enabledItems.isEmpty
     }
 
-    var body: some View {
+    private var mainView: some View {
         GeometryReader { proxy in
             ScrollView {
                 VStack {
@@ -158,9 +158,15 @@ struct NewTabPageView<FavoritesModelType: FavoritesModel>: View {
         }, content: {
             NavigationView {
                 NewTabPageSettingsView(shortcutsSettingsModel: shortcutsSettingsModel,
-                                          sectionsSettingsModel: sectionsSettingsModel)
+                                       sectionsSettingsModel: sectionsSettingsModel)
             }
         })
+    }
+
+    var body: some View {
+        if !newTabPageModel.isOnboarding {
+            mainView
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207981662892269/f
Tech Design URL:
CC: @alessandroboron @SabrinaTardio 

**Description**:

Integration of the new (improved) onboarding with New Tab Page. Previous Dax onboarding is not integrated since it will be removed after the experiment. NTP will start to roll out after the onboarding experiment is concluded.

**Steps to test this PR**:
1. Edit `DefaultVariantManager` so `.newOnboardingIntro` is always enabled.
2. Edit `NewTabPageManager.isNewTabPageSectionsEnabled` so it returns `true`.
3. Do a clean install and go through onboarding, verify if it looks as expected.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
