### PR TITLE
Show Add Favorite placeholder as last favorite item on New Tab Page

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 		6FB2A6802C2EA950004D20C8 /* FavoritesDefaultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultModel.swift */; };
 		6FBF0F8B2BD7C0A900136CF0 /* AllProtectedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */; };
 		6FD0C41F2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */; };
-		6FD0C4212C5BF774000561C9 /* NewTabPageModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD0C4202C5BF774000561C9 /* NewTabPageModelTests.swift */; };
+		6FD0C4212C5BF774000561C9 /* NewTabPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD0C4202C5BF774000561C9 /* NewTabPageViewModelTests.swift */; };
 		6FD1BAE42B87A107000C475C /* AdAttributionPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD1BAE12B87A107000C475C /* AdAttributionPixelReporter.swift */; };
 		6FD1BAE52B87A107000C475C /* AdAttributionReporterStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD1BAE22B87A107000C475C /* AdAttributionReporterStorage.swift */; };
 		6FD1BAE62B87A107000C475C /* AdAttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD1BAE32B87A107000C475C /* AdAttributionFetcher.swift */; };
@@ -342,7 +342,7 @@
 		6FD3F8132C3EFDA200DA5797 /* FavoritesPreviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewModel.swift */; };
 		6FD3F8192C41252900DA5797 /* NewTabPageControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8182C41252900DA5797 /* NewTabPageControllerDelegate.swift */; };
 		6FD8E51E2C5B84DE00345670 /* NewTabPageIntroMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8E51D2C5B84DE00345670 /* NewTabPageIntroMessageView.swift */; };
-		6FD8E5202C5BA23200345670 /* NewTabPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8E51F2C5BA23200345670 /* NewTabPageModel.swift */; };
+		6FD8E5202C5BA23200345670 /* NewTabPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8E51F2C5BA23200345670 /* NewTabPageViewModel.swift */; };
 		6FD8E5222C5BA5C400345670 /* NewTabPageIntroMessageSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8E5212C5BA5C400345670 /* NewTabPageIntroMessageSetup.swift */; };
 		6FDA1FB32B59584400AC962A /* AddressDisplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */; };
 		6FDC64012C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDC64002C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift */; };
@@ -1609,7 +1609,7 @@
 		6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesDefaultModel.swift; sourceTree = "<group>"; };
 		6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllProtectedCell.swift; sourceTree = "<group>"; };
 		6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroMessageSetupTests.swift; sourceTree = "<group>"; };
-		6FD0C4202C5BF774000561C9 /* NewTabPageModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageModelTests.swift; sourceTree = "<group>"; };
+		6FD0C4202C5BF774000561C9 /* NewTabPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageViewModelTests.swift; sourceTree = "<group>"; };
 		6FD1BAE12B87A107000C475C /* AdAttributionPixelReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdAttributionPixelReporter.swift; path = AdAttribution/AdAttributionPixelReporter.swift; sourceTree = "<group>"; };
 		6FD1BAE22B87A107000C475C /* AdAttributionReporterStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdAttributionReporterStorage.swift; path = AdAttribution/AdAttributionReporterStorage.swift; sourceTree = "<group>"; };
 		6FD1BAE32B87A107000C475C /* AdAttributionFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdAttributionFetcher.swift; path = AdAttribution/AdAttributionFetcher.swift; sourceTree = "<group>"; };
@@ -1619,7 +1619,7 @@
 		6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesPreviewModel.swift; sourceTree = "<group>"; };
 		6FD3F8182C41252900DA5797 /* NewTabPageControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageControllerDelegate.swift; sourceTree = "<group>"; };
 		6FD8E51D2C5B84DE00345670 /* NewTabPageIntroMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroMessageView.swift; sourceTree = "<group>"; };
-		6FD8E51F2C5BA23200345670 /* NewTabPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageModel.swift; sourceTree = "<group>"; };
+		6FD8E51F2C5BA23200345670 /* NewTabPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageViewModel.swift; sourceTree = "<group>"; };
 		6FD8E5212C5BA5C400345670 /* NewTabPageIntroMessageSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroMessageSetup.swift; sourceTree = "<group>"; };
 		6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressDisplayHelper.swift; sourceTree = "<group>"; };
 		6FDC64002C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroDataStoring.swift; sourceTree = "<group>"; };
@@ -3833,7 +3833,7 @@
 				6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */,
 				6F934F852C58DB00008364E4 /* NewTabPageSettingsPersistentStorageTests.swift */,
 				6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */,
-				6FD0C4202C5BF774000561C9 /* NewTabPageModelTests.swift */,
+				6FD0C4202C5BF774000561C9 /* NewTabPageViewModelTests.swift */,
 				6F7FB8DF2C660B1A00867DA7 /* NewTabPageFavoritesModelTests.swift */,
 				6F7FB8E42C66158D00867DA7 /* NewTabPageShortcutsSettingsModelTests.swift */,
 				6F7FB8E62C66197E00867DA7 /* NewTabPageSectionsSettingsModelTests.swift */,
@@ -3949,7 +3949,7 @@
 				6FE1273B2C204C0D00EB5724 /* Subviews */,
 				6F03CAF82C32C3AA004179A8 /* Messages */,
 				6FE127372C20492500EB5724 /* NewTabPage.swift */,
-				6FD8E51F2C5BA23200345670 /* NewTabPageModel.swift */,
+				6FD8E51F2C5BA23200345670 /* NewTabPageViewModel.swift */,
 				6FE127392C204BD000EB5724 /* NewTabPageView.swift */,
 				6FE127452C2054A900EB5724 /* NewTabPageViewController.swift */,
 				6FD3F8182C41252900DA5797 /* NewTabPageControllerDelegate.swift */,
@@ -7467,7 +7467,7 @@
 				C10CB5F32A1A5BDF0048E503 /* AutofillViews.swift in Sources */,
 				6FE127382C20492500EB5724 /* NewTabPage.swift in Sources */,
 				982E5630222C3D5B008D861B /* FeedbackPickerViewController.swift in Sources */,
-				6FD8E5202C5BA23200345670 /* NewTabPageModel.swift in Sources */,
+				6FD8E5202C5BA23200345670 /* NewTabPageViewModel.swift in Sources */,
 				37FCAABC2992F592000E420A /* MultilineScrollableTextFix.swift in Sources */,
 				85DFEDED24C7CCA500973FE7 /* AppWidthObserver.swift in Sources */,
 				4B6484F327FD1E350050A7A1 /* MenuControllerView.swift in Sources */,
@@ -7883,7 +7883,7 @@
 				1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */,
 				31C138A427A3352600FFD4B2 /* DownloadTests.swift in Sources */,
 				853A717820F645FB00FE60BC /* PixelTests.swift in Sources */,
-				6FD0C4212C5BF774000561C9 /* NewTabPageModelTests.swift in Sources */,
+				6FD0C4212C5BF774000561C9 /* NewTabPageViewModelTests.swift in Sources */,
 				984D036124AF49B80066CFB8 /* TabPreviewsSourceTests.swift in Sources */,
 				85D2187024BF24DB004373D2 /* FaviconRequestModifierTests.swift in Sources */,
 				EAB19EDA268963510015D3EA /* DomainMatchingTests.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -329,7 +329,7 @@
 		6FB2A67A2C2C5BAE004D20C8 /* FavoriteEmptyStateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A6792C2C5BAE004D20C8 /* FavoriteEmptyStateItem.swift */; };
 		6FB2A67C2C2D9DF0004D20C8 /* FavoritesEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67B2C2D9DF0004D20C8 /* FavoritesEmptyStateView.swift */; };
 		6FB2A67E2C2DAFB4004D20C8 /* NewTabPageGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67D2C2DAFB4004D20C8 /* NewTabPageGridView.swift */; };
