### PR TITLE
DuckPlayer: Temporary Fix for Watch In Youtube

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -229,15 +229,15 @@ final class DuckPlayerNavigationHandler {
             // Enroll user if not enrolled
             if !experiment.isEnrolled {
                 experiment.assignUserToCohort()
-            }
-            
-            // DuckPlayer is disabled before user enrolls,
-            // So trigger a settings change notification
-            // to let the FE know about the 'actual' setting
-            // and update Experiment value
-            if experiment.isExperimentCohort {
-                duckPlayer.settings.triggerNotification()
-                experiment.duckPlayerMode = duckPlayer.settings.mode
+                
+                // DuckPlayer is disabled before user enrolls,
+                // So trigger a settings change notification
+                // to let the FE know about the 'actual' setting
+                // and update Experiment value
+                if experiment.isExperimentCohort {
+                    duckPlayer.settings.triggerNotification()
+                    experiment.duckPlayerMode = duckPlayer.settings.mode
+                }
             }
             
             experiment.fireYoutubePixel(videoID: videoID)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:https://app.asana.com/0/1204099484721401/1208531438887018/f
Tech Design URL:
CC:

**Description**:
There is an issue in the Frontend that causes `allowFirstVideo` to remain 'true' even if it shouldn't.  This issue is triggered by sending more than one User-Settings Message per webpage view.

Moving this into the enrollment conditional, will buy us time to fix the issue in the FE and C.S.S and release as part of the regular release train.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

- [x] Set DuckPlayer to "Always Ask"
- [x] Go to https://m.youtube.com/watch?v=B_HSa1dEL9s
- [x] Tap "Turn On Duck Player"
- [x] Tap "Watch in Youtube"
- [x] Tap the first video from the "Recommended list below"
- [x] Confirm DuckPlayer Overlay appears again.

