### PR TITLE
Attempt to fix dissapearing privacy icon

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -181,6 +181,7 @@ class TabViewController: UIViewController {
     var errorData: SpecialErrorData?
     var failedURL: URL?
     var storedSpecialErrorPageUserScript: SpecialErrorPageUserScript?
+    var isSpecialErrorPageVisible: Bool = false
 
     let syncService: DDGSyncing
 
@@ -1003,7 +1004,7 @@ class TabViewController: UIViewController {
         if let isValid {
             privacyInfo.serverTrust = isValid ? webView.serverTrust : nil
         }
-        privacyInfo.isSpecialErrorPageVisible = (isValid == nil)
+        privacyInfo.isSpecialErrorPageVisible = isSpecialErrorPageVisible
 
         previousPrivacyInfosByURL[url] = privacyInfo
         
@@ -1384,6 +1385,9 @@ extension TabViewController: WKNavigationDelegate {
         }
 
         specialErrorPageUserScript?.isEnabled = webView.url == failedURL
+        if webView.url != failedURL {
+            isSpecialErrorPageVisible = false
+        }
     }
 
     var specialErrorPageUserScript: SpecialErrorPageUserScript? {
@@ -1609,6 +1613,7 @@ extension TabViewController: WKNavigationDelegate {
     private func loadSpecialErrorPage(url: URL) {
         let html = SpecialErrorPageHTMLTemplate.htmlFromTemplate
         webView?.loadSimulatedRequest(URLRequest(url: url), responseHTML: html)
+        isSpecialErrorPageVisible = true
     }
 
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
@@ -3020,6 +3025,7 @@ extension TabViewController: SpecialErrorPageUserScriptDelegate {
 
     func visitSite() {
         Pixel.fire(pixel: .certificateWarningProceedClicked)
+        isSpecialErrorPageVisible = false
         shouldBypassSSLError = true
         _ = webView.reload()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208225877520189/f

**Description**:
Fix disappearing privacy icon on sites without certificate.

**Steps to test this PR**:
1. Go to any http:// site and make sure privacy icon is visible.

1. Go to badssl.com
2. Select expired certificate
3. Our custom special error page should open.
- please validate the privacy shield icon in navigation bar is invisible.
4. Tap on leave site.
- you should be taken back (if it was possible) or the tab should be closed if this was first page in navigation
5. Go to badssl.com one more time and tap on advanced and accept the risk.
- please validate that expired.badssl.com has loaded (red background)
- please validate that privacy shield icon reappeared but has red dot on top of it
6. Go to wrong.host.badssl.com and make sure icon is invisible.
7. Go to cnn.com and make sure icon is visible.
8. Go back and make sure icon is invisible.
