### PR TITLE
[DuckPlayer] 25. Allow www.youtube.com as origin

### DIFF
--- a/DuckDuckGo/DuckPlayer/YoutubeOverlayUserScript.swift
+++ b/DuckDuckGo/DuckPlayer/YoutubeOverlayUserScript.swift
@@ -55,25 +55,6 @@ final class YoutubeOverlayUserScript: NSObject, Subfeature {
             .store(in: &cancellables)
     }
     
-    enum MessageOrigin {
-        case duckPlayer, serpOverlay, youtubeOverlay
-
-        init?(url: URL) {
-            switch url.host {
-            case DuckPlayerSettings.OriginDomains.duckduckgo:
-                self = .serpOverlay
-            case DuckPlayerSettings.OriginDomains.youtubeMobile:
-                self = .youtubeOverlay
-            case DuckPlayerSettings.OriginDomains.youtube:
-                self = .youtubeOverlay
-            case DuckPlayerSettings.OriginDomains.youtubeWWW:
-                self = .youtubeOverlay
-            default:
-                return nil
-            }
-        }
-    }
-    
     struct Handlers {
         static let setUserValues = "setUserValues"
         static let getUserValues = "getUserValues"
@@ -90,7 +71,8 @@ final class YoutubeOverlayUserScript: NSObject, Subfeature {
         .exact(hostname: "sosbourne.duckduckgo.com"),
         .exact(hostname: DuckPlayerSettings.OriginDomains.duckduckgo),
         .exact(hostname: DuckPlayerSettings.OriginDomains.youtube),
-        .exact(hostname: DuckPlayerSettings.OriginDomains.youtubeMobile)
+        .exact(hostname: DuckPlayerSettings.OriginDomains.youtubeMobile),
+        .exact(hostname: DuckPlayerSettings.OriginDomains.youtubeWWW)
     ])
     public var featureName: String = Constants.featureName
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208167725782497/f

**Description**:
- Add additional domain to show overlay on iPad

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Open App in iPad sim
2. Add custom configuration from https://www.jsonblob.com/api/1276215786342309888
3. Make yourself internal user
4. Set DuckPlayer to 'Always Ask'.  Settings > DuckPlayer
5. Open youtube.com
6. Search for 'Sad but true' and pick a video
7. Confirm the Youtube overlay shows up on iPad. (It's the same as macOS, but that will change in prod)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->