-		6FB2A6802C2EA950004D20C8 /* FavoritesDefaultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultModel.swift */; };
+		6FB2A6802C2EA950004D20C8 /* FavoritesDefaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultViewModel.swift */; };
 		6FBF0F8B2BD7C0A900136CF0 /* AllProtectedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */; };
 		6FD0C41F2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */; };
 		6FD0C4212C5BF774000561C9 /* NewTabPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD0C4202C5BF774000561C9 /* NewTabPageViewModelTests.swift */; };
@@ -338,8 +338,8 @@
 		6FD1BAE62B87A107000C475C /* AdAttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD1BAE32B87A107000C475C /* AdAttributionFetcher.swift */; };
 		6FD3AEE32B8F4EEB0060FCCC /* AdAttributionPixelReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3AEE12B8DFBB80060FCCC /* AdAttributionPixelReporterTests.swift */; };
 		6FD3F80F2C3EF4F000DA5797 /* DeviceOrientationEnvironmentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F80E2C3EF4F000DA5797 /* DeviceOrientationEnvironmentValue.swift */; };
-		6FD3F8112C3EFCDB00DA5797 /* FavoritesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8102C3EFCDB00DA5797 /* FavoritesModel.swift */; };
-		6FD3F8132C3EFDA200DA5797 /* FavoritesPreviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewModel.swift */; };
+		6FD3F8112C3EFCDB00DA5797 /* FavoritesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8102C3EFCDB00DA5797 /* FavoritesViewModel.swift */; };
+		6FD3F8132C3EFDA200DA5797 /* FavoritesPreviewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewDataSource.swift */; };
 		6FD3F8192C41252900DA5797 /* NewTabPageControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD3F8182C41252900DA5797 /* NewTabPageControllerDelegate.swift */; };
 		6FD8E51E2C5B84DE00345670 /* NewTabPageIntroMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8E51D2C5B84DE00345670 /* NewTabPageIntroMessageView.swift */; };
 		6FD8E5202C5BA23200345670 /* NewTabPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD8E51F2C5BA23200345670 /* NewTabPageViewModel.swift */; };
@@ -347,6 +347,7 @@
 		6FDA1FB32B59584400AC962A /* AddressDisplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */; };
 		6FDC64012C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDC64002C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift */; };
 		6FDC64032C92F4D600DB71B3 /* NewTabPageSettingsPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDC64022C92F4D600DB71B3 /* NewTabPageSettingsPersistentStore.swift */; };
+		6FDC64052C98515E00DB71B3 /* AddFavoritePlaceholderItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDC64042C98515E00DB71B3 /* AddFavoritePlaceholderItemView.swift */; };
 		6FE018402C25CB3F001F680D /* FavoritesSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE0183F2C25CB3F001F680D /* FavoritesSectionHeader.swift */; };
 		6FE095D82BD90AFB00490FF8 /* UniversalOmniBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE095D72BD90AFB00490FF8 /* UniversalOmniBarState.swift */; };
 		6FE127382C20492500EB5724 /* NewTabPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE127372C20492500EB5724 /* NewTabPage.swift */; };
@@ -356,6 +357,8 @@
 		6FE127432C204DF700EB5724 /* FavoriteItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE127422C204DF700EB5724 /* FavoriteItemView.swift */; };
 		6FE127462C2054A900EB5724 /* NewTabPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE127452C2054A900EB5724 /* NewTabPageViewController.swift */; };
 		6FE1274B2C20943500EB5724 /* ShortcutItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE1274A2C20943500EB5724 /* ShortcutItemView.swift */; };
+		6FEC0B852C999352006B4F6E /* FavoriteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEC0B842C999352006B4F6E /* FavoriteItem.swift */; };
+		6FEC0B882C999961006B4F6E /* FavoriteDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEC0B872C999961006B4F6E /* FavoriteDataSource.swift */; };
 		6FF915822B88E07A0042AC87 /* AdAttributionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF915802B88E0750042AC87 /* AdAttributionFetcherTests.swift */; };
 		7BC571202BDBB877003B0CCE /* VPNActivationDateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC5711F2BDBB877003B0CCE /* VPNActivationDateStore.swift */; };
 		7BC571212BDBB977003B0CCE /* VPNActivationDateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC5711F2BDBB877003B0CCE /* VPNActivationDateStore.swift */; };
@@ -1606,7 +1609,7 @@
 		6FB2A6792C2C5BAE004D20C8 /* FavoriteEmptyStateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteEmptyStateItem.swift; sourceTree = "<group>"; };
 		6FB2A67B2C2D9DF0004D20C8 /* FavoritesEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesEmptyStateView.swift; sourceTree = "<group>"; };
 		6FB2A67D2C2DAFB4004D20C8 /* NewTabPageGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageGridView.swift; sourceTree = "<group>"; };
-		6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesDefaultModel.swift; sourceTree = "<group>"; };
+		6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesDefaultViewModel.swift; sourceTree = "<group>"; };
 		6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllProtectedCell.swift; sourceTree = "<group>"; };
 		6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroMessageSetupTests.swift; sourceTree = "<group>"; };
 		6FD0C4202C5BF774000561C9 /* NewTabPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageViewModelTests.swift; sourceTree = "<group>"; };
@@ -1615,8 +1618,8 @@
 		6FD1BAE32B87A107000C475C /* AdAttributionFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdAttributionFetcher.swift; path = AdAttribution/AdAttributionFetcher.swift; sourceTree = "<group>"; };
 		6FD3AEE12B8DFBB80060FCCC /* AdAttributionPixelReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionPixelReporterTests.swift; sourceTree = "<group>"; };
 		6FD3F80E2C3EF4F000DA5797 /* DeviceOrientationEnvironmentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceOrientationEnvironmentValue.swift; sourceTree = "<group>"; };
-		6FD3F8102C3EFCDB00DA5797 /* FavoritesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesModel.swift; sourceTree = "<group>"; };
-		6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesPreviewModel.swift; sourceTree = "<group>"; };
+		6FD3F8102C3EFCDB00DA5797 /* FavoritesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewModel.swift; sourceTree = "<group>"; };
+		6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesPreviewDataSource.swift; sourceTree = "<group>"; };
 		6FD3F8182C41252900DA5797 /* NewTabPageControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageControllerDelegate.swift; sourceTree = "<group>"; };
 		6FD8E51D2C5B84DE00345670 /* NewTabPageIntroMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroMessageView.swift; sourceTree = "<group>"; };
 		6FD8E51F2C5BA23200345670 /* NewTabPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageViewModel.swift; sourceTree = "<group>"; };
@@ -1624,6 +1627,7 @@
 		6FDA1FB22B59584400AC962A /* AddressDisplayHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressDisplayHelper.swift; sourceTree = "<group>"; };
 		6FDC64002C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroDataStoring.swift; sourceTree = "<group>"; };
 		6FDC64022C92F4D600DB71B3 /* NewTabPageSettingsPersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSettingsPersistentStore.swift; sourceTree = "<group>"; };
+		6FDC64042C98515E00DB71B3 /* AddFavoritePlaceholderItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFavoritePlaceholderItemView.swift; sourceTree = "<group>"; };
 		6FE0183F2C25CB3F001F680D /* FavoritesSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesSectionHeader.swift; sourceTree = "<group>"; };
 		6FE095D72BD90AFB00490FF8 /* UniversalOmniBarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalOmniBarState.swift; sourceTree = "<group>"; };
 		6FE127372C20492500EB5724 /* NewTabPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPage.swift; sourceTree = "<group>"; };
@@ -1633,6 +1637,8 @@
 		6FE127422C204DF700EB5724 /* FavoriteItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteItemView.swift; sourceTree = "<group>"; };
 		6FE127452C2054A900EB5724 /* NewTabPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageViewController.swift; sourceTree = "<group>"; };
 		6FE1274A2C20943500EB5724 /* ShortcutItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutItemView.swift; sourceTree = "<group>"; };
+		6FEC0B842C999352006B4F6E /* FavoriteItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteItem.swift; sourceTree = "<group>"; };
+		6FEC0B872C999961006B4F6E /* FavoriteDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteDataSource.swift; sourceTree = "<group>"; };
 		6FF915802B88E0750042AC87 /* AdAttributionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionFetcherTests.swift; sourceTree = "<group>"; };
 		7BC5711F2BDBB877003B0CCE /* VPNActivationDateStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VPNActivationDateStore.swift; sourceTree = "<group>"; };
 		83004E7F2193BB8200DA013C /* WKNavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKNavigationExtension.swift; sourceTree = "<group>"; };
@@ -3887,11 +3893,13 @@
 		6FA3438D2C3D3BB800470677 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultModel.swift */,
