### PR TITLE
Fix failing password-management maestro test

### DIFF
--- a/.maestro/release_tests/password-management.yaml
+++ b/.maestro/release_tests/password-management.yaml
@@ -49,6 +49,14 @@ tags:
 
 - tapOn: "Save"
 - tapOn: "Passwords"
+
+# Dismiss Sync Promo if visible
+- runFlow:
+    when:
+        visible: "No Thanks"
+    commands:
+        - tapOn: "No Thanks"
+
 - tapOn: "Settings"
 - tapOn: "Done"
 

--- a/.maestro/release_tests/password-management.yaml
+++ b/.maestro/release_tests/password-management.yaml
@@ -49,14 +49,6 @@ tags:
 
 - tapOn: "Save"
 - tapOn: "Passwords"
-
-# Dismiss Sync Promo if visible
-- runFlow:
-    when:
-        visible: "No Thanks"
-    commands:
-        - tapOn: "No Thanks"
-
 - tapOn: "Settings"
 - tapOn: "Done"
 

--- a/DuckDuckGo/SyncPromoView.swift
+++ b/DuckDuckGo/SyncPromoView.swift
@@ -24,6 +24,7 @@ import DuckUI
 struct SyncPromoView: View {
 
     let viewModel: SyncPromoViewModel
+    @State private var isAccessibilityHidden = true
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -31,6 +32,8 @@ struct SyncPromoView: View {
                 Group {
                     Image(viewModel.image)
                         .scaledToFit()
+                        .accessibilityHidden(true)
+                    
                     Text(viewModel.title)
                         .padding(.top, 4)
                         .frame(maxWidth: .infinity)
@@ -83,6 +86,7 @@ struct SyncPromoView: View {
             .alignmentGuide(.top) { dimension in
                 dimension[.top]
             }
+            .accessibilityHidden(true)
         }
         .background(
             RoundedRectangle(cornerRadius: 8)
@@ -90,6 +94,13 @@ struct SyncPromoView: View {
         )
         .padding(.horizontal, 20)
         .padding(.bottom, 12)
+        .accessibilityHidden(isAccessibilityHidden)
+        .onAppear {
+            // Delay accessibility activation for maestro
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                isAccessibilityHidden = false
+            }
+        }
     }
 }
 

--- a/DuckDuckGo/SyncPromoView.swift
+++ b/DuckDuckGo/SyncPromoView.swift
@@ -48,6 +48,7 @@ struct SyncPromoView: View {
                         Text(viewModel.secondaryButtonTitle)
                     }
                     .buttonStyle(SecondaryFillButtonStyle(compact: true, fullWidth: false))
+                    .accessibilityLabel(viewModel.secondaryButtonTitle)
 
                     Button {
                         viewModel.primaryButtonAction?()
@@ -55,6 +56,7 @@ struct SyncPromoView: View {
                         Text(viewModel.primaryButtonTitle)
                     }
                     .buttonStyle(PrimaryButtonStyle(compact: true, fullWidth: false))
+                    .accessibilityLabel(viewModel.primaryButtonTitle)
 
                 }
                 .padding(.top, 12)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201462886803403/1208448205292549/f
Tech Design URL:
CC:

**Description**:
Fixes issue where including a swiftUI component in the tableview header caused a maestro crash as too many accessibility layout updates fired while animating from search controller results view back to normal table layout. I also improved the accessibility of the Sync Promo (setting irrelevant UI elements as hidden, accessibility labels on buttons etc)

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Confirm the `password-management` test flow completed successfully https://github.com/duckduckgo/iOS/actions/runs/11159554690/job/31018490538

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
