### PR TITLE
Add origin to /apps URL

### DIFF
--- a/Core/AppURLs.swift
+++ b/Core/AppURLs.swift
@@ -35,7 +35,7 @@ public extension URL {
     static let emailProtectionSupportLink = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/email/settings/support"))!
     static let emailProtectionHelpPageLink = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/duckduckgo-help-pages/email-protection/what-is-duckduckgo-email-protection/"))!
     static let aboutLink = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/about"))!
-    static let apps = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/apps"))!
+    static let apps = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/apps?origin=funnel_app_ios"))!
     static let searchSettings = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/settings"))!
     static let autofillHelpPageLink = URL(string: AppDeepLinkSchemes.quickLink.appending("\(ddg.host!)/duckduckgo-help-pages/sync-and-backup/password-manager-security/"))!
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1208314251851762/f

**Description**:
Add origin to /apps URL

**Steps to test this PR**:
1. Tap on  Settings → DuckDuckGo on Other Platforms
2. Check that we're appending `?origin=funnel_app_ios` to the URL
