### PR TITLE
Add 'Open in New Tab' support for DuckPlayer

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -37,6 +37,7 @@ public enum FeatureFlag: String {
     case history
     case newTabPageSections
     case duckPlayer
+    case duckPlayerOpenInNewTab
     case sslCertificatesBypass
     case syncPromotionBookmarks
     case syncPromotionPasswords
@@ -80,6 +81,8 @@ extension FeatureFlag: FeatureFlagSourceProviding {
             return .remoteDevelopment(.feature(.newTabPageImprovements))
         case .duckPlayer:
             return .remoteReleasable(.subfeature(DuckPlayerSubfeature.enableDuckPlayer))
+        case .duckPlayerOpenInNewTab:
+            return .remoteReleasable(.subfeature(DuckPlayerSubfeature.openInNewTab))
         case .sslCertificatesBypass:
             return .remoteReleasable(.subfeature(SslCertificatesSubfeature.allowBypass))
         case .syncPromotionBookmarks:

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -799,6 +799,8 @@ extension Pixel {
         case duckPlayerSettingNeverOverlayYoutube
         case duckPlayerContingencySettingsDisplayed
         case duckPlayerContingencyLearnMoreClicked
+        case duckPlayerNewTabSettingOn
+        case duckPlayerNewTabSettingOff
 
         // MARK: enhanced statistics
         case usageSegments
@@ -1618,6 +1620,8 @@ extension Pixel.Event {
         case .duckPlayerSettingNeverOverlayYoutube: return "duckplayer_setting_never_overlay_youtube"
         case .duckPlayerContingencySettingsDisplayed: return "duckplayer_ios_contingency_settings-displayed"
         case .duckPlayerContingencyLearnMoreClicked: return "duckplayer_ios_contingency_learn-more-clicked"
+        case .duckPlayerNewTabSettingOn: return "duckplayer_ios_newtab_setting-on"
+        case .duckPlayerNewTabSettingOff: return "duckplayer_ios_newtab_setting-off"
 
         // MARK: Enhanced statistics
         case .usageSegments: return "m_retention_segments"

--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -159,6 +159,7 @@ public struct UserDefaultsWrapper<T> {
         case duckPlayerMode = "com.duckduckgo.ios.duckPlayerMode"
         case duckPlayerAskModeOverlayHidden = "com.duckduckgo.ios.duckPlayerAskModeOverlayHidden"
         case userInteractedWithDuckPlayer = "com.duckduckgo.ios.userInteractedWithDuckPlayer"
+        case duckPlayerOpenInNewTab = "com.duckduckgo.ios.duckPlayerOpenInNewTab"
 
         case vpnRedditWorkaroundInstalled = "com.duckduckgo.ios.vpn.workaroundInstalled"
 

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -82,6 +82,7 @@ protocol AppSettings: AnyObject, AppDebugSettings {
     
     var duckPlayerMode: DuckPlayerMode { get set }
     var duckPlayerAskModeOverlayHidden: Bool { get set }
+    var duckPlayerOpenInNewTab: Bool { get set }
 }
 
 protocol AppDebugSettings {

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -416,7 +416,7 @@ public class AppUserDefaults: AppSettings {
         }
     }
     
-    @UserDefaultsWrapper(key: .duckPlayerOpenInNewTab, defaultValue: false)
+    @UserDefaultsWrapper(key: .duckPlayerOpenInNewTab, defaultValue: true)
     var duckPlayerOpenInNewTab: Bool
     
 

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -78,6 +78,7 @@ public class AppUserDefaults: AppSettings {
         
         static let duckPlayerMode = "com.duckduckgo.ios.duckPlayerMode"
         static let duckPlayerAskModeOverlayHidden = "com.duckduckgo.ios.duckPlayerAskModeOverlayHidden"
+        static let duckPlayerOpenInNewTab = "com.duckduckgo.ios.duckPlayerOpenInNewTab"
     }
 
     private struct DebugKeys {
@@ -414,6 +415,10 @@ public class AppUserDefaults: AppSettings {
                                             object: duckPlayerMode)
         }
     }
+    
+    @UserDefaultsWrapper(key: .duckPlayerOpenInNewTab, defaultValue: false)
+    var duckPlayerOpenInNewTab: Bool
+    
 
     @UserDefaultsWrapper(key: .debugOnboardingHighlightsEnabledKey, defaultValue: false)
     var onboardingHighlightsEnabled: Bool

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -552,7 +552,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
             isFeatureEnabled &&
             isSubFeatureEnabled &&
             isDuckPlayer &&
-            navigationAction.navigationType == .linkActivated &&
+            self.navigationType == .linkActivated &&
             isDuckPlayerEnabled {
             return true
         }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -252,7 +252,7 @@ final class DuckPlayerNavigationHandler {
         guard let url else {
             return
         }
-        let openInNewTab = true
+        let openInNewTab = appSettings.duckPlayerOpenInNewTab
         let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
         let newTab = url.isDuckPlayer && openInNewTab && isDuckPlayerEnabled
         if newTab {
@@ -536,7 +536,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
     func shouldOpenInNewTab(_ navigationAction: WKNavigationAction, webView: WKWebView) -> Bool {
         
         // let openInNewTab = appSettings.duckPlayerOpenInNewTab
-        let openInNewTab = true
+        let openInNewTab = appSettings.duckPlayerOpenInNewTab
         let isDuckPlayer = navigationAction.request.url?.isDuckPlayer ?? false
         let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
         

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -252,10 +252,17 @@ final class DuckPlayerNavigationHandler {
         guard let url else {
             return
         }
-        let openInNewTab = appSettings.duckPlayerOpenInNewTab && featureFlagger.isFeatureOn(.duckPlayer)
+        
+        // let openInNewTab = appSettings.duckPlayerOpenInNewTab
+        let openInNewTab = appSettings.duckPlayerOpenInNewTab
+        let isFeatureEnabled = featureFlagger.isFeatureOn(.duckPlayer)
+        let isSubFeatureEnabled = featureFlagger.isFeatureOn(.duckPlayerOpenInNewTab) || internalUserDecider.isInternalUser
         let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
-        let newTab = url.isDuckPlayer && openInNewTab && isDuckPlayerEnabled
-        if newTab {
+        
+        if openInNewTab &&
+            isFeatureEnabled &&
+            isSubFeatureEnabled &&
+            isDuckPlayerEnabled {
             navigationType = .linkActivated
         } else {
             navigationType = .other
@@ -535,11 +542,18 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
     func shouldOpenInNewTab(_ navigationAction: WKNavigationAction, webView: WKWebView) -> Bool {
         
         // let openInNewTab = appSettings.duckPlayerOpenInNewTab
-        let openInNewTab = appSettings.duckPlayerOpenInNewTab && featureFlagger.isFeatureOn(.duckPlayer)
+        let openInNewTab = appSettings.duckPlayerOpenInNewTab
+        let isFeatureEnabled = featureFlagger.isFeatureOn(.duckPlayer)
+        let isSubFeatureEnabled = featureFlagger.isFeatureOn(.duckPlayerOpenInNewTab) || internalUserDecider.isInternalUser
         let isDuckPlayer = navigationAction.request.url?.isDuckPlayer ?? false
         let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
         
-        if openInNewTab && isDuckPlayer && navigationAction.navigationType == .linkActivated && isDuckPlayerEnabled {
+        if openInNewTab &&
+            isFeatureEnabled &&
+            isSubFeatureEnabled &&
+            isDuckPlayer &&
+            navigationAction.navigationType == .linkActivated &&
+            isDuckPlayerEnabled {
             return true
         }
         return false

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -245,6 +245,23 @@ final class DuckPlayerNavigationHandler {
 
     }
     
+    // Determines if the link should be opened in a new tab
+    // And sets the correct navigationType
+    // This is uses for JS based navigation links
+    private func setOpenInNewTab(url: URL?) {
+        guard let url else {
+            return
+        }
+        let openInNewTab = true
+        let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
+        let newTab = url.isDuckPlayer && openInNewTab && isDuckPlayerEnabled
+        if newTab {
+            navigationType = .linkActivated
+        } else {
+            navigationType = .other
+        }
+    }
+    
 }
 
 extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
@@ -508,11 +525,16 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         switch event {
         case .youtubeVideoPageVisited:
             handleYouTubePageVisited(url: url, navigationAction: navigationAction)
+        case .JSTriggeredNavigation:
+            setOpenInNewTab(url: url)
+            
         }
     }
     
-    // Determine if the links should be open in a new tab, based on the User setting
+    // Determine if the links should be open in a new tab, based on the navigationAction and User setting
+    // This is used for manually activated links
     func shouldOpenInNewTab(_ navigationAction: WKNavigationAction, webView: WKWebView) -> Bool {
+        
         // let openInNewTab = appSettings.duckPlayerOpenInNewTab
         let openInNewTab = true
         let isDuckPlayer = navigationAction.request.url?.isDuckPlayer ?? false
@@ -524,4 +546,10 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         return false
     }
     
+}
+
+extension WKWebView {
+    var isEmptyTab: Bool {
+        return self.url == nil || self.url?.absoluteString == "about:blank"
+    }
 }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -440,7 +440,11 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Assume JS Navigation is user-triggered
         self.navigationType = .linkActivated
         
-        handleURLChange(url: url, webView: webView)
+        // Only handle URL changes if the allowFirstVideo is set to false
+        // This prevents Youtube redirects from triggering DuckPlayer when is not expected
+        if !duckPlayer.settings.allowFirstVideo {
+            handleURLChange(url: url, webView: webView)
+        }
     }
     
     @MainActor

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -252,7 +252,7 @@ final class DuckPlayerNavigationHandler {
         guard let url else {
             return
         }
-        let openInNewTab = appSettings.duckPlayerOpenInNewTab
+        let openInNewTab = appSettings.duckPlayerOpenInNewTab && featureFlagger.isFeatureOn(.duckPlayer)
         let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
         let newTab = url.isDuckPlayer && openInNewTab && isDuckPlayerEnabled
         if newTab {
@@ -527,7 +527,6 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
             handleYouTubePageVisited(url: url, navigationAction: navigationAction)
         case .JSTriggeredNavigation:
             setOpenInNewTab(url: url)
-            
         }
     }
     
@@ -536,11 +535,11 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
     func shouldOpenInNewTab(_ navigationAction: WKNavigationAction, webView: WKWebView) -> Bool {
         
         // let openInNewTab = appSettings.duckPlayerOpenInNewTab
-        let openInNewTab = appSettings.duckPlayerOpenInNewTab
+        let openInNewTab = appSettings.duckPlayerOpenInNewTab && featureFlagger.isFeatureOn(.duckPlayer)
         let isDuckPlayer = navigationAction.request.url?.isDuckPlayer ?? false
         let isDuckPlayerEnabled = duckPlayer.settings.mode == .enabled || duckPlayer.settings.mode == .alwaysAsk
         
-        if openInNewTab && isDuckPlayer && navigationType == .linkActivated && isDuckPlayerEnabled {
+        if openInNewTab && isDuckPlayer && navigationAction.navigationType == .linkActivated && isDuckPlayerEnabled {
             return true
         }
         return false

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
@@ -38,4 +38,6 @@ protocol DuckPlayerNavigationHandling: AnyObject {
     func handleEvent(event: DuckPlayerNavigationEvent,
                      url: URL?,
                      navigationAction: WKNavigationAction?)
+    func shouldOpenInNewTab(_ navigationAction: WKNavigationAction, webView: WKWebView) -> Bool
+    
 }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
@@ -21,6 +21,7 @@ import WebKit
 
 enum DuckPlayerNavigationEvent {
     case youtubeVideoPageVisited
+    case JSTriggeredNavigation
 }
 
 protocol DuckPlayerNavigationHandling: AnyObject {

--- a/DuckDuckGo/SettingsDuckPlayerView.swift
+++ b/DuckDuckGo/SettingsDuckPlayerView.swift
@@ -72,6 +72,9 @@ struct SettingsDuckPlayerView: View {
                                        options: DuckPlayerMode.allCases,
                                        selectedOption: viewModel.duckPlayerModeBinding)
                 .disabled(viewModel.shouldDisplayDuckPlayerContingencyMessage)
+                
+                SettingsCellView(label: UserText.settingsOpenDuckPlayerNewTabLabel,
+                                 accessory: .toggle(isOn: viewModel.duckPlayerOpenInNewTabBinding))
             }
         }
         .applySettingsListModifiers(title: UserText.duckPlayerFeatureName,

--- a/DuckDuckGo/SettingsDuckPlayerView.swift
+++ b/DuckDuckGo/SettingsDuckPlayerView.swift
@@ -73,8 +73,10 @@ struct SettingsDuckPlayerView: View {
                                        selectedOption: viewModel.duckPlayerModeBinding)
                 .disabled(viewModel.shouldDisplayDuckPlayerContingencyMessage)
                 
-                SettingsCellView(label: UserText.settingsOpenDuckPlayerNewTabLabel,
-                                 accessory: .toggle(isOn: viewModel.duckPlayerOpenInNewTabBinding))
+                if viewModel.state.duckPlayerOpenInNewTabEnabled || viewModel.isInternalUser {
+                    SettingsCellView(label: UserText.settingsOpenDuckPlayerNewTabLabel,
+                                     accessory: .toggle(isOn: viewModel.duckPlayerOpenInNewTabBinding))
+                }
             }
         }
         .applySettingsListModifiers(title: UserText.duckPlayerFeatureName,

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -99,6 +99,7 @@ struct SettingsState {
     // Duck Player Mode
     var duckPlayerEnabled: Bool
     var duckPlayerMode: DuckPlayerMode?
+    var duckPlayerOpenInNewTab: Bool
     
     static var defaults: SettingsState {
         return SettingsState(
@@ -136,7 +137,8 @@ struct SettingsState {
             sync: SyncSettings(enabled: false, title: ""),
             syncSource: nil,
             duckPlayerEnabled: false,
-            duckPlayerMode: .alwaysAsk
+            duckPlayerMode: .alwaysAsk,
+            duckPlayerOpenInNewTab: true
         )
     }
 }

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -100,6 +100,7 @@ struct SettingsState {
     var duckPlayerEnabled: Bool
     var duckPlayerMode: DuckPlayerMode?
     var duckPlayerOpenInNewTab: Bool
+    var duckPlayerOpenInNewTabEnabled: Bool
     
     static var defaults: SettingsState {
         return SettingsState(
@@ -138,7 +139,8 @@ struct SettingsState {
             syncSource: nil,
             duckPlayerEnabled: false,
             duckPlayerMode: .alwaysAsk,
-            duckPlayerOpenInNewTab: true
+            duckPlayerOpenInNewTab: true,
+            duckPlayerOpenInNewTabEnabled: false
         )
     }
 }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -421,7 +421,9 @@ extension SettingsViewModel {
             syncSource: nil,
             duckPlayerEnabled: featureFlagger.isFeatureOn(.duckPlayer) || shouldDisplayDuckPlayerContingencyMessage,
             duckPlayerMode: appSettings.duckPlayerMode,
-            duckPlayerOpenInNewTab: appSettings.duckPlayerOpenInNewTab
+            duckPlayerOpenInNewTab: appSettings.duckPlayerOpenInNewTab,
+            duckPlayerOpenInNewTabEnabled: featureFlagger.isFeatureOn(.duckPlayer)
+            
         )
         
         updateRecentlyVisitedSitesVisibility()

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -422,7 +422,7 @@ extension SettingsViewModel {
             duckPlayerEnabled: featureFlagger.isFeatureOn(.duckPlayer) || shouldDisplayDuckPlayerContingencyMessage,
             duckPlayerMode: appSettings.duckPlayerMode,
             duckPlayerOpenInNewTab: appSettings.duckPlayerOpenInNewTab,
-            duckPlayerOpenInNewTabEnabled: featureFlagger.isFeatureOn(.duckPlayer)
+            duckPlayerOpenInNewTabEnabled: featureFlagger.isFeatureOn(.duckPlayerOpenInNewTab)
             
         )
         

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -285,6 +285,11 @@ final class SettingsViewModel: ObservableObject {
             set: {
                 self.appSettings.duckPlayerOpenInNewTab = $0
                 self.state.duckPlayerOpenInNewTab = $0
+                if self.state.duckPlayerOpenInNewTab {
+                    Pixel.fire(pixel: Pixel.Event.duckPlayerNewTabSettingOn)
+                } else {
+                    Pixel.fire(pixel: Pixel.Event.duckPlayerNewTabSettingOff)
+                }
             }
         )
     }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -278,6 +278,16 @@ final class SettingsViewModel: ObservableObject {
             }
         )
     }
+    
+    var duckPlayerOpenInNewTabBinding: Binding<Bool> {
+        Binding<Bool>(
+            get: { self.state.duckPlayerOpenInNewTab },
+            set: {
+                self.appSettings.duckPlayerOpenInNewTab = $0
+                self.state.duckPlayerOpenInNewTab = $0
+            }
+        )
+    }
 
     func setVoiceSearchEnabled(to value: Bool) {
         if value {
@@ -410,7 +420,8 @@ extension SettingsViewModel {
             sync: getSyncState(),
             syncSource: nil,
             duckPlayerEnabled: featureFlagger.isFeatureOn(.duckPlayer) || shouldDisplayDuckPlayerContingencyMessage,
-            duckPlayerMode: appSettings.duckPlayerMode
+            duckPlayerMode: appSettings.duckPlayerMode,
+            duckPlayerOpenInNewTab: appSettings.duckPlayerOpenInNewTab
         )
         
         updateRecentlyVisitedSitesVisibility()

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -766,6 +766,12 @@ class TabViewController: UIViewController {
         }
         if let url {
             duckPlayerNavigationHandler?.referrer = url.isYoutube ? .youtube : .other
+            
+            // Open in new tab if required
+            // If the lastRenderedURL is nil, it means we're already in a new tab
+            if webView.url != nil && lastRenderedURL != nil {
+                duckPlayerNavigationHandler?.handleEvent(event: .JSTriggeredNavigation, url: webView.url, navigationAction: nil)
+            }
         }
     }
     

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1886,7 +1886,13 @@ extension TabViewController: WKNavigationDelegate {
             duckPlayerNavigationHandler?.handleEvent(event: .youtubeVideoPageVisited,
                                                      url: url,
                                                      navigationAction: navigationAction)
-            duckPlayerNavigationHandler?.handleNavigation(navigationAction, webView: webView)
+            
+            // Validate Duck Player setting to open in new tab or locally
+            if duckPlayerNavigationHandler?.shouldOpenInNewTab(navigationAction, webView: webView) ?? false {
+                delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false, inheritingAttribution: nil)
+            } else {
+                duckPlayerNavigationHandler?.handleNavigation(navigationAction, webView: webView)
+            }
             completion(.cancel)
             return
 

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -1277,6 +1277,9 @@ But if you *do* want a peek under the hood, you can find more information about 
     public static let duckPlayerDisabledLabel = NSLocalizedString("duckPlayer.never.label", value: "Never", comment: "Text displayed when DuckPlayer is in off.")
     public static let settingsOpenVideosInDuckPlayerLabel = NSLocalizedString("duckplayer.settings.open-videos-in", value: "Open Videos in Duck Player", comment: "Settings screen cell text for DuckPlayer settings")
     public static let duckPlayerFeatureName = NSLocalizedString("duckplayer.settings.title", value: "Duck Player", comment: "Settings screen cell text for DuckPlayer settings")
+    
+    public static let settingsOpenDuckPlayerNewTabLabel = NSLocalizedString("duckplayer.settings.open-new-tab-label", value: "Open Duck Player in a new tab", comment: "Settings screen cell text for DuckPlayer settings to open in new tab")    
+    
 
     public static let settingsOpenVideosInDuckPlayerTitle = NSLocalizedString("duckplayer.settings.title", value: "Duck Player", comment: "Settings screen cell text for DuckPlayer settings")
     public static let settingsDuckPlayerFooter = NSLocalizedString("duckplayer.settings.footer", value: "DuckDuckGo provides all the privacy essentials you need to protect yourself as you browse the web.", comment: "Footer label in the settings screen for Duck Player")

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1049,6 +1049,9 @@
 /* Button that takes the user to learn more about Duck Player. */
 "duckplayer.settings.learn-more" = "Learn More";
 
+/* Settings screen cell text for DuckPlayer settings to open in new tab */
+"duckplayer.settings.open-new-tab-label" = "Open Duck Player in a new tab";
+
 /* Settings screen cell text for DuckPlayer settings */
 "duckplayer.settings.open-videos-in" = "Open Videos in Duck Player";
 

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -86,7 +86,8 @@ class AppSettingsMock: AppSettings {
 
     var duckPlayerMode: DuckDuckGo.DuckPlayerMode = .alwaysAsk
     var duckPlayerAskModeOverlayHidden: Bool = false
-
+    var duckPlayerOpenInNewTab: Bool = false
+    
     var newTabPageShortcutsSettings: Data?
     var newTabPageSectionsSettings: Data?
 
@@ -94,4 +95,6 @@ class AppSettingsMock: AppSettings {
     var newTabPageIntroMessageSeenCount: Int = 0
 
     var onboardingHighlightsEnabled: Bool = false
+    
+    
 }

--- a/DuckDuckGoTests/DuckPlayerMocks.swift
+++ b/DuckDuckGoTests/DuckPlayerMocks.swift
@@ -76,13 +76,19 @@ class MockWebView: WKWebView {
 
 class MockNavigationAction: WKNavigationAction {
     private let _request: URLRequest
+    private let _navigationType: WKNavigationType
     
-    init(request: URLRequest) {
+    init(request: URLRequest, navigationType: WKNavigationType = .linkActivated ) {
         self._request = request
+        self._navigationType = navigationType
     }
     
     override var request: URLRequest {
         return _request
+    }
+    
+    override var navigationType: WKNavigationType {
+        return _navigationType
     }
 }
 

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -411,5 +411,94 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         
     }
     
+    func testShouldOpenInNewTabWhenEnabled() {
+        let youtubeURL = URL(string: "duck://player/abc123")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: youtubeURL))
+        
+        mockAppSettings.duckPlayerOpenInNewTab = true
+        
+        let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
+        let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
+        let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
+                
+        playerSettings.mode = .enabled
+                
+        XCTAssertTrue(handler.shouldOpenInNewTab(navigationAction, webView: webView))
+    }
+    
+    func testShouldNotOpenInNewTabWhenNotDuckPlayerURL() {
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=I9J120SZT14")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: youtubeURL))
+        
+        mockAppSettings.duckPlayerOpenInNewTab = true
+        
+        let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
+        let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
+        let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
+                
+        playerSettings.mode = .enabled
+        
+        XCTAssertFalse(handler.shouldOpenInNewTab(navigationAction, webView: webView))
+    }
+    
+    func testShouldNotOpenInNewTabWhenDisabled() {
+        let youtubeURL = URL(string: "duck://player/abc123")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: youtubeURL))
+        
+        mockAppSettings.duckPlayerOpenInNewTab = false
+        
+        let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
+        let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
+        let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
+                
+        playerSettings.mode = .enabled
+                
+        XCTAssertFalse(handler.shouldOpenInNewTab(navigationAction, webView: webView))
+    }
+    
+    func testHandleJSNavigationEventWhenEnabled() {
+        let youtubeURL = URL(string: "duck://player/abc123")!
+        
+        let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
+        let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
+        let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
+        
+        playerSettings.mode = .enabled
+        mockAppSettings.duckPlayerOpenInNewTab = true
+        
+        handler.handleEvent(event: .JSTriggeredNavigation, url: youtubeURL, navigationAction: nil)
+        
+        XCTAssertTrue(handler.navigationType == .linkActivated)
+    }
+    
+    func testHandleJSNavigationEventWhenDisabled() {
+        let youtubeURL = URL(string: "duck://player/abc123")!
+        
+        let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
+        let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
+        let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
+        
+        playerSettings.mode = .enabled
+        mockAppSettings.duckPlayerOpenInNewTab = false
+        
+        handler.handleEvent(event: .JSTriggeredNavigation, url: youtubeURL, navigationAction: nil)
+        
+        XCTAssertFalse(handler.navigationType == .linkActivated)
+    }
+    
+    func testHandleJSNavigationEventWhenDuckPlayerDisabled() {
+        let youtubeURL = URL(string: "duck://player/abc123")!
+        
+        let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
+        let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
+        let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
+        
+        playerSettings.mode = .disabled
+        mockAppSettings.duckPlayerOpenInNewTab = true
+        
+        handler.handleEvent(event: .JSTriggeredNavigation, url: youtubeURL, navigationAction: nil)
+        
+        XCTAssertFalse(handler.navigationType == .linkActivated)
+    }
 
 }

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -421,6 +421,7 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
         let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
                 
+        handler.navigationType = .linkActivated
         playerSettings.mode = .enabled
                 
         XCTAssertTrue(handler.shouldOpenInNewTab(navigationAction, webView: webView))
@@ -435,7 +436,8 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         let playerSettings = MockDuckPlayerSettings(appSettings: mockAppSettings, privacyConfigManager: mockPrivacyConfig)
         let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
         let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
-                
+        
+        handler.navigationType = .linkActivated
         playerSettings.mode = .enabled
         
         XCTAssertFalse(handler.shouldOpenInNewTab(navigationAction, webView: webView))
@@ -451,6 +453,7 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
         let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
                 
+        handler.navigationType = .linkActivated
         playerSettings.mode = .enabled
                 
         XCTAssertFalse(handler.shouldOpenInNewTab(navigationAction, webView: webView))

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -493,6 +493,7 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         let player = MockDuckPlayer(settings: playerSettings, featureFlagger: featureFlagger)
         let handler = DuckPlayerNavigationHandler(duckPlayer: player, featureFlagger: featureFlagger, appSettings: mockAppSettings, experiment: DuckPlayerExperimentMock())
         
+        handler.navigationType = .linkActivated
         playerSettings.mode = .disabled
         mockAppSettings.duckPlayerOpenInNewTab = true
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:  https://app.asana.com/0/1204099484721401/1208366641490350/f

**Description**:
Adds a setting to allow users to open DuckPlayer videos in a new tab. (On by default)

**Steps to test this PR**:

- [x] Make yourself internal user
- [x]  Go to Settings > All Debug Settings, and Tap "Override DuckPlayer Experiment (Experiment) 
- [x]  Go to Settings > DuckPlayer, Set it to 'Always', and Enable "Open Duck Player in a new tab"

**SERP**
- [x] Open a new tab
- [x] Search for 'metallica videos'
- [x] Tap a video 
- [x] Should open in new tab
- [x] Tap 'Back'
- [x] New tab should be closed

**SERP Videos Vertical**
- [x] Open a new tab
- [x] Search for 'metallica videos'
- [x] Go to 'Videos'
- [x] Tap a video
- [x] Should open in new tab
- [x] Tap 'Back'
- [x] New Tab should be closed

**Youtube**
- [x] Open a new tab
- [x] Go to [Youtube.com](https://youtube.com/)
- [x] Search for 'metallica videos'
- [x] Tap a video
- [x] Should open in new tab
- [x] Tap 'Back'
- [x] New Tab should be closed

**Other Page (Javascript link)**
- [x] Open a new tab
- [x] Go to to https://randomtests.netlify.app/ddg/duckplayer.html
- [x] Click the JS YouTube Link
- [x] Should  Open in New Tab
- [x] Tap 'Back'
- [x] New Tab should be closed

**Other Page (Direct link)**
- [x] Open a new tab
- [x] Go to to https://randomtests.netlify.app/ddg/duckplayer.html
- [x] Click the Regular Youtube link
- [x] Should  Open in New Tab
- [x] Tap 'Back'
- [x] New Tab should be closed

**Direct Navigation**
- [x] Open a new tab
- [x] Go to duck://player/WM8bTdBs-cw
- [x] DuckPlayer should load in the same tab

**Always ask mode**
- [x] Set DuckPlayer to 'Ask Every Time'
- [x] Open a new tab
- [x] Go to https://randomtests.netlify.app/ddg/duckplayer.html
- [x] Tap "Regular Youtube link"
- [x] Tap Turn On Duck Player in the Overlay
- [x] Should Open in a New tab
- [x] Tap 'Back'
- [x] New tab should be closed

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208366641664437