### PR TITLE
[DuckPlayer] 28. Open in Youtube -> Youtube App

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -213,8 +213,7 @@ extension DuckPlayerNavigationHandler: DuckNavigationHandling {
             duckPlayer.settings.allowFirstVideo = true
 
             // Attempt to open in YouTube app (if installed) or load in webView
-            if isSERPLink(navigationAction: navigationAction),
-               appSettings.allowUniversalLinks,
+            if appSettings.allowUniversalLinks,
                isYouTubeAppInstalled,
                 let url = URL(string: "\(Constants.youtubeScheme)\(id)") {
                 UIApplication.shared.open(url)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208192198782451/f
Tech Design URL:
CC:

**Description**:
- Opens the Youtube app if installed and "Open links in associated apps" is active

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
- [ ] Make yourself internal user
- [ ] Drag the latest C.S.S from branch [pr-releases/release-993](https://github.com/duckduckgo/content-scope-scripts/tree/pr-releases/pr-993)
- [ ] Go to Settings > Debug > Privacy Configurations and add a custom config from https://www.jsonblob.com/api/1276215786342309888
- [ ] Set DuckPlayer to 'always' mode
- [ ] Install the Youtube app on your device
- [ ] Go to youtube and open a video in Duck Player
- [ ] Tap "Watch in Youtube"
- [ ] Confirm the Video Opens in the Youtube app
- [ ] Disable "Open links in associated apps" (Settings > General). (Or uninstall Youtube app)
- [ ] Go to youtube and open a video in Duck Player
- [ ] Tap "Watch in Youtube"
- [ ] Confirm the Video Opens in the browser

