### PR TITLE
Update BSK version to support userTips NetP Flag

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -43,6 +43,9 @@ public enum FeatureFlag: String {
     case onboardingHighlights
     case autofillSurveys
     case autcompleteTabs
+
+    /// https://app.asana.com/0/72649045549333/1208231259093710/f
+    case networkProtectionUserTips
 }
 
 extension FeatureFlag: FeatureFlagSourceProviding {
@@ -92,6 +95,8 @@ extension FeatureFlag: FeatureFlagSourceProviding {
             return .remoteReleasable(.feature(.autofillSurveys))
         case .autcompleteTabs:
             return .remoteReleasable(.feature(.autocompleteTabs))
+        case .networkProtectionUserTips:
+            return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.userTips))
         }
     }
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10934,8 +10934,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 198.2.1;
+				branch = bunn/netp/featureflag;
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10934,8 +10934,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = bunn/netp/featureflag;
-				kind = branch;
+				kind = exactVersion;
+				version = 198.3.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "bunn/netp/featureflag",
-        "revision" : "ea54c9cd4bdadce0de3b4cb39ab9c5ab03d73e42"
+        "revision" : "4e6a8da6a088439565ed7f6a2ac83e83ad7fd10e",
+        "version" : "198.3.1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "b60b38bace7262e0c4a006018b7e4b060ba4b754",
-        "version" : "198.2.1"
+        "branch" : "bunn/netp/featureflag",
+        "revision" : "ea54c9cd4bdadce0de3b4cb39ab9c5ab03d73e42"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208381891916914/f
Tech Design URL:
CC:

**Description**:
Update BSK version to support userTips NetP Flag

**Steps to test this PR**:
1. You can add `print("USER ON? \(AppDependencyProvider.shared.featureFlagger.isFeatureOn(.networkProtectionUserTips))")` to the App Delegate and check if the flag is returning as true (it should)
2. You can also change the config URL to this: https://jsonblob.com/api/1292861631544287232 which has the flag set to false and make sure that now the `isFeatureOn` function returns false
