### PR TITLE
Onboarding highlights experiment updates

### DIFF
--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -279,7 +279,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     var isEnabled: Bool {
         // skip dax dialogs in integration tests
         guard ProcessInfo.processInfo.environment["DAXDIALOGS"] != "false" else { return false }
-        guard variantManager.shouldShowDaxDialogs else { return false }
         return !settings.isDismissed
     }
 

--- a/DuckDuckGo/FullscreenDaxDialogViewController.swift
+++ b/DuckDuckGo/FullscreenDaxDialogViewController.swift
@@ -79,7 +79,7 @@ class FullscreenDaxDialogViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if let spec = spec {
-            Pixel.fire(pixel: spec.pixelName, withAdditionalParameters: [ "wo": woShown ? "1" : "0" ])
+            Pixel.fire(pixel: spec.pixelName, withAdditionalParameters: [ "wo": woShown ? "1" : "0" ], includedParameters: [.appVersion, .atb])
         }
         containerHeight.constant = daxDialogViewController?.calculateHeight() ?? 0
         daxDialogViewController?.start()

--- a/DuckDuckGo/HomeViewController.swift
+++ b/DuckDuckGo/HomeViewController.swift
@@ -258,8 +258,6 @@ class HomeViewController: UIViewController, NewTabPage {
     }
 
     func presentNextDaxDialog() {
-        guard variantManager.shouldShowDaxDialogs else { return }
-
         if variantManager.isContextualDaxDialogsEnabled {
             showNextDaxDialogNew(dialogProvider: newTabDialogTypeProvider, factory: newTabDialogFactory)
         } else {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2737,8 +2737,7 @@ extension MainViewController: AutoClearWorker {
             self.privacyProDataReporter.saveFireCount()
 
             // Ideally this should happen once data clearing has finished AND the animation is finished
-            // `showNextDaxDialog: true` only set from old onboarding FireDialog ActionSheet
-            if showNextDaxDialog && self.variantManager.shouldShowDaxDialogs {
+            if showNextDaxDialog {
                 self.homeController?.showNextDaxDialog()
             } else if KeyboardSettings().onNewTab {
                 let showKeyboardAfterFireButton = DispatchWorkItem {

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -165,9 +165,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView<Favorit
     }
 
     func showNextDaxDialog() {
-        if variantManager.shouldShowDaxDialogs {
-            showNextDaxDialogNew(dialogProvider: newTabDialogTypeProvider, factory: newTabDialogFactory)
-        }
+        showNextDaxDialogNew(dialogProvider: newTabDialogTypeProvider, factory: newTabDialogFactory)
     }
 
     func onboardingCompleted() {

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualOnboardingPresenter.swift
@@ -47,9 +47,6 @@ final class ContextualOnboardingPresenter: ContextualOnboardingPresenting {
     }
 
     func presentContextualOnboarding(for spec: DaxDialogs.BrowsingSpec, in vc: TabViewOnboardingDelegate) {
-        // Extra safety net
-        guard variantManager.shouldShowDaxDialogs else { return }
-
         if variantManager.isContextualDaxDialogsEnabled {
             presentExperimentContextualOnboarding(for: spec, in: vc)
         } else {

--- a/DuckDuckGo/OnboardingExperiment/DefaultVariantManager+Onboarding.swift
+++ b/DuckDuckGo/OnboardingExperiment/DefaultVariantManager+Onboarding.swift
@@ -30,12 +30,6 @@ extension VariantManager {
         isSupported(feature: .newOnboardingIntroHighlights)
     }
 
-    var shouldShowDaxDialogs: Bool {
-        // Disable Dax Dialogs if only feature supported is .newOnboardingIntro
-        guard let features = currentVariant?.features else { return true }
-        return !(features.count == 1 && features.contains(.newOnboardingIntro))
-    }
-
     var isContextualDaxDialogsEnabled: Bool {
         isSupported(feature: .contextualDaxDialogs)
     }

--- a/DuckDuckGo/TabSwitcherViewController.swift
+++ b/DuckDuckGo/TabSwitcherViewController.swift
@@ -331,13 +331,7 @@ class TabSwitcherViewController: UIViewController {
         }
 
         Pixel.fire(pixel: .forgetAllPressedTabSwitching)
-        let variantManager = DefaultVariantManager()
-        let isNewOnboarding = variantManager.isContextualDaxDialogsEnabled
-
-        guard variantManager.shouldShowDaxDialogs else {
-            presentForgetDataAlert()
-            return
-        }
+        let isNewOnboarding = DefaultVariantManager().isContextualDaxDialogsEnabled
 
         if !isNewOnboarding
             && DaxDialogs.shared.shouldShowFireButtonPulse {

--- a/DuckDuckGo/TabsBarViewController.swift
+++ b/DuckDuckGo/TabsBarViewController.swift
@@ -104,14 +104,7 @@ class TabsBarViewController: UIViewController {
             self.present(controller: alert, fromView: fireButton)
         }
 
-        let variantManager = DefaultVariantManager()
-        
-        guard variantManager.shouldShowDaxDialogs else {
-            showClearDataAlert()
-            return
-        }
-
-        if variantManager.isContextualDaxDialogsEnabled {
+        if DefaultVariantManager().isContextualDaxDialogsEnabled {
             delegate?.tabsBarDidRequestFireEducationDialog(self)
             showClearDataAlert()
         } else {

--- a/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingPresenterTests.swift
@@ -76,29 +76,6 @@ final class ContextualOnboardingPresenterTests: XCTestCase {
         XCTAssertNotNil(parent.capturedChild)
     }
 
-    func testWhenPresentContextualOnboardingAndVariantShouldNotShowContextualDialogsThenDoNothing() {
-        // GIVEN
-        var variantManagerMock = MockVariantManager()
-        variantManagerMock.currentVariant = MockVariant(features: [.newOnboardingIntro])
-        let sut = ContextualOnboardingPresenter(variantManager: variantManagerMock, daxDialogsFactory: contextualDaxDialogsFactory)
-        let parent = TabViewControllerMock()
-        XCTAssertFalse(parent.didCallAddChild)
-        XCTAssertNil(parent.capturedChild)
-        XCTAssertFalse(parent.didCallPerformSegue)
-        XCTAssertNil(parent.capturedSegueIdentifier)
-        XCTAssertNil(parent.capturedSender)
-
-        // WHEN
-        sut.presentContextualOnboarding(for: .afterSearch, in: parent)
-
-        // THEN
-        XCTAssertFalse(parent.didCallAddChild)
-        XCTAssertNil(parent.capturedChild)
-        XCTAssertFalse(parent.didCallPerformSegue)
-        XCTAssertNil(parent.capturedSegueIdentifier)
-        XCTAssertNil(parent.capturedSender)
-    }
-
     func testWhenPresentContextualOnboardingForFireEducational_andBarAtTheTop_TheMessageHandPointsInTheRightDirection() throws {
         // GIVEN
         var variantManagerMock = MockVariantManager()

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -1100,19 +1100,6 @@ final class DaxDialog: XCTestCase {
         XCTAssertTrue(result)
     }
 
-    func testWhenIsEnabledIsCalled_AndShouldShowDaxDialogsIsFalse_ThenReturnFalse() {
-        // GIVEN
-        var mockVariantManager = MockVariantManager()
-        mockVariantManager.currentVariant = MockVariant(features: [.newOnboardingIntro])
-        let sut = DaxDialogs(settings: settings, entityProviding: entityProvider, variantManager: mockVariantManager)
-
-        // WHEN
-        let result = sut.isEnabled
-
-        // THEN
-        XCTAssertFalse(result)
-    }
-
     private func detectedTrackerFrom(_ url: URL, pageUrl: String) -> DetectedRequest {
         let entity = entityProvider.entity(forHost: url.host!)
         return DetectedRequest(url: url.absoluteString,

--- a/DuckDuckGoTests/DefaultVariantManagerOnboardingTests.swift
+++ b/DuckDuckGoTests/DefaultVariantManagerOnboardingTests.swift
@@ -94,52 +94,6 @@ final class DefaultVariantManagerOnboardingTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    // MARK: - Should Show Dax Dialogs
-
-    func testWhenShouldShowDaxDialogs_AndFeaturesContainOnboardingIntro_ThenReturnFalse() {
-        // GIVEN
-        let sut = makeVariantManager(features: [.newOnboardingIntro])
-
-        // WHEN
-        let result = sut.shouldShowDaxDialogs
-
-        // THEN
-        XCTAssertFalse(result)
-    }
-
-    func testWhenShouldShowDaxDialogs_AndFeaturesContainOnboardingIntroAndContextualDaxDialogs_ThenReturnTrue() {
-        // GIVEN
-        let sut = makeVariantManager(features: [.newOnboardingIntro, .contextualDaxDialogs])
-
-        // WHEN
-        let result = sut.shouldShowDaxDialogs
-
-        // THEN
-        XCTAssertTrue(result)
-    }
-
-    func testWhenShouldShowDaxDialogs_AndFeaturesContainOnboardingHighlights_ThenReturnTrue() {
-        // GIVEN
-        let sut = makeVariantManager(features: [.newOnboardingIntroHighlights])
-
-        // WHEN
-        let result = sut.shouldShowDaxDialogs
-
-        // THEN
-        XCTAssertTrue(result)
-    }
-
-    func testWhenShouldShowDaxDialogs_AndFeaturesIsEmpty_ThenReturnTrue() {
-        // GIVEN
-        let sut = makeVariantManager(features: [])
-
-        // WHEN
-        let result = sut.shouldShowDaxDialogs
-
-        // THEN
-        XCTAssertTrue(result)
-    }
-
     // MARK: - Is Contextual Dax Dialogs Enabled
 
     func testWhenIsContextualDaxDialogsEnabled_AndFeaturesContainContextualDaxDialogs_ThenReturnTrue() {

--- a/DuckDuckGoTests/HomeViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/HomeViewControllerDaxDialogTests.swift
@@ -109,23 +109,6 @@ final class HomeViewControllerDaxDialogTests: XCTestCase {
         XCTAssertNotNil(self.dialogFactory.onDismiss)
     }
 
-    func testWhenDaxDialogsAreNotEnabled_OnDidAppear_NothingHappens() throws {
-        // GIVEN
-        variantManager.currentVariant = MockVariant(features: [.newOnboardingIntro])
-        let expectedSpec = randomDialogType()
-        specProvider.specToReturn = expectedSpec
-
-        // WHEN
-        hvc.viewDidAppear(false)
-
-        // THEN
-        XCTAssertNil(self.variantManager.capturedFeatureName)
-        XCTAssertFalse(self.specProvider.nextHomeScreenMessageCalled)
-        XCTAssertFalse(self.specProvider.nextHomeScreenMessageNewCalled)
-        XCTAssertNil(self.dialogFactory.homeDialog)
-        XCTAssertNil(self.dialogFactory.onDismiss)
-    }
-
     func testWhenOldOnboarding_OnDidAppear_NothingPassedDialogFactory() throws {
         // GIVEN
         variantManager.supportedFeatures = []
@@ -194,18 +177,6 @@ final class HomeViewControllerDaxDialogTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(specProvider.nextHomeScreenMessageCalled)
-        XCTAssertFalse(specProvider.nextHomeScreenMessageNewCalled)
-    }
-
-    func testWhenShowNextDaxDialog_AndShouldNotShowDaxDialogs_ThenReturnFalse() {
-        // GIVEN
-        variantManager.currentVariant = MockVariant(features: [.newOnboardingIntro])
-
-        // WHEN
-        hvc.showNextDaxDialog()
-
-        // THEN
-        XCTAssertFalse(specProvider.nextHomeScreenMessageCalled)
         XCTAssertFalse(specProvider.nextHomeScreenMessageNewCalled)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1208416729129331/f

**Description**:

1. Updates the experiment setup based on [the latest experiment analysis conversation](https://app.asana.com/0/0/1208314441219794/1208411648765130/f)
2. Add atb for old dax dialogs. This was already agreed on Privacy Triage but was missed in previous implementation.

**Steps to test this PR**:
1. Ensure unit tests pass.
1. Test that “ms” variant shows new intro and old Dax Dialogs.
2. Test that “mu” variant shows new onboarding intro and new in context dax dialogs.
3. Test that “mx” variant shows onboarding highlights and new in context dax dialogs.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
