### PR TITLE
Fix `never used` warning

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -249,7 +249,7 @@ final class DuckPlayerNavigationHandler {
     // And sets the correct navigationType
     // This is uses for JS based navigation links
     private func setOpenInNewTab(url: URL?) {
-        guard let url else {
+        guard url != nil else {
             return
         }
         

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1120,7 +1120,7 @@ class MainViewController: UIViewController {
 
     private func hideNotificationBarIfBrokenSitePromptShown(afterRefresh: Bool = false) {
         guard brokenSitePromptViewHostingController != nil,
-                let event = brokenSitePromptEvent?.rawValue else { return }
+              brokenSitePromptEvent != nil else { return }
         brokenSitePromptViewHostingController = nil
         hideNotification()
     }

--- a/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -88,10 +88,7 @@ final class PrivacyDashboardViewController: UIViewController {
           contentBlockingManager: ContentBlockerRulesManager,
           breakageAdditionalInfo: BreakageAdditionalInfo?) {
 
-        var variant: PrivacyDashboardVariant {
-            let isExperimentEnabled = privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .brokenSiteReportExperiment)
-            return PrivacyDashboardVariant.control
-        }
+        let variant: PrivacyDashboardVariant = .control
 
         let toggleReportingConfiguration = ToggleReportingConfiguration(privacyConfigurationManager: privacyConfigurationManager)
         let toggleReportingFeature = ToggleReportingFeature(toggleReportingConfiguration: toggleReportingConfiguration)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2148,7 +2148,7 @@ extension TabViewController {
      */
     private func setupOrClearTemporaryDownload(for response: URLResponse) -> WKNavigationResponsePolicy? {
         let downloadManager = AppDependencyProvider.shared.downloadManager
-        guard let url = response.url,
+        guard response.url != nil,
               let downloadMetaData = downloadManager.downloadMetaData(for: response),
               !downloadMetaData.mimeType.isHTML
         else {


### PR DESCRIPTION
**Description**:

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->
This PR fixed the following warning:

- `Value 'XXX' was defined but never used; consider replacing with boolean test`
- `Immutable value 'XXX' was never used; consider replacing with '_' or removing it`
- `Initialization of immutable value 'XXX' was never used; consider replacing with assignment to '_' or removing it`

**Steps to test this PR**:
All unit tests passed.
