### PR TITLE
Break DuckPlayer ref cycle

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckNavigationHandling.swift
+++ b/DuckDuckGo/DuckPlayer/DuckNavigationHandling.swift
@@ -19,7 +19,7 @@
 
 import WebKit
 
-protocol DuckNavigationHandling {
+protocol DuckNavigationHandling: AnyObject {
     var referrer: DuckPlayerReferrer { get set }
     var duckPlayer: DuckPlayerProtocol { get }
     func handleNavigation(_ navigationAction: WKNavigationAction, webView: WKWebView)

--- a/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -78,7 +78,7 @@ public enum DuckPlayerReferrer {
     case youtube, other
 }
 
-protocol DuckPlayerProtocol {
+protocol DuckPlayerProtocol: AnyObject {
     
     var settings: DuckPlayerSettingsProtocol { get }
     var hostView: UIViewController? { get }

--- a/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -103,7 +103,7 @@ final class DuckPlayer: DuckPlayerProtocol {
     static let commonName = "Duck Player"
         
     private(set) var settings: DuckPlayerSettingsProtocol
-    private(set) var hostView: UIViewController?
+    private(set) weak var hostView: UIViewController?
     
     init(settings: DuckPlayerSettingsProtocol = DuckPlayerSettings()) {
         self.settings = settings

--- a/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
@@ -64,7 +64,7 @@ enum DuckPlayerMode: Equatable, Codable, CustomStringConvertible, CaseIterable {
     }
 }
 
-protocol DuckPlayerSettingsProtocol {
+protocol DuckPlayerSettingsProtocol: AnyObject {
     
     var duckPlayerSettingsPublisher: AnyPublisher<Void, Never> { get }
     var mode: DuckPlayerMode { get }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -294,7 +294,7 @@ class TabViewController: UIViewController {
                                    bookmarksDatabase: CoreDataDatabase,
                                    historyManager: HistoryManaging,
                                    syncService: DDGSyncing,
-                                   duckPlayer: DuckPlayerProtocol,
+                                   duckPlayer: DuckPlayerProtocol?,
                                    privacyProDataReporter: PrivacyProDataReporting,
                                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                                    contextualOnboardingLogic: ContextualOnboardingLogic,
@@ -323,7 +323,7 @@ class TabViewController: UIViewController {
 
     let historyManager: HistoryManaging
     let historyCapture: HistoryCapture
-    var duckPlayer: DuckPlayerProtocol
+    weak var duckPlayer: DuckPlayerProtocol?
     var duckPlayerNavigationHandler: DuckNavigationHandling?
 
     let contextualOnboardingPresenter: ContextualOnboardingPresenting
@@ -336,7 +336,7 @@ class TabViewController: UIViewController {
                    bookmarksDatabase: CoreDataDatabase,
                    historyManager: HistoryManaging,
                    syncService: DDGSyncing,
-                   duckPlayer: DuckPlayerProtocol,
+                   duckPlayer: DuckPlayerProtocol?,
                    privacyProDataReporter: PrivacyProDataReporting,
                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                    contextualOnboardingLogic: ContextualOnboardingLogic,
@@ -348,7 +348,9 @@ class TabViewController: UIViewController {
         self.historyCapture = HistoryCapture(historyManager: historyManager)
         self.syncService = syncService
         self.duckPlayer = duckPlayer
-        self.duckPlayerNavigationHandler = DuckPlayerNavigationHandler(duckPlayer: duckPlayer)
+        if let duckPlayer {
+            self.duckPlayerNavigationHandler = DuckPlayerNavigationHandler(duckPlayer: duckPlayer)
+        }
         self.privacyProDataReporter = privacyProDataReporter
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
         self.contextualOnboardingLogic = contextualOnboardingLogic


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207998631270910/f

**Description**:
Breaks reference cycle between DuckPlayer and TabViewController, which can contribute to containers not being properly cleaned up

**Steps to test this PR**:
1.  Fire up the app, navigate away
2. Check Memory Graph, confirm the duckPlayer property in TabViewController is now a weak reference,
3. Fire button everything.  
4. There should not be leftovers.
