### PR TITLE
Fix browsing menu bottom offset when bar location set to bottom

### DIFF
--- a/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
+++ b/DuckDuckGo/BrowsingMenu/BrowsingMenuViewController.swift
@@ -217,8 +217,7 @@ final class BrowsingMenuViewController: UIViewController {
         topConstraint.constant = frame.minY + (isIPhoneLandscape ? -10 : 5)
         // Move menu up in Landscape, as bottom toolbar shrinks
 
-        let barPositionOffset: CGFloat = appSettings.currentAddressBarPosition.isBottom ? 52 : 0
-        bottomConstraint.constant = windowBounds.maxY - frame.maxY - (isIPhoneLandscape ? 2 : 10) - barPositionOffset
+        bottomConstraint.constant = windowBounds.maxY - frame.maxY - (isIPhoneLandscape ? 2 : 10)
         rightConstraint.constant = isIPad ? 67 : 10
 
         recalculatePreferredWidthConstraint()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208517558228307/f
Tech Design URL:
CC:

**Description**:

Looks like the bottom offset for the browsing menu is no longer needed when address bar is set to bottom location. Applying existing offset causes menu to cover the toolbar.

**Steps to test this PR**:
1. Set URL bar position to bottom.
2. Open browsing menu on **multiple devices** and verify it does not cover the toolbar. 
3. Rotate to landscape, check again.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
