### PR TITLE
Fix math expressions on address bar

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -784,6 +784,7 @@
 		B6BA95C528894A28004ABA20 /* BrowsingMenuViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6BA95C428894A28004ABA20 /* BrowsingMenuViewController.storyboard */; };
 		B6BA95E828924730004ABA20 /* JSAlertController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6BA95E728924730004ABA20 /* JSAlertController.storyboard */; };
 		B6CB93E5286445AB0090FEB4 /* Base64DownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CB93E4286445AB0090FEB4 /* Base64DownloadSession.swift */; };
+		BBFF18B12C76448100C48D7D /* QuerySubmittedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFF18B02C76448100C48D7D /* QuerySubmittedTests.swift */; };
 		BD15DB852B959CFD00821457 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD15DB842B959CFD00821457 /* BundleExtension.swift */; };
 		BD2F39EB2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2F39EA2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift */; };
 		BD862E032B30DA170073E2EE /* VPNFeedbackFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD862E022B30DA170073E2EE /* VPNFeedbackFormViewModel.swift */; };
@@ -2532,6 +2533,7 @@
 		B6CB93E4286445AB0090FEB4 /* Base64DownloadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64DownloadSession.swift; sourceTree = "<group>"; };
 		B6DFE6CF2BC7E47500A9CE59 /* SwiftLintTool.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftLintTool.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6DFE6D92BC7E61B00A9CE59 /* SwiftLintToolBundleConfiguration.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SwiftLintToolBundleConfiguration.xcconfig; sourceTree = "<group>"; };
+		BBFF18B02C76448100C48D7D /* QuerySubmittedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuerySubmittedTests.swift; sourceTree = "<group>"; };
 		BD15DB842B959CFD00821457 /* BundleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
 		BD2F39EA2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDNSSettingsView.swift; sourceTree = "<group>"; };
 		BD862E022B30DA170073E2EE /* VPNFeedbackFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNFeedbackFormViewModel.swift; sourceTree = "<group>"; };
@@ -5959,6 +5961,7 @@
 		F1D477C71F2139210031ED49 /* OmniBar */ = {
 			isa = PBXGroup;
 			children = (
+				BBFF18B02C76448100C48D7D /* QuerySubmittedTests.swift */,
 				8588026424E4209900C24AB6 /* LargeOmniBarStateTests.swift */,
 				85F20005221702F7006BB258 /* AddressDisplayHelperTests.swift */,
 				F1D477C81F2139410031ED49 /* SmallOmniBarStateTests.swift */,
@@ -7666,6 +7669,7 @@
 				56D0602F2C384F70003BAEB5 /* OnboardingSuggestedSitesProviderTests.swift in Sources */,
 				851B1283221FE65E004781BC /* ImproveOnboardingExperiment1Tests.swift in Sources */,
 				F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */,
+				BBFF18B12C76448100C48D7D /* QuerySubmittedTests.swift in Sources */,
 				9F23B8092C2BE9B700950875 /* MockURLOpener.swift in Sources */,
 				9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */,
 				F40F843728C939760081AE75 /* AutofillLoginListViewModelTests.swift in Sources */,
@@ -10579,7 +10583,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 185.1.0;
+				version = 185.1.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "8b62a829899f1e635aa91deded017ed72be0d4a1",
-        "version" : "185.1.0"
+        "revision" : "c92b86502e0ea852ea3669e7c5e06e265becb4a8",
+        "version" : "185.1.1"
       }
     },
     {

--- a/DuckDuckGoTests/QuerySubmittedTests.swift
+++ b/DuckDuckGoTests/QuerySubmittedTests.swift
@@ -1,0 +1,147 @@
+//
+//  QuerySubmittedTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Suggestions
+
+@testable import DuckDuckGo
+
+class QuerySubmittedTests: XCTestCase {
+    let mock = MockOmniBarDelegate()
+    let sut = OmniBar.loadFromXib()
+
+    override func setUp() {
+        super.setUp()
+        sut.omniDelegate = mock
+    }
+
+    override func tearDown() {
+        mock.clear()
+        super.tearDown()
+    }
+
+    func testValidAddressSubmissions() {
+        let validQueries = [
+            ("www.test.com", "http://www.test.com"),
+            ("http://example.com/path?query=123", "http://example.com/path?query=123"),
+            (" www.test.com ", "http://www.test.com")
+        ]
+
+        for (query, expected) in validQueries {
+            assertQuerySubmission(query: query, expected: expected)
+        }
+    }
+
+    func testInvalidAddressSubmissions() {
+        let invalidQueries = [
+            "16385-12228.75",
+            "invalid-url",
+            "http://[::1]:80",
+            "12345"
+        ]
+
+        for query in invalidQueries {
+            assertQuerySubmission(query: query, expected: query)
+        }
+    }
+
+    func testSuggestionSelectionCallsDelegate() {
+        mock.suggestion = .website(url: URL(string: "www.testing.com")!)
+
+        sut.onQuerySubmitted()
+
+        XCTAssertTrue(mock.wasOnOmniSuggestionSelectedCalled)
+        XCTAssertFalse(mock.wasOnOmniQuerySubmittedCalled)
+    }
+
+    func testEmptyQueryDoesNotCallDelegate() {
+        sut.textField.text = ""
+        sut.onQuerySubmitted()
+
+        XCTAssertFalse(mock.wasOnOmniQuerySubmittedCalled)
+        XCTAssertFalse(mock.wasOnOmniSuggestionSelectedCalled)
+    }
+
+    func testBlankQueryDoesNotCallDelegate() {
+        sut.textField.text = "   "
+        sut.onQuerySubmitted()
+
+        XCTAssertFalse(mock.wasOnOmniQuerySubmittedCalled)
+        XCTAssertFalse(mock.wasOnOmniSuggestionSelectedCalled)
+    }
+
+    // MARK: - Helper Methods
+
+    private func assertQuerySubmission(query: String, expected: String) {
+        sut.textField.text = query
+        sut.onQuerySubmitted()
+
+        XCTAssertEqual(mock.query, expected)
+        XCTAssertFalse(mock.wasOnOmniSuggestionSelectedCalled)
+    }
+}
+
+final class MockOmniBarDelegate: OmniBarDelegate {
+    var query: String = ""
+    var suggestion: Suggestion?
+    var wasOnOmniQuerySubmittedCalled = false
+    var wasOnOmniSuggestionSelectedCalled = false
+
+    func onOmniQuerySubmitted(_ query: String) {
+        wasOnOmniQuerySubmittedCalled = true
+        self.query = query
+    }
+
+    func onOmniSuggestionSelected(_ suggestion: Suggestion) {
+        wasOnOmniSuggestionSelectedCalled = true
+    }
+
+    func clear() {
+        query = ""
+        suggestion = nil
+        wasOnOmniQuerySubmittedCalled = false
+        wasOnOmniSuggestionSelectedCalled = false
+    }
+
+    func selectedSuggestion() -> Suggestion? {
+        return suggestion
+    }
+
+    // MARK: - Unused methods
+
+    func onEditingEnd() -> OmniBarEditingEndResult {
+        return .dismissed
+    }
+
+    func onClearPressed() {
+    }
+
+    func onEnterPressed() {
+    }
+
+    func onVoiceSearchPressed() {
+    }
+
+    func onTextFieldWillBeginEditing(_ omniBar: DuckDuckGo.OmniBar, tapped: Bool) {
+    }
+
+    func onTextFieldDidBeginEditing(_ omniBar: DuckDuckGo.OmniBar) -> Bool {
+        return false
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1208002970105121/f
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/952

**Description**:
This pull request introduces a change on how we check for valid hostnames. The current regurlar expression had an issue where some mathematical expressions where valid hostnames.

Also, following the philosophy about leaving the code a bit better when you touched it. I’ve added tests for the query submitted flow on the `OmniBar`.

This PR fixes 

**Steps to test this PR**:
1. Open the app
2. Put `16385-12228.75` in the address bar
3. This should do a search on our SERP instead of trying to open a webpage
4. Test other usual web sites URLs and check those are working.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?
