### PR TITLE
Add pixels for adding favorites with autocomplete 

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -781,6 +781,16 @@ extension Pixel {
         case newTabPageCustomizeShortcutRemoved(_ shortcutName: String)
         case newTabPageCustomizeShortcutAdded(_ shortcutName: String)
 
+        // MARK: New Tab Page Add Favorite flow
+        case newTabPageAddFavorite
+        case newTabPageFavoriteAddedAutocomplete
+        case newTabPageFavoriteAddedCustomEntry
+
+        case addFavoriteAddCustomWebsite
+        case addFavoriteCustomEntryCancel
+        case addFavoriteBookmarkAdded
+        case addFavoriteToastEdit
+
         // MARK: DuckPlayer        
         case duckPlayerDailyUniqueView
         case duckPlayerViewFromYoutubeViaMainOverlay
@@ -1599,6 +1609,22 @@ extension Pixel.Event {
             return "m_new_tab_page_customize_shortcut_removed_\(shortcutName)"
         case .newTabPageCustomizeShortcutAdded(let shortcutName):
             return "m_new_tab_page_customize_shortcut_added_\(shortcutName)"
+
+        case .newTabPageAddFavorite:
+            return "m_new_tab_page_add_favorite_click"
+        case .newTabPageFavoriteAddedAutocomplete:
+            return "m_new_tab_page_favorite_added_autocomplete"
+        case .newTabPageFavoriteAddedCustomEntry:
+            return "m_new_tab_page_favorite_added_custom_entry"
+
+        case .addFavoriteAddCustomWebsite:
+            return "m_add_favorite_add_custom_website_click"
+        case .addFavoriteCustomEntryCancel:
+            return "m_add_favorite_custom_entry_cancel"
+        case .addFavoriteBookmarkAdded:
+            return "m_add_favorite_bookmark_added"
+        case .addFavoriteToastEdit:
+            return "m_add_favorite_toast_edit"
 
         // MARK: DuckPlayer
         case .duckPlayerDailyUniqueView: return "duckplayer_daily-unique-view"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		6F5C74DD2CA416CE00409F5A /* FavoriteSearchResultBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C74DC2CA416CE00409F5A /* FavoriteSearchResultBaseView.swift */; };
 		6F5C74DF2CA4537D00409F5A /* AddFavoriteURLMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5C74DE2CA4537D00409F5A /* AddFavoriteURLMatcher.swift */; };
 		6F5CC0812C2AFFE400AFC840 /* ToggleExpandButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonStyle.swift */; };
+		6F5E93952CA6D491002C5FDC /* AddFavoriteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5E93942CA6D491002C5FDC /* AddFavoriteViewModelTests.swift */; };
 		6F64AA532C47E92600CF4489 /* FavoritesFaviconLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F64AA522C47E92600CF4489 /* FavoritesFaviconLoader.swift */; };
 		6F64AA592C4818D700CF4489 /* NewTabPageShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F64AA582C4818D700CF4489 /* NewTabPageShortcut.swift */; };
 		6F64AA5B2C481AAA00CF4489 /* NewTabPage.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F64AA5A2C481AAA00CF4489 /* NewTabPage.xcassets */; };
@@ -1596,6 +1597,7 @@
 		6F5C74DC2CA416CE00409F5A /* FavoriteSearchResultBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteSearchResultBaseView.swift; sourceTree = "<group>"; };
 		6F5C74DE2CA4537D00409F5A /* AddFavoriteURLMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFavoriteURLMatcher.swift; sourceTree = "<group>"; };
 		6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleExpandButtonStyle.swift; sourceTree = "<group>"; };
+		6F5E93942CA6D491002C5FDC /* AddFavoriteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFavoriteViewModelTests.swift; sourceTree = "<group>"; };
 		6F64AA522C47E92600CF4489 /* FavoritesFaviconLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesFaviconLoader.swift; sourceTree = "<group>"; };
 		6F64AA582C4818D700CF4489 /* NewTabPageShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageShortcut.swift; sourceTree = "<group>"; };
 		6F64AA5A2C481AAA00CF4489 /* NewTabPage.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = NewTabPage.xcassets; sourceTree = "<group>"; };
@@ -3865,6 +3867,7 @@
 				6F7FB8E62C66197E00867DA7 /* NewTabPageSectionsSettingsModelTests.swift */,
 				564DE4562C4150E600D23241 /* HomeViewControllerDaxDialogTests.swift */,
 				6FABAA682C6116FD003762EC /* NewTabPageShortcutsSettingsStorageTests.swift */,
+				6F5E93942CA6D491002C5FDC /* AddFavoriteViewModelTests.swift */,
 			);
 			name = NewTabPage;
 			sourceTree = "<group>";
