### PR TITLE
Fix AppUserDefaultsTests

### DIFF
--- a/DuckDuckGoTests/AppUserDefaultsTests.swift
+++ b/DuckDuckGoTests/AppUserDefaultsTests.swift
@@ -108,11 +108,13 @@ class AppUserDefaultsTests: XCTestCase {
 
     func testDefaultAutofillStateIsFalse() {
         let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = createFeatureFlagger(withSubfeatureEnabled: false)
         XCTAssertFalse(appUserDefaults.autofillCredentialsEnabled)
     }
 
     func testWhenAutofillCredentialsIsDisabledAndHasNotBeenTurnedOnAutomaticallyBeforeWhenSavePromptShownThenDefaultAutofillStateIsFalse() {
         let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = createFeatureFlagger(withSubfeatureEnabled: false)
         appUserDefaults.autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary = false
         appUserDefaults.autofillCredentialsSavePromptShowAtLeastOnce = true
 
@@ -121,6 +123,7 @@ class AppUserDefaultsTests: XCTestCase {
 
     func testWhenAutofillCredentialsIsDisabledAndHasNotBeenTurnedOnAutomaticallyBeforeAndPromptHasNotBeenSeenAndIsNotNewInstallThenDefaultAutofillStateIsFalse() {
         let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = createFeatureFlagger(withSubfeatureEnabled: false)
         appUserDefaults.autofillCredentialsHasBeenEnabledAutomaticallyIfNecessary = false
         appUserDefaults.autofillCredentialsSavePromptShowAtLeastOnce = false
         appUserDefaults.autofillIsNewInstallForOnByDefault = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205237866452338/1208035684471701/f


**Description**:

Tests are broken because of a feature flag rollout. I've mocked the feature flagger to fix.

**Steps to test this PR**:
1. Just CI

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
