### PR TITLE
defer loading the tab switcher button until view did load

### DIFF
--- a/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/DuckDuckGo/BlankSnapshotViewController.swift
@@ -35,7 +35,7 @@ class BlankSnapshotViewController: UIViewController {
     
     let menuButton = MenuButton()
 
-    let tabSwitcherButton = TabSwitcherButton()
+    var tabSwitcherButton: TabSwitcherButton!
     let appSettings: AppSettings
 
     var viewCoordinator: MainViewCoordinator!
@@ -53,6 +53,8 @@ class BlankSnapshotViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        tabSwitcherButton = TabSwitcherButton()
 
         viewCoordinator = MainViewFactory.createViewHierarchy(view)
         if appSettings.currentAddressBarPosition.isBottom {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -136,8 +136,8 @@ class MainViewController: UIViewController {
     }()
     
     weak var tabSwitcherController: TabSwitcherViewController?
-    let tabSwitcherButton = TabSwitcherButton()
-    
+    var tabSwitcherButton: TabSwitcherButton!
+
     /// Do not reference directly, use `presentedMenuButton`
     let menuButton = MenuButton()
     var presentedMenuButton: MenuButton {
@@ -639,6 +639,7 @@ class MainViewController: UIViewController {
     }
 
     private func initTabButton() {
+        tabSwitcherButton = TabSwitcherButton()
         tabSwitcherButton.delegate = self
         viewCoordinator.toolbarTabSwitcherButton.customView = tabSwitcherButton
         viewCoordinator.toolbarTabSwitcherButton.isAccessibilityElement = true

--- a/DuckDuckGo/TabsBarViewController.swift
+++ b/DuckDuckGo/TabsBarViewController.swift
@@ -52,7 +52,7 @@ class TabsBarViewController: UIViewController {
     weak var delegate: TabsBarDelegate?
     private weak var tabsModel: TabsModel?
 
-    let tabSwitcherButton = TabSwitcherButton()
+    var tabSwitcherButton: TabSwitcherButton!
     private let longPressTabGesture = UILongPressGestureRecognizer()
     
     private weak var pressedCell: TabsBarCell?
@@ -71,6 +71,8 @@ class TabsBarViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        tabSwitcherButton = TabSwitcherButton()
 
         decorate()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208092544762425/f
Tech Design URL: 
CC: @bwaresiak 

**Description**:
Defer loading the tab switcher button until view did load to avoid Lottie trying to do something with the view hierarchy when not available.

**Steps to test this PR**:
1. On the phone, open, close and re-order tabs. Make sure tab switcher button reflects correct state.
3. On the iPad, open, close and re-order tabs. Make sure tab switcher button reflects correct state.
4. Enable "app lock" from settings. Background app. Ensure blank snapshot view is correct.  Foreground app and open / close tabs.
5. Launch the app using a link from cold and while in the background.
