### PR TITLE
Ensure toast closures are called on the main thread

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1381,14 +1381,18 @@ class MainViewController: UIViewController {
 
     private func makeBrokenSitePromptViewHostingController(event: UserBehaviorEvent) -> UIHostingController<BrokenSitePromptView> {
         let viewModel = BrokenSitePromptViewModel(onDidDismiss: { [weak self] in
-            self?.hideNotification()
-            self?.brokenSitePromptLimiter.didDismissToast()
-            self?.brokenSitePromptViewHostingController = nil
+            Task { @MainActor in
+                self?.hideNotification()
+                self?.brokenSitePromptLimiter.didDismissToast()
+                self?.brokenSitePromptViewHostingController = nil
+            }
         }, onDidSubmit: { [weak self] in
-            self?.segueToReportBrokenSite(entryPoint: .prompt(event.rawValue))
-            self?.hideNotification()
-            self?.brokenSitePromptLimiter.didOpenReport()
-            self?.brokenSitePromptViewHostingController = nil
+            Task { @MainActor in
+                self?.segueToReportBrokenSite(entryPoint: .prompt(event.rawValue))
+                self?.hideNotification()
+                self?.brokenSitePromptLimiter.didOpenReport()
+                self?.brokenSitePromptViewHostingController = nil
+            }
         })
         return UIHostingController(rootView: BrokenSitePromptView(viewModel: viewModel), ignoreSafeArea: true)
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1164476816987988/1208244627536574/f
Tech Design URL:
CC: @jaceklyp @samsymons 

**Description**:

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Refresh a webpage twice quickly
2. If the toast doesn't show reinstall the app or explicitly set `lastToastShownDate` to `.distantPast` in `BrokenSitePromptLimiter.swift`. Optionally comment line 95 in that file to have the toast shown every time
3. Ensure both buttons on the toast prompt work correctly

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
