### PR TITLE
[DuckPlayer] Experiment Fix - Update Test Variables and pixel names

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -1619,11 +1619,11 @@ extension Pixel.Event {
         case .pproFeedbackSubmitScreenFAQClick: return "m_ppro_feedback_submit-screen-faq_click"
             
         // MARK: Duckplayer experiment
-        case .duckplayerExperimentCohortAssign: return "duckplayer_experiment_cohort_assign"
-        case .duckplayerExperimentSearch: return "duckplayer_experiment_search"
-        case .duckplayerExperimentDailySearch: return "duckplayer_experiment_daily_search"
-        case .duckplayerExperimentWeeklySearch: return "duckplayer_experiment_weekly_search"
-        case .duckplayerExperimentYoutubePageView: return "duckplayer_experiment_youtube_page_view"
+        case .duckplayerExperimentCohortAssign: return "duckplayer_experiment_cohort_assign_v2"
+        case .duckplayerExperimentSearch: return "duckplayer_experiment_search_v2"
+        case .duckplayerExperimentDailySearch: return "duckplayer_experiment_daily_search_v2"
+        case .duckplayerExperimentWeeklySearch: return "duckplayer_experiment_weekly_search_v2"
+        case .duckplayerExperimentYoutubePageView: return "duckplayer_experiment_youtube_page_view_v2"
             
         }
     }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -216,26 +216,27 @@ final class DuckPlayerNavigationHandler {
         if let navigationAction, isSERPLink(navigationAction: navigationAction) {
             referrer = .serp
         }
-        
-        
-        // DuckPlayer Experiment run
-        let experiment = DuckPlayerLaunchExperiment(duckPlayerMode: duckPlayerMode, referrer: referrer)
-        
-        // Enroll user if not enrolled
-        if !experiment.isEnrolled {
-            experiment.assignUserToCohort()
+                
+        if featureFlagger.isFeatureOn(.duckPlayer) {
+            // DuckPlayer Experiment run
+            let experiment = DuckPlayerLaunchExperiment(duckPlayerMode: duckPlayerMode, referrer: referrer)
+            
+            // Enroll user if not enrolled
+            if !experiment.isEnrolled {
+                experiment.assignUserToCohort()
+            }
+            
+            // DuckPlayer is disabled before user enrolls,
+            // So trigger a settings change notification
+            // to let the FE know about the 'actual' setting
+            // and update Experiment value
+            if experiment.isExperimentCohort {
+                duckPlayer.settings.triggerNotification()
+                experiment.duckPlayerMode = duckPlayer.settings.mode
+            }
+            
+            experiment.fireYoutubePixel(videoID: videoID)
         }
-        
-        // DuckPlayer is disabled before user enrolls,
-        // So trigger a settings change notification
-        // to let the FE know about the 'actual' setting
-        // and update Experiment value
-        if experiment.isExperimentCohort {
-            duckPlayer.settings.triggerNotification()
-            experiment.duckPlayerMode = duckPlayer.settings.mode
-        }
-        
-        experiment.fireYoutubePixel(videoID: videoID)
 
     }
     

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -34,6 +34,7 @@ final class DuckPlayerNavigationHandler {
     var featureFlagger: FeatureFlagger
     var appSettings: AppSettings
     var experiment: DuckPlayerLaunchExperimentHandling
+    private lazy var internalUserDecider = AppDependencyProvider.shared.internalUserDecider
     
     private struct Constants {
         static let SERPURL =  "duckduckgo.com/"
@@ -217,7 +218,7 @@ final class DuckPlayerNavigationHandler {
             referrer = .serp
         }
                 
-        if featureFlagger.isFeatureOn(.duckPlayer) {
+        if featureFlagger.isFeatureOn(.duckPlayer) || internalUserDecider.isInternalUser {
             // DuckPlayer Experiment run
             let experiment = DuckPlayerLaunchExperiment(duckPlayerMode: duckPlayerMode, referrer: referrer)
             

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -219,8 +219,11 @@ final class DuckPlayerNavigationHandler {
         }
                 
         if featureFlagger.isFeatureOn(.duckPlayer) || internalUserDecider.isInternalUser {
+            
             // DuckPlayer Experiment run
-            let experiment = DuckPlayerLaunchExperiment(duckPlayerMode: duckPlayerMode, referrer: referrer)
+            let experiment = DuckPlayerLaunchExperiment(duckPlayerMode: duckPlayerMode,
+                                                        referrer: referrer,
+                                                        isInternalUser: internalUserDecider.isInternalUser)
             
             // Enroll user if not enrolled
             if !experiment.isEnrolled {

--- a/DuckDuckGoTests/DuckPlayerExperimentTests.swift
+++ b/DuckDuckGoTests/DuckPlayerExperimentTests.swift
@@ -106,9 +106,9 @@ final class DuckPlayerLaunchExperimentTests: XCTestCase {
         sut.assignUserToCohort()
 
         XCTAssertTrue(sut.isEnrolled, "User should be enrolled after assigning to cohort.")
-        XCTAssertNotNil(sut.experimentCohort, "Experiment cohort should be assigned.")
-        XCTAssertNotNil(sut.enrollmentDate, "Enrollment date should be set.")
-        XCTAssertEqual(DuckPlayerLaunchExperiment.formattedDate(sut.enrollmentDate ?? Date()), "20240910", "The assigned date should match.")
+        XCTAssertNotNil(sut.experimentCohortV2, "Experiment cohort should be assigned.")
+        XCTAssertNotNil(sut.enrollmentDateV2, "Enrollment date should be set.")
+        XCTAssertEqual(DuckPlayerLaunchExperiment.formattedDate(sut.enrollmentDateV2 ?? Date()), "20240910", "The assigned date should match.")
 
         // Check the pixel event history
         let history = DuckPlayerExperimentPixelFireMock.capturedPixelEventHistory
@@ -142,7 +142,7 @@ final class DuckPlayerLaunchExperimentTests: XCTestCase {
         sut.assignUserToCohort()
         XCTAssertEqual(DuckPlayerExperimentPixelFireMock.capturedPixelEventHistory.count, 0, "Enrollment pixel should not have fired again")
         XCTAssertEqual(sut.isEnrolled, true, "The assigned date should not change.")
-        XCTAssertEqual(DuckPlayerLaunchExperiment.formattedDate(sut.enrollmentDate ?? Date()), "20240910", "The assigned date should not change.")
+        XCTAssertEqual(DuckPlayerLaunchExperiment.formattedDate(sut.enrollmentDateV2 ?? Date()), "20240910", "The assigned date should not change.")
     }
     
     func testIfUserIsEnrolled_SearchDailyPixelsFire() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208336598845809/f

**Description**:
- Moves DuckPlayer launch experiment to be behind the Launch Feature flag to avoid enrolling users before time.  (As it happened)
- Renames variables and pixels to avoid collisions with the old (bogus) experiment

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make yourself internal user
2. Tap to Settings > All Debug Options > Reset DuckPlayer Launch Experiment. (End of list)
3. Set a breakpoint [here](https://github.com/duckduckgo/iOS/pull/3363/files#diff-b024d67f44c561d35d8f144721f428379a29e52861b543c3902d668ce94401dcR150)
4. Run the app and watch a YouTube video
5. Confirm app stops at the breakpoint
6. Refresh the page, and confirm app won't stop there anymore
