### PR TITLE
Update attribution call

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -139,6 +139,7 @@ public struct PixelParameters {
     public static let adAttributionCountryOrRegion = "country_or_region"
     public static let adAttributionKeywordID = "keyword_id"
     public static let adAttributionAdID = "ad_id"
+    public static let adAttributionToken = "attribution_token"
 
     // Autofill
     public static let countBucket = "count_bucket"

--- a/DuckDuckGo/AdAttribution/AdAttributionFetcher.swift
+++ b/DuckDuckGo/AdAttribution/AdAttributionFetcher.swift
@@ -21,7 +21,7 @@ import AdServices
 import Common
 
 protocol AdAttributionFetcher {
-    func fetch() async -> AdServicesAttributionResponse?
+    func fetch() async -> (String, AdServicesAttributionResponse)?
 }
 
 /// Fetches ad attribution data for from Apple.
@@ -45,7 +45,7 @@ struct DefaultAdAttributionFetcher: AdAttributionFetcher {
         self.retryInterval = retryInterval
     }
 
-    func fetch() async -> AdServicesAttributionResponse? {
+    func fetch() async -> (String, AdServicesAttributionResponse)? {
         var lastToken: String?
 
         for _ in 0..<Constant.maxRetries {
@@ -79,7 +79,7 @@ struct DefaultAdAttributionFetcher: AdAttributionFetcher {
         return nil
     }
 
-    private func fetchAttributionData(using token: String) async throws -> AdServicesAttributionResponse {
+    private func fetchAttributionData(using token: String) async throws -> (String, AdServicesAttributionResponse) {
         let request = createAttributionDataRequest(with: token)
         let (data, response) = try await urlSession.data(for: request)
 
@@ -92,7 +92,7 @@ struct DefaultAdAttributionFetcher: AdAttributionFetcher {
             let decoder = JSONDecoder()
             let decoded = try decoder.decode(AdServicesAttributionResponse.self, from: data)
 
-            return decoded
+            return (token, decoded)
         case 400:
             throw AdAttributionFetcherError.invalidToken
         case 404:

--- a/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
+++ b/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
@@ -55,9 +55,9 @@ final actor AdAttributionPixelReporter {
             isSendingAttribution = false
         }
 
-        if let attributionData = await self.attributionFetcher.fetch() {
+        if let (token, attributionData) = await self.attributionFetcher.fetch() {
             if attributionData.attribution {
-                let parameters = self.pixelParametersForAttribution(attributionData)
+                let parameters = self.pixelParametersForAttribution(attributionData, attributionToken: token)
                 do {
                     try await pixelFiring.fire(
                         pixel: .appleAdAttribution,
@@ -77,7 +77,7 @@ final actor AdAttributionPixelReporter {
         return false
     }
 
-    private func pixelParametersForAttribution(_ attribution: AdServicesAttributionResponse) -> [String: String] {
+    private func pixelParametersForAttribution(_ attribution: AdServicesAttributionResponse, attributionToken: String) -> [String: String] {
         var params: [String: String] = [:]
 
         params[PixelParameters.adAttributionAdGroupID] = attribution.adGroupId.map(String.init)
@@ -88,6 +88,7 @@ final actor AdAttributionPixelReporter {
         params[PixelParameters.adAttributionCountryOrRegion] = attribution.countryOrRegion
         params[PixelParameters.adAttributionKeywordID] = attribution.keywordId.map(String.init)
         params[PixelParameters.adAttributionAdID] = attribution.adId.map(String.init)
+        params[PixelParameters.adAttributionToken] = attributionToken
 
         return params
     }

--- a/DuckDuckGoTests/AdAttributionPixelReporterTests.swift
+++ b/DuckDuckGoTests/AdAttributionPixelReporterTests.swift
@@ -40,7 +40,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testReportsAttribution() async {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: true)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
 
         let result = await sut.reportAttributionIfNeeded()
 
@@ -50,7 +50,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testReportsOnce() async {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: true)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
 
         await fetcherStorage.markAttributionReportSuccessful()
         let result = await sut.reportAttributionIfNeeded()
@@ -61,7 +61,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testPixelname() async {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: true)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
 
         let result = await sut.reportAttributionIfNeeded()
 
@@ -71,7 +71,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testPixelAttributesNaming() async throws {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: true)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
 
         await sut.reportAttributionIfNeeded()
 
@@ -84,11 +84,12 @@ final class AdAttributionPixelReporterTests: XCTestCase {
         XCTAssertEqual(pixelAttributes["country_or_region"], "countryOrRegion")
         XCTAssertEqual(pixelAttributes["keyword_id"], "4")
         XCTAssertEqual(pixelAttributes["ad_id"], "5")
+        XCTAssertEqual(pixelAttributes["attribution_token"], "example")
     }
 
     func testPixelAdditionalParameters() async throws {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: true)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
 
         await sut.reportAttributionIfNeeded()
 
@@ -99,7 +100,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testPixelAttributes_WhenPartialAttributionData() async throws {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(
             attribution: true,
             orgId: 1,
             campaignId: 2,
@@ -108,7 +109,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
             countryOrRegion: nil,
             keywordId: nil,
             adId: nil
-        )
+        ))
 
         await sut.reportAttributionIfNeeded()
 
@@ -125,7 +126,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testPixelNotFiredAndMarksReport_WhenAttributionFalse() async {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: false)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: false))
 
         let result = await sut.reportAttributionIfNeeded()
 
@@ -147,7 +148,7 @@ final class AdAttributionPixelReporterTests: XCTestCase {
 
     func testDoesNotMarkSuccessful_WhenPixelFiringFailed() async {
         let sut = createSUT()
-        attributionFetcher.fetchResponse = AdServicesAttributionResponse(attribution: true)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
         PixelFiringMock.expectedFireError = NSError(domain: "PixelFailure", code: 1)
 
         let result = await sut.reportAttributionIfNeeded()
@@ -172,8 +173,8 @@ class AdAttributionReporterStorageMock: AdAttributionReporterStorage {
 }
 
 class AdAttributionFetcherMock: AdAttributionFetcher {
-    var fetchResponse: AdServicesAttributionResponse?
-    func fetch() async -> AdServicesAttributionResponse? {
+    var fetchResponse: (String, AdServicesAttributionResponse)?
+    func fetch() async -> (String, AdServicesAttributionResponse)? {
         fetchResponse
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1208185326103221/f
Tech Design URL:
CC:

**Description**:

This PR updates the attribution call.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the app on a device and look for the `m_apple-ad-attribution` pixel, check that the parameters look correct

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
