### PR TITLE
fix progress view crash by removing call to flush

### DIFF
--- a/DuckDuckGo/ProgressView.swift
+++ b/DuckDuckGo/ProgressView.swift
@@ -83,7 +83,6 @@ class ProgressView: UIView, CAAnimationDelegate {
         progressMask.bounds = calculateProgressMaskRect()
         progressMask.opacity = 1
         CATransaction.commit()
-        CATransaction.flush()
         
         startGradientAnimation()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1207778385841673/f
Tech Design URL:
CC:

**Description**:
Removes the call to CATransaction.flush which Apple recommends you don't do anyway. It was there for legacy reasons but after testing it seems to be fine.

**Steps to test this PR**:
1. Browse a few pages and see the progress bar.
