### PR TITLE
Mitigate Onboarding pixels firing with empty atb

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -100,6 +100,7 @@ import WebKit
     private var didCrashDuringCrashHandlersSetUp: Bool
 
     private let launchOptionsHandler = LaunchOptionsHandler()
+    private let onboardingPixelReporter = OnboardingPixelReporter()
 
     override init() {
         super.init()
@@ -336,7 +337,7 @@ import WebKit
                                           variantManager: variantManager,
                                           contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager),
                                           contextualOnboardingLogic: daxDialogs,
-                                          contextualOnboardingPixelReporter: OnboardingPixelReporter())
+                                          contextualOnboardingPixelReporter: onboardingPixelReporter)
 
             main.loadViewIfNeeded()
             syncErrorHandler.alertPresenter = main
@@ -500,6 +501,7 @@ import WebKit
             StatisticsLoader.shared.refreshAppRetentionAtb()
             self.fireAppLaunchPixel()
             self.reportAdAttribution()
+            self.onboardingPixelReporter.fireEnqueuedPixelsIfNeeded()
         }
         
         if appIsLaunching {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -323,6 +323,8 @@ import WebKit
 
             presentInsufficientDiskSpaceAlert()
         } else {
+            let daxDialogsFactory = ExperimentContextualDaxDialogsFactory(contextualOnboardingLogic: daxDialogs, contextualOnboardingPixelReporter: onboardingPixelReporter)
+            let contextualOnboardingPresenter = ContextualOnboardingPresenter(variantManager: variantManager, daxDialogsFactory: daxDialogsFactory)
             let main = MainViewController(bookmarksDatabase: bookmarksDatabase,
                                           bookmarksDatabaseCleaner: syncDataProviders.bookmarksAdapter.databaseCleaner,
                                           historyManager: historyManager,
@@ -335,7 +337,7 @@ import WebKit
                                           syncPausedStateManager: syncErrorHandler,
                                           privacyProDataReporter: privacyProDataReporter,
                                           variantManager: variantManager,
-                                          contextualOnboardingPresenter: ContextualOnboardingPresenter(variantManager: variantManager),
+                                          contextualOnboardingPresenter: contextualOnboardingPresenter,
                                           contextualOnboardingLogic: daxDialogs,
                                           contextualOnboardingPixelReporter: onboardingPixelReporter)
 

--- a/DuckDuckGo/DaxOnboardingViewController.swift
+++ b/DuckDuckGo/DaxOnboardingViewController.swift
@@ -54,7 +54,7 @@ class DaxOnboardingViewController: UIViewController, Onboarding {
 
     private let pixelReporting: OnboardingIntroImpressionReporting
 
-    init?(coder: NSCoder, pixelReporting: OnboardingIntroImpressionReporting = OnboardingPixelReporter()) {
+    init?(coder: NSCoder, pixelReporting: OnboardingIntroImpressionReporting) {
         self.pixelReporting = pixelReporting
         super.init(coder: coder)
     }

--- a/DuckDuckGo/MainViewController+Segues.swift
+++ b/DuckDuckGo/MainViewController+Segues.swift
@@ -35,11 +35,11 @@ extension MainViewController {
         var controller: (Onboarding & UIViewController)?
 
         if DefaultVariantManager().isSupported(feature: .newOnboardingIntro) {
-            controller = OnboardingIntroViewController()
+            controller = OnboardingIntroViewController(onboardingPixelReporter: contextualOnboardingPixelReporter)
         } else {
             let storyboard = UIStoryboard(name: "DaxOnboarding", bundle: nil)
             controller = storyboard.instantiateInitialViewController(creator: { coder in
-                DaxOnboardingViewController(coder: coder)
+                DaxOnboardingViewController(coder: coder, pixelReporting: self.contextualOnboardingPixelReporter)
             })
         }
         

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -106,7 +106,7 @@ class MainViewController: UIViewController {
     private let variantManager: VariantManager
     private let tutorialSettings: TutorialSettings
     private let contextualOnboardingLogic: ContextualOnboardingLogic
-    private let contextualOnboardingPixelReporter: OnboardingCustomInteractionPixelReporting
+    let contextualOnboardingPixelReporter: OnboardingPixelReporting
     private let statisticsStore: StatisticsStore
 
     @UserDefaultsWrapper(key: .syncDidShowSyncPausedByFeatureFlagAlert, defaultValue: false)
@@ -189,7 +189,7 @@ class MainViewController: UIViewController {
         variantManager: VariantManager,
         contextualOnboardingPresenter: ContextualOnboardingPresenting,
         contextualOnboardingLogic: ContextualOnboardingLogic,
-        contextualOnboardingPixelReporter: OnboardingCustomInteractionPixelReporting,
+        contextualOnboardingPixelReporter: OnboardingPixelReporting,
         tutorialSettings: TutorialSettings = DefaultTutorialSettings(),
         statisticsStore: StatisticsStore = StatisticsUserDefaults()
     ) {
@@ -212,7 +212,8 @@ class MainViewController: UIViewController {
                                      syncService: syncService,
                                      privacyProDataReporter: privacyProDataReporter,
                                      contextualOnboardingPresenter: contextualOnboardingPresenter,
-                                     contextualOnboardingLogic: contextualOnboardingLogic)
+                                     contextualOnboardingLogic: contextualOnboardingLogic,
+                                     onboardingPixelReporter: contextualOnboardingPixelReporter)
         self.syncPausedStateManager = syncPausedStateManager
         self.privacyProDataReporter = privacyProDataReporter
         self.homeTabManager = NewTabPageManager()
@@ -769,7 +770,7 @@ class MainViewController: UIViewController {
             fatalError("No tab model")
         }
 
-        let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, contextualOnboardingLogic: DaxDialogs.shared)
+        let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, contextualOnboardingLogic: DaxDialogs.shared, onboardingPixelReporter: contextualOnboardingPixelReporter)
         if homeTabManager.isNewTabPageSectionsEnabled {
             let controller = NewTabPageViewController(tab: tabModel,
                                                       interactionModel: favoritesViewModel,

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -194,17 +194,17 @@ struct OnboardingFinalDialog: View {
 // MARK: - Preview
 
 #Preview("Try Search") {
-    OnboardingTrySearchDialog(viewModel: OnboardingSearchSuggestionsViewModel())
+    OnboardingTrySearchDialog(viewModel: OnboardingSearchSuggestionsViewModel(pixelReporter: OnboardingPixelReporter()))
         .padding()
 }
 
 #Preview("Try Site Top") {
-    OnboardingTryVisitingSiteDialog(logoPosition: .top, viewModel: OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle))
+    OnboardingTryVisitingSiteDialog(logoPosition: .top, viewModel: OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, pixelReporter: OnboardingPixelReporter()))
         .padding()
 }
 
 #Preview("Try Site Left") {
-    OnboardingTryVisitingSiteDialog(logoPosition: .left, viewModel: OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle))
+    OnboardingTryVisitingSiteDialog(logoPosition: .left, viewModel: OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, pixelReporter: OnboardingPixelReporter()))
         .padding()
 }
 
