### PR TITLE
Fix site owned by major network

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10678,7 +10678,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 190.0.2;
+				version = 191.0.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "2e9282d79f4a36ad851e9e130ffd936a5c8e74c7",
-        "version" : "190.0.2"
+        "revision" : "bbfd3f12ffbc958a7f97f2ccb4779025a44380b5",
+        "version" : "191.0.0"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
-        "branch" : "alessandro/fix-site-owned-by-major-network",
-        "revision" : "c02419f6968b953aee052fc2999fadf41ab090a9"
+        "revision" : "5de0a610a7927b638a5fd463a53032c9934a2c3b",
+        "version" : "3.0.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/TrackerRadarKit",
       "state" : {
-        "revision" : "1403e17eeeb8493b92fb9d11eb8c846bb9776581",
-        "version" : "2.1.2"
+        "branch" : "alessandro/fix-site-owned-by-major-network",
+        "revision" : "c02419f6968b953aee052fc2999fadf41ab090a9"
       }
     },
     {

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -54,7 +54,7 @@ protocol ContextualOnboardingLogic {
 extension ContentBlockerRulesManager: EntityProviding {
     
     func entity(forHost host: String) -> Entity? {
-        currentMainRules?.trackerData.findEntity(forHost: host)
+        currentMainRules?.trackerData.findParentEntityOrFallback(forHost: host)
     }
     
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -993,8 +993,9 @@ class TabViewController: UIViewController {
     
     public func makePrivacyInfo(url: URL) -> PrivacyInfo? {
         guard let host = url.host else { return nil }
+        
+        let entity = ContentBlocking.shared.trackerDataManager.trackerData.findParentEntityOrFallback(forHost: host)
 
-        let entity = ContentBlocking.shared.trackerDataManager.trackerData.findEntity(forHost: host)
         let privacyInfo = PrivacyInfo(url: url,
                                       parentEntity: entity,
                                       protectionStatus: makeProtectionStatus(for: host))

--- a/DuckDuckGoTests/ContentBlockingUpdatingTests.swift
+++ b/DuckDuckGoTests/ContentBlockingUpdatingTests.swift
@@ -278,7 +278,7 @@ final class ContentBlockingUpdatingTests: XCTestCase {
 
     static let tracker = KnownTracker(domain: "tracker.com",
                                defaultAction: .block,
-                               owner: KnownTracker.Owner(name: "Tracker Inc", displayName: "Tracker Inc company"),
+                               owner: KnownTracker.Owner(name: "Tracker Inc", displayName: "Tracker Inc company", ownedBy: nil),
                                prevalence: 0.1,
                                subdomains: nil,
                                categories: nil,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1176956903599313/1208164650000833/f

**Description**:

There’s an existing [issue](https://app.asana.com/0/0/1207970856546695/1208097565947206/f) that causes showing the wrong education dialog for websites that are owned by a major network like Facebook and Google.

In addition, the Privacy Dashboard [does not reflect weather an entity is owned by a major tracker](https://app.asana.com/0/0/1207970856546695/1208114308033513/f)

This PR exposes the field “ownedBy” with the purpose of identifying when a tracker is owned by another entity. e.g. Instagram is ownedBy is Facebook

**BEFORE CONTROL GROUP**
![before-a-result](https://github.com/user-attachments/assets/3e07a346-048b-4271-8feb-b1346505659c)

**BEFORE EXPERIMENT GROUP**
![before-b-result](https://github.com/user-attachments/assets/0fea2c46-a198-4ede-94d6-418989267f68)

**AFTER CONTROL GROUP**
![after-a-result](https://github.com/user-attachments/assets/78c3e44f-3e45-44d1-8ecf-b2b7d25348e5)

**AFTER EXPERIMENT GROUP**
![after-b-result](https://github.com/user-attachments/assets/0428b6c9-0c59-4b0b-a6d7-037eef748564)

**Steps to test this PR**:

Repeat the below tests for Control and Experiment Group.
To force variant, add `return VariantIOS(name: "ma", weight: 1, isIncluded: VariantIOS.When.always, features: [.newOnboardingIntro])` at line 152 in `DefaultVariantManager`

**SCENARIO 1 - Instagram**
1. Launch App.
2. Tap the “Lets do it” button.
3. Tap on Skip
4. Input instagram.com
Expected Result: The contextual dialog should show that Facebook owns Instagram.
5. Open Privacy Dashboard
Expected Result: The Privacy dashboard should show that instagram.com is owned by Facebook.


**SCENARIO 2 - Youtube**
1. Launch App.
2. Tap the “Lets do it” button.
3. Tap on Skip
4. Input instagram.com
Expected Result: The contextual dialog should show that Google owns Youtube.
5. Open Privacy Dashboard
Expected Result: The Privacy dashboard should show that youtube.com is owned by Google.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