+				6FB2A67F2C2EA950004D20C8 /* FavoritesDefaultViewModel.swift */,
 				6F64AA522C47E92600CF4489 /* FavoritesFaviconLoader.swift */,
-				6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewModel.swift */,
-				6FD3F8102C3EFCDB00DA5797 /* FavoritesModel.swift */,
+				6FD3F8122C3EFDA200DA5797 /* FavoritesPreviewDataSource.swift */,
+				6FD3F8102C3EFCDB00DA5797 /* FavoritesViewModel.swift */,
 				6FA3438E2C3D3BC300470677 /* Favorite.swift */,
+				6FEC0B842C999352006B4F6E /* FavoriteItem.swift */,
+				6FEC0B872C999961006B4F6E /* FavoriteDataSource.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -3901,6 +3909,7 @@
 			children = (
 				6FE127422C204DF700EB5724 /* FavoriteItemView.swift */,
 				6FA343912C3D3C3B00470677 /* FavoriteIconView.swift */,
+				6FDC64042C98515E00DB71B3 /* AddFavoritePlaceholderItemView.swift */,
 			);
 			name = Item;
 			sourceTree = "<group>";
@@ -7567,7 +7576,7 @@
 				31B2F11F287846320040427A /* NoMicPermissionAlert.swift in Sources */,
 				310C4B45281B5A9A00BA79A9 /* AutofillLoginDetailsView.swift in Sources */,
 				6F9FFE2D2C57AE8F00A238BE /* NewTabPageShortcutsSettingsModel.swift in Sources */,
-				6FD3F8112C3EFCDB00DA5797 /* FavoritesModel.swift in Sources */,
+				6FD3F8112C3EFCDB00DA5797 /* FavoritesViewModel.swift in Sources */,
 				D62EC3C22C248AF800FC9D04 /* DuckPlayerNavigationHandling.swift in Sources */,
 				9FB027142C252E0C009EA190 /* OnboardingView+BrowsersComparisonContent.swift in Sources */,
 				D664C7B62B289AA200CBFA76 /* SubscriptionFlowViewModel.swift in Sources */,
@@ -7598,6 +7607,7 @@
 				D6E83C662B23936F006C8AFB /* SettingsDebugView.swift in Sources */,
 				C1641EB12BC2F52B0012607A /* ImportPasswordsView.swift in Sources */,
 				CBFCB30E2B2CD47800253E9E /* ConfigurationURLDebugViewController.swift in Sources */,
+				6FDC64052C98515E00DB71B3 /* AddFavoritePlaceholderItemView.swift in Sources */,
 				982686AD2600C0850011A8D6 /* ActionMessageView.swift in Sources */,
 				F446B9B5251150AC00324016 /* HomeMessageViewSectionRenderer.swift in Sources */,
 				D6E0C1852B7A2B9400D5E1E9 /* DesktopDownloadPlatformConstants.swift in Sources */,
@@ -7687,7 +7697,7 @@
 				9FDEC7BC2C91204900C7A692 /* AppIconPickerViewModel.swift in Sources */,
 				F1FDC9352BF51E41006B1435 /* VPNSettings+Environment.swift in Sources */,
 				850ABD012AC3961100A733DF /* MainViewController+Segues.swift in Sources */,
-				6FB2A6802C2EA950004D20C8 /* FavoritesDefaultModel.swift in Sources */,
+				6FB2A6802C2EA950004D20C8 /* FavoritesDefaultViewModel.swift in Sources */,
 				9817C9C321EF594700884F65 /* AutoClear.swift in Sources */,
 				9FE05CEE2C36424E00D9046B /* OnboardingPixelReporter.swift in Sources */,
 				9821234E2B6D0A6300F08C57 /* UserAuthenticator.swift in Sources */,
@@ -7806,7 +7816,7 @@
 				1E4FAA6627D8DFC800ADC5B3 /* CompleteDownloadRowViewModel.swift in Sources */,
 				3712091E2C21E390003ADF3D /* RemoteMessagingStoreErrorHandling.swift in Sources */,
 				83004E862193E5ED00DA013C /* TabViewControllerBrowsingMenuExtension.swift in Sources */,
-				6FD3F8132C3EFDA200DA5797 /* FavoritesPreviewModel.swift in Sources */,
+				6FD3F8132C3EFDA200DA5797 /* FavoritesPreviewDataSource.swift in Sources */,
 				6FD1BAE62B87A107000C475C /* AdAttributionFetcher.swift in Sources */,
 				EE01EB402AFBD0000096AAC9 /* NetworkProtectionVPNSettingsViewModel.swift in Sources */,
 				EE72CA852A862D000043B5B3 /* NetworkProtectionDebugViewController.swift in Sources */,
@@ -7836,8 +7846,10 @@
 				1E4DCF4627B6A33600961E25 /* DownloadsListViewModel.swift in Sources */,
 				37C696772C4957940073E131 /* RemoteMessagingDebugViewController.swift in Sources */,
 				31860A5B2C57ED2D005561F5 /* DuckPlayerStorage.swift in Sources */,
+				6FEC0B882C999961006B4F6E /* FavoriteDataSource.swift in Sources */,
 				F4F6DFB626E6B71300ED7E12 /* BookmarkFoldersTableViewController.swift in Sources */,
 				8586A11024CCCD040049720E /* TabsBarViewController.swift in Sources */,
+				6FEC0B852C999352006B4F6E /* FavoriteItem.swift in Sources */,
 				F1D796F41E7C2A410019D451 /* BookmarksDelegate.swift in Sources */,
 				D664C7B92B289AA200CBFA76 /* WKUserContentController+Handler.swift in Sources */,
 				1E8AD1D727C2E24E00ABA377 /* DownloadsListRowViewModel.swift in Sources */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10979,7 +10979,7 @@
 			repositoryURL = "https://github.com/duckduckgo/DesignResourcesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 3.2.0;
