### PR TITLE
Onboarding highlights feature flag setup

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -40,6 +40,7 @@ public enum FeatureFlag: String {
     case sslCertificatesBypass
     case syncPromotionBookmarks
     case syncPromotionPasswords
+    case onboardingHighlights
 }
 
 extension FeatureFlag: FeatureFlagSourceProviding {
@@ -83,6 +84,8 @@ extension FeatureFlag: FeatureFlagSourceProviding {
             return .remoteReleasable(.subfeature(SyncPromotionSubfeature.bookmarks))
         case .syncPromotionPasswords:
             return .remoteReleasable(.subfeature(SyncPromotionSubfeature.passwords))
+        case .onboardingHighlights:
+            return .internalOnly
         }
     }
 }

--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -171,6 +171,8 @@ public struct UserDefaultsWrapper<T> {
         // Debug keys
 
         case debugNewTabPageSectionsEnabledKey = "com.duckduckgo.ios.debug.newTabPageSectionsEnabled"
+
+        case debugOnboardingHighlightsEnabledKey = "com.duckduckgo.ios.debug.onboardingHighlightsEnabled"
     }
 
     private let key: Key

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -691,6 +691,7 @@
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F9A922E2C86A56B001D036D /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A922D2C86A56B001D036D /* OnboardingManager.swift */; };
+		9F9A92312C86AAE9001D036D /* OnboardingDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A92302C86AAE9001D036D /* OnboardingDebugView.swift */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
 		9F9EE4D42C37BB1300D4118E /* OnboardingView+Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */; };
 		9FA5E44B2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */; };
@@ -2451,6 +2452,7 @@
 		9F7CFF772C86E3E10012833E /* OnboardingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManagerTests.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
 		9F9A922D2C86A56B001D036D /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
+		9F9A92302C86AAE9001D036D /* OnboardingDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDebugView.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewFactory.swift; sourceTree = "<group>"; };
@@ -4267,6 +4269,7 @@
 			isa = PBXGroup;
 			children = (
 				6FB1FE9C2C24D4060075B68B /* NewTabPageSectionsDebugView */,
+				9F9A922F2C86AACB001D036D /* OnboardingDebugView */,
 				C14D43002B45D6CD00ACA4DC /* AutofillDebugViewController.swift */,
 				858566E7252E4F56007501B8 /* Debug.storyboard */,
 				D6F93E3B2B4FFA97004C268D /* SubscriptionDebugViewController.swift */,
@@ -4664,6 +4667,14 @@
 				9F9A922D2C86A56B001D036D /* OnboardingManager.swift */,
 			);
 			path = Manager;
+			sourceTree = "<group>";
+		};
+		9F9A922F2C86AACB001D036D /* OnboardingDebugView */ = {
+			isa = PBXGroup;
+			children = (
+				9F9A92302C86AAE9001D036D /* OnboardingDebugView.swift */,
+			);
+			name = OnboardingDebugView;
 			sourceTree = "<group>";
 		};
 		9F9EE4CB2C377D2400D4118E /* Mocks */ = {
@@ -7330,6 +7341,7 @@
 				9FB027142C252E0C009EA190 /* OnboardingView+BrowsersComparisonContent.swift in Sources */,
 				D664C7B62B289AA200CBFA76 /* SubscriptionFlowViewModel.swift in Sources */,
 				4BD96E0B2C4DCE55003BC32C /* VPNSnoozeLiveActivityManager.swift in Sources */,
+				9F9A92312C86AAE9001D036D /* OnboardingDebugView.swift in Sources */,
 				1EFDCBC127D2393C00916BC5 /* DownloadsDeleteHelper.swift in Sources */,
 				C1836CE12C359EC90016D057 /* AutofillBreakageReportCellContentView.swift in Sources */,
 				6F9FFE282C579DEA00A238BE /* NewTabPageSectionsSettingsStorage.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -687,8 +687,10 @@
 		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
 		9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */; };
 		9F6933212C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */; };
+		9F7CFF782C86E3E10012833E /* OnboardingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7CFF772C86E3E10012833E /* OnboardingManagerTests.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
+		9F9A922E2C86A56B001D036D /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A922D2C86A56B001D036D /* OnboardingManager.swift */; };
 		9F9EE4CE2C377D4900D4118E /* OnboardingFirePixelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */; };
 		9F9EE4D42C37BB1300D4118E /* OnboardingView+Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */; };
 		9FA5E44B2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */; };
