### PR TITLE
ensure no atb or app version sent with pixel

### DIFF
--- a/Core/UsageSegmentation.swift
+++ b/Core/UsageSegmentation.swift
@@ -76,7 +76,7 @@ final class UsageSegmentation: UsageSegmenting {
         }
 
         if let pixelInfo {
-            pixelFiring.fire(.usageSegments, withAdditionalParameters: pixelInfo)
+            pixelFiring.fire(.usageSegments, withAdditionalParameters: pixelInfo, includedParameters: [], onComplete: { _ in })
         }
     }
 

--- a/DuckDuckGoTests/UsageSegmentationTests.swift
+++ b/DuckDuckGoTests/UsageSegmentationTests.swift
@@ -124,6 +124,7 @@ final class UsageSegmentationTests: XCTestCase {
 
         XCTAssertEqual(activityType == .appUse ? appUseAtbs : searchAtbs, [installAtb])
         XCTAssertEqual(Pixel.Event.usageSegments, PixelFiringMock.lastPixel, file: file, line: line)
+        XCTAssertEqual([], PixelFiringMock.lastPixelInfo?.includedParams)
     }
 
     private func assertWhenNewATBReceivedWithInstallAtb_ThenBothStoredAndPixelFired(_ activityType: UsageActivityType, file: StaticString = #filePath, line: UInt = #line) {
@@ -135,6 +136,7 @@ final class UsageSegmentationTests: XCTestCase {
 
         XCTAssertEqual(activityType == .appUse ? appUseAtbs : searchAtbs, [installAtb, atb], file: file, line: line)
         XCTAssertEqual(Pixel.Event.usageSegments, PixelFiringMock.lastPixel, file: file, line: line)
+        XCTAssertEqual([], PixelFiringMock.lastPixelInfo?.includedParams)
     }
 
     private func assertWhenATBReceivedTwice_ThenNotStoredAndNoPixelFired(_ activityType: UsageActivityType, file: StaticString = #filePath, line: UInt = #line) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208213671229670/f
Tech Design URL:
CC:

**Description**:
Do not send any default parameters with this pixel. 

**Steps to test this PR**:
1. Run the app and get the usage segmentation pixel to fire, see #3263 
2. Ensure that pixel does not include the atb or app version parameters

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?
