### PR TITLE
Dismiss Text Size sheet on tapping outside

### DIFF
--- a/DuckDuckGo/TextSizeSettingsViewController.swift
+++ b/DuckDuckGo/TextSizeSettingsViewController.swift
@@ -61,7 +61,6 @@ class TextSizeSettingsViewController: UITableViewController {
         if !hasAdjustedDetent, let sheetController = navigationController?.presentationController as? UISheetPresentationController {
             sheetController.detents = [.medium(), .large()]
             sheetController.delegate = self
-            sheetController.largestUndimmedDetentIdentifier = .medium
             sheetController.preferredCornerRadius = 16
 
             sheetController.animateChanges {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208125622173258/f
Tech Design URL:
CC:

**Description**:

Undimmed area below the sheet allowed interaction with the website content. This addresses the issue. Side effect is that the content will be slightly dimmed, but that's ok. See task for details.

**Steps to test this PR**:
1. Go to Settings -> Accessibility -> Text Size
2. Tap on the website content
3. Sheet should be dismissed.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
