### PR TITLE
fix tab switcher crashes (speculative fix)

### DIFF
--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -518,9 +518,12 @@ extension TabSwitcherViewController: TabObserver {
             return
         }
 
-        if let index = tabsModel.indexOf(tab: tab), index < collectionView.numberOfItems(inSection: 0) {
-            collectionView.reconfigureItems(at: [IndexPath(row: index, section: 0)])
-        }
+        collectionView.performBatchUpdates({}, completion: { [weak self] completed in
+            guard completed, let self = self else { return }
+            if let index = self.tabsModel.indexOf(tab: tab), index < self.collectionView.numberOfItems(inSection: 0) {
+                self.collectionView.reconfigureItems(at: [IndexPath(row: index, section: 0)])
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207531239053735/f
Tech Design URL:
CC:

**Description**:
Use a batch update to queue changes, hopefully to fix the crash.

**Steps to test this PR**:
1. Open and close the tab switcher
2. Open and close one tab
3. Open, close and re-order many tabs
4. Using something to create a slow network (I use ProxyMan's "slow network conditions") load pages and then update the order of tabs in the tab switcher and also close the tab where the request is running

