### PR TITLE
Prevent autofill prompt crash for edge case where a context menu is also visible on screen

### DIFF
--- a/DuckDuckGo/PasswordGenerationPromptViewController.swift
+++ b/DuckDuckGo/PasswordGenerationPromptViewController.swift
@@ -63,11 +63,24 @@ class PasswordGenerationPromptViewController: UIViewController {
         presentationController?.delegate = self
         installChildViewController(controller)
     }
+
+    /// This is to handle cases where a webpage may have also presented a context menu, which ends up getting dismissed instead of this sheet
+    private func dismissSheetWithRetry(attempts: Int = 2, useGeneratedPassword: Bool) {
+        dismiss(animated: true) { [weak self] in
+            if self?.presentingViewController != nil && attempts > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self?.dismissSheetWithRetry(attempts: attempts - 1, useGeneratedPassword: useGeneratedPassword)
+                }
+            } else {
+                self?.completion?(useGeneratedPassword)
+            }
+        }
+    }
 }
 
 extension PasswordGenerationPromptViewController: UISheetPresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-            Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed)
+        Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed)
 
         self.completion?(false)
     }
@@ -77,17 +90,13 @@ extension PasswordGenerationPromptViewController: PasswordGenerationPromptViewMo
     func passwordGenerationPromptViewModelDidSelect(_ viewModel: PasswordGenerationPromptViewModel) {
         Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptConfirmed)
 
-        dismiss(animated: true) {
-            self.completion?(true)
-        }
+        dismissSheetWithRetry(useGeneratedPassword: true)
     }
 
     func passwordGenerationPromptViewModelDidCancel(_ viewModel: PasswordGenerationPromptViewModel) {
         Pixel.fire(pixel: .autofillLoginsPasswordGenerationPromptDismissed)
 
-        dismiss(animated: true) {
-            self.completion?(false)
-        }
+        dismissSheetWithRetry(useGeneratedPassword: false)
     }
 
     func passwordGenerationPromptViewModelDidResizeContent(_ viewModel: PasswordGenerationPromptViewModel, contentHeight: CGFloat) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2786,8 +2786,17 @@ extension TabViewController: SecureVaultManagerDelegate {
     func secureVaultManager(_: SecureVaultManager,
                             promptUserWithGeneratedPassword password: String,
                             completionHandler: @escaping (Bool) -> Void) {
+
+        var responseSent: Bool = false
+
+        let sendResponse: (Bool) -> Void = { useGeneratedPassword in
+            guard !responseSent else { return }
+            responseSent = true
+            completionHandler(useGeneratedPassword)
+        }
+
         let passwordGenerationPromptViewController = PasswordGenerationPromptViewController(generatedPassword: password) { useGeneratedPassword in
-                completionHandler(useGeneratedPassword)
+            sendResponse(useGeneratedPassword)
         }
 
         if let presentationController = passwordGenerationPromptViewController.presentationController as? UISheetPresentationController {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2819,6 +2819,15 @@ extension TabViewController: SecureVaultManagerDelegate {
                                              useLargeDetent: Bool,
                                              onAccountSelected: @escaping (SecureVaultModels.WebsiteAccount?) -> Void,
                                              completionHandler: @escaping (SecureVaultModels.WebsiteAccount?) -> Void) {
+
+        var responseSent: Bool = false
+
+        let sendResponse: (SecureVaultModels.WebsiteAccount?) -> Void = { account in
+            guard !responseSent else { return }
+            responseSent = true
+            completionHandler(account)
+        }
+
         let autofillPromptViewController = AutofillLoginPromptViewController(accounts: accountMatches,
                                                                              domain: domain,
                                                                              trigger: trigger,
@@ -2834,10 +2843,10 @@ extension TabViewController: SecureVaultManagerDelegate {
                     onAccountSelected(account)
                 },
                                                          completionHandler: { account in
-                    completionHandler(account)
+                    sendResponse(account)
                 })
             } else {
-                completionHandler(account)
+                sendResponse(account)
             }
         })
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1208361080593409/f
Tech Design URL:
CC:

**Description**:
Fixes a potential crash that is triggered when dismissing the password generation prompt fails where a context menu is also present, requiring a subsequent attempt which results in `crashing on: NSInternalInconsistencyException: replyHandler passed to userContentController:didReceiveScriptMessage:replyHandler: should not be called twice`

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go to https://amddg44.github.io/registration-form/ (I’ve spun up this webpage to make it easier to trigger the original edge case report)
2. Tap into the Username field, then the Password field so that the password generation prompt appears
3. The webpage will programmatically focus on the Title field every 10 seconds, so wait until the “Select your title” context menu appears over the password generation prompt
4. Select either option from the password generation prompt and confirm the prompt dismisses correctly (along with the context menu), with no second attempt needed (and therefore no crash)

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