@@ -216,7 +216,7 @@ struct OnboardingFinalDialog: View {
 }
 
 #Preview("First Search Dialog") {
-    OnboardingFirstSearchDoneDialog(shouldFollowUp: true, viewModel: OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle), gotItAction: {})
+    OnboardingFirstSearchDoneDialog(shouldFollowUp: true, viewModel: OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, pixelReporter: OnboardingPixelReporter()), gotItAction: {})
         .padding()
 }
 

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -28,12 +28,12 @@ protocol NewTabDaxDialogProvider {
 final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     private var delegate: OnboardingNavigationDelegate?
     private let contextualOnboardingLogic: ContextualOnboardingLogic
-    private let onboardingPixelReporter: OnboardingScreenImpressionReporting
+    private let onboardingPixelReporter: OnboardingPixelReporting
 
     init(
         delegate: OnboardingNavigationDelegate?,
         contextualOnboardingLogic: ContextualOnboardingLogic,
-        onboardingPixelReporter: OnboardingScreenImpressionReporting = OnboardingPixelReporter()
+        onboardingPixelReporter: OnboardingPixelReporting
     ) {
         self.delegate = delegate
         self.contextualOnboardingLogic = contextualOnboardingLogic
@@ -58,7 +58,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     }
 
     private func createInitialDialog() -> some View {
-        let viewModel = OnboardingSearchSuggestionsViewModel(delegate: delegate)
+        let viewModel = OnboardingSearchSuggestionsViewModel(pixelReporter: onboardingPixelReporter, delegate: delegate)
         return FadeInView {
             OnboardingTrySearchDialog(viewModel: viewModel)
                 .onboardingDaxDialogStyle()
@@ -70,7 +70,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     }
 
     private func createSubsequentDialog() -> some View {
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteNTPTitle, delegate: delegate)
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteNTPTitle, pixelReporter: onboardingPixelReporter, delegate: delegate)
         return FadeInView {
             OnboardingTryVisitingSiteDialog(logoPosition: .top, viewModel: viewModel)
                 .onboardingDaxDialogStyle()

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
@@ -30,9 +30,9 @@ struct OnboardingSearchSuggestionsViewModel {
     private let pixelReporter: OnboardingSearchSuggestionsPixelReporting
 
     init(
+        pixelReporter: OnboardingSearchSuggestionsPixelReporting,
         suggestedSearchesProvider: OnboardingSuggestionsItemsProviding = OnboardingSuggestedSearchesProvider(),
-        delegate: OnboardingNavigationDelegate? = nil,
-        pixelReporter: OnboardingSearchSuggestionsPixelReporting = OnboardingPixelReporter()
+        delegate: OnboardingNavigationDelegate? = nil
     ) {
         self.suggestedSearchesProvider = suggestedSearchesProvider
         self.delegate = delegate
@@ -56,9 +56,9 @@ struct OnboardingSiteSuggestionsViewModel {
 
     init(
         title: String,
+        pixelReporter: OnboardingSiteSuggestionsPixelReporting,
         suggestedSitesProvider: OnboardingSuggestionsItemsProviding = OnboardingSuggestedSitesProvider(),
-        delegate: OnboardingNavigationDelegate? = nil,
-        pixelReporter: OnboardingSiteSuggestionsPixelReporting = OnboardingPixelReporter()
+        delegate: OnboardingNavigationDelegate? = nil
     ) {
         self.title = title
         self.suggestedSitesProvider = suggestedSitesProvider

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -45,12 +45,12 @@ protocol ContextualDaxDialogsFactory {
 final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     private let contextualOnboardingLogic: ContextualOnboardingLogic
     private let contextualOnboardingSettings: ContextualOnboardingSettings
-    private let contextualOnboardingPixelReporter: OnboardingScreenImpressionReporting
+    private let contextualOnboardingPixelReporter: OnboardingPixelReporting
 
     init(
         contextualOnboardingLogic: ContextualOnboardingLogic,
         contextualOnboardingSettings: ContextualOnboardingSettings = DefaultDaxDialogsSettings(),
-        contextualOnboardingPixelReporter: OnboardingScreenImpressionReporting = OnboardingPixelReporter()
+        contextualOnboardingPixelReporter: OnboardingPixelReporting
     ) {
         self.contextualOnboardingSettings = contextualOnboardingSettings
         self.contextualOnboardingLogic = contextualOnboardingLogic
@@ -103,8 +103,8 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         afterSearchPixelEvent: Pixel.Event,
         onSizeUpdate: @escaping () -> Void
     ) -> some View {
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, delegate: delegate)
-        
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, pixelReporter: contextualOnboardingPixelReporter, delegate: delegate)
+
         // If should not show websites search after searching inform the delegate that the user dimissed the dialog, otherwise let the dialog handle it.
         let gotItAction: () -> Void = if shouldFollowUpToWebsiteSearch {
             { [weak delegate, weak self] in
@@ -125,7 +125,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     }
 
     private func tryVisitingSiteDialog(delegate: ContextualOnboardingDelegate) -> some View {
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, delegate: delegate)
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingTryASiteTitle, pixelReporter: contextualOnboardingPixelReporter, delegate: delegate)
         return OnboardingTryVisitingSiteDialog(logoPosition: .left, viewModel: viewModel)
             .onFirstAppear { [weak self] in
                 self?.contextualOnboardingPixelReporter.trackScreenImpression(event: .onboardingContextualTryVisitSiteUnique)

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
@@ -38,7 +38,7 @@ final class ContextualOnboardingPresenter: ContextualOnboardingPresenting {
 
     init(
         variantManager: VariantManager,
-        daxDialogsFactory: ContextualDaxDialogsFactory = ExperimentContextualDaxDialogsFactory(contextualOnboardingLogic: DaxDialogs.shared),
+        daxDialogsFactory: ContextualDaxDialogsFactory,
         appSettings: AppSettings = AppUserDefaults()
     ) {
         self.variantManager = variantManager

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewController.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewController.swift
@@ -23,8 +23,8 @@ final class OnboardingIntroViewController: UIHostingController<OnboardingView>, 
     weak var delegate: OnboardingDelegate?
     private let viewModel: OnboardingIntroViewModel
 
-    init() {
-        viewModel = OnboardingIntroViewModel()
+    init(onboardingPixelReporter: OnboardingPixelReporting) {
+        viewModel = OnboardingIntroViewModel(pixelReporter: onboardingPixelReporter)
         let rootView = OnboardingView(model: viewModel)
         super.init(rootView: rootView)
         

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -28,7 +28,7 @@ final class OnboardingIntroViewModel: ObservableObject {
     private let pixelReporter: OnboardingIntroPixelReporting
     private let urlOpener: URLOpener
 
-    init(pixelReporter: OnboardingIntroPixelReporting = OnboardingPixelReporter(), urlOpener: URLOpener = UIApplication.shared) {
+    init(pixelReporter: OnboardingIntroPixelReporting, urlOpener: URLOpener = UIApplication.shared) {
         self.pixelReporter = pixelReporter
         self.urlOpener = urlOpener
     }

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -191,11 +191,11 @@ private enum Metrics {
 // MARK: - Preview
 
 #Preview("Onboarding - Light") {
-    OnboardingView(model: .init())
+    OnboardingView(model: .init(pixelReporter: OnboardingPixelReporter()))
         .preferredColorScheme(.light)
 }
 
 #Preview("Onboarding - Dark") {
-    OnboardingView(model: .init())
+    OnboardingView(model: .init(pixelReporter: OnboardingPixelReporter()))
         .preferredColorScheme(.dark)
 }

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -80,6 +80,8 @@ final class OnboardingPixelReporter {
     private let userDefaults: UserDefaults
     private let siteVisitedUserDefaultsKey = "com.duckduckgo.ios.site-visited"
 
+    private(set) var enqueuedPixels: [EnqueuedPixel] = []
+
     init(
         pixel: OnboardingPixelFiring.Type = Pixel.self,
         uniquePixel: OnboardingPixelFiring.Type = UniquePixel.self,
@@ -97,6 +99,21 @@ final class OnboardingPixelReporter {
     }
 
     private func fire(event: Pixel.Event, unique: Bool, additionalParameters: [String: String] = [:], includedParameters: [Pixel.QueryParameters] = [.appVersion, .atb]) {
+        
+        func enqueue(event: Pixel.Event, unique: Bool, additionalParameters: [String: String], includedParameters: [Pixel.QueryParameters]) {
+            enqueuedPixels.append(.init(event: event, unique: unique, additionalParameters: additionalParameters, includedParameters: includedParameters))
+        }
+
+        // If the Pixel needs the ATB and ATB is available, fire the Pixel immediately. Otherwise enqueue the pixel and process it once the ATB is available.
+        // If the Pixel does not need the ATB there's no need to wait for the ATB to become available.
+        if includedParameters.contains(.atb) && statisticsStore.atb == nil {
+            enqueue(event: event, unique: unique, additionalParameters: additionalParameters, includedParameters: includedParameters)
+        } else {
+            performFire(event: event, unique: unique, additionalParameters: additionalParameters, includedParameters: includedParameters)
+        }
+    }
+
+    private func performFire(event: Pixel.Event, unique: Bool, additionalParameters: [String: String], includedParameters: [Pixel.QueryParameters]) {
         if unique {
             uniquePixel.fire(pixel: event, withAdditionalParameters: additionalParameters, includedParameters: includedParameters)
         } else {
@@ -104,6 +121,18 @@ final class OnboardingPixelReporter {
         }
     }
 
+}
+
+// MARK: - Fire Enqueued Pixels
+
+extension OnboardingPixelReporter {
+
+    func fireEnqueuedPixelsIfNeeded() {
+        while !enqueuedPixels.isEmpty {
+            let event = enqueuedPixels.removeFirst()
+            performFire(event: event.event, unique: event.unique, additionalParameters: event.additionalParameters, includedParameters: event.includedParameters)
+        }
+    }
 }
 
 // MARK: - OnboardingPixelReporter + Intro
@@ -181,4 +210,11 @@ extension OnboardingPixelReporter: OnboardingScreenImpressionReporting {
         fire(event: event, unique: true)
     }
 
+}
+
+struct EnqueuedPixel {
+    let event: Pixel.Event
+    let unique: Bool
+    let additionalParameters: [String: String]
+    let includedParameters: [Pixel.QueryParameters]
 }

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -69,6 +69,8 @@ protocol OnboardingScreenImpressionReporting {
     func trackScreenImpression(event: Pixel.Event)
 }
 
+typealias OnboardingPixelReporting = OnboardingIntroImpressionReporting & OnboardingIntroPixelReporting & OnboardingSearchSuggestionsPixelReporting & OnboardingSiteSuggestionsPixelReporting & OnboardingCustomInteractionPixelReporting & OnboardingScreenImpressionReporting
+
 // MARK: - Implementation
 
 final class OnboardingPixelReporter {

--- a/DuckDuckGo/RootDebugViewController+Onboarding.swift
+++ b/DuckDuckGo/RootDebugViewController+Onboarding.swift
@@ -22,7 +22,7 @@ import UIKit
 extension RootDebugViewController {
 
     func showOnboardingIntro() {
-        let controller = OnboardingIntroViewController()
+        let controller = OnboardingIntroViewController(onboardingPixelReporter: OnboardingPixelReporter())
         controller.delegate = self
         controller.modalPresentationStyle = .overFullScreen
         present(controller: controller, fromView: self.view)

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -39,6 +39,7 @@ class TabManager {
     private var privacyProDataReporter: PrivacyProDataReporting
     private let contextualOnboardingPresenter: ContextualOnboardingPresenting
     private let contextualOnboardingLogic: ContextualOnboardingLogic
+    private let onboardingPixelReporter: OnboardingPixelReporting
 
     weak var delegate: TabDelegate?
 
@@ -54,7 +55,8 @@ class TabManager {
          duckPlayer: DuckPlayer = DuckPlayer(),
          privacyProDataReporter: PrivacyProDataReporting,
          contextualOnboardingPresenter: ContextualOnboardingPresenting,
-         contextualOnboardingLogic: ContextualOnboardingLogic) {
+         contextualOnboardingLogic: ContextualOnboardingLogic,
+         onboardingPixelReporter: OnboardingPixelReporting) {
         self.model = model
         self.previewsSource = previewsSource
         self.bookmarksDatabase = bookmarksDatabase
@@ -64,6 +66,7 @@ class TabManager {
         self.privacyProDataReporter = privacyProDataReporter
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
         self.contextualOnboardingLogic = contextualOnboardingLogic
+        self.onboardingPixelReporter = onboardingPixelReporter
         registerForNotifications()
     }
 
@@ -83,7 +86,8 @@ class TabManager {
                                                               duckPlayer: duckPlayer,
                                                               privacyProDataReporter: privacyProDataReporter,
                                                               contextualOnboardingPresenter: contextualOnboardingPresenter,
-                                                              contextualOnboardingLogic: contextualOnboardingLogic)
+                                                              contextualOnboardingLogic: contextualOnboardingLogic,
+                                                              onboardingPixelReporter: onboardingPixelReporter)
         controller.applyInheritedAttribution(inheritedAttribution)
         controller.attachWebView(configuration: configuration,
                                  andLoadRequest: url == nil ? nil : URLRequest.userInitiated(url!),
@@ -159,7 +163,8 @@ class TabManager {
                                                               duckPlayer: duckPlayer,
                                                               privacyProDataReporter: privacyProDataReporter,
                                                               contextualOnboardingPresenter: contextualOnboardingPresenter,
-                                                              contextualOnboardingLogic: contextualOnboardingLogic)
+                                                              contextualOnboardingLogic: contextualOnboardingLogic,
+                                                              onboardingPixelReporter: onboardingPixelReporter)
         controller.attachWebView(configuration: configCopy,
                                  andLoadRequest: request,
                                  consumeCookies: !model.hasActiveTabs,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -298,7 +298,7 @@ class TabViewController: UIViewController {
                                    privacyProDataReporter: PrivacyProDataReporting,
                                    contextualOnboardingPresenter: ContextualOnboardingPresenting,
                                    contextualOnboardingLogic: ContextualOnboardingLogic,
-                                   onboardingPixelReporter: OnboardingCustomInteractionPixelReporting = OnboardingPixelReporter()) -> TabViewController {
+                                   onboardingPixelReporter: OnboardingCustomInteractionPixelReporting) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
             TabViewController(coder: coder,

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -109,7 +109,8 @@ extension TabViewController {
                                                                  duckPlayer: duckPlayer,
                                                                  privacyProDataReporter: privacyProDataReporter,
                                                                  contextualOnboardingPresenter: contextualOnboardingPresenter,
-                                                                 contextualOnboardingLogic: contextualOnboardingLogic)
+                                                                 contextualOnboardingLogic: contextualOnboardingLogic,
+                                                                 onboardingPixelReporter: onboardingPixelReporter)
         tabController.isLinkPreview = true
         let configuration = WKWebViewConfiguration.nonPersistent()
         tabController.attachWebView(configuration: configuration, andLoadRequest: URLRequest.userInitiated(url), consumeCookies: false)

--- a/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
@@ -22,6 +22,18 @@ import SwiftUI
 @testable import DuckDuckGo
 
 final class ContextualOnboardingPresenterTests: XCTestCase {
+    private var contextualDaxDialogsFactory: ExperimentContextualDaxDialogsFactory!
+
+    override func setUpWithError() throws {
+        contextualDaxDialogsFactory = ExperimentContextualDaxDialogsFactory(contextualOnboardingLogic: DaxDialogs.shared, contextualOnboardingPixelReporter: OnboardingPixelReporterMock())
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        contextualDaxDialogsFactory = nil
+        try super.tearDownWithError()
+    }
+
 
     func testWhenPresentContextualOnboardingAndVariantDoesNotSupportOnboardingIntroThenOldContextualOnboardingIsPresented() throws {
         // GIVEN
@@ -29,7 +41,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         variantManagerMock.isSupportedBlock = { feature in
             feature != .newOnboardingIntro
         }
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock)
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory)
         let parent = TabViewControllerMock()
         XCTAssertFalse(parent.didCallPerformSegue)
         XCTAssertNil(parent.capturedSegueIdentifier)
@@ -51,7 +63,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         variantManagerMock.isSupportedBlock = { feature in
             feature == .newOnboardingIntro
         }
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock)
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory)
         let parent = TabViewControllerMock()
         XCTAssertFalse(parent.didCallAddChild)
         XCTAssertNil(parent.capturedChild)
@@ -71,7 +83,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
             feature == .newOnboardingIntro
         }
         let appSettings = AppSettingsMock()
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, appSettings: appSettings)
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory, appSettings: appSettings)
         let parent = TabViewControllerMock()
 
         // WHEN
@@ -90,7 +102,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         }
         let appSettings = AppSettingsMock()
         appSettings.currentAddressBarPosition = .bottom
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, appSettings: appSettings)
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory, appSettings: appSettings)
         let parent = TabViewControllerMock()
 
         // WHEN
@@ -108,7 +120,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         variantManagerMock.isSupportedBlock = { feature in
             feature == .newOnboardingIntro
         }
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock)
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory)
         let parent = TabViewControllerMock()
         let daxController = DaxContextualOnboardingControllerMock()
         daxController.removeFromParentExpectation = expectation
@@ -136,7 +148,7 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         variantManagerMock.isSupportedBlock = { feature in
             feature != .newOnboardingIntro
         }
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock)
+        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory)
         let parent = TabViewControllerMock()
         let daxController = DaxContextualOnboardingControllerMock()
         daxController.removeFromParentExpectation = expectation

--- a/DuckDuckGoTests/OnboardingFirePixelMock.swift
+++ b/DuckDuckGoTests/OnboardingFirePixelMock.swift
@@ -48,11 +48,14 @@ final class OnboardingUniquePixelFireMock: OnboardingPixelFiring {
     static private(set) var capturedParams: [String: String] = [:]
     static private(set) var capturedIncludeParameters: [Pixel.QueryParameters] = []
 
+    static private(set) var capturedPixelEventHistory: [Pixel.Event] = []
+
     static func fire(pixel: Pixel.Event, withAdditionalParameters params: [String: String], includedParameters: [Pixel.QueryParameters]) {
         didCallFire = true
         capturedPixelEvent = pixel
         capturedParams = params
         capturedIncludeParameters = includedParameters
+        capturedPixelEventHistory.append(pixel)
     }
 
     static func tearDown() {
@@ -60,5 +63,6 @@ final class OnboardingUniquePixelFireMock: OnboardingPixelFiring {
         capturedPixelEvent = nil
         capturedParams = [:]
         capturedIncludeParameters = []
+        capturedPixelEventHistory = []
     }
 }

--- a/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -26,7 +26,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenSubscribeToViewStateThenShouldSendLanding() {
         // GIVEN
-        let sut = OnboardingIntroViewModel(urlOpener: MockURLOpener())
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingIntroPixelReporterMock(), urlOpener: MockURLOpener())
 
         // WHEN
         let result = sut.state
@@ -37,7 +37,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenOnAppearIsCalledThenViewStateChangesToStartOnboardingDialog() {
         // GIVEN
-        let sut = OnboardingIntroViewModel(urlOpener: MockURLOpener())
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingIntroPixelReporterMock(), urlOpener: MockURLOpener())
         XCTAssertEqual(sut.state, .landing)
 
         // WHEN
@@ -49,7 +49,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenStartOnboardingActionIsCalledThenViewStateChangesToBrowsersComparisonDialog() {
         // GIVEN
-        let sut = OnboardingIntroViewModel()
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingIntroPixelReporterMock())
         XCTAssertEqual(sut.state, .landing)
 
         // WHEN
@@ -62,7 +62,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
     func testWhenSetDefaultBrowserActionIsCalledThenURLOpenerOpensSettingsURL() {
         // GIVEN
         let urlOpenerMock = MockURLOpener()
-        let sut = OnboardingIntroViewModel(urlOpener: urlOpenerMock)
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingIntroPixelReporterMock(), urlOpener: urlOpenerMock)
         XCTAssertFalse(urlOpenerMock.didCallOpenURL)
         XCTAssertNil(urlOpenerMock.capturedURL)
 
@@ -77,7 +77,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
     func testWhenSetDefaultBrowserActionIsCalledThenOnCompletingOnboardingIntroIsCalled() {
         // GIVEN
         var didCallOnCompletingOnboardingIntro = false
-        let sut = OnboardingIntroViewModel(urlOpener: MockURLOpener())
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingIntroPixelReporterMock(), urlOpener: MockURLOpener())
         sut.onCompletingOnboardingIntro = {
             didCallOnCompletingOnboardingIntro = true
         }
@@ -93,7 +93,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
     func testWhenCancelSetDefaultBrowserActionIsCalledThenOnCompletingOnboardingIntroIsCalled() {
         // GIVEN
         var didCallOnCompletingOnboardingIntro = false
-        let sut = OnboardingIntroViewModel(urlOpener: MockURLOpener())
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingIntroPixelReporterMock(), urlOpener: MockURLOpener())
         sut.onCompletingOnboardingIntro = {
             didCallOnCompletingOnboardingIntro = true
         }

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -21,7 +21,11 @@ import Foundation
 import Core
 @testable import DuckDuckGo
 
-final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingScreenImpressionReporting {
+final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingScreenImpressionReporting {
+    
+    private(set) var didCallTrackOnboardingIntroImpression = false
+    private(set) var didCallTrackBrowserComparisonImpression = false
+    private(set) var didCallChooseBrowserCTAAction = false
     private(set) var didCallTrackSearchOptionTapped = false
     private(set) var didCallTrackSiteOptionTapped = false
     private(set) var didCallTrackCustomSearch = false
@@ -35,6 +39,18 @@ final class OnboardingPixelReporterMock: OnboardingSiteSuggestionsPixelReporting
     private(set) var didCallTrackScreenImpressionCalled = false
     private(set) var capturedScreenImpression: Pixel.Event?
     private(set) var didCallTrackPrivacyDashboardOpenedForFirstTime = false
+
+    func trackOnboardingIntroImpression() {
+        didCallTrackOnboardingIntroImpression = true
+    }
+
+    func trackBrowserComparisonImpression() {
+        didCallTrackBrowserComparisonImpression = true
+    }
+
+    func trackChooseBrowserCTAAction() {
+        didCallChooseBrowserCTAAction = true
+    }
 
     func trackSiteSuggetionOptionTapped() {
         didCallTrackSiteOptionTapped = true

--- a/DuckDuckGoTests/OnboardingSuggestionsViewModelsTests.swift
+++ b/DuckDuckGoTests/OnboardingSuggestionsViewModelsTests.swift
@@ -32,8 +32,8 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         suggestionsProvider = MockOnboardingSuggestionsProvider()
         navigationDelegate = CapturingOnboardingNavigationDelegate()
         pixelReporterMock = OnboardingPixelReporterMock()
-        searchSuggestionsVM = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestionsProvider, delegate: navigationDelegate, pixelReporter: pixelReporterMock)
-        siteSuggestionsVM = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestionsProvider, delegate: navigationDelegate, pixelReporter: pixelReporterMock)
+        searchSuggestionsVM = OnboardingSearchSuggestionsViewModel(pixelReporter: pixelReporterMock, suggestedSearchesProvider: suggestionsProvider, delegate: navigationDelegate)
+        siteSuggestionsVM = OnboardingSiteSuggestionsViewModel(title: "", pixelReporter: pixelReporterMock, suggestedSitesProvider: suggestionsProvider, delegate: navigationDelegate)
     }
 
     override func tearDown() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208108104325249/f

**Description**:

This PR mitigates the issue that causes onboarding Pixels to fire with an empty ATB.

I split the PR in two commits for easier review:
1. Implement the logic to enqueue and dequeue pixels when needed.
2. Inject the same instance of the OnboardingPixelReporter everywhere it is needed.

**Problem**

There is a race condition where Onboarding pixels are fired as soon the App is launched but the ATB may not be present as it is fetched from an endpoint. 

**Approach**

I modified the `OnboardingPixelReporter` to enqueue Pixels if they need to send the ATB and the ATB is not available.
In the AppDelegate when the `StatisticsLoader` `load` closure completes we ask the OnboardingPixelReporter to fire the enqueued pixels.

**Note**
This is not a bulletproof approach. Currently there’s no check for errors in `StatisticsLoader` `load` closure. If the endpoints fail we will encounter the same issue. Probably this is a broader discussion about what we should do if the ATB/EXTI endpoints fail.

**Screenshot**
After the Fix I can see the atb showing up for the first pixel sent.

<img width="1727" alt="Screenshot 2024-08-22 at 12 10 33 PM" src="https://github.com/user-attachments/assets/3a939314-1c22-45d2-b040-0a2106c73ee3">

**Steps to test this PR**:
1. Repeat this test for `mb` and `ma` variant.
2. Set `Pixel.isDryRun = false` in `AppDelegate` line 133.
3. Replace  requestInstallStatistics(completion: completion) in `StatisticsLoader` line 46 with         
```
DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
    self.requestInstallStatistics(completion: completion)
}
```
4. Launch the App.
5. Ensure that Pixel are shown in Kibana and ATB is not empty.
6. Remove changed code
7. Ensure `OboardingPixelReporter` tests are all green.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
