### PR TITLE
[DuckPlayer] 21. Allow First video

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "c3ae1865ba36ebbcb5451a836424213ea875d135",
-        "version" : "183.0.0"
+        "revision" : "b7f595594d9e5d8500a93704d36a5521553bd314",
+        "version" : "184.0.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/DesignResourcesKit",
       "state" : {
-        "revision" : "ae83941bb277a2750abc2d6697fa278f8c8c5f5e",
-        "version" : "3.0.0"
+        "revision" : "fe3c383b5e21e0a419e0f979f7f2cd4e67385b15",
+        "version" : "3.2.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "9fea1c6762db726328b14bb9ebfd6508849eae28",
-        "version" : "12.1.0"
+        "revision" : "1f12b78d9bac4a1d9b6bad18dc2ef0593bed34a3",
+        "version" : "13.0.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "b7f595594d9e5d8500a93704d36a5521553bd314",
-        "version" : "184.0.1"
+        "revision" : "c3ae1865ba36ebbcb5451a836424213ea875d135",
+        "version" : "183.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/DesignResourcesKit",
       "state" : {
-        "revision" : "fe3c383b5e21e0a419e0f979f7f2cd4e67385b15",
-        "version" : "3.2.0"
+        "revision" : "ae83941bb277a2750abc2d6697fa278f8c8c5f5e",
+        "version" : "3.0.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "1f12b78d9bac4a1d9b6bad18dc2ef0593bed34a3",
-        "version" : "13.0.0"
+        "revision" : "9fea1c6762db726328b14bb9ebfd6508849eae28",
+        "version" : "12.1.0"
       }
     },
     {

--- a/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -54,6 +54,7 @@ struct InitialPlayerSettings: Codable {
     }
 
     let userValues: UserValues
+    let ui: UIValues
     let settings: PlayerSettings
     let platform: Platform
     let locale: Locale
@@ -67,6 +68,13 @@ public struct UserValues: Codable {
     }
     let duckPlayerMode: DuckPlayerMode
     let askModeOverlayHidden: Bool
+}
+
+public struct UIValues: Codable {
+    enum CodingKeys: String, CodingKey {
+        case allowFirstVideo = "allowFirstVideo"
+    }
+    let allowFirstVideo: Bool
 }
 
 public enum DuckPlayerReferrer {
@@ -193,6 +201,12 @@ final class DuckPlayer: DuckPlayerProtocol {
             askModeOverlayHidden: settings.askModeOverlayHidden
         )
     }
