### PR TITLE
Fix bookmarks toolbar behaviour with Sync Promo on iOS 15

### DIFF
--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -924,8 +924,6 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
             headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: totalHeight)
 
             tableView.tableHeaderView = headerView
-
-            tableView.layoutIfNeeded()
         } else if !headerView.subviews.contains(searchBar) || headerView.subviews.count != 1 {
 
             if syncPromoViewHostingController.view != nil {

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -897,12 +897,17 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
             }
 
             syncPromoViewHostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
             // This is needed to ensure the toolbar displays correctly on iOS 15
             if #available(iOS 16.0, *) {
                 addChild(syncPromoViewHostingController)
+            }
+
+            headerView.addSubview(syncPromoViewHostingController.view)
+
+            if #available(iOS 16.0, *) {
                 syncPromoViewHostingController.didMove(toParent: self)
             }
-            headerView.addSubview(syncPromoViewHostingController.view)
 
             NSLayoutConstraint.deactivate([
                 searchBarBottomConstraint

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -897,7 +897,11 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
             }
 
             syncPromoViewHostingController.view.translatesAutoresizingMaskIntoConstraints = false
-            addChild(syncPromoViewHostingController)
+            // This is needed to ensure the toolbar displays correctly on iOS 15
+            if #available(iOS 16.0, *) {
+                addChild(syncPromoViewHostingController)
+                syncPromoViewHostingController.didMove(toParent: self)
+            }
             headerView.addSubview(syncPromoViewHostingController.view)
 
             NSLayoutConstraint.deactivate([
@@ -920,7 +924,6 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
             headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: totalHeight)
 
             tableView.tableHeaderView = headerView
-            syncPromoViewHostingController.didMove(toParent: self)
 
             tableView.layoutIfNeeded()
         } else if !headerView.subviews.contains(searchBar) || headerView.subviews.count != 1 {

--- a/DuckDuckGo/SyncAssets.xcassets/Sync-Downloads-24.imageset/Contents.json
+++ b/DuckDuckGo/SyncAssets.xcassets/Sync-Downloads-24.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1208220515829639/f
Tech Design URL:
CC:

**Description**:
Fixes a SwiftUI issue which caused the toolbar to not appear correctly on the bookmarks screen


<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
Note: The visibility of the Sync Promo can be reset from the debug screen (final row on that screen)
1. Ensure Sync is disabled and at least 1 bookmark is saved
2. Go the bookmarks screen and confirm the Sync Promo & the toolbar appear correctly
3. Dismiss the promo and confirm the screen updates correctly
4. Go to the Sync screen and toggle dark mode. Confirm the colour of the icon next to “Get DuckDuckGo on Other Devices” updates correctly

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
