### PR TITLE
fix return user segmentation

### DIFF
--- a/Core/ReturnUserMeasurement.swift
+++ b/Core/ReturnUserMeasurement.swift
@@ -20,8 +20,12 @@
 import Foundation
 import BrowserServicesKit
 
+/// This is only intended to be used during the install (first run after downloading from the app store).
 protocol ReturnUserMeasurement {
 
+    /// Based on the value in the keychain, so if you use this after the install process it will return true.
+    ///  If you really want to know if the user is "returning" then look at the variant in the `StatisticsStore`
+    ///  which will be set to `ru`.
     var isReturningUser: Bool { get }
     func installCompletedWithATB(_ atb: Atb)
     func updateStoredATB(_ atb: Atb)

--- a/Core/StatisticsLoader.swift
+++ b/Core/StatisticsLoader.swift
@@ -155,9 +155,10 @@ public class StatisticsLoader {
 
     private func processUsageSegmentation(atb: Atb?, activityType: UsageActivityType) {
         guard let installAtbValue = statisticsStore.atb else { return }
-        let installAtb = Atb(version: installAtbValue, updateVersion: nil)
-        let actualAtb = atb ?? installAtb
-        self.usageSegmentation.processATB(actualAtb, withInstallAtb: installAtb, andActivityType: activityType)
+        let installAtb = Atb(version: installAtbValue + (statisticsStore.variant ?? ""), updateVersion: nil)
+        let usageAtb = atb ?? installAtb
+
+        self.usageSegmentation.processATB(usageAtb, withInstallAtb: installAtb, andActivityType: activityType)
     }
 
     private func updateUsageSegmentationWithAtb(_ atb: Atb, activityType: UsageActivityType) {

--- a/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -42,6 +42,34 @@ class StatisticsLoaderTests: XCTestCase {
         super.tearDown()
     }
 
+    func testWhenAppRefreshHappensButNotInstalledAndReturningUser_ThenRetentionSegmentationNotified() {
+        mockStatisticsStore.variant = "ru"
+        mockStatisticsStore.atb = "v101-1"
+        
+        loadSuccessfulExiStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshAppRetentionAtb {
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 5.0)
+        XCTAssertTrue(mockUsageSegmentation.atbs[0].installAtb.isReturningUser)
+    }
+
+    func testWhenReturnUser_ThenSegmentationIncludesCorrectVariant() {
+        mockStatisticsStore.variant = "ru"
+        mockStatisticsStore.atb = "v101-1"
+        mockStatisticsStore.searchRetentionAtb = "v101-2"
+        loadSuccessfulAtbStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshSearchRetentionAtb {
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 5.0)
+        XCTAssertTrue(mockUsageSegmentation.atbs[0].installAtb.isReturningUser)
+    }
+
     func testWhenSearchRefreshHappensButNotInstalled_ThenRetentionSegmentationNotified() {
         loadSuccessfulExiStub()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208380046395184/f
Tech Design URL:
CC:

**Description**:
Fix usage segmentation for return users.

**Steps to test this PR**:
1. Reset the simulator `xcrun simctl erase all`
2. Add the following lines to the start of the `load` func of `StatisticsLoader`: 

        statisticsStore.variant = "ru"
        statisticsStore.atb = "v446-1"
        statisticsStore.appRetentionAtb = "v447-1"
        statisticsStore.searchRetentionAtb = "v447-2"

4. Run the app and check for a pixel like this:

        Pixel fired m.retention.segments ["count_as_mau_n": "tttt", "new_set_atb": "v448-7", "count_as_wau": "true", "segments_today": "first_month,reactivated_wau,reinstaller", "activity_type": "app_use"]

5. Ensure that `reinstaller` and `"activity_type": "app_use"` are in the parameters as above
6. Get through onboarding and do a search
7. Check for a similar pixel ensuring that `reinstaller` and `"activity_type": "search"` are in the parameters

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?