+				version = 3.3.0;
 			};
 		};
 		F486D2EF25069482002D07D7 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/DesignResourcesKit",
       "state" : {
-        "revision" : "fe3c383b5e21e0a419e0f979f7f2cd4e67385b15",
-        "version" : "3.2.0"
+        "revision" : "ad133f76501edcb2bfa841e33aebc0da5f92bb5c",
+        "version" : "3.3.0"
       }
     },
     {

--- a/DuckDuckGo/AddFavoritePlaceholderItemView.swift
+++ b/DuckDuckGo/AddFavoritePlaceholderItemView.swift
@@ -1,5 +1,5 @@
 //
-//  FavoritesSectionHeader.swift
+//  AddFavoritePlaceholderItemView.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -19,31 +19,20 @@
 
 import SwiftUI
 import DesignResourcesKit
-import Core
 
-struct FavoritesSectionHeader: View {
-
-    let model: any FavoritesEmptyStateModel
-
+struct AddFavoritePlaceholderItemView: View {
     var body: some View {
-        HStack(spacing: 16, content: {
-            Text(UserText.newTabPageFavoritesSectionHeaderTitle)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(Color(designSystemColor: .textPrimary))
-                .frame(alignment: .leading)
-
-            Spacer()
-
-            Button(action: {
-                model.toggleTooltip()
-            }, label: {
-                Image(.info12)
-                    .foregroundStyle(Color(designSystemColor: .textPrimary))
-            })
-        })
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(.clear)
+            .overlay {
+                Image(.add24)
+                    .tintIfAvailable(Color(designSystemColor: .icons))
+            }
+            .aspectRatio(1.0, contentMode: .fit)
     }
 }
 
 #Preview {
-    FavoritesSectionHeader(model: FavoritesPreviewModel())
+    AddFavoritePlaceholderItemView()
+        .frame(width: 100)
 }

--- a/DuckDuckGo/EditableShortcutsView.swift
+++ b/DuckDuckGo/EditableShortcutsView.swift
@@ -61,11 +61,11 @@ private extension View {
 
 extension NewTabPageSettingsModel.NTPSetting<NewTabPageShortcut>: Reorderable, Hashable, Equatable {
 
-    var dropItemProvider: NSItemProvider {
-        NSItemProvider(object: item.id as NSString)
+    var trait: ReorderableTrait {
+        let itemProvider = NSItemProvider(object: item.id as NSString)
+        let metadata = MoveMetadata(itemProvider: itemProvider, type: .text)
+        return .movable(metadata)
     }
-
-    var dropType: UTType { .text }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.item == rhs.item

--- a/DuckDuckGo/FavoriteDataSource.swift
+++ b/DuckDuckGo/FavoriteDataSource.swift
@@ -1,0 +1,95 @@
+//
+//  FavoriteDataSource.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Combine
+import Bookmarks
+
+final class FavoritesListInteractingAdapter: NewTabPageFavoriteDataSource {
+
+    let favoritesListInteracting: FavoritesListInteracting
+
+    init(favoritesListInteracting: FavoritesListInteracting) {
+        self.favoritesListInteracting = favoritesListInteracting
+    }
+
+    var externalUpdates: AnyPublisher<Void, Never> { favoritesListInteracting.externalUpdates }
+
+    var favorites: [Favorite] {
+        (try? favoritesListInteracting.favorites.map(Favorite.init)) ?? []
+    }
+
+    func moveFavorite(_ favorite: Favorite, fromIndex: Int, toIndex: Int) {
+        guard let entity = bookmarkEntity(for: favorite) else { return }
+
+        // adjust for different target index handling
+        let toIndex = toIndex > fromIndex ? toIndex - 1 : toIndex
+        favoritesListInteracting.moveFavorite(entity, fromIndex: fromIndex, toIndex: toIndex)
+    }
+    
+    func bookmarkEntity(for favorite: Favorite) -> BookmarkEntity? {
+        favoritesListInteracting.favorites.first {
+            $0.uuid == favorite.id
+        }
+    }
+    
+    func favorite(at index: Int) throws -> Favorite? {
+        try favoritesListInteracting.favorite(at: index).map(Favorite.init)
+    }
+    
+    func removeFavorite(_ favorite: Favorite) {
+        guard let entity = bookmarkEntity(for: favorite) else { return }
+
+        favoritesListInteracting.removeFavorite(entity)
+    }
+}
+
+private extension Favorite {
+    init(_ bookmark: BookmarkEntity) throws {
+        guard let uuid = bookmark.uuid else {
+            throw FavoriteMappingError.missingUUID
+        }
+
+        self.id = uuid
+        self.title = bookmark.displayTitle
+        self.domain = bookmark.host
+        self.urlObject = bookmark.urlObject
+    }
+}
+
+private extension BookmarkEntity {
+
+    var displayTitle: String {
+        if let title = title?.trimmingWhitespace(), !title.isEmpty {
+            return title
+        }
+
+        if let host = urlObject?.host?.droppingWwwPrefix() {
+            return host
+        }
+
+        assertionFailure("Unable to create display title")
+        return ""
+    }
+
+    var host: String {
+        return urlObject?.host ?? ""
+    }
+
+}

--- a/DuckDuckGo/FavoriteItem.swift
+++ b/DuckDuckGo/FavoriteItem.swift
@@ -1,0 +1,50 @@
+//
+//  FavoriteItem.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+enum FavoriteItem {
+    case favorite(Favorite)
+    case itemPlaceholder
+}
+
+extension FavoriteItem: Identifiable {
+    var id: String {
+        switch self {
+        case .favorite(let favorite):
+            return favorite.id
+        case .itemPlaceholder:
+            return "placeholder"
+        }
+    }
+}
+
+extension FavoriteItem: Reorderable {
+    var trait: ReorderableTrait {
+        switch self {
+        case .favorite(let favorite):
+            let itemProvider = NSItemProvider(object: (favorite.urlObject?.absoluteString ?? "") as NSString)
+            let metadata = MoveMetadata(itemProvider: itemProvider, type: .plainText)
+            return .movable(metadata)
+        case .itemPlaceholder:
+            return .stationary
+        }
+    }
+}

--- a/DuckDuckGo/FavoriteItem.swift
+++ b/DuckDuckGo/FavoriteItem.swift
@@ -22,7 +22,7 @@ import UniformTypeIdentifiers
 
 enum FavoriteItem {
     case favorite(Favorite)
-    case itemPlaceholder
+    case addFavorite
 }
 
 extension FavoriteItem: Identifiable {
@@ -30,7 +30,7 @@ extension FavoriteItem: Identifiable {
         switch self {
         case .favorite(let favorite):
             return favorite.id
-        case .itemPlaceholder:
+        case .addFavorite:
             return "placeholder"
         }
     }
@@ -43,7 +43,7 @@ extension FavoriteItem: Reorderable {
             let itemProvider = NSItemProvider(object: (favorite.urlObject?.absoluteString ?? "") as NSString)
             let metadata = MoveMetadata(itemProvider: itemProvider, type: .plainText)
             return .movable(metadata)
-        case .itemPlaceholder:
+        case .addFavorite:
             return .stationary
         }
     }

--- a/DuckDuckGo/FavoriteItem.swift
+++ b/DuckDuckGo/FavoriteItem.swift
@@ -31,7 +31,7 @@ extension FavoriteItem: Identifiable {
         case .favorite(let favorite):
             return favorite.id
         case .addFavorite:
-            return "placeholder"
+            return "addFavorite"
         }
     }
 }

--- a/DuckDuckGo/FavoritesDefaultViewModel.swift
+++ b/DuckDuckGo/FavoritesDefaultViewModel.swift
@@ -52,7 +52,7 @@ class FavoritesDefaultViewModel: FavoritesViewModel, FavoritesEmptyStateModel {
     private let dailyPixelFiring: DailyPixelFiring.Type
 
     var isEmpty: Bool {
-        allFavorites.isEmpty
+        allFavorites.filter(\.isFavorite).isEmpty
     }
 
     init(favoriteDataSource: NewTabPageFavoriteDataSource,
@@ -167,7 +167,7 @@ class FavoritesDefaultViewModel: FavoritesViewModel, FavoritesEmptyStateModel {
         var allFavorites = favoriteDataSource.favorites.map {
             FavoriteItem.favorite($0)
         }
-        allFavorites.append(.itemPlaceholder)
+        allFavorites.append(.addFavorite)
         
         self.allFavorites = allFavorites
     }
@@ -203,5 +203,16 @@ private final class MissingFaviconWrapper: FavoritesFaviconLoading {
 
     func existingFavicon(for favorite: Favorite, size: CGFloat) -> Favicon? {
         loader.existingFavicon(for: favorite, size: size)
+    }
+}
+
+private extension FavoriteItem {
+    var isFavorite: Bool {
+        switch self {
+        case .favorite:
+            return true
+        case .addFavorite:
+            return false
+        }
     }
 }

--- a/DuckDuckGo/FavoritesEmptyStateView.swift
+++ b/DuckDuckGo/FavoritesEmptyStateView.swift
@@ -18,12 +18,11 @@
 //
 
 import SwiftUI
+import DuckUI
 
 struct FavoritesEmptyStateView<Model: FavoritesEmptyStateModel>: View {
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @Environment(\.isLandscapeOrientation) var isLandscape
-
     @ObservedObject var model: Model
+    @Binding var isAddingFavorite: Bool
 
     let geometry: GeometryProxy?
 
@@ -33,7 +32,15 @@ struct FavoritesEmptyStateView<Model: FavoritesEmptyStateModel>: View {
                 FavoritesSectionHeader(model: model)
 
                 NewTabPageGridView(geometry: geometry) { placeholdersCount in
-                    let placeholders = Array(0..<placeholdersCount)
+                    Button(action: {
+                        isAddingFavorite = true
+                    }, label: {
+                        AddFavoritePlaceholderItemView()
+                    })
+                    .buttonStyle(SecondaryFillButtonStyle(isFreeform: true))
+                    .frame(width: NewTabPageGrid.Item.edgeSize)
+
+                    let placeholders = Array(0..<placeholdersCount - 1)
                     ForEach(placeholders, id: \.self) { _ in
                         FavoriteEmptyStateItem()
                             .frame(width: NewTabPageGrid.Item.edgeSize, height: NewTabPageGrid.Item.edgeSize)
@@ -55,5 +62,17 @@ struct FavoritesEmptyStateView<Model: FavoritesEmptyStateModel>: View {
 }
 
 #Preview {
-    return FavoritesEmptyStateView(model: FavoritesPreviewModel(), geometry: nil)
+    PreviewViewWrapper()
+}
+
+private struct PreviewViewWrapper: View {
+    @State var isAddingFavorite = false
+
+    var body: some View {
+        FavoritesEmptyStateView(
+            model: FavoritesPreviewModel(),
+            isAddingFavorite: $isAddingFavorite,
+            geometry: nil
+        )
+    }
 }

--- a/DuckDuckGo/FavoritesPreviewDataSource.swift
+++ b/DuckDuckGo/FavoritesPreviewDataSource.swift
@@ -1,0 +1,77 @@
+//
+//  FavoritesPreviewDataSource.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Bookmarks
+import Foundation
+
+final class FavoritesPreviewModel: FavoritesDefaultViewModel {
+    init(favorites: [Favorite] = randomFavorites) {
+        super.init(favoriteDataSource: FavoritesPreviewDataSource(favorites: favorites), faviconLoader: EmptyFaviconLoading())
+    }
+
+    static var randomFavorites: [Favorite] {
+        (0...20).map {
+            Favorite(
+                id: UUID().uuidString,
+                title: "Favorite \($0)",
+                domain: "favorite\($0).domain.com")
+        }
+    }
+}
+
+final class FavoritesPreviewDataSource: NewTabPageFavoriteDataSource {
+    var externalUpdates: AnyPublisher<Void, Never> = Empty().eraseToAnyPublisher()
+
+    var favorites: [Favorite]
+
+    init(favorites: [Favorite]) {
+        self.favorites = favorites
+    }
+
+    func moveFavorite(_ favorite: Favorite, fromIndex: Int, toIndex: Int) {
+        favorites.move(fromOffsets: IndexSet(integer: fromIndex), toOffset: toIndex)
+    }
+    
+    func bookmarkEntity(for favorite: Favorite) -> Bookmarks.BookmarkEntity? {
+        nil
+    }
+    
+    func favorite(at index: Int) throws -> Favorite? {
+        favorites[index]
+    }
+    
+    func removeFavorite(_ favorite: Favorite) {
+        // no-op
+    }
+}
+
+struct EmptyFaviconLoading: FavoritesFaviconLoading {
+    func existingFavicon(for favorite: Favorite, size: CGFloat) -> Favicon? {
+        nil
+    }
+
+    func fakeFavicon(for favorite: Favorite, size: CGFloat) -> Favicon {
+        .empty
+    }
+
+    func loadFavicon(for favorite: Favorite, size: CGFloat) async -> Favicon? {
+        nil
+    }
+}

--- a/DuckDuckGo/FavoritesView.swift
+++ b/DuckDuckGo/FavoritesView.swift
@@ -27,6 +27,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
     @Environment(\.isLandscapeOrientation) var isLandscape
 
     @ObservedObject var model: Model
+    @Binding var isAddingFavorite: Bool
     let geometry: GeometryProxy?
 
     private let selectionFeedback = UISelectionFeedbackGenerator()
@@ -107,7 +108,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
             })
         case .addFavorite:
             Button(action: {
-                // add favorite
+                isAddingFavorite = true
             }, label: {
                 AddFavoritePlaceholderItemView()
             })
@@ -124,5 +125,12 @@ private extension View {
 }
 
 #Preview {
-    FavoritesView(model: FavoritesPreviewModel(), geometry: nil)
+    PreviewWrapperView()
+}
+
+private struct PreviewWrapperView: View {
+    @State var isAddingFavorite = false
+    var body: some View {
+        FavoritesView(model: FavoritesPreviewModel(), isAddingFavorite: $isAddingFavorite, geometry: nil)
+    }
 }

--- a/DuckDuckGo/FavoritesView.swift
+++ b/DuckDuckGo/FavoritesView.swift
@@ -72,7 +72,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
         .padding(0)
     }
 
-@ViewBuilder
+    @ViewBuilder
     private func previewFor(_ item: FavoriteItem) -> some View {
         switch item {
         case .favorite(let favorite):
@@ -80,7 +80,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
                 .frame(width: NewTabPageGrid.Item.edgeSize)
                 .previewShape()
                 .transition(.opacity)
-        case .itemPlaceholder:
+        case .addFavorite:
             EmptyView()
         }
     }
@@ -105,7 +105,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
                 .background(.clear)
                 .frame(width: NewTabPageGrid.Item.edgeSize)
             })