+    
+    private func encodeUIValues() -> UIValues {
+        UIValues(
+            allowFirstVideo: settings.allowFirstVideo
+        )
+    }
 
     @MainActor
     private func encodedPlayerSettings(with webView: WKWebView?) async -> InitialPlayerSettings {
@@ -203,7 +217,12 @@ final class DuckPlayer: DuckPlayerProtocol {
         let locale = InitialPlayerSettings.Locale.en
         let playerSettings = InitialPlayerSettings.PlayerSettings(pip: pip)
         let userValues = encodeUserValues()
-        return InitialPlayerSettings(userValues: userValues, settings: playerSettings, platform: platform, locale: locale)
+        let uiValues = encodeUIValues()
+        return InitialPlayerSettings(userValues: userValues,
+                                           ui: uiValues,
+                                           settings: playerSettings,
+                                           platform: platform,
+                                           locale: locale)
     }
         
     // Accessing WKMessage needs main thread

--- a/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -72,7 +72,7 @@ public struct UserValues: Codable {
 
 public struct UIValues: Codable {
     enum CodingKeys: String, CodingKey {
-        case allowFirstVideo = "allowFirstVideo"
+        case allowFirstVideo
     }
     let allowFirstVideo: Bool
 }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -108,6 +108,9 @@ final class DuckPlayerNavigationHandler {
             return
         }
         
+        // This setting allows the FE to skip showing the overlay on some videos
+        duckPlayer.settings.allowFirstVideo = false
+        
         if let (videoID, _) = url.youtubeVideoParams,
             videoID == lastHandledVideoID {
             os_log("DP: URL (%s) already handled, skipping", log: .duckPlayerLog, type: .debug, url.absoluteString)
@@ -118,7 +121,8 @@ final class DuckPlayerNavigationHandler {
          // These should not be handled by DuckPlayer
         if url.isYoutubeVideo,
             url.hasWatchInYoutubeQueryParameter {
-                 return
+                duckPlayer.settings.allowFirstVideo = true
+            return
          }
                 
         if url.isYoutubeVideo,
@@ -143,6 +147,9 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
         
         os_log("DP: Handling DuckPlayer Player Navigation for %s", log: .duckPlayerLog, type: .debug, navigationAction.request.url?.absoluteString ?? "")
        
+        // This setting allows the FE to skip showing the overlay on some videos
+        duckPlayer.settings.allowFirstVideo = false
+        
         guard let url = navigationAction.request.url else { return }
         
         guard featureFlagger.isFeatureOn(.duckPlayer) else {
@@ -167,6 +174,8 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
                 if let videoParameterItem = queryItems.first(where: { $0.name == Constants.watchInYoutubeVideoParameter }),
                    let id = videoParameterItem.value,
                     let newURL = URL.youtube(id, timestamp: nil).addingWatchInYoutubeQueryParameter() {
+                        // These links should always skip the overlay
+                        duckPlayer.settings.allowFirstVideo = true
                         Pixel.fire(pixel: Pixel.Event.duckPlayerWatchOnYoutube)
                         webView.load(URLRequest(url: newURL))
                         return
@@ -220,6 +229,9 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
             return
         }
         
+        // This setting allows the FE to skip showing the overlay on some videos
+        duckPlayer.settings.allowFirstVideo = false
+        
         if let (videoID, _) = url.youtubeVideoParams,
            videoID == lastHandledVideoID,
             !url.hasWatchInYoutubeQueryParameter {
@@ -229,9 +241,10 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
         }
         
          // Handle Youtube internal links like "Age restricted" and "Copyright restricted" videos
-         // These should not be handled by DuckPlayer
+         // These should not be handled by DuckPlayer and not include overlays
          if url.isYoutubeVideo,
             url.hasWatchInYoutubeQueryParameter {
+                duckPlayer.settings.allowFirstVideo = true
                 completion(.allow)
                 return
          }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -108,7 +108,7 @@ final class DuckPlayerNavigationHandler {
             return
         }
         
-        // This setting allows the FE to skip showing the overlay on some videos
+        // This is passed to the FE overlay at init to disable the overlay for one video
         duckPlayer.settings.allowFirstVideo = false
         
         if let (videoID, _) = url.youtubeVideoParams,
@@ -147,7 +147,7 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
         
         os_log("DP: Handling DuckPlayer Player Navigation for %s", log: .duckPlayerLog, type: .debug, navigationAction.request.url?.absoluteString ?? "")
        
-        // This setting allows the FE to skip showing the overlay on some videos
+        // This is passed to the FE overlay at init to disable the overlay for one video
         duckPlayer.settings.allowFirstVideo = false
         
         guard let url = navigationAction.request.url else { return }
@@ -229,7 +229,7 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
             return
         }
         
-        // This setting allows the FE to skip showing the overlay on some videos
+        // This is passed to the FE overlay at init to disable the overlay for one video
         duckPlayer.settings.allowFirstVideo = false
         
         if let (videoID, _) = url.youtubeVideoParams,

--- a/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
@@ -69,6 +69,7 @@ protocol DuckPlayerSettingsProtocol: AnyObject {
     var duckPlayerSettingsPublisher: AnyPublisher<Void, Never> { get }
     var mode: DuckPlayerMode { get }
     var askModeOverlayHidden: Bool { get }
+    var allowFirstVideo: Bool { get set }
     
     init(appSettings: AppSettings, privacyConfigManager: PrivacyConfigurationManaging)
     
@@ -132,6 +133,8 @@ final class DuckPlayerSettings: DuckPlayerSettingsProtocol {
             return false
         }
     }
+    
+    var allowFirstVideo: Bool = false
     
     private func registerConfigPublisher() {
         isFeatureEnabledCancellable = privacyConfigManager.updatesPublisher

--- a/DuckDuckGo/DuckPlayer/YoutubeOverlayUserScript.swift
+++ b/DuckDuckGo/DuckPlayer/YoutubeOverlayUserScript.swift
@@ -87,6 +87,7 @@ final class YoutubeOverlayUserScript: NSObject, Subfeature {
     weak var webView: WKWebView?
     
     let messageOriginPolicy: MessageOriginPolicy = .only(rules: [
+        .exact(hostname: "sosbourne.duckduckgo.com"),
         .exact(hostname: DuckPlayerSettings.OriginDomains.duckduckgo),
         .exact(hostname: DuckPlayerSettings.OriginDomains.youtube),
         .exact(hostname: DuckPlayerSettings.OriginDomains.youtubeMobile)

--- a/DuckDuckGoTests/DuckPlayerMocks.swift
+++ b/DuckDuckGoTests/DuckPlayerMocks.swift
@@ -95,6 +95,7 @@ final class MockDuckPlayerSettings: DuckPlayerSettingsProtocol {
     
     var mode: DuckPlayerMode = .disabled
     var askModeOverlayHidden: Bool = false
+    var allowFirstVideo: Bool = false
     
     init(appSettings: AppSettings = AppSettingsMock(), privacyConfigManager: any BrowserServicesKit.PrivacyConfigurationManaging) {}
     func triggerNotification() {}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:  https://app.asana.com/0/1204099484721401/1208057529481154/f
**Description**:
Do not show the video overlays when navigating to YouTube via "Watch in YouTube" links.  
<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make yourself internal user 
-- All Debug Options > Internal User state
2. Add a custom Privacy config. 
--  All Debug Options > Configurations URL.
--  Tap in the first item, and paste the following URL: https://jsonblob.com/api/1253721903368888320
3. Close and re-open settings
4. Confirm DuckPlayer is in "Ask every time" mode
5. Navigate to a Youtube video and when presented with the overlay, tap "Turn On Duck Player" (Do not enable "remember my choice)
6. Once in DuckPlayer, tap the "Watch in Youtube" button
7. Confirm the video loads in Youtube and there is no overlay
8. Refresh the page and confirm there's still no overlay
9. Scroll down and tap another video
10. Confirm the overlay appears again

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