@@ -2446,7 +2448,9 @@
 		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
 		9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
 		9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHostingControllerMock.swift; sourceTree = "<group>"; };
+		9F7CFF772C86E3E10012833E /* OnboardingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManagerTests.swift; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
+		9F9A922D2C86A56B001D036D /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
 		9F9EE4CC2C377D3F00D4118E /* OnboardingFirePixelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirePixelMock.swift; sourceTree = "<group>"; };
 		9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		9FA5E44A2BF1AF3400BDEF02 /* SubscriptionContainerViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionContainerViewFactory.swift; sourceTree = "<group>"; };
@@ -4632,6 +4636,7 @@
 				9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */,
 				9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */,
 				9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */,
+				9F7CFF772C86E3E10012833E /* OnboardingManagerTests.swift */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -4651,6 +4656,14 @@
 				9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */,
 			);
 			path = ContextualOnboarding;
+			sourceTree = "<group>";
+		};
+		9F9A922C2C86A560001D036D /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				9F9A922D2C86A56B001D036D /* OnboardingManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 		9F9EE4CB2C377D2400D4118E /* Mocks */ = {
@@ -4701,6 +4714,7 @@
 		9FF7E9802C22A19800902BE5 /* OnboardingExperiment */ = {
 			isa = PBXGroup;
 			children = (
+				9F9A922C2C86A560001D036D /* Manager */,
 				9FE05CEC2C36423C00D9046B /* Pixels */,
 				56D060202C356B0B003BAEB5 /* ContextualDaxDialogs */,
 				9FE08BD42C2A60BD001D5EBC /* MetricBuilder */,
@@ -7268,6 +7282,7 @@
 				BDE91CDC2C62AA3A0005CB74 /* DefaultMetadataCollector.swift in Sources */,
 				D664C7C82B289AA200CBFA76 /* SubscriptionFlowView.swift in Sources */,
 				EE458D142ABB652900FC651A /* NetworkProtectionDebugUtilities.swift in Sources */,
+				9F9A922E2C86A56B001D036D /* OnboardingManager.swift in Sources */,
 				8528AE7C212EF4A200D0BD74 /* AppRatingPrompt.swift in Sources */,
 				BD2F39EB2C19F955005B19E7 /* NetworkProtectionDNSSettingsView.swift in Sources */,
 				CB2A7EEF283D185100885F67 /* RulesCompilationMonitor.swift in Sources */,
@@ -7740,6 +7755,7 @@
 				F198D7981E3A45D90088DA8A /* WKWebViewConfigurationExtensionTests.swift in Sources */,
 				564DE45E2C45218500D23241 /* OnboardingNavigationDelegateTests.swift in Sources */,
 				C14E2F7729DE14EA002AC515 /* AutofillInterfaceUsernameTruncatorTests.swift in Sources */,
+				9F7CFF782C86E3E10012833E /* OnboardingManagerTests.swift in Sources */,
 				564DE45A2C450BE600D23241 /* DaxDialogsNewTabTests.swift in Sources */,
 				C174CE602BD6A6CE00AED2EA /* MockDDGSyncing.swift in Sources */,
 				9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */,

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -91,4 +91,5 @@ protocol AppSettings: AnyObject, AppDebugSettings {
 
 protocol AppDebugSettings {
     var newTabPageSectionsEnabled: Bool { get set }
+    var onboardingHighlightsEnabled: Bool { get set }
 }

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -429,6 +429,9 @@ public class AppUserDefaults: AppSettings {
 
     @UserDefaultsWrapper(key: .newTabPageIntroMessageSeenCount, defaultValue: 0)
     var newTabPageIntroMessageSeenCount: Int
+
+    @UserDefaultsWrapper(key: .debugOnboardingHighlightsEnabledKey, defaultValue: false)
+    var onboardingHighlightsEnabled: Bool
 }
 
 extension AppUserDefaults: AppConfigurationFetchStatistics {

--- a/DuckDuckGo/Debug.storyboard
+++ b/DuckDuckGo/Debug.storyboard
@@ -350,14 +350,14 @@
                                         </tableViewCellContentView>
                                         <listContentConfiguration key="contentConfiguration" text="Reset Upload Crash Logs Prompt"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" tag="676" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="wKg-4u-kJ4">
+                                    <tableViewCell clipsSubviews="YES" tag="676" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="wKg-4u-kJ4">
                                         <rect key="frame" x="0.0" y="1108" width="414" height="44.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wKg-4u-kJ4" id="8Jc-Co-wqO">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
-                                        <listContentConfiguration key="contentConfiguration" text="Show New Onboarding Intro"/>
+                                        <listContentConfiguration key="contentConfiguration" text="New Onboarding"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" tag="677" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="zgg-vb-khj">
                                         <rect key="frame" x="0.0" y="1152.5" width="414" height="44.5"/>

--- a/DuckDuckGo/OnboardingDebugView.swift
+++ b/DuckDuckGo/OnboardingDebugView.swift
@@ -1,0 +1,75 @@
+//
+//  OnboardingDebugView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+struct OnboardingDebugView: View {
+
+    @StateObject private var viewModel = OnboardingDebugViewModel()
+
+    private let newOnboardingIntroStartAction: () -> Void
+
+    init(onNewOnboardingIntroStartAction: @escaping () -> Void) {
+        newOnboardingIntroStartAction = onNewOnboardingIntroStartAction
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Toggle(
+                    isOn: $viewModel.isLocalFlagEnabled,
+                    label: {
+                        Text(verbatim: "Onboarding Highlights local setting enabled")
+                    }
+                )
+            } header: {
+                Text(verbatim: "Onboarding Higlights settings")
+            } footer: {
+                Text(verbatim: "Requires internal user flag set to have an effect.")
+            }
+
+            Section {
+                Button(action: newOnboardingIntroStartAction, label: {
+                    let onboardingType = viewModel.isLocalFlagEnabled ? "Highlights" : ""
+                    Text(verbatim: "Preview New Onboarding Intro \(onboardingType)")
+                })
+            }
+        }
+    }
+}
+
+final class OnboardingDebugViewModel: ObservableObject {
+    @Published var isLocalFlagEnabled: Bool {
+        didSet {
+            manager.isLocalFlagEnabled = isLocalFlagEnabled
+        }
+    }
+
+    private let manager: OnboardingHighlightsDebugging
+
+    init(manager: OnboardingHighlightsDebugging = OnboardingManager()) {
+        self.manager = manager
+        isLocalFlagEnabled = manager.isLocalFlagEnabled
+    }
+
+}
+
+#Preview {
+    OnboardingDebugView(onNewOnboardingIntroStartAction: {})
+}

--- a/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -1,0 +1,60 @@
+//
+//  OnboardingManager.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Core
+
+protocol OnboardingHighlightsManaging: AnyObject {
+    var isOnboardingHighlightsEnabled: Bool { get }
+}
+
+protocol OnboardingHighlightsDebugging: OnboardingHighlightsManaging {
+    var isLocalFlagEnabled: Bool { get set }
+    var isFeatureFlagEnabled: Bool { get }
+}
+
+final class OnboardingManager: OnboardingHighlightsManaging, OnboardingHighlightsDebugging {
+    private var appDefaults: AppDebugSettings
+    private let featureFlagger: FeatureFlagger
+
+    init(
+        appDefaults: AppDebugSettings = AppDependencyProvider.shared.appSettings,
+        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger
+    ) {
+        self.appDefaults = appDefaults
+        self.featureFlagger = featureFlagger
+    }
+
+    var isOnboardingHighlightsEnabled: Bool {
+        isLocalFlagEnabled && isFeatureFlagEnabled
+    }
+
+    var isLocalFlagEnabled: Bool {
+        get {
+            appDefaults.onboardingHighlightsEnabled
+        }
+        set {
+            appDefaults.onboardingHighlightsEnabled = newValue
+        }
+    }
+
+    var isFeatureFlagEnabled: Bool {
+        featureFlagger.isFeatureOn(.onboardingHighlights)
+    }
+}

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -26,10 +26,16 @@ final class OnboardingIntroViewModel: ObservableObject {
 
     var onCompletingOnboardingIntro: (() -> Void)?
     private let pixelReporter: OnboardingIntroPixelReporting
+    private let onboardingManager: OnboardingHighlightsManaging
     private let urlOpener: URLOpener
 
-    init(pixelReporter: OnboardingIntroPixelReporting, urlOpener: URLOpener = UIApplication.shared) {
+    init(
+        pixelReporter: OnboardingIntroPixelReporting,
+        onboardingManager: OnboardingHighlightsManaging = OnboardingManager(),
+        urlOpener: URLOpener = UIApplication.shared
+    ) {
         self.pixelReporter = pixelReporter
+        self.onboardingManager = onboardingManager
         self.urlOpener = urlOpener
     }
 
@@ -48,10 +54,31 @@ final class OnboardingIntroViewModel: ObservableObject {
             urlOpener.open(url)
         }
         pixelReporter.trackChooseBrowserCTAAction()
-        onCompletingOnboardingIntro?()
+
+        handleSetDefaultBrowserAction()
     }
 
     func cancelSetDefaultBrowserAction() {
+        handleSetDefaultBrowserAction()
+    }
+
+    func appIconPickerContinueAction() {
+       // TODO: Remove below and implement proper logic
         onCompletingOnboardingIntro?()
     }
+
+}
+
+// MARK: - Private
+
+private extension OnboardingIntroViewModel {
+
+    func handleSetDefaultBrowserAction() {
+        if onboardingManager.isOnboardingHighlightsEnabled {
+            state = .onboarding(.chooseAppIconDialog)
+        } else {
+            onCompletingOnboardingIntro?()
+        }
+    }
+
 }

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -82,6 +82,8 @@ struct OnboardingView: View {
                                 introView
                             case .browsersComparisonDialog:
                                 browsersComparisonView
+                            case .chooseAppIconDialog:
+                                appIconPickerView
                             }
                         }
                     }
