### PR TITLE
Fix PrivacyProDataReporter crash due to premature secure vault use

### DIFF
--- a/DuckDuckGoTests/Subscription/PrivacyProDataReporterTests.swift
+++ b/DuckDuckGoTests/Subscription/PrivacyProDataReporterTests.swift
@@ -69,7 +69,9 @@ final class PrivacyProDataReporterTests: XCTestCase {
             tutorialSettings: MockTutorialSettings(hasSeenOnboarding: false),
             appSettings: AppSettingsMock(),
             statisticsStore: statisticsStore,
-            secureVault: nil,
+            featureFlagger: MockFeatureFlagger(),
+            autofillCheck: { true },
+            secureVaultMaker: { nil },
             tabsModel: TabsModel(tabs: [], desktop: false),
             dateGenerator: mockCalendar.now
         )
@@ -80,7 +82,9 @@ final class PrivacyProDataReporterTests: XCTestCase {
             emailManager: EmailManager(storage: MockEmailStorage.anotherMock),
             tutorialSettings: MockTutorialSettings(hasSeenOnboarding: true),
             appSettings: AppSettingsMock.mockWithWidget,
-            secureVault: nil,
+            featureFlagger: MockFeatureFlagger(),
+            autofillCheck: { true },
+            secureVaultMaker: { nil },
             tabsModel: TabsModel(tabs: [Tab(), Tab(), Tab(), Tab()], desktop: false)
         )
     }
@@ -219,5 +223,11 @@ class MockCalendar {
 
     func now() -> Date {
         date
+    }
+}
+
+struct MockFeatureFlagger: FeatureFlagger {
+    func isFeatureOn<F>(forProvider: F) -> Bool where F: FeatureFlagSourceProviding {
+        false
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1207998804540584/f
Tech Design URL:
CC:

**Description**:

This updates the reporter to mimic `FireproofFaviconUpdater` behaviour, so that the secure vault is only initialized when used.

**Steps to test this PR**:
1. Go to Debug > Subscription > Show randomized params
2. The count next to autofill should correspond to the number of saved passwords in your vault
3. If the count > 10, the associated bool should be true, and false otherwise

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
