### PR TITLE
Fix #3298: Add support for Xcode 16

### DIFF
--- a/Core/URLOpener.swift
+++ b/Core/URLOpener.swift
@@ -21,13 +21,11 @@ import UIKit
 
 public protocol URLOpener: AnyObject {
     func canOpenURL(_ url: URL) -> Bool
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?)
+    func open(_ url: URL)
 }
 
-public extension URLOpener {
-    func open(_ url: URL) {
+extension UIApplication: URLOpener {
+    public func open(_ url: URL) {
         open(url, options: [:], completionHandler: nil)
     }
 }
-
-extension UIApplication: URLOpener {}

--- a/DuckDuckGo/CriticalAlerts.swift
+++ b/DuckDuckGo/CriticalAlerts.swift
@@ -43,7 +43,7 @@ struct CriticalAlerts {
 
         let openSettingsButton = UIAlertAction(title: UserText.insufficientDiskSpaceAction, style: .default) { _ in
             let url = URL(string: UIApplication.openSettingsURLString)!
-            UIApplication.shared.open(url, options: [:]) { _ in
+            UIApplication.shared.open(url) { _ in
                 fatalError("App is in unrecoverable state")
             }
         }
@@ -59,7 +59,7 @@ struct CriticalAlerts {
 
         let closeButton = UIAlertAction(title: UserText.keyCommandClose, style: .cancel)
         let signInButton = UIAlertAction(title: UserText.emailProtectionSignInAction, style: .default) { _ in
-            UIApplication.shared.open(URL.emailProtectionQuickLink, options: [:], completionHandler: nil)
+            UIApplication.shared.open(URL.emailProtectionQuickLink)
         }
 
         alertController.addAction(closeButton)

--- a/DuckDuckGo/MainViewController+Email.swift
+++ b/DuckDuckGo/MainViewController+Email.swift
@@ -26,7 +26,7 @@ extension MainViewController {
 
     func newEmailAddress() {
         guard emailManager.isSignedIn else {
-            UIApplication.shared.open(URL.emailProtectionQuickLink, options: [:], completionHandler: nil)
+            UIApplication.shared.open(URL.emailProtectionQuickLink)
             return
         }
 

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -39,7 +39,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
     private let shortcutsModel: ShortcutsModel
     private let shortcutsSettingsModel: NewTabPageShortcutsSettingsModel
     private let sectionsSettingsModel: NewTabPageSectionsSettingsModel
-    private let tab: Tab
+    private let _tab: Tab
 
     private var hostingController: UIHostingController<AnyView>?
 
@@ -53,7 +53,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
          newTabDialogFactory: any NewTabDaxDialogProvider,
          newTabDialogTypeProvider: NewTabDialogSpecProvider) {
 
-        self.tab = tab
+        self._tab = tab
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
         self.variantManager = variantManager
@@ -82,7 +82,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        tab.viewed = true
+        _tab.viewed = true
 
         presentNextDaxDialog()
 

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -39,7 +39,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
     private let shortcutsModel: ShortcutsModel
     private let shortcutsSettingsModel: NewTabPageShortcutsSettingsModel
     private let sectionsSettingsModel: NewTabPageSectionsSettingsModel
-    private let _tab: Tab
+    private let associatedTab: Tab
 
     private var hostingController: UIHostingController<AnyView>?
 
@@ -53,7 +53,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
          newTabDialogFactory: any NewTabDaxDialogProvider,
          newTabDialogTypeProvider: NewTabDialogSpecProvider) {
 
-        self._tab = tab
+        self.associatedTab = tab
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
         self.variantManager = variantManager
@@ -82,7 +82,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        _tab.viewed = true
+        associatedTab.viewed = true
 
         presentNextDaxDialog()
 

--- a/DuckDuckGo/NoMicPermissionAlert.swift
+++ b/DuckDuckGo/NoMicPermissionAlert.swift
@@ -29,7 +29,7 @@ struct NoMicPermissionAlert {
 
         let openSettingsButton = UIAlertAction(title: UserText.noVoicePermissionActionSettings, style: .default) { _ in
             let url = URL(string: UIApplication.openSettingsURLString)!
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            UIApplication.shared.open(url)
         }
         let cancelAction = UIAlertAction(title: UserText.actionCancel, style: .cancel, handler: nil)
 

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -518,33 +518,23 @@ extension SettingsViewModel {
     }
     
     func openEmailProtection() {
-        UIApplication.shared.open(URL.emailProtectionQuickLink,
-                                  options: [:],
-                                  completionHandler: nil)
+        UIApplication.shared.open(URL.emailProtectionQuickLink)
     }
 
     func openEmailAccountManagement() {
-        UIApplication.shared.open(URL.emailProtectionAccountLink,
-                                  options: [:],
-                                  completionHandler: nil)
+        UIApplication.shared.open(URL.emailProtectionAccountLink)
     }
 
     func openEmailSupport() {
-        UIApplication.shared.open(URL.emailProtectionSupportLink,
-                                  options: [:],
-                                  completionHandler: nil)
+        UIApplication.shared.open(URL.emailProtectionSupportLink)
     }
 
     func openOtherPlatforms() {
-        UIApplication.shared.open(URL.apps,
-                                  options: [:],
-                                  completionHandler: nil)
+        UIApplication.shared.open(URL.apps)
     }
 
     func openMoreSearchSettings() {
-        UIApplication.shared.open(URL.searchSettings,
-                                  options: [:],
-                                  completionHandler: nil)
+        UIApplication.shared.open(URL.searchSettings)
     }
 
     var shouldDisplayDuckPlayerContingencyMessage: Bool {
@@ -554,9 +544,7 @@ extension SettingsViewModel {
     func openDuckPlayerContingencyMessageSite() {
         guard let url = duckPlayerContingencyHandler.learnMoreURL else { return }
         Pixel.fire(pixel: .duckPlayerContingencyLearnMoreClicked)
-        UIApplication.shared.open(url,
-                                  options: [:],
-                                  completionHandler: nil)
+        UIApplication.shared.open(url)
     }
 
     @MainActor func openCookiePopupManagement() {

--- a/DuckDuckGo/Subscription/AsyncHeadlessWebview/HeadlessWebViewCoordinator.swift
+++ b/DuckDuckGo/Subscription/AsyncHeadlessWebview/HeadlessWebViewCoordinator.swift
@@ -164,7 +164,7 @@ extension HeadlessWebViewCoordinator: WKNavigationDelegate {
         
         // Handle custom schemes (e.g., tel:, facetime:, etc.)
         if Constants.externalSchemes.contains(scheme), UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            UIApplication.shared.open(url)
             decisionHandler(.cancel)
             return
         }

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -317,7 +317,7 @@ final class SubscriptionSettingsViewModel: ObservableObject {
     @MainActor
     private func openURL(_ url: URL) {
         if UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            UIApplication.shared.open(url)
         }
     }
     

--- a/DuckDuckGo/SyncSettingsViewController.swift
+++ b/DuckDuckGo/SyncSettingsViewController.swift
@@ -402,7 +402,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
 
     func gotoSettings() {
         if let appSettings = URL(string: UIApplication.openSettingsURLString) {
-            UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)
+            UIApplication.shared.open(appSettings)
         }
     }
 

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1040,7 +1040,7 @@ class TabViewController: UIViewController {
     private func openExternally(url: URL) {
         self.url = webView.url
         delegate?.tabLoadingStateDidChange(tab: self)
-        UIApplication.shared.open(url, options: [:]) { opened in
+        UIApplication.shared.open(url) { opened in
             if !opened {
                 let addressBarBottom = self.appSettings.currentAddressBarPosition.isBottom
                 ActionMessageView.present(message: UserText.failedToOpenExternally,

--- a/DuckDuckGoTests/MockURLOpener.swift
+++ b/DuckDuckGoTests/MockURLOpener.swift
@@ -33,7 +33,7 @@ final class MockURLOpener: URLOpener {
         return canOpenURL
     }
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
+    func open(_ url: URL) {
         didCallOpenURL = true
         capturedURL = url
     }

--- a/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
+++ b/LocalPackages/SyncUI/Sources/SyncUI/Views/SyncSettingsView.swift
@@ -95,9 +95,7 @@ public struct SyncSettingsView: View {
                     title: Text("Secure Your Device to Use Sync & Backup"),
                     message: Text("A device password is required to use Sync & Backup."),
                     dismissButton: .default(Text("Go to Settings"), action: {
-                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!,
-                                                  options: [:],
-                                                  completionHandler: nil)
+                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
                         model.shouldShowPasscodeRequiredAlert = false
                     })
                 )


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://github.com/duckduckgo/iOS/issues/3298 & https://app.asana.com/0/414709148257752/1208200157992058/f
Tech Design URL:
CC:

**Description**:

Resolves https://github.com/duckduckgo/iOS/issues/3298

This PR allows this repo to be compiled with Xcode 16.
Two changes had to be made:
1. In iOS 18 Apple added a new field to UIViewController named `tab`.
It causes ambiguity and has to be renamed.
Source https://developer.apple.com/documentation/uikit/uiviewcontroller/4434584-tab
I renamed it to `_tab`, I am open to any other rename suggestion

2. The URLOpener protocol and Apple's UIApplication shared the same
signature for url opening function. This resulted in ambiguous compile
time error.
Code is now simplified and still allows to be used in mocks.

Changes I made should be backwards compatible and work in Xcode 15 as well

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
These steps are more for devs than QA
1. Download Xcode 16 beta from https://developer.apple.com/download/
2. Compile the app

QA STR:
1. Launch the app
2. Go to settings tap "set as default browser"
3. Verify it did not regress, and it took you to the iOS settings screen.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:
No UI changes in this PR

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