@@ -133,6 +135,18 @@ struct OnboardingView: View {
         .onboardingDaxDialogStyle()
     }
 
+    private var appIconPickerView: some View {
+        // TODO: Implement AppIconPicker
+        VStack(spacing: 30) {
+            Text(verbatim: "Choose App Icon")
+
+            Button(action: model.appIconPickerContinueAction) {
+                Text(verbatim: "Continue")
+            }
+        }
+        .onboardingDaxDialogStyle()
+    }
+
     private func animateBrowserComparisonViewState() {
         // Hide content of Intro dialog before animating
         showIntroViewContent = false
@@ -176,6 +190,7 @@ extension OnboardingView.ViewState {
     enum Intro: Equatable {
         case startOnboardingDialog
         case browsersComparisonDialog
+        case chooseAppIconDialog
     }
     
 }

--- a/DuckDuckGo/RootDebugViewController+Onboarding.swift
+++ b/DuckDuckGo/RootDebugViewController+Onboarding.swift
@@ -25,7 +25,7 @@ extension RootDebugViewController {
         let controller = OnboardingIntroViewController(onboardingPixelReporter: OnboardingPixelReporter())
         controller.delegate = self
         controller.modalPresentationStyle = .overFullScreen
-        present(controller: controller, fromView: self.view)
+        parent?.present(controller: controller, fromView: self.view)
     }
     
 }

