### PR TITLE
Fixes DuckPlayer Experiment issue

### DIFF
--- a/DuckDuckGo/Debug.storyboard
+++ b/DuckDuckGo/Debug.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="fgi-g1-scz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="fgi-g1-scz">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -360,7 +360,7 @@
                                         <rect key="frame" x="0.0" y="1108" width="414" height="44.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wKg-4u-kJ4" id="8Jc-Co-wqO">
-                                            <rect key="frame" x="0.0" y="0.0" width="395.5" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="44.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <listContentConfiguration key="contentConfiguration" text="New Onboarding"/>
@@ -390,7 +390,16 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
-                                        <listContentConfiguration key="contentConfiguration" text="Override DuckPlayer Experiment"/>
+                                        <listContentConfiguration key="contentConfiguration" text="Override DuckPlayer Experiment (Experiment)"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" tag="680" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="fW5-D1-guK">
+                                        <rect key="frame" x="0.0" y="1286" width="414" height="44.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fW5-D1-guK" id="HTT-aN-Wcy">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                        <listContentConfiguration key="contentConfiguration" text="Override DuckPlayer Experiment (Control)"/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -974,34 +983,34 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ConfigurationURLTableViewCell" id="i6Y-Di-PX3" customClass="ConfigurationURLTableViewCell" customModule="DuckDuckGo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="50" width="414" height="92"/>
+                                <rect key="frame" x="0.0" y="50" width="414" height="94"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i6Y-Di-PX3" id="qn4-gq-5fa">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="92"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="94"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="pKD-Xm-Eu1">
-                                            <rect key="frame" x="20" y="11" width="374" height="70"/>
+                                            <rect key="frame" x="20" y="11" width="374" height="72"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="j3A-OZ-DWy">
-                                                    <rect key="frame" x="0.0" y="0.0" width="44" height="70"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="44" height="72"/>
                                                     <subviews>
                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gKw-J7-XIW">
-                                                            <rect key="frame" x="0.0" y="0.0" width="44" height="23"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="44" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UrI-B0-rWf">
-                                                            <rect key="frame" x="0.0" y="23" width="44" height="23.5"/>
+                                                            <rect key="frame" x="0.0" y="24" width="44" height="23.5"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                             <color key="textColor" name="accent"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6RK-ug-mZa">
-                                                            <rect key="frame" x="0.0" y="47" width="44" height="23"/>
+                                                            <rect key="frame" x="0.0" y="48" width="44" height="24"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -1009,7 +1018,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nkj-yK-cgm">
-                                                    <rect key="frame" x="350" y="0.0" width="24" height="70"/>
+                                                    <rect key="frame" x="350" y="0.0" width="24" height="72"/>
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                     <state key="normal" image="Reload-24"/>
                                                 </button>

--- a/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -184,6 +184,9 @@ final class DuckPlayer: DuckPlayerProtocol {
     }
     
     public func getUserValues(params: Any, message: WKScriptMessage) -> Encodable? {
+        // If the user is in the 'control' group, sending 'nil' effectively disables
+        // Duckplayer in SERP, showing old overlays.
+        // Fixes: https://app.asana.com/0/1207252092703676/1208450923559111
         let duckPlayerExperiment = DuckPlayerLaunchExperiment()
         if duckPlayerExperiment.isEnrolled && duckPlayerExperiment.isExperimentCohort {
             return encodeUserValues()

--- a/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -184,7 +184,12 @@ final class DuckPlayer: DuckPlayerProtocol {
     }
     
     public func getUserValues(params: Any, message: WKScriptMessage) -> Encodable? {
-        encodeUserValues()
+        let duckPlayerExperiment = DuckPlayerLaunchExperiment()
+        if duckPlayerExperiment.isEnrolled && duckPlayerExperiment.isExperimentCohort {
+            return encodeUserValues()
+        }
+        return nil
+        
     }
     
     @MainActor

--- a/DuckDuckGo/DuckPlayer/DuckPlayerLaunchExperiment.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerLaunchExperiment.swift
@@ -227,9 +227,9 @@ final class DuckPlayerLaunchExperiment: DuckPlayerLaunchExperimentHandling {
         lastVideoIDReportedV2 = nil
     }
     
-    func override() {
+    func override(control: Bool = false) {
         enrollmentDateV2 = Date()
-        experimentCohortV2 = "experiment"
+        experimentCohortV2 = control ? "control" : "experiment"
         lastDayPixelFiredV2 = nil
         lastWeekPixelFiredV2 = nil
         lastVideoIDReportedV2 = nil

--- a/DuckDuckGo/RootDebugViewController.swift
+++ b/DuckDuckGo/RootDebugViewController.swift
@@ -49,6 +49,7 @@ class RootDebugViewController: UITableViewController {
         case resetSyncPromoPrompts = 677
         case resetDuckPlayerExperiment = 678
         case overrideDuckPlayerExperiment = 679
+        case overrideDuckPlayerExperimentControl = 680
     }
 
     @IBOutlet weak var shareButton: UIBarButtonItem!
@@ -189,6 +190,9 @@ class RootDebugViewController: UITableViewController {
             case .overrideDuckPlayerExperiment:
                 DuckPlayerLaunchExperiment().override()
                 ActionMessageView.present(message: "Overriding experiment.  You are now in the 'experiment' group.  Restart the app to complete")
+            case .overrideDuckPlayerExperimentControl:
+                DuckPlayerLaunchExperiment().override(control: true)
+                ActionMessageView.present(message: "Overriding experiment.  You are now in the 'control' group.  Restart the app to complete")
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1207252092703676/1208450923559111/f

**Description**:
- Fix an issue with DP experiment that causes Control users to not see overlays

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1.  Go to Settings > All Debug Settings > Override DuckPlayer Experiment (Control)
2. Force-close / Restart the app

3. Go to SERP, and then confirm you can this page:
![10-09 at 13 38 @2x](https://github.com/user-attachments/assets/88a31467-93f9-4b6c-8570-e6fa1e44f51b)

4. Go to SERP, search for a video and tap it
5. Confirm you see the old overlay

![10-09 at 13 32 @2x](https://github.com/user-attachments/assets/5551b108-e8a3-489e-9078-edeabc679d99)


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
