### PR TITLE
SKAD4 crash fix

### DIFF
--- a/DuckDuckGo/AppDelegate+Attribution.swift
+++ b/DuckDuckGo/AppDelegate+Attribution.swift
@@ -43,7 +43,7 @@ extension AppDelegate {
             try await AdAttributionKit.Postback.updateConversionValue(conversionValue, coarseConversionValue: .high, lockPostback: true)
             Logger.general.debug("Attribution: AdAttributionKit postback succeeded")
         } catch {
-            Logger.general.error("Attribution: AdAttributionKit postback failed \(error.localizedDescription, privacy: .public)")
+            Logger.general.error("Attribution: AdAttributionKit postback failed \(String(describing: error), privacy: .public)")
         }
     }
 
@@ -52,8 +52,8 @@ extension AppDelegate {
         do {
             try await SKAdNetwork.updatePostbackConversionValue(conversionValue, coarseValue: .high, lockWindow: true)
             Logger.general.debug("Attribution: SKAN 4 postback succeeded")
-        } catch {
-            Logger.general.error("Attribution: SKAN 4 postback failed \(error.localizedDescription, privacy: .public)")
+        } catch let error {
+            Logger.general.error("Attribution: SKAN 4 postback failed \(String(describing: error), privacy: .public)")
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208303110742725/f
CC: @samsymons @graeme 

**Description**:

Fix for a logging string interpolation in SKAD4 attribution.
I think this could be an internal AdAttributionKit error because every thrown error should be not nil and responding to `localisedDescription`, but here looks like something is going wrong when we try to log `Logger.general.error("Attribution: SKAN 4 postback failed \(error.localizedDescription, privacy: .public)")` and accessing `error.localizedDescription `
This attempt tries not to assume anything about the error and just logs a string representation.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