-        case .itemPlaceholder:
+        case .addFavorite:
             Button(action: {
                 // add favorite
             }, label: {

--- a/DuckDuckGo/FavoritesViewModel.swift
+++ b/DuckDuckGo/FavoritesViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  FavoritesModel.swift
+//  FavoritesViewModel.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -19,8 +19,8 @@
 
 import Foundation
 
-protocol FavoritesModel: AnyObject, ObservableObject {
-    var allFavorites: [Favorite] { get }
+protocol FavoritesViewModel: AnyObject, ObservableObject {
+    var allFavorites: [FavoriteItem] { get }
     var faviconLoader: FavoritesFaviconLoading? { get }
 
     var isEmpty: Bool { get }
@@ -49,6 +49,6 @@ protocol FavoritesEmptyStateModel: AnyObject, ObservableObject {
 }
 
 struct FavoritesSlice {
-    let items: [Favorite]
+    let items: [FavoriteItem]
     let isCollapsible: Bool
 }

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -32,6 +32,7 @@ struct NewTabPageView<FavoritesModelType: FavoritesViewModel & FavoritesEmptySta
     @ObservedObject private var sectionsSettingsModel: NewTabPageSectionsSettingsModel
 
     @State private var customizeButtonShowedInline = false
+    @State private var isAddingFavorite: Bool = false
 
     init(viewModel: NewTabPageViewModel,
          messagesModel: NewTabPageMessagesModel,
@@ -143,6 +144,9 @@ private extension NewTabPageView {
                         .padding([.trailing, .bottom], Metrics.largePadding)
                 }
             }
+            .sheet(isPresented: $isAddingFavorite) {
+                EmptyView()
+            }
         }
     }
 
@@ -179,10 +183,14 @@ private extension NewTabPageView {
     private func favoritesSectionView(proxy: GeometryProxy) -> some View {
         Group {
             if favoritesModel.isEmpty {
-                FavoritesEmptyStateView(model: favoritesModel, geometry: proxy)
+                FavoritesEmptyStateView(model: favoritesModel,
+                                        isAddingFavorite: $isAddingFavorite,
+                                        geometry: proxy)
                     .padding(.top, Metrics.nonGridSectionTopPadding)
             } else {
-                FavoritesView(model: favoritesModel, geometry: proxy)
+                FavoritesView(model: favoritesModel,
+                              isAddingFavorite: $isAddingFavorite,
+                              geometry: proxy)
             }
         }
     }

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 import DuckUI
 import RemoteMessaging
 
-struct NewTabPageView<FavoritesModelType: FavoritesModel & FavoritesEmptyStateModel>: View {
+struct NewTabPageView<FavoritesModelType: FavoritesViewModel & FavoritesEmptyStateModel>: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
     @ObservedObject private var viewModel: NewTabPageViewModel
@@ -306,7 +306,7 @@ private struct CustomizeButtonPrefKey: PreferenceKey {
                 homeMessages: []
             )
         ),
-        favoritesModel: FavoritesPreviewModel(allFavorites: []),
+        favoritesModel: FavoritesPreviewModel(favorites: []),
         shortcutsModel: ShortcutsModel(),
         shortcutsSettingsModel: NewTabPageShortcutsSettingsModel(),
         sectionsSettingsModel: NewTabPageSectionsSettingsModel()

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -24,7 +24,7 @@ import RemoteMessaging
 struct NewTabPageView<FavoritesModelType: FavoritesModel & FavoritesEmptyStateModel>: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
-    @ObservedObject private var newTabPageModel: NewTabPageModel
+    @ObservedObject private var viewModel: NewTabPageViewModel
     @ObservedObject private var messagesModel: NewTabPageMessagesModel
     @ObservedObject private var favoritesModel: FavoritesModelType
     @ObservedObject private var shortcutsModel: ShortcutsModel
@@ -33,13 +33,13 @@ struct NewTabPageView<FavoritesModelType: FavoritesModel & FavoritesEmptyStateMo
 
     @State private var customizeButtonShowedInline = false
 
-    init(newTabPageModel: NewTabPageModel,
+    init(viewModel: NewTabPageViewModel,
          messagesModel: NewTabPageMessagesModel,
          favoritesModel: FavoritesModelType,
          shortcutsModel: ShortcutsModel,
          shortcutsSettingsModel: NewTabPageShortcutsSettingsModel,
          sectionsSettingsModel: NewTabPageSectionsSettingsModel) {
-        self.newTabPageModel = newTabPageModel
+        self.viewModel = viewModel
         self.messagesModel = messagesModel
         self.favoritesModel = favoritesModel
         self.shortcutsModel = shortcutsModel
@@ -58,7 +58,7 @@ struct NewTabPageView<FavoritesModelType: FavoritesModel & FavoritesEmptyStateMo
     }
 
     var body: some View {
-        if !newTabPageModel.isOnboarding {
+        if !viewModel.isOnboarding {
             mainView
                 .background(Color(designSystemColor: .background))
                 .if(favoritesModel.isShowingTooltip) {
@@ -66,7 +66,7 @@ struct NewTabPageView<FavoritesModelType: FavoritesModel & FavoritesEmptyStateMo
                         favoritesModel.toggleTooltip()
                     })
                 }
-                .sheet(isPresented: $newTabPageModel.isShowingSettings, onDismiss: {
+                .sheet(isPresented: $viewModel.isShowingSettings, onDismiss: {
                     shortcutsSettingsModel.save()
                     sectionsSettingsModel.save()
                 }, content: {
@@ -200,7 +200,7 @@ private extension NewTabPageView {
             Spacer()
 
             Button(action: {
-                newTabPageModel.customizeNewTabPage()
+                viewModel.customizeNewTabPage()
             }, label: {
                 NewTabPageCustomizeButtonView()
                 // Needed to reduce default button margins
@@ -211,14 +211,14 @@ private extension NewTabPageView {
 
     @ViewBuilder
     private var introMessageView: some View {
-        if newTabPageModel.isIntroMessageVisible {
+        if viewModel.isIntroMessageVisible {
             NewTabPageIntroMessageView(onClose: {
                 withAnimation {
-                    newTabPageModel.dismissIntroMessage()
+                    viewModel.dismissIntroMessage()
                 }
             })
             .onFirstAppear {
-                newTabPageModel.introMessageDisplayed()
+                viewModel.introMessageDisplayed()
             }
             .transition(.scale.combined(with: .opacity))
         }
@@ -260,7 +260,7 @@ private struct CustomizeButtonPrefKey: PreferenceKey {
 
 #Preview("Regular") {
     NewTabPageView(
-        newTabPageModel: NewTabPageModel(),
+        viewModel: NewTabPageViewModel(),
         messagesModel: NewTabPageMessagesModel(
             homePageMessagesConfiguration: PreviewMessagesConfiguration(
                 homeMessages: []
@@ -275,7 +275,7 @@ private struct CustomizeButtonPrefKey: PreferenceKey {
 
 #Preview("With message") {
     NewTabPageView(
-        newTabPageModel: NewTabPageModel(),
+        viewModel: NewTabPageViewModel(),
         messagesModel: NewTabPageMessagesModel(
             homePageMessagesConfiguration: PreviewMessagesConfiguration(
                 homeMessages: [
@@ -298,9 +298,24 @@ private struct CustomizeButtonPrefKey: PreferenceKey {
     )
 }
 
-#Preview("Empty state") {
+#Preview("No favorites") {
     NewTabPageView(
-        newTabPageModel: NewTabPageModel(),
+        viewModel: NewTabPageViewModel(),
+        messagesModel: NewTabPageMessagesModel(
+            homePageMessagesConfiguration: PreviewMessagesConfiguration(
+                homeMessages: []
+            )
+        ),
+        favoritesModel: FavoritesPreviewModel(allFavorites: []),
+        shortcutsModel: ShortcutsModel(),
+        shortcutsSettingsModel: NewTabPageShortcutsSettingsModel(),
+        sectionsSettingsModel: NewTabPageSectionsSettingsModel()
+    )
+}
+
+#Preview("Empty") {
+    NewTabPageView(
+        viewModel: NewTabPageViewModel(),
         messagesModel: NewTabPageMessagesModel(
             homePageMessagesConfiguration: PreviewMessagesConfiguration(
                 homeMessages: []

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -33,7 +33,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
 
     private(set) lazy var faviconsFetcherOnboarding = FaviconsFetcherOnboarding(syncService: syncService, syncBookmarksAdapter: syncBookmarksAdapter)
 
-    private let newTabPageModel: NewTabPageModel
+    private let newTabPageViewModel: NewTabPageViewModel
     private let messagesModel: NewTabPageMessagesModel
     private let favoritesModel: FavoritesDefaultModel
     private let shortcutsModel: ShortcutsModel
@@ -61,13 +61,14 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
         self.newTabDialogFactory = newTabDialogFactory
         self.newTabDialogTypeProvider = newTabDialogTypeProvider
 
-        newTabPageModel = NewTabPageModel()
+        newTabPageViewModel = NewTabPageViewModel()
         shortcutsSettingsModel = NewTabPageShortcutsSettingsModel()
         sectionsSettingsModel = NewTabPageSectionsSettingsModel()
         favoritesModel = FavoritesDefaultModel(interactionModel: interactionModel, faviconLoader: faviconLoader)
         shortcutsModel = ShortcutsModel()
         messagesModel = NewTabPageMessagesModel(homePageMessagesConfiguration: homePageMessagesConfiguration, privacyProDataReporter: privacyProDataReporting)
-        let newTabPageView = NewTabPageView(newTabPageModel: newTabPageModel,
+
+        let newTabPageView = NewTabPageView(viewModel: newTabPageViewModel,
                                             messagesModel: messagesModel,
                                             favoritesModel: favoritesModel,
                                             shortcutsModel: shortcutsModel,
@@ -244,7 +245,7 @@ extension NewTabPageViewController {
 
         hostingController.didMove(toParent: self)
 
-        newTabPageModel.startOnboarding()
+        newTabPageViewModel.startOnboarding()
     }
 
     private func dismissHostingController(didFinishNTPOnboarding: Bool) {
@@ -252,7 +253,7 @@ extension NewTabPageViewController {
         hostingController?.view.removeFromSuperview()
         hostingController?.removeFromParent()
         if didFinishNTPOnboarding {
-            self.newTabPageModel.finishOnboarding()
+            self.newTabPageViewModel.finishOnboarding()
         }
     }
 }

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -23,7 +23,7 @@ import Bookmarks
 import BrowserServicesKit
 import Core
 
-final class NewTabPageViewController: UIHostingController<NewTabPageView<FavoritesDefaultModel>>, NewTabPage {
+final class NewTabPageViewController: UIHostingController<NewTabPageView<FavoritesDefaultViewModel>>, NewTabPage {
 
     private let syncService: DDGSyncing
     private let syncBookmarksAdapter: SyncBookmarksAdapter
@@ -35,7 +35,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
 
     private let newTabPageViewModel: NewTabPageViewModel
     private let messagesModel: NewTabPageMessagesModel
-    private let favoritesModel: FavoritesDefaultModel
+    private let favoritesModel: FavoritesDefaultViewModel
     private let shortcutsModel: ShortcutsModel
     private let shortcutsSettingsModel: NewTabPageShortcutsSettingsModel
     private let sectionsSettingsModel: NewTabPageSectionsSettingsModel
@@ -64,7 +64,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
         newTabPageViewModel = NewTabPageViewModel()
         shortcutsSettingsModel = NewTabPageShortcutsSettingsModel()
         sectionsSettingsModel = NewTabPageSectionsSettingsModel()
-        favoritesModel = FavoritesDefaultModel(interactionModel: interactionModel, faviconLoader: faviconLoader)
+        favoritesModel = FavoritesDefaultViewModel(favoriteDataSource: FavoritesListInteractingAdapter(favoritesListInteracting: interactionModel), faviconLoader: faviconLoader)
         shortcutsModel = ShortcutsModel()
         messagesModel = NewTabPageMessagesModel(homePageMessagesConfiguration: homePageMessagesConfiguration, privacyProDataReporter: privacyProDataReporting)
 

--- a/DuckDuckGo/NewTabPageViewModel.swift
+++ b/DuckDuckGo/NewTabPageViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  NewTabPageModel.swift
+//  NewTabPageViewModel.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -20,7 +20,7 @@
 import Foundation
 import Core
 
-final class NewTabPageModel: ObservableObject {
+final class NewTabPageViewModel: ObservableObject {
 
     @Published private(set) var isIntroMessageVisible: Bool
     @Published private(set) var isOnboarding: Bool

--- a/DuckDuckGo/ToggleExpandButtonStyle.swift
+++ b/DuckDuckGo/ToggleExpandButtonStyle.swift
@@ -18,13 +18,12 @@
 //
 
 import SwiftUI
-import DuckUI
+import DesignResourcesKit
 
 struct ToggleExpandButtonStyle: ButtonStyle {
-    @Environment(\.colorScheme) private var colorScheme
-
+    
     func makeBody(configuration: Configuration) -> some View {
-        let isDark = colorScheme == .dark
+        let backgroundColor = configuration.isPressed ? Color(designSystemColor: .buttonsSecondaryFillPressed) : Color(designSystemColor: .buttonsSecondaryFillDefault)
 
         HStack(spacing: 0) {
             VStack {
@@ -34,17 +33,13 @@ struct ToggleExpandButtonStyle: ButtonStyle {
             Circle()
                 .stroke(Color(designSystemColor: .lines), lineWidth: 1)
                 .frame(width: 32, height: 32)
-                .if(configuration.isPressed) {
-                    $0.background(isDark ? Color.tint(0.12) : Color.shade(0.06))
-                        .clipShape(Circle())
-                }
                 .background(
                     Circle()
-                        .fill(Color(designSystemColor: .background))
+                        .fill(backgroundColor)
                 )
                 .overlay {
                     configuration.label
-                        .foregroundColor(isDark ? .tint(0.6) : .shade(0.6))
+                        .foregroundColor(Color(designSystemColor: .iconsSecondary))
                         .frame(width: 16, height: 16)
                         
                 }

--- a/DuckDuckGo/ViewExtension.swift
+++ b/DuckDuckGo/ViewExtension.swift
@@ -20,21 +20,6 @@
 import SwiftUI
 
 extension View {
-    /// Applies the given transform if the given condition evaluates to `true`.
-    /// - Parameters:
-    ///   - condition: The condition to evaluate.
-    ///   - transform: The transform to apply to the source `View`.
-    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
-    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
-extension View {
     /// Disables scroll if available for current system version
     @available(iOS, deprecated: 16.0, renamed: "scrollDisabled")
     @ViewBuilder

--- a/DuckDuckGoTests/NewTabPageViewModelTests.swift
+++ b/DuckDuckGoTests/NewTabPageViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  NewTabPageModelTests.swift
+//  NewTabPageViewModelTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -20,7 +20,7 @@
 import XCTest
 @testable import DuckDuckGo
 
-final class NewTabPageModelTests: XCTestCase {
+final class NewTabPageViewModelTests: XCTestCase {
 
     let introDataStorage = NewTabPageIntroDataStoringMock()
 
@@ -29,21 +29,21 @@ final class NewTabPageModelTests: XCTestCase {
     }
 
     func testDoesNotShowIntroIfSettingUndefined() {
-        let sut = NewTabPageModel(introDataStorage: introDataStorage)
+        let sut = NewTabPageViewModel(introDataStorage: introDataStorage)
 
         XCTAssertFalse(sut.isIntroMessageVisible)
     }
 
     func testShowsIntroMessage() {
         introDataStorage.newTabPageIntroMessageEnabled = true
-        let sut = NewTabPageModel(introDataStorage: introDataStorage)
+        let sut = NewTabPageViewModel(introDataStorage: introDataStorage)
 
         XCTAssertTrue(sut.isIntroMessageVisible)
     }
 
     func testDisablesIntroMessageWhenDismissed() {
         introDataStorage.newTabPageIntroMessageEnabled = true
-        let sut = NewTabPageModel(introDataStorage: introDataStorage)
+        let sut = NewTabPageViewModel(introDataStorage: introDataStorage)
 
         sut.dismissIntroMessage()
 
@@ -53,7 +53,7 @@ final class NewTabPageModelTests: XCTestCase {
 
     func testDisablesIntroMessageAfterMultipleImpressions() {
         introDataStorage.newTabPageIntroMessageEnabled = true
-        let sut = NewTabPageModel(introDataStorage: introDataStorage)
+        let sut = NewTabPageViewModel(introDataStorage: introDataStorage)
 
         for _ in 1...3 {
             sut.introMessageDisplayed()
@@ -64,7 +64,7 @@ final class NewTabPageModelTests: XCTestCase {
     }
 
     func testFiresPixelWhenIntroMessageDismissed() {
-        let sut = NewTabPageModel(pixelFiring: PixelFiringMock.self)
+        let sut = NewTabPageViewModel(pixelFiring: PixelFiringMock.self)
 
         sut.dismissIntroMessage()
 
@@ -72,7 +72,7 @@ final class NewTabPageModelTests: XCTestCase {
     }
 
     func testFiresPixelWhenIntroMessageDisplayed() {
-        let sut = NewTabPageModel(pixelFiring: PixelFiringMock.self)
+        let sut = NewTabPageViewModel(pixelFiring: PixelFiringMock.self)
 
         sut.introMessageDisplayed()
 
@@ -80,7 +80,7 @@ final class NewTabPageModelTests: XCTestCase {
     }
 
     func testFiresPixelOnNewTabPageCustomize() {
-        let sut = NewTabPageModel(pixelFiring: PixelFiringMock.self)
+        let sut = NewTabPageViewModel(pixelFiring: PixelFiringMock.self)
 
         sut.customizeNewTabPage()
 

--- a/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
+++ b/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
@@ -124,24 +124,14 @@ public struct SecondaryFillButtonStyle: ButtonStyle {
             .lineLimit(nil)
             .font(Font(UIFont.boldAppFont(ofSize: Consts.fontSize)))
             .foregroundColor(configuration.isPressed ? defaultForegroundColor : foregroundColor)
-            .modify {
-                if !isFreeform {
-                    $0
-                        .padding(.vertical)
-                        .padding(.horizontal, fullWidth ? nil : 24)
-                        .frame(minWidth: 0, maxWidth: fullWidth ? .infinity : nil, maxHeight: compact ? Consts.height - 10 : Consts.height)
-                } else {
-                    $0
-                }
+            .if(!isFreeform) { view in
+                view
+                    .padding(.vertical)
+                    .padding(.horizontal, fullWidth ? nil : 24)
+                    .frame(minWidth: 0, maxWidth: fullWidth ? .infinity : nil, maxHeight: compact ? Consts.height - 10 : Consts.height)
             }
             .background(configuration.isPressed ? pressedBackgroundColor : backgroundColor)
             .cornerRadius(Consts.cornerRadius)
-    }
-}
-
-extension View {
-    func modify(@ViewBuilder _ modifierClosure: (Self) -> some View) -> some View {
-        modifierClosure(self)
     }
 }
 

--- a/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
+++ b/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
@@ -99,11 +99,13 @@ public struct SecondaryFillButtonStyle: ButtonStyle {
     let disabled: Bool
     let compact: Bool
     let fullWidth: Bool
+    let isFreeform: Bool
 
-    public init(disabled: Bool = false, compact: Bool = false, fullWidth: Bool = true) {
+    public init(disabled: Bool = false, compact: Bool = false, fullWidth: Bool = true, isFreeform: Bool = false) {
         self.disabled = disabled
         self.compact = compact
         self.fullWidth = fullWidth
+        self.isFreeform = isFreeform
     }
 
     public func makeBody(configuration: Configuration) -> some View {
@@ -122,11 +124,24 @@ public struct SecondaryFillButtonStyle: ButtonStyle {
             .lineLimit(nil)
             .font(Font(UIFont.boldAppFont(ofSize: Consts.fontSize)))
             .foregroundColor(configuration.isPressed ? defaultForegroundColor : foregroundColor)
-            .padding(.vertical)
-            .padding(.horizontal, fullWidth ? nil : 24)
-            .frame(minWidth: 0, maxWidth: fullWidth ? .infinity : nil, maxHeight: compact ? Consts.height - 10 : Consts.height)
+            .modify {
+                if !isFreeform {
+                    $0
+                        .padding(.vertical)
+                        .padding(.horizontal, fullWidth ? nil : 24)
+                        .frame(minWidth: 0, maxWidth: fullWidth ? .infinity : nil, maxHeight: compact ? Consts.height - 10 : Consts.height)
+                } else {
+                    $0
+                }
+            }
             .background(configuration.isPressed ? pressedBackgroundColor : backgroundColor)
             .cornerRadius(Consts.cornerRadius)
+    }
+}
+
+extension View {
+    func modify(@ViewBuilder _ modifierClosure: (Self) -> some View) -> some View {
+        modifierClosure(self)
     }
 }
 

--- a/LocalPackages/DuckUI/Sources/DuckUI/ViewExtensions/ViewModifyExtension.swift
+++ b/LocalPackages/DuckUI/Sources/DuckUI/ViewExtensions/ViewModifyExtension.swift
@@ -1,0 +1,23 @@
+//
+//  ViewModifyExtension.swift
+//  DuckUI
+//
+//  Created by Mariusz Śpiewak on 20/09/2024.
+//
+
+import SwiftUI
+
+public extension View {
+    /// Applies the given transform if the given condition evaluates to `true`.
+    /// - Parameters:
+    ///   - condition: The condition to evaluate.
+    ///   - transform: The transform to apply to the source `View`.
+    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/LocalPackages/DuckUI/Sources/DuckUI/ViewExtensions/ViewModifyExtension.swift
+++ b/LocalPackages/DuckUI/Sources/DuckUI/ViewExtensions/ViewModifyExtension.swift
@@ -1,8 +1,20 @@
 //
 //  ViewModifyExtension.swift
-//  DuckUI
+//  DuckDuckGo
 //
-//  Created by Mariusz Śpiewak on 20/09/2024.
+//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import SwiftUI

--- a/LocalPackages/SyncUI/Package.swift
+++ b/LocalPackages/SyncUI/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../DuckUI"),
-        .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "3.2.0"),
+        .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "3.3.0"),
         .package(url: "https://github.com/duckduckgo/apple-toolbox.git", exact: "3.1.2"),
     ],
     targets: [

--- a/LocalPackages/Waitlist/Package.swift
+++ b/LocalPackages/Waitlist/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Waitlist", "WaitlistMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "3.2.0"),
+        .package(url: "https://github.com/duckduckgo/DesignResourcesKit", exact: "3.3.0"),
         .package(url: "https://github.com/duckduckgo/apple-toolbox.git", exact: "3.1.2"),
     ],
     targets: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208244619690578/f
Tech Design URL:
CC:

**Description**:

Adds a possibility to show an Add button in favorites collection, allowing to create a favorite right from New Tab Page. ([Figma](https://www.figma.com/design/N2GbF5HEvopp5iwmAlMwyD/New-Tab-Page-Customization?node-id=611-147700&m=dev)).
Add button is currently navigating to an empty view, which is expected. The view will be implemented in additional PR.

In order to reduce the amount of duplicated code and separate additional display elements from pure Favorites data,  DataSource for Favorites was defined which is used in common ViewModel logic for Favorites, hence the rename of `NewTabPageModel` -> `NewTabPageViewModel`.

There was also a need to keep some of the items immovable, which required a change in `ReorderableForEach`.

**Steps to test this PR**:

1. Open NTP without Favorites, + button should be visible as a first element.
2. Add a couple of Favorites, + button should be visible as last item.
3. Try reordering Favorites, + button should be kept stationary and it shouldn't be posible to drop favorite after it.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
