### PR TITLE
Refactor Core Data usage in RemoteMessagingStore

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10946,8 +10946,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 198.4.0;
+				branch = "dominik/rmf-store";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -10946,8 +10946,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "dominik/rmf-store";
-				kind = branch;
+				kind = exactVersion;
+				version = 199.0.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "dominik/rmf-store",
-        "revision" : "5cfda4f13f83047b130fd131ef28039bf1ccae5f"
+        "revision" : "ec46d991838527dd8c7041a3673428c0e18e0fdc",
+        "version" : "199.0.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "c642e92389688016e2dad549f6d6e7c4cd1642d3",
-        "version" : "198.4.0"
+        "branch" : "dominik/rmf-store",
+        "revision" : "5cfda4f13f83047b130fd131ef28039bf1ccae5f"
       }
     },
     {

--- a/DuckDuckGo/HomeMessageView.swift
+++ b/DuckDuckGo/HomeMessageView.swift
@@ -103,7 +103,9 @@ struct HomeMessageView: View {
     
     private var closeButton: some View {
         Button {
-            viewModel.onDidClose(.close)
+            Task {
+                await viewModel.onDidClose(.close)
+            }
         } label: {
             Image("Close-24")
                 .foregroundColor(.primary)
@@ -143,9 +145,11 @@ struct HomeMessageView: View {
     private var buttons: some View {
         ForEach(viewModel.buttons, id: \.title) { buttonModel in
             Button {
-                buttonModel.action()
-                if case .share(let value, let title) = buttonModel.actionStyle {
-                    activityItem = ShareItem(value: value, title: title)
+                Task { @MainActor in
+                    await buttonModel.action()
+                    if case .share(let value, let title) = buttonModel.actionStyle {
+                        activityItem = ShareItem(value: value, title: title)
+                    }
                 }
             } label: {
                 HStack {

--- a/DuckDuckGo/HomeMessageViewModel.swift
+++ b/DuckDuckGo/HomeMessageViewModel.swift
@@ -118,40 +118,40 @@ struct HomeMessageViewModel {
         }
     }
     
-    let onDidClose: (ButtonAction?) -> Void
+    let onDidClose: (ButtonAction?) async -> Void
     let onDidAppear: () -> Void
     let onAttachAdditionalParameters: ((_ useCase: PrivacyProDataReportingUseCase, _ params: [String: String]) -> [String: String])?
 
     func mapActionToViewModel(remoteAction: RemoteAction,
                               buttonAction: HomeMessageViewModel.ButtonAction,
-                              onDidClose: @escaping (HomeMessageViewModel.ButtonAction?) -> Void) -> () -> Void {
+                              onDidClose: @escaping (HomeMessageViewModel.ButtonAction?) async -> Void) -> () async -> Void {
 
         switch remoteAction {
         case .share:
-            return {
-                onDidClose(buttonAction)
+            return { @MainActor in
+                await onDidClose(buttonAction)
             }
         case .url(let value):
-            return {
+            return { @MainActor in
                 LaunchTabNotification.postLaunchTabNotification(urlString: value)
-                onDidClose(buttonAction)
+                await onDidClose(buttonAction)
             }
         case .survey(let value):
-            return {
+            return { @MainActor in
                 LaunchTabNotification.postLaunchTabNotification(urlString: value)
-                onDidClose(buttonAction)
+                await onDidClose(buttonAction)
             }
         case .appStore:
-            return {
+            return { @MainActor in
                 let url = URL.appStore
                 if UIApplication.shared.canOpenURL(url as URL) {
                     UIApplication.shared.open(url)
                 }
-                onDidClose(buttonAction)
+                await onDidClose(buttonAction)
             }
         case .dismiss:
-            return {
-                onDidClose(buttonAction)
+            return { @MainActor in
+                await onDidClose(buttonAction)
             }
         }
     }
@@ -166,6 +166,6 @@ struct HomeMessageButtonViewModel {
     
     let title: String
     var actionStyle: ActionStyle = .default
-    let action: () -> Void
+    let action: () async -> Void
 
 }

--- a/DuckDuckGo/HomeMessageViewModelBuilder.swift
+++ b/DuckDuckGo/HomeMessageViewModelBuilder.swift
@@ -34,7 +34,7 @@ struct HomeMessageViewModelBuilder {
 
     static func build(for remoteMessage: RemoteMessageModel,
                       with privacyProDataReporter: PrivacyProDataReporting?,
-                      onDidClose: @escaping (HomeMessageViewModel.ButtonAction?) -> Void,
+                      onDidClose: @escaping (HomeMessageViewModel.ButtonAction?) async -> Void,
                       onDidAppear: @escaping () -> Void) -> HomeMessageViewModel? {
             guard let content = remoteMessage.content else { return nil }
 

--- a/DuckDuckGo/HomeMessageViewSectionRenderer.swift
+++ b/DuckDuckGo/HomeMessageViewSectionRenderer.swift
@@ -184,9 +184,11 @@ class HomeMessageViewSectionRenderer: NSObject, HomeViewSectionRenderer {
     private func dismissHomeMessage(_ message: HomeMessage,
                                     at indexPath: IndexPath,
                                     in collectionView: UICollectionView) {
-        homePageConfiguration.dismissHomeMessage(message)
-        animateCellDismissal(at: indexPath, in: collectionView) {
-            self.controller?.homeMessageRenderer(self, didDismissHomeMessage: message)
+        Task { @MainActor in
+            await homePageConfiguration.dismissHomeMessage(message)
+            animateCellDismissal(at: indexPath, in: collectionView) {
+                self.controller?.homeMessageRenderer(self, didDismissHomeMessage: message)
+            }
         }
     }
     

--- a/DuckDuckGo/HomePageConfiguration.swift
+++ b/DuckDuckGo/HomePageConfiguration.swift
@@ -84,11 +84,12 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         return .remoteMessage(remoteMessage: remoteMessageToPresent)
     }
 
-    func dismissHomeMessage(_ homeMessage: HomeMessage) {
+    @MainActor
+    func dismissHomeMessage(_ homeMessage: HomeMessage) async {
         switch homeMessage {
         case .remoteMessage(let remoteMessage):
             Logger.remoteMessaging.info("Home message dismissed: \(remoteMessage.id)")
-            remoteMessagingClient.store.dismissRemoteMessage(withID: remoteMessage.id)
+            await remoteMessagingClient.store.dismissRemoteMessage(withID: remoteMessage.id)
 
             if let index = homeMessages.firstIndex(of: homeMessage) {
                 homeMessages.remove(at: index)
@@ -113,7 +114,9 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
                     Pixel.fire(pixel: .remoteMessageShownUnique,
                                withAdditionalParameters: additionalParameters(for: remoteMessage.id))
                 }
-                remoteMessagingClient.store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+                Task {
+                    await remoteMessagingClient.store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+                }
             }
 
         default:

--- a/DuckDuckGo/HomePageMessagesConfiguration.swift
+++ b/DuckDuckGo/HomePageMessagesConfiguration.swift
@@ -24,6 +24,6 @@ protocol HomePageMessagesConfiguration {
 
     func refresh()
     
-    func dismissHomeMessage(_ homeMessage: HomeMessage)
+    func dismissHomeMessage(_ homeMessage: HomeMessage) async
     func didAppear(_ homeMessage: HomeMessage)
 }

--- a/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -54,8 +54,10 @@ final class NewTabPageMessagesModel: ObservableObject {
     }
 
     func dismissHomeMessage(_ homeMessage: HomeMessage) {
-        homePageMessagesConfiguration.dismissHomeMessage(homeMessage)
-        updateHomeMessageViewModel()
+        Task { @MainActor in
+            await homePageMessagesConfiguration.dismissHomeMessage(homeMessage)
+            updateHomeMessageViewModel()
+        }
     }
 
     func didAppear(_ homeMessage: HomeMessage) {

--- a/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -53,11 +53,10 @@ final class NewTabPageMessagesModel: ObservableObject {
         refresh()
     }
 
-    func dismissHomeMessage(_ homeMessage: HomeMessage) {
-        Task { @MainActor in
-            await homePageMessagesConfiguration.dismissHomeMessage(homeMessage)
-            updateHomeMessageViewModel()
-        }
+    @MainActor
+    func dismissHomeMessage(_ homeMessage: HomeMessage) async {
+        await homePageMessagesConfiguration.dismissHomeMessage(homeMessage)
+        updateHomeMessageViewModel()
     }
 
     func didAppear(_ homeMessage: HomeMessage) {
@@ -79,7 +78,7 @@ final class NewTabPageMessagesModel: ObservableObject {
         switch message {
         case .placeholder:
             return HomeMessageViewModel(messageId: "", sendPixels: false, modelType: .small(titleText: "", descriptionText: "")) { [weak self] _ in
-                self?.dismissHomeMessage(message)
+                await self?.dismissHomeMessage(message)
             } onDidAppear: {
                 // no-op
             } onAttachAdditionalParameters: { _, params in
@@ -91,7 +90,7 @@ final class NewTabPageMessagesModel: ObservableObject {
             // as a result of refreshing a config while the user was on a new tab page already.
             didAppear(message)
 
-            return HomeMessageViewModelBuilder.build(for: remoteMessage, with: privacyProDataReporter) { [weak self] action in
+            return HomeMessageViewModelBuilder.build(for: remoteMessage, with: privacyProDataReporter) { @MainActor [weak self] action in
                 guard let action,
                       let self else { return }
 
@@ -99,7 +98,7 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 case .action(let isSharing):
                     if !isSharing {
-                        self.dismissHomeMessage(message)
+                        await self.dismissHomeMessage(message)
                     }
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessageActionClicked,
@@ -108,7 +107,7 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 case .primaryAction(let isSharing):
                     if !isSharing {
-                        self.dismissHomeMessage(message)
+                        await self.dismissHomeMessage(message)
                     }
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessagePrimaryActionClicked,
@@ -117,7 +116,7 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 case .secondaryAction(let isSharing):
                     if !isSharing {
-                        self.dismissHomeMessage(message)
+                        await self.dismissHomeMessage(message)
                     }
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessageSecondaryActionClicked,
@@ -125,7 +124,7 @@ final class NewTabPageMessagesModel: ObservableObject {
                     }
 
                 case .close:
-                    self.dismissHomeMessage(message)
+                    await self.dismissHomeMessage(message)
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessageDismissed,
                                          withAdditionalParameters: self.additionalParameters(for: remoteMessage.id))

--- a/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -55,7 +55,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
     // MARK: Callbacks
 
-    func testCallsDismissOnClose() throws {
+    func testCallsDismissOnClose() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -64,12 +64,12 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.close)
+        await model.onDidClose(.close)
 
         XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
     }
 
-    func testCallsDismissOnAction() throws {
+    func testCallsDismissOnAction() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -78,12 +78,12 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.action(isShare: false))
+        await model.onDidClose(.action(isShare: false))
 
         XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
     }
 
-    func testCallsDismissOnPrimaryAction() throws {
+    func testCallsDismissOnPrimaryAction() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -92,12 +92,12 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.primaryAction(isShare: false))
+        await model.onDidClose(.primaryAction(isShare: false))
 
         XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
     }
 
-    func testCallsDismissOnSecondaryAction() throws {
+    func testCallsDismissOnSecondaryAction() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -106,12 +106,12 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.secondaryAction(isShare: false))
+        await model.onDidClose(.secondaryAction(isShare: false))
 
         XCTAssertEqual(messagesConfiguration.lastDismissedHomeMessage, messagesConfiguration.homeMessages.first)
     }
 
-    func testDoesNotCallDismissWhenSharing() throws {
+    func testDoesNotCallDismissWhenSharing() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -120,16 +120,16 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.action(isShare: true))
-        model.onDidClose(.primaryAction(isShare: true))
-        model.onDidClose(.secondaryAction(isShare: true))
+        await model.onDidClose(.action(isShare: true))
+        await model.onDidClose(.primaryAction(isShare: true))
+        await model.onDidClose(.secondaryAction(isShare: true))
 
         XCTAssertNil(messagesConfiguration.lastDismissedHomeMessage)
     }
 
     // MARK: Pixels
 
-    func testFiresPixelOnClose() throws {
+    func testFiresPixelOnClose() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -138,13 +138,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.close)
+        await model.onDidClose(.close)
 
         XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessageDismissed)
         XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
     }
 
-    func testFiresPixelOnAction() throws {
+    func testFiresPixelOnAction() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -152,13 +152,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
-        model.onDidClose(.action(isShare: false))
+        await model.onDidClose(.action(isShare: false))
 
         XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessageActionClicked)
         XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
     }
 
-    func testFiresPixelOnPrimaryAction() throws {
+    func testFiresPixelOnPrimaryAction() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -166,13 +166,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
-        model.onDidClose(.primaryAction(isShare: false))
+        await model.onDidClose(.primaryAction(isShare: false))
 
         XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessagePrimaryActionClicked)
         XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
     }
 
-    func testFiresPixelOnSecondaryAction() throws {
+    func testFiresPixelOnSecondaryAction() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: "")),
@@ -180,13 +180,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
-        model.onDidClose(.secondaryAction(isShare: false))
+        await model.onDidClose(.secondaryAction(isShare: false))
 
         XCTAssertEqual(PixelFiringMock.lastPixel, .remoteMessageSecondaryActionClicked)
         XCTAssertEqual(PixelFiringMock.lastParams, [PixelParameters.message: "foo"])
     }
 
-    func testDoesNotFirePixelOnCloseWhenMetricsAreDisabled() throws {
+    func testDoesNotFirePixelOnCloseWhenMetricsAreDisabled() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: ""), isMetricsEnabled: false),
@@ -195,13 +195,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
 
-        model.onDidClose(.close)
+        await model.onDidClose(.close)
 
         XCTAssertNil(PixelFiringMock.lastPixel)
         XCTAssertNil(PixelFiringMock.lastParams)
     }
 
-    func testDoesNotFirePixelOnActionWhenMetricsAreDisabled() throws {
+    func testDoesNotFirePixelOnActionWhenMetricsAreDisabled() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: ""), isMetricsEnabled: false),
@@ -209,13 +209,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
-        model.onDidClose(.action(isShare: false))
+        await model.onDidClose(.action(isShare: false))
 
         XCTAssertNil(PixelFiringMock.lastPixel)
         XCTAssertNil(PixelFiringMock.lastParams)
     }
 
-    func testDoesNotFirePixelOnPrimaryActionWhenMetricsAreDisabled() throws {
+    func testDoesNotFirePixelOnPrimaryActionWhenMetricsAreDisabled() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: ""), isMetricsEnabled: false),
@@ -223,13 +223,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
-        model.onDidClose(.primaryAction(isShare: false))
+        await model.onDidClose(.primaryAction(isShare: false))
 
         XCTAssertNil(PixelFiringMock.lastPixel)
         XCTAssertNil(PixelFiringMock.lastParams)
     }
 
-    func testDoesNotFirePixelOnSecondaryActionWhenMetricsAreDisabled() throws {
+    func testDoesNotFirePixelOnSecondaryActionWhenMetricsAreDisabled() async throws {
         let sut = createSUT()
         messagesConfiguration.homeMessages = [
             .mockRemote(withType: .small(titleText: "", descriptionText: ""), isMetricsEnabled: false),
@@ -237,7 +237,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         let model = try XCTUnwrap(sut.homeMessageViewModels.first)
-        model.onDidClose(.secondaryAction(isShare: false))
+        await model.onDidClose(.secondaryAction(isShare: false))
 
         XCTAssertNil(PixelFiringMock.lastPixel)
         XCTAssertNil(PixelFiringMock.lastParams)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201048563534612/1208493869353425/f

**Description**:
This change updates RMF client to use new async API from BSK's RemoteMessagingStore.

**Steps to test this PR**:
See [BSK PR](https://github.com/duckduckgo/BrowserServicesKit/pull/1013) for testing steps.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
