### PR TITLE
Fix PrivacyDashboard appearance on entering foreground

### DIFF
--- a/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -171,14 +171,14 @@ extension PrivacyDashboardViewController {
     private func decorate() {
         let theme = ThemeManager.shared.currentTheme
         view.backgroundColor = theme.privacyDashboardWebviewBackgroundColor
-        privacyDashboardController.theme = .init(theme)
+        privacyDashboardController.theme = .init(traitCollection)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            privacyDashboardController.theme = .init()
+            privacyDashboardController.theme = .init(traitCollection)
         }
     }
 }
@@ -378,20 +378,12 @@ extension PrivacyDashboardViewController {
 }
 
 private extension PrivacyDashboardTheme {
-    init(_ userInterfaceStyle: UIUserInterfaceStyle = ThemeManager.shared.currentInterfaceStyle) {
-        switch userInterfaceStyle {
+    init(_ traitCollection: UITraitCollection) {
+        switch traitCollection.userInterfaceStyle {
         case .light: self = .light
         case .dark: self = .dark
         case .unspecified: self = .light
         @unknown default: self = .light
-        }
-    }
-
-    init(_ theme: Theme) {
-        switch theme.name {
-        case .light: self = .light
-        case .dark: self = .dark
-        case .systemDefault: self.init(ThemeManager.shared.currentInterfaceStyle)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208197595138828/f
Tech Design URL:
CC:

**Description**:

`PrivacyDashboardViewController` used a shared `interfaceStyle` accessor when window was not yet visible on entering foreground. This caused a fallback to `.light` color appearance.

**Steps to test this PR**:
1. Enable dark mode
2. Open Privacy Dashboard
3. Move app to background,
4. Go back to the app - Privacy Dashboard should keep the dark appearance.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
