### PR TITLE
DuckPlayer contingency messages pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -744,6 +744,8 @@ extension Pixel {
         case duckPlayerSettingNeverSettings
         case duckPlayerSettingBackToDefault
         case duckPlayerWatchOnYoutube
+        case duckPlayerContingencySettingsDisplayed
+        case duckPlayerContingencyLearnMoreClicked
     }
 
 }
@@ -1476,6 +1478,8 @@ extension Pixel.Event {
         case .duckPlayerSettingNeverSettings: return "m_duck-player_setting_never_settings"
         case .duckPlayerSettingBackToDefault: return "m_duck-player_setting_back-to-default"
         case .duckPlayerWatchOnYoutube: return "m_duck-player_watch_on_youtube"
+        case .duckPlayerContingencySettingsDisplayed: return "duckplayer_ios_contingency_settings-displayed"
+        case .duckPlayerContingencyLearnMoreClicked: return "duckplayer_ios_contingency_learn-more-clicked"
         }
     }
 }

--- a/DuckDuckGo/SettingsDuckPlayerView.swift
+++ b/DuckDuckGo/SettingsDuckPlayerView.swift
@@ -25,6 +25,10 @@ import DuckUI
 struct SettingsDuckPlayerView: View {
     private static let learnMoreURL = URL(string: "https://duckduckgo.com/duckduckgo-help-pages/duck-player/")!
 
+    /// The ContingencyMessageView may be redrawn multiple times in the onAppear method if the user scrolls it outside the list bounds.
+    /// This property ensures that the associated action is only triggered once per viewing session, preventing redundant executions.
+    @State private var hasFiredSettingsDisplayedPixel = false
+
     @EnvironmentObject var viewModel: SettingsViewModel
     var body: some View {
         List {
@@ -32,6 +36,11 @@ struct SettingsDuckPlayerView: View {
                 Section {
                     ContingencyMessageView {
                         viewModel.openDuckPlayerContingencyMessageSite()
+                    }.onAppear {
+                        if !hasFiredSettingsDisplayedPixel {
+                            Pixel.fire(pixel: .duckPlayerContingencySettingsDisplayed)
+                            hasFiredSettingsDisplayedPixel = true
+                        }
                     }
                 }
             }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -547,8 +547,8 @@ extension SettingsViewModel {
     }
 
     func openDuckPlayerContingencyMessageSite() {
-        Pixel.fire(pixel: .duckPlayerContingencyLearnMoreClicked)
         guard let url = duckPlayerContingencyHandler.learnMoreURL else { return }
+        Pixel.fire(pixel: .duckPlayerContingencyLearnMoreClicked)
         UIApplication.shared.open(url,
                                   options: [:],
                                   completionHandler: nil)

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -547,6 +547,7 @@ extension SettingsViewModel {
     }
 
     func openDuckPlayerContingencyMessageSite() {
+        Pixel.fire(pixel: .duckPlayerContingencyLearnMoreClicked)
         guard let url = duckPlayerContingencyHandler.learnMoreURL else { return }
         UIApplication.shared.open(url,
                                   options: [:],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1208023423226059/f

**Description**:
Add pixels for contingency message on duck player

**Steps to test this PR**:
1. Display the contingency message with the steps in https://github.com/duckduckgo/iOS/pull/3190
2. See if the pixels are fired when UI is shown and when the learn more button is tapped

