### PR TITLE
add assertions for tabs in suggestions

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -103,7 +103,6 @@ jobs:
 
     steps:
     - name: Create Asana task when workflow failed
-      if: ${{ failure() }}
       run: |
         curl -s "https://app.asana.com/api/1.0/tasks" \
           --header "Accept: application/json" \

--- a/.maestro/release_tests/tabs.yaml
+++ b/.maestro/release_tests/tabs.yaml
@@ -46,6 +46,27 @@ tags:
 - assertVisible: ".*Privacy Test Pages.*"
 - tapOn: "Refresh Page"
 
+# Suggestions
+- assertVisible:
+    id: "searchEntry"
+
+- tapOn: 
+    id: "searchEntry"
+- inputText: "ad click"
+- assertVisible: "Switch to Tab.*search-company.site"
+- tapOn: "Switch to Tab.*search-company.site"
+- assertVisible: ".*Ad Click Flow.*"
+
+- tapOn: 
+    id: "searchEntry"
+- inputText: "privacy"
+- assertVisible: "Switch to Tab.*privacy-test-pages.site"
+- tapOn: "Switch to Tab.*privacy-test-pages.site"
+- assertVisible: ".*Privacy Test Pages.*"
+
+# Needed or else test can't see the Tab Switcher button for some reason
+- tapOn: "Refresh Page"
+
 # Close Tab
 - assertVisible: Tab Switcher
 - tapOn: Tab Switcher

--- a/.maestro/release_tests/tabs.yaml
+++ b/.maestro/release_tests/tabs.yaml
@@ -78,3 +78,26 @@ tags:
 - assertNotVisible: ".*Ad Click Flow.*"
 - assertVisible: "1 Private Tab"
 - tapOn: "Done"
+
+# Switch tabs from new tab
+- tapOn: "Refresh Page"
+- assertVisible: Tab Switcher
+- tapOn: Tab Switcher
+- assertVisible: ".*Privacy Test Pages.*"
+- assertVisible: 
+    id: "Add"
+- tapOn:
+    id: "Add"
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "privacy"
+- assertVisible: "Switch to Tab.*privacy-test-pages.site"
+- tapOn: "Switch to Tab.*privacy-test-pages.site"
+- assertVisible: ".*Privacy Test Pages.*"
+- tapOn: "Refresh Page"
+- assertVisible: Tab Switcher
+- tapOn: Tab Switcher
+- assertVisible: "1 Private Tab"
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208350972189287/f
Tech Design URL:
CC: @ayoy 

**Description**:
Adds assertions that validate tabs in suggestions and switching tabs

Fixes failure check for sending notification in the workflow

**Steps to test this PR**:
1. Check this test run passes: https://github.com/duckduckgo/iOS/actions/runs/11037282165
(However End to End tests have not passed for some time so as long as tabs.yaml passes that is the main thing)

3. Run the release/tabs.yaml test locally
