### PR TITLE
Pixels for new Sync promos

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -612,6 +612,14 @@ extension Pixel {
         case syncDeleteAccountError
         case syncLoginExistingAccountError
 
+        case syncGetOtherDevices
+        case syncGetOtherDevicesCopy
+        case syncGetOtherDevicesShare
+
+        case syncPromoDisplayed
+        case syncPromoConfirmed
+        case syncPromoDismissed
+
         case swipeTabsUsedDaily
         case swipeToOpenNewTab
 
@@ -1363,6 +1371,14 @@ extension Pixel.Event {
         case .syncRemoveDeviceError: return "m_d_sync_remove_device_error"
         case .syncDeleteAccountError: return "m_d_sync_delete_account_error"
         case .syncLoginExistingAccountError: return "m_d_sync_login_existing_account_error"
+
+        case .syncGetOtherDevices: return "sync_get_other_devices"
+        case .syncGetOtherDevicesCopy: return "sync_get_other_devices_copy"
+        case .syncGetOtherDevicesShare: return "sync_get_other_devices_share"
+
+        case .syncPromoDisplayed: return "sync_promotion_displayed"
+        case .syncPromoConfirmed: return "sync_promotion_confirmed"
+        case .syncPromoDismissed: return "sync_promotion_dismissed"
 
         case .swipeTabsUsedDaily: return "m_swipe-tabs-used-daily"
         case .swipeToOpenNewTab: return "m_addressbar_swipe_new_tab"

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -150,6 +150,7 @@ final class AutofillLoginSettingsListViewController: UIViewController {
 
     private lazy var syncPromoViewHostingController: UIHostingController<SyncPromoView> = {
         let headerView = SyncPromoView(viewModel: SyncPromoViewModel(touchpointType: .passwords, primaryButtonAction: { [weak self] in
+            self?.segueToSync(source: "promotion_passwords")
             Pixel.fire(.syncPromoConfirmed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.passwords.rawValue])
         }, dismissButtonAction: { [weak self] in
             self?.viewModel.dismissSyncPromo()
@@ -420,13 +421,17 @@ final class AutofillLoginSettingsListViewController: UIViewController {
         navigationController?.pushViewController(importController, animated: true)
     }
 
-    private func segueToSync() {
+    private func segueToSync(source: String? = nil) {
         if let settingsVC = self.navigationController?.children.first as? SettingsHostingController {
             navigationController?.popToRootViewController(animated: true)
-            settingsVC.viewModel.presentLegacyView(.sync)
+            if let source = source {
+                settingsVC.viewModel.shouldPresentSyncViewWithSource(source)
+            } else {
+                settingsVC.viewModel.presentLegacyView(.sync)
+            }
         } else if let mainVC = self.presentingViewController as? MainViewController {
             dismiss(animated: true) {
-                mainVC.segueToSettingsSync()
+                mainVC.segueToSettingsSync(with: source)
             }
         }
     }

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -150,11 +150,13 @@ final class AutofillLoginSettingsListViewController: UIViewController {
 
     private lazy var syncPromoViewHostingController: UIHostingController<SyncPromoView> = {
         let headerView = SyncPromoView(viewModel: SyncPromoViewModel(touchpointType: .passwords, primaryButtonAction: { [weak self] in
-            self?.segueToSync()
+            Pixel.fire(.syncPromoConfirmed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.passwords.rawValue])
         }, dismissButtonAction: { [weak self] in
             self?.viewModel.dismissSyncPromo()
             self?.updateTableHeaderView()
         }))
+
+        Pixel.fire(.syncPromoDisplayed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.passwords.rawValue])
 
         let hostingController = UIHostingController(rootView: headerView)
         hostingController.view.backgroundColor = .clear

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -125,10 +125,13 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
                     mainVC.segueToSettingsSync()
                 }
             }
+            Pixel.fire(.syncPromoConfirmed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.bookmarks.rawValue])
         }, dismissButtonAction: { [weak self] in
             self?.syncPromoManager.dismissPromoFor(.bookmarks)
             self?.refreshTableHeaderView()
         }))
+
+        Pixel.fire(.syncPromoDisplayed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.bookmarks.rawValue])
 
         let hostingController = UIHostingController(rootView: headerView)
         hostingController.view.backgroundColor = .clear

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -122,7 +122,7 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
         let headerView = SyncPromoView(viewModel: SyncPromoViewModel(touchpointType: .bookmarks, primaryButtonAction: { [weak self] in
             if let mainVC = self?.presentingViewController as? MainViewController {
                 self?.dismiss(animated: true) {
-                    mainVC.segueToSettingsSync()
+                    mainVC.segueToSettingsSync(with: "promotion_bookmarks")
                 }
             }
             Pixel.fire(.syncPromoConfirmed, withAdditionalParameters: ["source": SyncPromoManager.Touchpoint.bookmarks.rawValue])

--- a/DuckDuckGo/MainViewController+Segues.swift
+++ b/DuckDuckGo/MainViewController+Segues.swift
@@ -276,14 +276,18 @@ extension MainViewController {
         }
     }
 
-    func segueToSettingsSync() {
+    func segueToSettingsSync(with source: String? = nil) {
         os_log(#function, log: .generalLog, type: .debug)
         hideAllHighlightsIfNeeded()
         launchSettings {
-            $0.presentLegacyView(.sync)
+            if let source = source {
+                $0.shouldPresentSyncViewWithSource(source)
+            } else {
+                $0.presentLegacyView(.sync)
+            }
         }
     }
-    
+
     func launchSettings(completion: ((SettingsViewModel) -> Void)? = nil,
                         deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection? = nil) {
         let legacyViewProvider = SettingsLegacyViewProvider(syncService: syncService,

--- a/DuckDuckGo/SettingsLegacyViewProvider.swift
+++ b/DuckDuckGo/SettingsLegacyViewProvider.swift
@@ -84,12 +84,13 @@ class SettingsLegacyViewProvider: ObservableObject {
     var netP: UIViewController { NetworkProtectionRootViewController() }
     
     @MainActor
-    var syncSettings: UIViewController {
+    func syncSettings(source: String? = nil) -> SyncSettingsViewController {
         return SyncSettingsViewController(syncService: self.syncService,
                                           syncBookmarksAdapter: self.syncDataProviders.bookmarksAdapter,
                                           syncCredentialsAdapter: self.syncDataProviders.credentialsAdapter,
                                           appSettings: self.appSettings,
-                                          syncPausedStateManager: self.syncPausedStateManager)
+                                          syncPausedStateManager: self.syncPausedStateManager,
+                                          source: source)
     }
     
     func loginSettings(delegate: AutofillLoginSettingsListViewControllerDelegate,

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -94,7 +94,8 @@ struct SettingsState {
     
     // Sync Properties
     var sync: SyncSettings
-    
+    var syncSource: String?
+
     // Duck Player Mode
     var duckPlayerEnabled: Bool
     var duckPlayerMode: DuckPlayerMode?
@@ -133,6 +134,7 @@ struct SettingsState {
                                        platform: .unknown,
                                        isShowingStripeView: false),
             sync: SyncSettings(enabled: false, title: ""),
+            syncSource: nil,
             duckPlayerEnabled: false,
             duckPlayerMode: .alwaysAsk
         )

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -399,6 +399,7 @@ extension SettingsViewModel {
             networkProtectionConnected: false,
             subscription: SettingsState.defaults.subscription,
             sync: getSyncState(),
+            syncSource: nil,
             duckPlayerEnabled: featureFlagger.isFeatureOn(.duckPlayer) || shouldDisplayDuckPlayerContingencyMessage,
             duckPlayerMode: appSettings.duckPlayerMode
         )
@@ -507,7 +508,12 @@ extension SettingsViewModel {
         state.activeWebsiteAccount = accountDetails
         presentLegacyView(.logins)
     }
-    
+
+    @MainActor func shouldPresentSyncViewWithSource(_ source: String? = nil) {
+        state.syncSource = source
+        presentLegacyView(.sync)
+    }
+
     func openEmailProtection() {
         UIApplication.shared.open(URL.emailProtectionQuickLink,
                                   options: [:],
@@ -573,7 +579,7 @@ extension SettingsViewModel {
         case .addToDock:
             presentViewController(legacyViewProvider.addToDock, modal: true)
         case .sync:
-            pushViewController(legacyViewProvider.syncSettings)
+            pushViewController(legacyViewProvider.syncSettings(source: state.syncSource))
         case .appIcon: pushViewController(legacyViewProvider.appIcon)
         case .unprotectedSites: pushViewController(legacyViewProvider.unprotectedSites)
         case .fireproofSites: pushViewController(legacyViewProvider.fireproofSites)

--- a/DuckDuckGo/SyncPromoManager.swift
+++ b/DuckDuckGo/SyncPromoManager.swift
@@ -83,6 +83,8 @@ final class SyncPromoManager: SyncPromoManaging {
         case .passwords:
             syncPromoPasswordsDismissed = Date()
         }
+
+        Pixel.fire(.syncPromoDismissed, withAdditionalParameters: ["source": touchpoint.rawValue])
     }
 
     func resetPromos() {

--- a/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -144,7 +144,8 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     self.dismissPresentedViewController()
                     self.showPreparingSync()
                     try await self.syncService.createAccount(deviceName: self.deviceName, deviceType: self.deviceType)
-                    Pixel.fire(pixel: .syncSignupDirect, includedParameters: [.appVersion])
+                    let additionalParameters = self.source.map { ["source": $0] } ?? [:]
+                    try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
                     self.rootView.model.syncEnabled(recoveryCode: self.recoveryCode)
                     self.refreshDevices()
                     self.navigationController?.topViewController?.dismiss(animated: true, completion: self.showRecoveryPDF)

--- a/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -227,8 +227,21 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             return
         }
 
-        let controller = UIHostingController(rootView: PlatformLinksView(model: viewModel))
+        let controller = UIHostingController(rootView: PlatformLinksView(model: viewModel, source: .activating))
         navigationController?.pushViewController(controller, animated: true)
+    }
+
+    func fireOtherPlatformLinksPixel(event: SyncSettingsViewModel.PlatformLinksPixelEvent, with source: SyncSettingsViewModel.PlatformLinksPixelSource) {
+        let params = ["source": source.rawValue]
+
+        switch event {
+        case .appear:
+            Pixel.fire(.syncGetOtherDevices, withAdditionalParameters: params)
+        case .copy:
+            Pixel.fire(.syncGetOtherDevicesCopy, withAdditionalParameters: params)
+        case .share:
+            Pixel.fire(.syncGetOtherDevicesShare, withAdditionalParameters: params)
+        }
     }
 
     func showPreparingSync() {

--- a/DuckDuckGoTests/SyncUI/SyncManagementViewModelTests.swift
+++ b/DuckDuckGoTests/SyncUI/SyncManagementViewModelTests.swift
@@ -249,6 +249,10 @@ class SyncManagementViewModelTests: XCTestCase, SyncManagementViewModelDelegate 
         monitor.incrementCalls(function: #function.cleaningFunctionName())
     }
 
+    func fireOtherPlatformLinksPixel(event: SyncUI.SyncSettingsViewModel.PlatformLinksPixelEvent, with source: SyncUI.SyncSettingsViewModel.PlatformLinksPixelSource) {
+        monitor.incrementCalls(function: #function.cleaningFunctionName())
+    }
+
     func shareLink(for url: URL, with message: String, from rect: CGRect) {
         monitor.incrementCalls(function: #function.cleaningFunctionName())
     }

--- a/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/ViewModels/SyncSettingsViewModel.swift
@@ -40,6 +40,7 @@ public protocol SyncManagementViewModelDelegate: AnyObject {
     func launchBookmarksViewController()
     func launchAutofillViewController()
     func showOtherPlatformLinks()
+    func fireOtherPlatformLinksPixel(event: SyncSettingsViewModel.PlatformLinksPixelEvent, with source: SyncSettingsViewModel.PlatformLinksPixelSource)
     func shareLink(for url: URL, with message: String, from rect: CGRect)
 
     var syncBookmarksPausedTitle: String? { get }
@@ -82,6 +83,18 @@ public class SyncSettingsViewModel: ObservableObject {
     enum ScannedCodeValidity {
         case invalid
         case valid
+    }
+
+    public enum PlatformLinksPixelEvent {
+        case appear
+        case copy
+        case share
+    }
+
+    public enum PlatformLinksPixelSource: String {
+        case notActivated = "not_activated"
+        case activating
+        case activated
     }
 
     @Published public var isSyncEnabled = false {
@@ -239,6 +252,10 @@ public class SyncSettingsViewModel: ObservableObject {
 
     public func showOtherPlatformsPressed() {
         delegate?.showOtherPlatformLinks()
+    }
+
+    public func fireOtherPlatformLinksPixel(for event: PlatformLinksPixelEvent, source: PlatformLinksPixelSource) {
+        delegate?.fireOtherPlatformLinksPixel(event: event, with: source)
     }
 
     public func recoverSyncDataPressed() {

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -72,7 +72,7 @@ public struct SyncSettingsView: View {
 
                     devices()
 
-                    otherPlatformsLinks()
+                    otherPlatformsLinks(source: .activated)
 
                     options()
 
@@ -88,7 +88,7 @@ public struct SyncSettingsView: View {
 
                     otherOptions()
 
-                    otherPlatformsLinks()
+                    otherPlatformsLinks(source: .notActivated)
                 }
             }
             .navigationTitle(UserText.syncTitle)

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsViewExtension.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsViewExtension.swift
@@ -107,9 +107,9 @@ extension SyncSettingsView {
     }
 
     @ViewBuilder
-    func otherPlatformsLinks() -> some View {
+    func otherPlatformsLinks(source: SyncSettingsViewModel.PlatformLinksPixelSource) -> some View {
         Section {
-            NavigationLink(destination: PlatformLinksView(model: model)) {
+            NavigationLink(destination: PlatformLinksView(model: model, source: source)) {
                 HStack(spacing: 6) {
                     Image("Sync-Downloads-24")
                     Text(UserText.syncGetOnOtherDevices)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1142021229838617/1208017419957479/f
Tech Design URL:
CC:

**Description**:
Pixels for the new Sync Promo feature + new platform links in Sync screen

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Disable Sync if it’s enabled & ensure at least 1 bookmark & 1 password is saved
2. Visit the Passwords screen and confirm this pixel fires: `sync.promotion.displayed ["source": “password”]`
3. Tap “Set Up Sync” in the promo & confirm this pixel fires: `sync.promotion.confirmed ["source": "passwords”]`
4. Go back to the Passwords screen and tap the “No Thanks” button on the promo & confirm this pixel fires: `sync.promotion.dismissed ["source": "passwords”]`
5. Visit the Bookmarks screen and repeat steps 2 -4, confirming that this time the pixel source is `bookmarks`
6. Reset the Sync Promos via the debug menu (last entry on the main debug screen)
7. Go to Passwords, tap “Set Up Sync” and from the Sync screen select “Sync and Back Up This Device” and complete the setup flow.
8. Confirm this pixel fires with `promotion_passwords ` as the source: `m.sync.signup.direct ["source": "promotion_passwords”]`
9. Disable Sync and repeat from the Bookmarks screen. 
10. Confirm this pixel fires with `promotion_bookmarks` as the source: `m.sync.signup.direct ["source": "promotion_bookmarks”]`
11. Disable Sync again and back out of the Sync screen, then come back in
12. Select “Sync and Back Up This Device” again and confirm `m.sync.signup.direct` fires without the “source” parameter
13. Disable Sync and repeat steps 7 - 12, except this time set up sync with another device and checking instead for the pixel `m.sync.signup.connect`
14. Disable Sync, and from the Sync screen select `Get DuckDuckGo on other Devices`.
15. Confirm this pixel fires: `sync.get.other.devices ["source": "not_activated”]`
16. Tap the link & copy to clipboard. Confirm this pixel fires: `sync.get.other.devices.copy ["source": "not_activated”]`
17. Tap the share action and confirm this pixel fires:  `sync.get.other.devices.share ["source": "not_activated”]`
18. Set up Sync (again, sorry! can be as a backup) and on the “Your data is synced” screen tap `Get DuckDuckGo on other Devices` instead of Done.
19. Repeat steps 15 - 17, where the same pixels should fire but with source = `activating`
20. Go back to the Sync screen and select `Get DuckDuckGo on other Devices`
21.  Repeat steps 15 - 17, where the same pixels should fire but with source = `activated`


<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
