### PR TITLE
Sync test: check the status of unified favs before toggling

### DIFF
--- a/.maestro/shared/sync_verify_unified_favorites.yaml
+++ b/.maestro/shared/sync_verify_unified_favorites.yaml
@@ -4,9 +4,15 @@ appId: com.duckduckgo.mobile.ios
 - tapOn: Sync & Backup
 - scroll
 - assertVisible: Unify Favorites Across Devices
-- tapOn:
-     rightOf: 
-      id: "UnifiedFavoritesToggle"
+- runFlow: # TODO: Remove this! This was added to validate an hypothesis about some flacky tests. If this test doesn't fail anymore, we need to investigate why the toggle is already enabled when the test starts.
+    when:
+      visible: # Check that UnifiedFavoritesToggle is off
+        text: "0" 
+        index: 1 
+    commands:
+        - tapOn:
+            rightOf: 
+              id: "UnifiedFavoritesToggle"
 - tapOn: Settings
 - tapOn: Done
 - tapOn: Bookmarks


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204165176092271/1208016612344540/f
Tech Design URL:
CC:

**Description**:
I've seen this test to fail randomly over time. Looking at logs/recordings, I think the problem is that the unified favorites toggle is not in the expected state at the start of the test. I couldn't find a straightforward reason for that, but my hypothesis is that it's related to how we run the tests in parallel. 
This PR should fix the immediate flakiness of the test and, at the same time, validate my hypothesis. 
I have a follow up task to investigate more in depth when I'm back if the hypothesis is validated in the meantime.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the test locally and validate it passes. 
2. Validate CI is green (This is the last action run: https://github.com/duckduckgo/iOS/actions/runs/10353979645)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