--- a/DuckDuckGo/RootDebugViewController.swift
+++ b/DuckDuckGo/RootDebugViewController.swift
@@ -45,7 +45,7 @@ class RootDebugViewController: UITableViewController {
         case resetSendCrashLogs = 671
         case refreshConfig = 672
         case newTabPageSections = 674
-        case showNewOnboardingIntro = 676
+        case onboarding = 676
         case resetSyncPromoPrompts = 677
     }
 
@@ -169,8 +169,13 @@ class RootDebugViewController: UITableViewController {
             case .newTabPageSections:
                 let controller = UIHostingController(rootView: NewTabPageSectionsDebugView())
                 show(controller, sender: nil)
-            case .showNewOnboardingIntro:
-                showOnboardingIntro()
+            case .onboarding:
+                let action = { [weak self] in
+                    guard let self else { return }
+                    self.showOnboardingIntro()
+                }
+                let controller = UIHostingController(rootView: OnboardingDebugView(onNewOnboardingIntroStartAction: action))
+                show(controller, sender: nil)
             case .resetSyncPromoPrompts:
                 guard let sync = sync else { return }
                 let syncPromoPresenter = SyncPromoManager(syncService: sync)

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -92,4 +92,6 @@ class AppSettingsMock: AppSettings {
 
     var newTabPageIntroMessageEnabled: Bool?
     var newTabPageIntroMessageSeenCount: Int = 0
+
+    var onboardingHighlightsEnabled: Bool = false
 }

--- a/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -1,0 +1,122 @@
+//
+//  OnboardingManagerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Core
+@testable import DuckDuckGo
+
+final class OnboardingManagerTests: XCTestCase {
+    private var sut: OnboardingManager!
+    private var appSettingsMock: AppSettingsMock!
+    private var featureFlaggerMock: MockFeatureFlagger!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        appSettingsMock = AppSettingsMock()
+        featureFlaggerMock = MockFeatureFlagger()
+        sut = OnboardingManager(appDefaults: appSettingsMock, featureFlagger: featureFlaggerMock)
+    }
+
+    override func tearDownWithError() throws {
+        appSettingsMock = nil
+        featureFlaggerMock = nil
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testWhenIsLocalFlagEnabledIsCalledAndAppDefaultsOnboardingHiglightsEnabledIsTrueThenReturnTrue() {
+        // GIVEN
+        appSettingsMock.onboardingHighlightsEnabled = true
+
+        // WHEN
+        let result = sut.isLocalFlagEnabled
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenIsLocalFlagEnabledIsCalledAndAppDefaultsOnboardingHiglightsEnabledIsFalseThenReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingHighlightsEnabled = false
+
+        // WHEN
+        let result = sut.isLocalFlagEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsFeatureFlagEnabledIsCalledAndFeaturFlaggerFeatureIsOnThenReturnTrue() {
+        // GIVEN
+        featureFlaggerMock.enabledFeatureFlags = [FeatureFlag.onboardingHighlights]
+
+        // WHEN
+        let result = sut.isFeatureFlagEnabled
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenIsFeatureFlagEnabledIsCalledAndFeaturFlaggerFeatureIsOffThenReturnFalse() {
+        // GIVEN
+        featureFlaggerMock.enabledFeatureFlags = []
+
+        // WHEN
+        let result = sut.isFeatureFlagEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsOnboardingHiglightsEnabledAndIsLocalFlagEnabledIsFalseReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingHighlightsEnabled = false
+        featureFlaggerMock.enabledFeatureFlags = [FeatureFlag.onboardingHighlights]
+
+        // WHEN
+        let result = sut.isOnboardingHighlightsEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsOnboardingHiglightsEnabledAndIsFeatureFlagEnabledIsFalseReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingHighlightsEnabled = true
+        featureFlaggerMock.enabledFeatureFlags = []
+
+        // WHEN
+        let result = sut.isOnboardingHighlightsEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsOnboardingHiglightsEnabledAndIsLocalFlagEnabledIsTrueAndIsFeatureFlagEnabledIsTrueThenReturnTrue() {
+        // GIVEN
+        appSettingsMock.onboardingHighlightsEnabled = true
+        featureFlaggerMock.enabledFeatureFlags = [FeatureFlag.onboardingHighlights]
+
+        // WHEN
+        let result = sut.isOnboardingHighlightsEnabled
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208084960727034/f
CC: @brindy 

**Description**:

Adds local feature flag to enable/disable onboarding highlights with a debug toggle.

**Steps to test this PR**:

**SCENARIO 1 - New Onboarding**
1. Tap the ⚙️ icon located on the Address bar right-hand side. (iPad tap … button first)
2. Scroll to the bottom and select `All Debug Options` under `Debug` section.
3. Scroll to the bottom and select `New Onboarding` to navigate to the Onboarding debug section.
5. Ensure that `Onboarding Highlights local settings enabled` is turned off.
6. Tap on `Preview New Onboarding Intro`.
7. Wait for the onboarding intro to appear.
8. Tap the “Let’s do it Button”.
9. The browser comparison chart should appear.
10. Tap the “Skip” button.
Expected Result:  The onboarding should dismiss.

**SCENARIO 2 - Onboarding Highlights**
1. Tap the ⚙️ icon located on the Address bar right-hand side. (iPad tap … button first)
2. Scroll to the bottom and select `All Debug Options` under `Debug` section.
3. Scroll to the bottom and select `New Onboarding` to navigate to the Onboarding debug section.
5. Ensure that `Onboarding Highlights local settings enabled` is turned on.
6. Tap on `Preview New Onboarding Intro`.
7. Wait for the onboarding intro to appear.
8. Tap the “Let’s do it Button”.
9. The browser comparison chart should appear.
10. Tap the “Skip” button.
11. Wait for a dialog with title “Choose App Icon” appears.
12. Tap the “Continue” button
Expected Result:  The onboarding should dismiss.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
