### PR TITLE
Resets allowFirstVideo on Navigation complete

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -180,10 +180,6 @@ final class DuckPlayerNavigationHandler {
         return false
     }
     
-    private func isOpenInYoutubeURL(url: URL) -> Bool {
-        return isWatchInYouTubeURL(url: url)
-    }
-
     private func getYoutubeURLFromOpenInYoutubeLink(url: URL) -> URL? {
         guard isWatchInYouTubeURL(url: url),
               let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -217,7 +213,7 @@ final class DuckPlayerNavigationHandler {
         if let navigationAction, isSERPLink(navigationAction: navigationAction) {
             referrer = .serp
         }
-                
+        
         if featureFlagger.isFeatureOn(.duckPlayer) || internalUserDecider.isInternalUser {
             
             // DuckPlayer Experiment run
@@ -496,6 +492,8 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         switch event {
         case .youtubeVideoPageVisited:
             handleYouTubePageVisited(url: url, navigationAction: navigationAction)
+        case .pageDidFinishLoading:
+            duckPlayer.settings.allowFirstVideo = false
         }
     }
     

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
@@ -21,6 +21,7 @@ import WebKit
 
 enum DuckPlayerNavigationEvent {
     case youtubeVideoPageVisited
+    case pageDidFinishLoading
 }
 
 protocol DuckPlayerNavigationHandling: AnyObject {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1466,6 +1466,8 @@ extension TabViewController: WKNavigationDelegate {
                 inferredOpenerContext = .serp
             }
         }
+        
+        duckPlayerNavigationHandler?.handleEvent(event: .pageDidFinishLoading, url: webView.url, navigationAction: nil)
     }
 
     func trackSecondSiteVisitIfNeeded(url: URL?) {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208531438887018/f

**Description**:
- Forces a resets the state of `allowFirstVideo` when a page loads.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Set DuckPlayer to Always Ask
2. Watch a Vide
3. Tap Turn On Duck Player in the overlay 
5. Set a breakpoint [here](https://github.com/duckduckgo/iOS/pull/3433/files#diff-ad1081d4b55c408c4fe105fd8f5765e0b0513ee1a9fa80c6b938db165baef57cR496)
6. Tap watch on Youtube
7. Confirm the Breakpoint is hit.
