### PR TITLE
DuckPlayer: Fixes Back Navigation for Video Previews

### DIFF
--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "e0c0c85c18372f73fb97c5cf070f1de70c906a1f",
-        "version" : "199.1.0"
+        "revision" : "ffcbeb215c53e29b10cf511a98468a4456f6b965",
+        "version" : "199.2.0"
       }
     },
     {
@@ -138,7 +138,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -429,7 +429,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
     }
     
     @MainActor
-    func handleJSNavigation(url: URL?, webView: WKWebView) {
+    func handleJSNavigation(url: URL?, webView: WKWebView, isNewTab: Bool = false) {
         
         Logger.duckPlayer.debug("Handling JS Navigation for \(url?.absoluteString ?? "")")
         
@@ -439,6 +439,16 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         
         // Assume JS Navigation is user-triggered
         self.navigationType = .linkActivated
+        
+        // If the WebView is not a new tab and Opening in New tab setting is enabled
+        // Set things up, and navigate back in the current view as the video will load there
+        if !isNewTab &&
+            duckPlayer.settings.openInNewTab &&
+            duckPlayer.settings.mode != .disabled {
+            setOpenInNewTab(url: url)
+            webView.stopLoading()
+            webView.goBack()
+        }
         
         // Only handle URL changes if the allowFirstVideo is set to false
         // This prevents Youtube redirects from triggering DuckPlayer when is not expected
@@ -536,8 +546,6 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         switch event {
         case .youtubeVideoPageVisited:
             handleYouTubePageVisited(url: url, navigationAction: navigationAction)
-        case .JSTriggeredNavigation:
-            setOpenInNewTab(url: url)
         }
     }
     

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -446,8 +446,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
             duckPlayer.settings.openInNewTab &&
             duckPlayer.settings.mode != .disabled {
             setOpenInNewTab(url: url)
-            webView.stopLoading()
-            webView.goBack()
+            handleGoBack(webView: webView)
         }
         
         // Only handle URL changes if the allowFirstVideo is set to false

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
@@ -21,14 +21,13 @@ import WebKit
 
 enum DuckPlayerNavigationEvent {
     case youtubeVideoPageVisited
-    case JSTriggeredNavigation
 }
 
 protocol DuckPlayerNavigationHandling: AnyObject {
     var referrer: DuckPlayerReferrer { get set }
     var duckPlayer: DuckPlayerProtocol { get }
     func handleNavigation(_ navigationAction: WKNavigationAction, webView: WKWebView)
-    func handleJSNavigation(url: URL?, webView: WKWebView)
+    func handleJSNavigation(url: URL?, webView: WKWebView, isNewTab: Bool)
     func handleDecidePolicyFor(_ navigationAction: WKNavigationAction,
                                completion: @escaping (WKNavigationActionPolicy) -> Void,
                                webView: WKWebView)

--- a/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
@@ -70,6 +70,7 @@ protocol DuckPlayerSettings: AnyObject {
     var mode: DuckPlayerMode { get }
     var askModeOverlayHidden: Bool { get }
     var allowFirstVideo: Bool { get set }
+    var openInNewTab: Bool { get }
     
     init(appSettings: AppSettings, privacyConfigManager: PrivacyConfigurationManaging)
     
@@ -137,6 +138,10 @@ final class DuckPlayerSettingsDefault: DuckPlayerSettings {
     }
     
     var allowFirstVideo: Bool = false
+    
+    var openInNewTab: Bool {
+        appSettings.duckPlayerOpenInNewTab
+    }
     
     private func registerConfigPublisher() {
         isFeatureEnabledCancellable = privacyConfigManager.updatesPublisher

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1914,7 +1914,7 @@ extension TabViewController: WKNavigationDelegate {
             
             // Validate Duck Player setting to open in new tab or locally
             if duckPlayerNavigationHandler?.shouldOpenInNewTab(navigationAction, webView: webView) ?? false {
-                delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false, inheritingAttribution: nil)
+                delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: true, inheritingAttribution: nil)
             } else {
                 duckPlayerNavigationHandler?.handleNavigation(navigationAction, webView: webView)
             }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -762,7 +762,7 @@ class TabViewController: UIViewController {
                                                          navigationAction: nil)
                 
                 if duckPlayerNavigationHandler?.duckPlayer.settings.mode == .enabled {
-                 duckPlayerNavigationHandler?.handleJSNavigation(url: url, webView: webView)
+                    duckPlayerNavigationHandler?.handleJSNavigation(url: url, webView: webView, isNewTab: openingTab != nil)
                 }
             }
                
@@ -770,12 +770,6 @@ class TabViewController: UIViewController {
         }
         if let url {
             duckPlayerNavigationHandler?.referrer = url.isYoutube ? .youtube : .other
-            
-            // Open in new tab if required
-            // If the lastRenderedURL is nil, it means we're already in a new tab
-            if webView.url != nil && lastRenderedURL != nil {
-                duckPlayerNavigationHandler?.handleEvent(event: .JSTriggeredNavigation, url: webView.url, navigationAction: nil)
-            }
         }
     }
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1208551250449279/f

**Description**:
- Fixes an issue causing navigation to break when navigating back from Video Previews
- Removes the JSTriggerednavigation logic as it's not needed anymore.
- Adds new tab animation

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

**Scenario 1:**
- [ ] Set DuckPlayer to 'always'
- [ ] Enable "Open in new tab"
- [ ] Go to [Youtube.com](https://youtube.com/), search for "Metallica"
- [ ] Scroll and stop until a video starts playing inline
- [ ] Tap it
- [ ] Confirm it opens in a new Tab
- [ ] Hit the back Button
- [ ] Confirm you're taken back to the YouTube search results page


**Scenario 2:**
- [ ] Go to [Youtube.com](https://youtube.com/), search for "Metallica"
- [ ] Scroll and stop until a video starts playing inline
- [ ] Tap on a video that's NOT playing
- [ ] Go back
- [ ] Confirm you're taken back to the youtube search page 


<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->