@@ -8005,6 +8008,7 @@
 				8598F67B2405EB8D00FBC70C /* KeyboardSettingsTests.swift in Sources */,
 				98AAF8E4292EB46000DBDF06 /* BookmarksMigrationTests.swift in Sources */,
 				85D2187224BF24F2004373D2 /* NotFoundCachingDownloaderTests.swift in Sources */,
+				6F5E93952CA6D491002C5FDC /* AddFavoriteViewModelTests.swift in Sources */,
 				C1935A242C89CC6D001AD72D /* AutofillHeaderViewFactoryTests.swift in Sources */,
 				C111B26927F579EF006558B1 /* BookmarkOrFolderTests.swift in Sources */,
 				6F7FB8E72C66197E00867DA7 /* NewTabPageSectionsSettingsModelTests.swift in Sources */,

--- a/DuckDuckGo/AddFavoriteViewModel.swift
+++ b/DuckDuckGo/AddFavoriteViewModel.swift
@@ -43,6 +43,7 @@ class AddFavoriteViewModel: ObservableObject {
     private let booksmarksSearch: BookmarksStringSearch
     private let faviconLoading: FavoritesFaviconLoading
     private let faviconUpdating: FaviconUpdating
+    private let pixelFiring: PixelFiring.Type
 
     var onAddCustomWebsite: ((_ text: String) -> Void)?
     var onFavoriteAdded: ((_ favorite: BookmarkEntity) -> Void)?
@@ -51,12 +52,14 @@ class AddFavoriteViewModel: ObservableObject {
          favoritesCreating: MenuBookmarksInteracting,
          booksmarksSearch: BookmarksStringSearch,
          faviconLoading: FavoritesFaviconLoading,
-         faviconUpdating: FaviconUpdating = Favicons.shared) {
+         faviconUpdating: FaviconUpdating = Favicons.shared,
+         pixelFiring: PixelFiring.Type = Pixel.self) {
         self.websiteSearch = websiteSearching
         self.favoritesCreating = favoritesCreating
         self.booksmarksSearch = booksmarksSearch
         self.faviconLoading = faviconLoading
         self.faviconUpdating = faviconUpdating
+        self.pixelFiring = pixelFiring
 
         $searchTerm
             .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
@@ -111,6 +114,7 @@ class AddFavoriteViewModel: ObservableObject {
     func createOrToggleFavorite(title: String, url: URL) {
         favoritesCreating.createOrToggleFavorite(title: title, url: url)
         if let favorite = favoritesCreating.favorite(for: url) {
+            pixelFiring.fire(.newTabPageFavoriteAddedAutocomplete, withAdditionalParameters: [:])
             onFavoriteAdded?(favorite)
         }
     }

--- a/DuckDuckGo/AddFavoriteViewModel.swift
+++ b/DuckDuckGo/AddFavoriteViewModel.swift
@@ -120,6 +120,7 @@ class AddFavoriteViewModel: ObservableObject {
     }
 
     func addCustomWebsite() {
+        pixelFiring.fire(.addFavoriteAddCustomWebsite, withAdditionalParameters: [:])
         let customWebsiteInput = searchTerm.trimmingWhitespace()
         guard !customWebsiteInput.isEmpty,
               let url = URL(string: customWebsiteInput) else {

--- a/DuckDuckGo/AddOrEditBookmarkViewController.swift
+++ b/DuckDuckGo/AddOrEditBookmarkViewController.swift
@@ -30,7 +30,7 @@ protocol AddOrEditBookmarkViewControllerDelegate: AnyObject {
 
     func finishedEditing(_: AddOrEditBookmarkViewController, entityID: NSManagedObjectID)
     func deleteBookmark(_: AddOrEditBookmarkViewController, entityID: NSManagedObjectID)
-
+    func canceledEditing(_: AddOrEditBookmarkViewController)
 }
 
 class AddOrEditBookmarkViewController: UIViewController {
@@ -153,6 +153,7 @@ class AddOrEditBookmarkViewController: UIViewController {
     }
 
     @IBAction func onCancelPressed(_ sender: Any) {
+        delegate?.canceledEditing(self)
         dismiss(animated: true, completion: nil)
     }
     
@@ -226,6 +227,9 @@ extension AddOrEditBookmarkViewController: AddOrEditBookmarkViewControllerDelega
         self.delegate?.deleteBookmark(self, entityID: entityID)
     }
 
+    func canceledEditing(_: AddOrEditBookmarkViewController) {
+        // no-op
+    }
 }
 
 extension AddOrEditBookmarkViewController {

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -1074,6 +1074,10 @@ extension BookmarksViewController: AddOrEditBookmarkViewControllerDelegate {
         tableView.reloadData()
     }
 
+    func canceledEditing(_: AddOrEditBookmarkViewController) {
+        // no-op
+    }
+
     func showBookmarkDeletedMessage(_ bookmark: BookmarkEntity) {
         guard let parent = bookmark.parent,
               let index = parent.childrenArray.firstIndex(of: bookmark),

--- a/DuckDuckGo/FavoritesView.swift
+++ b/DuckDuckGo/FavoritesView.swift
@@ -27,7 +27,6 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
     @Environment(\.isLandscapeOrientation) var isLandscape
 
     @ObservedObject var model: Model
-    @Binding var isAddingFavorite: Bool
     let geometry: GeometryProxy?
 
     private let selectionFeedback = UISelectionFeedbackGenerator()
@@ -108,7 +107,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
             })
         case .addFavorite:
             Button(action: {
-                isAddingFavorite = true
+                model.addFavorite()
             }, label: {
                 FavoriteAddItemView()
             })
@@ -132,12 +131,5 @@ private extension View {
 }
 
 #Preview {
-    PreviewWrapperView()
-}
-
-private struct PreviewWrapperView: View {
-    @State var isAddingFavorite = false
-    var body: some View {
-        FavoritesView(model: FavoritesPreviewModel(), isAddingFavorite: $isAddingFavorite, geometry: nil)
-    }
+    FavoritesView(model: FavoritesPreviewModel(), geometry: nil)
 }

--- a/DuckDuckGo/FavoritesViewModel.swift
+++ b/DuckDuckGo/FavoritesViewModel.swift
@@ -46,6 +46,7 @@ class FavoritesViewModel: ObservableObject {
 
     @Published private(set) var allFavorites: [FavoriteItem] = []
     @Published private(set) var isCollapsed: Bool = true
+    @Published var isAddingFavorite: Bool = false
 
     private(set) var faviconLoader: FavoritesFaviconLoading?
 
@@ -106,6 +107,12 @@ class FavoritesViewModel: ObservableObject {
         }
 
         return .init(items: favorites, isCollapsible: isCollapsible)
+    }
+
+    func addFavorite() {
+        isAddingFavorite = true
+
+        pixelFiring.fire(.newTabPageAddFavorite, withAdditionalParameters: [:])
     }
 
     // MARK: - External actions

--- a/DuckDuckGo/MainViewController+Segues.swift
+++ b/DuckDuckGo/MainViewController+Segues.swift
@@ -104,6 +104,8 @@ extension MainViewController {
             sanitization: .navigational
         )
 
+        addBookmark.delegate = newTabPageViewController
+
         let controller = UINavigationController(rootViewController: addBookmark)
         controller.modalPresentationStyle = .automatic
         present(controller, animated: true)

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -794,6 +794,7 @@ class MainViewController: UIViewController {
                                                       interactionModel: favoritesViewModel,
                                                       bookmarksInteracting: menuBookmarksViewModel,
                                                       syncService: syncService,
+                                                      bookmarksDatabase: self.bookmarksDatabase,
                                                       syncBookmarksAdapter: syncDataProviders.bookmarksAdapter,
                                                       bookmarksStringSearch: bookmarksCachingSearch,
                                                       homePageMessagesConfiguration: homePageConfiguration,

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -144,7 +144,7 @@ private extension NewTabPageView {
                         .padding([.trailing, .bottom], Metrics.largePadding)
                 }
             }
-            .sheet(isPresented: $isAddingFavorite, content: {
+            .sheet(isPresented: $favoritesViewModel.isAddingFavorite, content: {
                 NavigationView {
                     AddFavoriteView(viewModel: addFavoriteViewModel)
                 }
@@ -184,7 +184,6 @@ private extension NewTabPageView {
 
     private func favoritesSectionView(proxy: GeometryProxy) -> some View {
                 FavoritesView(model: favoritesViewModel,
-                              isAddingFavorite: $isAddingFavorite,
                               geometry: proxy)
     }
 

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -164,6 +164,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
             ActionMessageView.present(message: message, actionTitle: UserText.actionGenericEdit) { [weak self] in
                 guard let self else { return }
 
+                Pixel.fire(pixel: .addFavoriteToastEdit)
                 self.delegate?.newTabPageDidEditFavorite(self, favorite: favorite)
             } onDidDismiss: {
                 

--- a/DuckDuckGoTests/AddFavoriteViewModelTests.swift
+++ b/DuckDuckGoTests/AddFavoriteViewModelTests.swift
@@ -1,0 +1,97 @@
+//
+//  AddFavoriteViewModelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Bookmarks
+import Persistence
+@testable import DuckDuckGo
+import Core
+import CoreData
+
+final class AddFavoriteViewModelTests: XCTestCase {
+
+    let websiteSearching = MockWebsiteSearching()
+    let favoritesCreating = MockMenuBookmarksInterating()
+    let booksmarksSearch = MockBookmarksStringSearch()
+
+    override func tearDown() {
+        PixelFiringMock.tearDown()
+    }
+
+    func testFiresPixelOnCustomWebsite() {
+        let sut = createSUT()
+
+        sut.addCustomWebsite()
+
+        XCTAssertEqual(PixelFiringMock.lastPixel, .addFavoriteAddCustomWebsite)
+        XCTAssertEqual(PixelFiringMock.lastParams, [:])
+    }
+
+    private func createSUT() -> AddFavoriteViewModel {
+        AddFavoriteViewModel(websiteSearching: websiteSearching,
+                             favoritesCreating: favoritesCreating,
+                             booksmarksSearch: booksmarksSearch,
+                             faviconLoading: FavoritesFaviconLoader(),
+                             faviconUpdating: MockFaviconUpdating(),
+                             pixelFiring: PixelFiringMock.self)
+    }
+}
+
+final class MockMenuBookmarksInterating: MenuBookmarksInteracting {
+
+    var stubEntity: BookmarkEntity?
+
+    var favoritesDisplayMode: FavoritesDisplayMode = .displayNative(.mobile)
+
+    func createOrToggleFavorite(title: String, url: URL) {
+
+    }
+
+    func createBookmark(title: String, url: URL) {
+
+    }
+
+    func favorite(for url: URL) -> BookmarkEntity? {
+        stubEntity
+    }
+
+    func bookmark(for url: URL) -> BookmarkEntity? {
+        stubEntity
+    }
+}
+
+final class MockBookmarksStringSearch: BookmarksStringSearch {
+    var hasData: Bool = false
+    func search(query: String) -> [BookmarksStringSearchResult] {
+        []
+    }
+}
+
+final class MockWebsiteSearching: WebsiteSearching {
+    var results: [URL] = []
+    func search(term: String) async throws -> [URL] {
+        results
+    }
+}
+
+final class MockFaviconUpdating: FaviconUpdating {
+    func updateFavicon(forDomain domain: String, with image: UIImage) {
+
+    }
+}

--- a/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
+++ b/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
@@ -88,6 +88,15 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
         XCTAssertEqual(PixelFiringMock.lastPixel, .newTabPageFavoritesPlaceholderTapped)
     }
 
+    func testFiresPixelOnAddFavorite() {
+        let sut = createSUT()
+
+        sut.addFavorite()
+
+        XCTAssertEqual(PixelFiringMock.lastPixel, .newTabPageAddFavorite)
+        XCTAssertEqual(PixelFiringMock.lastParams, [:])
+    }
+
     func testPrefixFavoritesCreatesRemainingPlaceholders() {
         let sut = createSUT()
 
@@ -125,6 +134,14 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
         XCTAssertTrue(firstItem == .addFavorite)
     }
 
+    func testSetsPropertyOnAddingFavorite() {
+        let sut = createSUT()
+        
+        sut.addFavorite()
+
+        XCTAssertTrue(sut.isAddingFavorite)
+    }
+
     private func createSUT() -> FavoritesViewModel {
         FavoritesViewModel(favoriteDataSource: favoriteDataSource,
                            faviconLoader: FavoritesFaviconLoader(),
@@ -135,12 +152,12 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
 
 private final class MockNewTabPageFavoriteDataSource: NewTabPageFavoriteDataSource {
     var externalUpdates: AnyPublisher<Void, Never> = Empty().eraseToAnyPublisher()
-    var favorites: [DuckDuckGo.Favorite] = []
+    var favorites: [Favorite] = []
 
-    func moveFavorite(_ favorite: DuckDuckGo.Favorite, fromIndex: Int, toIndex: Int) { }
-    func favorite(at index: Int) throws -> DuckDuckGo.Favorite? { nil }
-    func removeFavorite(_ favorite: DuckDuckGo.Favorite) { }
-    func bookmarkEntity(for favorite: DuckDuckGo.Favorite) -> Bookmarks.BookmarkEntity? {
+    func moveFavorite(_ favorite: Favorite, fromIndex: Int, toIndex: Int) { }
+    func favorite(at index: Int) throws -> Favorite? { nil }
+    func removeFavorite(_ favorite: Favorite) { }
+    func bookmarkEntity(for favorite: Favorite) -> Bookmarks.BookmarkEntity? {
         createStubBookmark()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208413911032918/f
Tech Design URL:
CC:

**Description**:

Adds pixels reporting as described in [task](https://app.asana.com/0/0/1208415565175583/f).

**Steps to test this PR**:
Verify pixels are sent according to the mentioned task on:
1. "+" button in favorites collection is pressed.
2. Favorite is added using autocomplete result.
3. "Add custom website" button is pressed.
4. Favorite is saved using custom edit.
    1. Bookmark is saved instead of favorite. 
6. Custom editing is cancelled.
7. Started editing newly added favorite from action message.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
