### PR TITLE
fix UI tests broken by tabs suggestions

### DIFF
--- a/.maestro/release_tests/bookmarks.yaml
+++ b/.maestro/release_tests/bookmarks.yaml
@@ -34,6 +34,7 @@ tags:
 - assertVisible: "Privacy Test Pages - Home"
 - assertVisible: "privacy-test-pages.site"
 - tapOn: "Privacy Test Pages - Home"
+- tapOn: "Refresh Page"
 
 # Verify site has been bookmarked
 - assertVisible: "Browsing menu"

--- a/.maestro/release_tests/firebutton.yaml
+++ b/.maestro/release_tests/firebutton.yaml
@@ -36,9 +36,13 @@ tags:
 - inputText: "https://example.com"
 - pressKey: Enter
 
-# Check history
-- longPressOn: "Tab Switcher"
+# Close tab
+- tapOn: "Tab Switcher"
+- tapOn: "Close \"Example Domain\" at example.com"
+- tapOn:
+    id: "Add"
 
+# Check history
 - assertVisible:
     id: "searchEntry"
 - tapOn: 
@@ -46,7 +50,7 @@ tags:
 - inputText: "ex"
 - assertVisible: "example.com"
 - assertVisible: "Example Domain"
-- tapOn: "Cancel"
+- tapOn: "Example Domain"
 
 # Fire button
 - tapOn: "Close Tabs and Clear Data"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208408323212083/f
Tech Design URL:
CC:

**Description**:
Adding tabs to suggestions broke a test.
Maestro is behaving strangely in another test.

**Steps to test this PR**:
1. Check the state of this end to end run: https://github.com/duckduckgo/iOS/actions/runs/11056977820
* release tests should all pass, the other tests may pass if re-run but currently appear to be flakey

2. Run release/ tests locally
