### PR TITLE
Trigger add-task-to-project when PR marked ready for review

### DIFF
--- a/.github/workflows/pr-task-url.yml
+++ b/.github/workflows/pr-task-url.yml
@@ -2,7 +2,7 @@ name: Asana PR Task URL
 
 on: 
   pull_request:
-    types: [opened, edited, closed, synchronize, review_requested]
+    types: [opened, edited, closed, synchronize, review_requested, ready_for_review]
 
 jobs:
 
@@ -13,6 +13,8 @@ jobs:
     name: Add Task to App Board Project
 
     runs-on: ubuntu-latest
+
+    if: ${{ !github.event.pull_request.draft }}
 
     outputs:
       task_id: ${{ steps.get-task-id.outputs.task_id }}
@@ -47,7 +49,7 @@ jobs:
 
     - name: Add Task to the App Board Project
       id: add-task-to-project
-      if: ${{ github.event.action == 'opened' && steps.check-board-membership.outputs.task_in_project == '0' }}
+      if: ${{ (github.event.action == 'opened' || github.event.action == 'ready_for_review') && steps.check-board-membership.outputs.task_in_project == '0' }}
       env:
         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         ASANA_PROJECT_ID: ${{ vars.IOS_APP_BOARD_ASANA_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1207931637636063/f
Tech Design URL:
CC:

**Description**:

Trigger add-task-to-project when PR marked ready for review.

Counterpart of https://github.com/duckduckgo/macos-browser/pull/3273.

**Steps to test this PR**:

* Create a copy of this branch and open a draft PR. 
* Mark as ready for review and check if the "Add Task to App Board Project" action is successful.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)