### PR TITLE
New autofill device authentication pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -291,6 +291,8 @@ extension Pixel {
         case autofillToggledOn
         case autofillToggledOff
         case autofillLoginsStacked
+        case autofillDeviceCapabilityDeviceAuthDisabled
+        case autofillDeviceCapabilityCapable
 
         case autofillManagementOpened
         case autofillManagementCopyUsername
@@ -1107,6 +1109,9 @@ extension Pixel.Event {
         case .autofillToggledOff: return "m_autofill_toggled_off"
 
         case .autofillLoginsStacked: return "m_autofill_logins_stacked"
+
+        case .autofillDeviceCapabilityDeviceAuthDisabled: return "m_autofill_device_capability_device_auth_disabled"
+        case .autofillDeviceCapabilityCapable: return "m_autofill_device_capability_capable"
 
         case .autofillManagementOpened:
             return "m_autofill_management_opened"

--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -93,6 +93,7 @@ public struct UserDefaultsWrapper<T> {
         case autofillFillDate = "com.duckduckgo.app.autofill.FillDate"
         case autofillOnboardedUser = "com.duckduckgo.app.autofill.OnboardedUser"
         case autofillSurveysCompleted = "com.duckduckgo.app.autofill.SurveysCompleted"
+        case autofillDeviceAuthStatusChecked = "com.duckduckgo.app.autofill.DeviceAuthStatusChecked"
 
         case syncPromoBookmarksDismissed = "com.duckduckgo.app.sync.PromoBookmarksDismissed"
         case syncPromoPasswordsDismissed = "com.duckduckgo.app.sync.PromoPasswordsDismissed"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10934,8 +10934,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 198.2.1;
+				kind = revision;
+				revision = e6a229d82ecbb32513f783a5b04727fa35c86597;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "b60b38bace7262e0c4a006018b7e4b060ba4b754",
-        "version" : "198.2.1"
+        "revision" : "e6a229d82ecbb32513f783a5b04727fa35c86597"
       }
     },
     {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -938,6 +938,7 @@ import os.log
         autofillPixelReporter = AutofillPixelReporter(
             userDefaults: .standard,
             autofillEnabled: AppDependencyProvider.shared.appSettings.autofillCredentialsEnabled,
+            deviceAuthEnabled: isDeviceAuthEnabled,
             eventMapping: EventMapping<AutofillPixelEvent> {event, _, params, _ in
                 switch event {
                 case .autofillActiveUser:

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -928,6 +928,13 @@ import os.log
     }
 
     private func setUpAutofillPixelReporter() {
+        let isDeviceAuthEnabled = AppDependencyProvider.shared.autofillSettingStatus.deviceAuthenticationEnabled
+
+        if !AppDependencyProvider.shared.appSettings.autofillDeviceAuthStatusChecked {
+            Pixel.fire(pixel: isDeviceAuthEnabled ? .autofillDeviceCapabilityCapable : .autofillDeviceCapabilityDeviceAuthDisabled)
+            AppDependencyProvider.shared.appSettings.autofillDeviceAuthStatusChecked = true
+        }
+
         autofillPixelReporter = AutofillPixelReporter(
             userDefaults: .standard,
             autofillEnabled: AppDependencyProvider.shared.appSettings.autofillCredentialsEnabled,

--- a/DuckDuckGo/AppDependencyProvider.swift
+++ b/DuckDuckGo/AppDependencyProvider.swift
@@ -38,6 +38,7 @@ protocol DependencyProvider {
     var downloadManager: DownloadManager { get }
     var autofillLoginSession: AutofillLoginSession { get }
     var autofillNeverPromptWebsitesManager: AutofillNeverPromptWebsitesManager { get }
+    var autofillSettingStatus: AutofillSettingStatusProtocol { get }
     var configurationManager: ConfigurationManager { get }
     var configurationStore: ConfigurationStore { get }
     var userBehaviorMonitor: UserBehaviorMonitor { get }
@@ -69,6 +70,7 @@ final class AppDependencyProvider: DependencyProvider {
     let downloadManager = DownloadManager()
     let autofillLoginSession = AutofillLoginSession()
     lazy var autofillNeverPromptWebsitesManager = AutofillNeverPromptWebsitesManager()
+    lazy var autofillSettingStatus: AutofillSettingStatusProtocol = AutofillSettingStatus()
 
     let configurationManager: ConfigurationManager
     let configurationStore = ConfigurationStore()

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -71,6 +71,7 @@ protocol AppSettings: AnyObject, AppDebugSettings {
     func setAutofillIsNewInstallForOnByDefault()
     var autofillImportViaSyncStart: Date? { get set }
     func clearAutofillImportViaSyncStart()
+    var autofillDeviceAuthStatusChecked: Bool { get set }
 
     var voiceSearchEnabled: Bool { get set }
 

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -310,6 +310,9 @@ public class AppUserDefaults: AppSettings {
         autofillImportViaSyncStart = nil
     }
 
+    @UserDefaultsWrapper(key: .autofillDeviceAuthStatusChecked, defaultValue: false)
+    var autofillDeviceAuthStatusChecked: Bool
+
     @UserDefaultsWrapper(key: .voiceSearchEnabled, defaultValue: false)
     var voiceSearchEnabled: Bool
 

--- a/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
+++ b/DuckDuckGo/AutofillContentScopeFeatureToggles.swift
@@ -26,7 +26,7 @@ extension ContentScopeFeatureToggles {
     static let featureFlagger = AppDependencyProvider.shared.featureFlagger
 
     static var supportedFeaturesOniOS: ContentScopeFeatureToggles {
-        let isAutofillEnabledInSettings = AutofillSettingStatus.isAutofillEnabledInSettings
+        let isAutofillEnabledInSettings = AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings
         return ContentScopeFeatureToggles(emailProtection: true,
                                    emailProtectionIncontextSignup: featureFlagger.isFeatureOn(.incontextSignup) && Locale.current.isEnglishLanguage,
                                    credentialsAutofill: featureFlagger.isFeatureOn(.autofillCredentialInjecting) && isAutofillEnabledInSettings,

--- a/DuckDuckGo/AutofillDebugViewController.swift
+++ b/DuckDuckGo/AutofillDebugViewController.swift
@@ -66,7 +66,8 @@ class AutofillDebugViewController: UITableViewController {
                 try? secureVault?.deleteAllWebsiteCredentials()
                 let autofillPixelReporter = AutofillPixelReporter(
                         userDefaults: .standard,
-                        autofillEnabled: AppUserDefaults().autofillCredentialsEnabled,
+                        autofillEnabled: AppDependencyProvider.shared.appSettings.autofillCredentialsEnabled,
+                        deviceAuthEnabled: AppDependencyProvider.shared.autofillSettingStatus.deviceAuthenticationEnabled,
                         eventMapping: EventMapping<AutofillPixelEvent> { _, _, _, _ in })
                 autofillPixelReporter.resetStoreDefaults()
                 ActionMessageView.present(message: "Autofill Data reset")

--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -469,10 +469,10 @@ final class AutofillLoginListViewModel: ObservableObject {
     private func updateViewState() {
         var newViewState: AutofillLoginListViewModel.ViewState
         
-        if authenticator.state == .loggedOut && !authenticationNotRequired {
-            newViewState = .authLocked
-        } else if authenticator.state == .notAvailable {
+        if !authenticator.canAuthenticate() {
             newViewState = .noAuthAvailable
+        } else if authenticator.state == .loggedOut && !authenticationNotRequired {
+            newViewState = .authLocked
         } else if isSearching {
             if sections.count == 0 {
                 newViewState = .searchingNoResults

--- a/DuckDuckGo/EmailSignupViewController.swift
+++ b/DuckDuckGo/EmailSignupViewController.swift
@@ -366,7 +366,7 @@ extension EmailSignupViewController: SecureVaultManagerDelegate {
     }
 
     func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType?) -> Bool {
-        let isEnabled = AutofillSettingStatus.isAutofillEnabledInSettings && featureFlagger.isFeatureOn(.autofillCredentialInjecting)
+        let isEnabled = AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings && featureFlagger.isFeatureOn(.autofillCredentialInjecting)
         return isEnabled
     }
 

--- a/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -115,7 +115,7 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
     }
 
     private func initSecureVault() -> (any AutofillSecureVault)? {
-        if featureFlagger.isFeatureOn(.autofillCredentialInjecting) && AutofillSettingStatus.isAutofillEnabledInSettings {
+        if featureFlagger.isFeatureOn(.autofillCredentialInjecting) && AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings {
             if secureVault == nil {
                 secureVault = try? AutofillSecureVaultFactory.makeVault(reporter: SecureVaultReporter())
             }

--- a/DuckDuckGo/Subscription/PrivacyProDataReporting.swift
+++ b/DuckDuckGo/Subscription/PrivacyProDataReporting.swift
@@ -122,7 +122,7 @@ final class PrivacyProDataReporter: PrivacyProDataReporting {
          appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
          statisticsStore: StatisticsStore = StatisticsUserDefaults(),
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         autofillCheck: @escaping () -> Bool = { AutofillSettingStatus.isAutofillEnabledInSettings },
+         autofillCheck: @escaping () -> Bool = { AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings },
          secureVaultMaker: @escaping () -> (any AutofillSecureVault)? = { try? AutofillSecureVaultFactory.makeVault(reporter: SecureVaultReporter()) },
          syncService: DDGSyncing? = nil,
          tabsModel: TabsModel? = nil,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1554,7 +1554,7 @@ extension TabViewController: WKNavigationDelegate {
     private func checkLoginDetectionAfterNavigation() {
         if preserveLoginsWorker?.handleLoginDetection(detectedURL: detectedLoginURL,
                                                       currentURL: url,
-                                                      isAutofillEnabled: AutofillSettingStatus.isAutofillEnabledInSettings,
+                                                      isAutofillEnabled: AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings,
                                                       saveLoginPromptLastDismissed: saveLoginPromptLastDismissed,
                                                       saveLoginPromptIsPresenting: saveLoginPromptIsPresenting)
            ?? false {
@@ -2668,7 +2668,7 @@ extension NSError {
 extension TabViewController: SecureVaultManagerDelegate {
 
     private func presentSavePasswordModal(with vault: SecureVaultManager, credentials: SecureVaultModels.WebsiteCredentials) {
-        guard AutofillSettingStatus.isAutofillEnabledInSettings,
+        guard AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings,
               featureFlagger.isFeatureOn(.autofillCredentialsSaving),
               let autofillUserScript = autofillUserScript else { return }
 
@@ -2706,7 +2706,7 @@ extension TabViewController: SecureVaultManagerDelegate {
     }
 
     func secureVaultManagerIsEnabledStatus(_ manager: SecureVaultManager, forType type: AutofillType?) -> Bool {
-        let isEnabled = AutofillSettingStatus.isAutofillEnabledInSettings &&
+        let isEnabled = AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings &&
                         featureFlagger.isFeatureOn(.autofillCredentialInjecting) &&
                         !isLinkPreview
         let isDataProtected = !UIApplication.shared.isProtectedDataAvailable
@@ -2726,7 +2726,7 @@ extension TabViewController: SecureVaultManagerDelegate {
                             withTrigger trigger: AutofillUserScript.GetTriggerType?) {
         
         if let credentials = data.credentials,
-            AutofillSettingStatus.isAutofillEnabledInSettings,
+            AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings,
             featureFlagger.isFeatureOn(.autofillCredentialsSaving) {
             if data.automaticallySavedCredentials, let trigger = trigger {
                 if trigger == AutofillUserScript.GetTriggerType.passwordGeneration {
@@ -2756,7 +2756,7 @@ extension TabViewController: SecureVaultManagerDelegate {
                             onAccountSelected: @escaping (SecureVaultModels.WebsiteAccount?) -> Void,
                             completionHandler: @escaping (SecureVaultModels.WebsiteAccount?) -> Void) {
   
-        if !AutofillSettingStatus.isAutofillEnabledInSettings, featureFlagger.isFeatureOn(.autofillCredentialInjecting) {
+        if !AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings, featureFlagger.isFeatureOn(.autofillCredentialInjecting) {
             completionHandler(nil)
             return
         }
@@ -2890,7 +2890,7 @@ extension TabViewController: SecureVaultManagerDelegate {
     private func buildContentScopePropertiesForDomain(_ domain: String) -> ContentScopeProperties {
         var supportedFeatures = ContentScopeFeatureToggles.supportedFeaturesOniOS
 
-        if AutofillSettingStatus.isAutofillEnabledInSettings,
+        if AppDependencyProvider.shared.autofillSettingStatus.isAutofillEnabledInSettings,
            featureFlagger.isFeatureOn(.autofillCredentialsSaving),
            autofillNeverPromptWebsitesManager.hasNeverPromptWebsitesFor(domain: domain) {
             supportedFeatures.passwordGeneration = false

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -71,6 +71,8 @@ class AppSettingsMock: AppSettings {
         autofillImportViaSyncStart = nil
     }
 
+    var autofillDeviceAuthStatusChecked: Bool = false
+
     var voiceSearchEnabled: Bool = false
 
     var widgetInstalled: Bool = false

--- a/DuckDuckGoTests/MockDependencyProvider.swift
+++ b/DuckDuckGoTests/MockDependencyProvider.swift
@@ -37,6 +37,7 @@ class MockDependencyProvider: DependencyProvider {
     var downloadManager: DownloadManager
     var autofillLoginSession: AutofillLoginSession
     var autofillNeverPromptWebsitesManager: AutofillNeverPromptWebsitesManager
+    var autofillSettingStatus: AutofillSettingStatusProtocol
     var configurationManager: ConfigurationManager
     var configurationStore: ConfigurationStore
     var userBehaviorMonitor: UserBehaviorMonitor
@@ -61,6 +62,7 @@ class MockDependencyProvider: DependencyProvider {
         downloadManager = defaultProvider.downloadManager
         autofillLoginSession = defaultProvider.autofillLoginSession
         autofillNeverPromptWebsitesManager = defaultProvider.autofillNeverPromptWebsitesManager
+        autofillSettingStatus = defaultProvider.autofillSettingStatus
         configurationStore = defaultProvider.configurationStore
         configurationManager = defaultProvider.configurationManager
         userBehaviorMonitor = defaultProvider.userBehaviorMonitor


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201462886803403/1208356133120985/f
Tech Design URL:
CC:

**Description**:
Two new autofill pixels added (to bring iOS inline with Android) to report as a one-off if a user has device authentication enabled / disabled. Updates the rules around the `autofill_toggled_on|off` so that these pixels only fire if device authentication is enabled. Also fixes a bug where the incorrect UI was shown on the Passwords screen if device auth is disabled, along with an optimisation to cache device auth state which can be checked repeatedly causing hangs


<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.
2.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
