### PR TITLE
Fix an issue that causes the fire dialog to show multiple times for the same website after dismissing it

### DIFF
--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -316,6 +316,9 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
     func dismiss() {
         settings.isDismissed = true
+        // Reset last shown dialog as we don't have to show it anymore.
+        removeLastShownDaxDialog()
+        removeLastVisitedOnboardingWebsite()
     }
     
     func primeForUse() {
@@ -375,6 +378,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     }
 
     private func removeLastShownDaxDialog() {
+        guard isNewOnboarding else { return }
         settings.lastShownContextualOnboardingDialogType = nil
     }
 
@@ -499,11 +503,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
     private func nextBrowsingMessageExperiment(privacyInfo: PrivacyInfo) -> BrowsingSpec? {
 
-        if let lastVisitedOnboardingWebsiteURLPath,
-            compareUrls(url1: URL(string: lastVisitedOnboardingWebsiteURLPath), url2: privacyInfo.url) {
-            return lastShownDaxDialog(privacyInfo: privacyInfo)
-        }
-
         func hasTrackers(host: String) -> Bool {
             isFacebookOrGoogle(privacyInfo.url) || isOwnedByFacebookOrGoogle(host) != nil || blockedEntityNames(privacyInfo.trackerInfo) != nil
         }
@@ -512,6 +511,11 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         currentHomeSpec = nil
 
         guard isEnabled, nextHomeScreenMessageOverride == nil else { return nil }
+
+        if let lastVisitedOnboardingWebsiteURLPath,
+            compareUrls(url1: URL(string: lastVisitedOnboardingWebsiteURLPath), url2: privacyInfo.url) {
+            return lastShownDaxDialog(privacyInfo: privacyInfo)
+        }
 
         guard let host = privacyInfo.domain else { return nil }
 

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -1002,6 +1002,40 @@ final class DaxDialog: XCTestCase {
         XCTAssertEqual(result?.type, .siteOwnedByMajorTracker)
     }
 
+    func testWhenExperimentGroup_AndDismissIsCalled_ThenLastVisitedOnboardingWebsiteAndLastShownDaxDialogAreSetToNil() {
+        // GIVEN
+        let settings = InMemoryDaxDialogsSettings()
+        settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
+        settings.lastVisitedOnboardingWebsiteURLPath = "https://www.example.com"
+        let sut = makeExperimentSUT(settings: settings)
+        XCTAssertNotNil(settings.lastShownContextualOnboardingDialogType)
+        XCTAssertNotNil(settings.lastVisitedOnboardingWebsiteURLPath)
+
+        // WHEN
+        sut.dismiss()
+
+        // THEN
+        XCTAssertNil(settings.lastShownContextualOnboardingDialogType)
+        XCTAssertNil(settings.lastVisitedOnboardingWebsiteURLPath)
+    }
+
+    func testWhenExperimentGroup_AndIsEnabledIsFalse_AndReloadWebsite_ThenReturnNilBrowsingSpec() throws {
+        // GIVEN
+        let lastVisitedWebsitePath = "https://www.example.com"
+        let lastVisitedWebsiteURL = try XCTUnwrap(URL(string: lastVisitedWebsitePath))
+        let settings = InMemoryDaxDialogsSettings()
+        settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
+        settings.lastVisitedOnboardingWebsiteURLPath = lastVisitedWebsitePath
+        let sut = makeExperimentSUT(settings: settings)
+        sut.dismiss()
+
+        // WHEN
+        let result = sut.nextBrowsingMessageIfShouldShow(for: makePrivacyInfo(url: lastVisitedWebsiteURL))
+
+        // THEN
+        XCTAssertNil(result)
+    }
+
     private func detectedTrackerFrom(_ url: URL, pageUrl: String) -> DetectedRequest {
         let entity = entityProvider.entity(forHost: url.host!)
         return DetectedRequest(url: url.absoluteString,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1208180024223015/f
Cc: @SabrinaTardio 

**Description**:
This PR addresses an issue that causes the fire dialog to show multiple times for the same website.

**Context**

We have logic in place to re-present the dialog if the user reloads the webpage or relaunches the app, allowing them to resume onboarding from where they left off.

We consider the onboarding flow “complete" when the user taps the "High Five" button.

**Problem**

The issue was that the dialog presentation logic was executed before verifying if the onboarding was complete. As a result, the dialog would reappear every time the website for which it was shown was opened.

**Solution**
1. Cancel held information about last visited onboarding website and presented dialog when onboarding completes.
2. Execute the logic to present the last shown dialog if the onboarding has not been considered completed.

**Video Before**

https://github.com/user-attachments/assets/03ed52e7-e143-4026-ba0c-e972479af6ac

**Video After**

https://github.com/user-attachments/assets/fd8fd282-5a6e-4533-9608-6b77debd11c1


**Steps to test this PR**:
Ensure experiment group is returned by adding `return VariantIOS(name: "mb", weight: 1, isIncluded: VariantIOS.When.always, features: [.newOnboardingIntro])` in `DefaultVariantManager` at line 153.

1. Run the new onboarding flow and wait for the first dialogue to appear on screen.
2. Tap on “Let’s do it”.
3. Tap on  “Skip".
4. Go Back to DuckDuckGo App.
5. The New Tab Page should appear on the screen with a new Dax dialogue suggesting DDG searches.
6. Tap on one of the searches. E.g. “local weather”.
7. A Dax dialogue should appear informing the user about the DDG search.
8. Tap on the "Got it!” button.
9. The Dax dialogue should update and suggest to the user a list of websites to try.
10. Tap on one of the websites. E.g. “yahoo.com”.
11. The Dax dialogue should now inform the user of the trackers that have been blocked.
12. Tap the “Got It!” Button.
13. The Fire Button dialog should appear.
14. Open a new tab.
15. The end of journey dialog should appear.
16. Tap “High Five” button.
17. Type the same website loaded when the fire dialog was shown, e.g. “yahoo.com”
Expected Result: The fire dialog should not show again.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
