### PR TITLE
Makes AppDependencyProvider non-instantiatable

### DIFF
--- a/DuckDuckGo/AppDependencyProvider.swift
+++ b/DuckDuckGo/AppDependencyProvider.swift
@@ -54,7 +54,7 @@ protocol DependencyProvider {
 
 /// Provides dependencies for objects that are not directly instantiated
 /// through `init` call (e.g. ViewControllers created from Storyboards).
-class AppDependencyProvider: DependencyProvider {
+final class AppDependencyProvider: DependencyProvider {
 
     static var shared: DependencyProvider = AppDependencyProvider()
     
@@ -89,12 +89,12 @@ class AppDependencyProvider: DependencyProvider {
     let networkProtectionTunnelController: NetworkProtectionTunnelController
 
     let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
-    
+
     let connectionObserver: ConnectionStatusObserver = ConnectionStatusObserverThroughSession()
     let serverInfoObserver: ConnectionServerInfoObserver = ConnectionServerInfoObserverThroughSession()
     let vpnSettings = VPNSettings(defaults: .networkProtectionGroupDefaults)
 
-    init() {
+    private init() {
         featureFlagger = DefaultFeatureFlagger(internalUserDecider: internalUserDecider,
                                                privacyConfigManager: ContentBlocking.shared.privacyConfigurationManager)
 
@@ -143,5 +143,11 @@ class AppDependencyProvider: DependencyProvider {
                                                                               tokenStore: networkProtectionKeychainTokenStore)
         vpnFeatureVisibility = DefaultNetworkProtectionVisibility(userDefaults: .networkProtectionGroupDefaults,
                                                                   accountManager: accountManager)
+    }
+
+    /// Only meant to be used for testing.
+    ///
+    static func makeTestingInstance() -> Self {
+        Self.init()
     }
 }

--- a/DuckDuckGoTests/AutoClearSettingsScreenTests.swift
+++ b/DuckDuckGoTests/AutoClearSettingsScreenTests.swift
@@ -35,7 +35,7 @@ class AutoClearSettingsScreenTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         
-        AppDependencyProvider.shared = AppDependencyProvider()
+        AppDependencyProvider.shared = AppDependencyProvider.makeTestingInstance()
     }
     
     func testWhenOpeningSettingsThenClearDataToggleIsSetBasedOnAppSettings() {

--- a/DuckDuckGoTests/LargeOmniBarStateTests.swift
+++ b/DuckDuckGoTests/LargeOmniBarStateTests.swift
@@ -36,7 +36,7 @@ class LargeOmniBarStateTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         
-        AppDependencyProvider.shared = AppDependencyProvider()
+        AppDependencyProvider.shared = AppDependencyProvider.makeTestingInstance()
     }
     
     func testWhenInHomeEmptyEditingStateWithoutVoiceSearchThenCorrectButtonsAreShown() {

--- a/DuckDuckGoTests/MockDependencyProvider.swift
+++ b/DuckDuckGoTests/MockDependencyProvider.swift
@@ -51,7 +51,7 @@ class MockDependencyProvider: DependencyProvider {
     var vpnSettings: NetworkProtection.VPNSettings
 
     init() {
-        let defaultProvider = AppDependencyProvider()
+        let defaultProvider = AppDependencyProvider.makeTestingInstance()
         appSettings = defaultProvider.appSettings
         variantManager = defaultProvider.variantManager
         featureFlagger = defaultProvider.featureFlagger

--- a/DuckDuckGoTests/SmallOmniBarStateTests.swift
+++ b/DuckDuckGoTests/SmallOmniBarStateTests.swift
@@ -36,7 +36,7 @@ class SmallOmniBarStateTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         
-        AppDependencyProvider.shared = AppDependencyProvider()
+        AppDependencyProvider.shared = AppDependencyProvider.makeTestingInstance()
     }
     
     func testWhenInHomeEmptyEditingStateWithoutVoiceSearchThenCorrectButtonsAreShown() {

--- a/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -169,7 +169,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         pixelsFired.removeAll()
         HTTPStubs.removeAllStubs()
 
-        AppDependencyProvider.shared = AppDependencyProvider()
+        AppDependencyProvider.shared = AppDependencyProvider.makeTestingInstance()
 
         subscriptionService = nil
         authService = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1208353288582614/f

## Description

This is a follow up to [NetworkProtectionTunnelController leaking](https://app.asana.com/0/inbox/1203108348814444/1208331423616717/1208348963925370)

We want to make AppDependencyProvider non instantiatable, since it's really not meant to be.

## Testing

1. Making sure the CI is green should be enough because usage of `AppDependencyProvider` in the app only happens through it's `shared` instance.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
