### PR TITLE
support third party marketplace URLs

### DIFF
--- a/Core/SchemeHandler.swift
+++ b/Core/SchemeHandler.swift
@@ -51,6 +51,7 @@ public class SchemeHandler {
         case shortcuts
         case shortcutsProduction = "shortcuts-production"
         case workflow
+        case marketKit = "marketplace-kit"
     }
 
     private enum BlockedScheme: String {
@@ -74,6 +75,12 @@ public class SchemeHandler {
         }
 
         switch PlatformScheme(rawValue: schemeString) {
+        case .marketKit:
+            if #available(iOS 17.4, *) {
+                return .external(.askForConfirmation)
+            } else {
+                return .unknown
+            }
         case .sms, .mailto, .itms, .itmss, .itunes, .itmsApps, .itmsAppss, .shortcuts, .shortcutsProduction, .workflow:
             return .external(.askForConfirmation)
         case .none:

--- a/Core/SchemeHandler.swift
+++ b/Core/SchemeHandler.swift
@@ -29,6 +29,7 @@ public class SchemeHandler {
     }
 
     public enum SchemeType: Equatable {
+        case allow
         case navigational
         case external(Action)
         case blob
@@ -77,7 +78,7 @@ public class SchemeHandler {
         switch PlatformScheme(rawValue: schemeString) {
         case .marketKit:
             if #available(iOS 17.4, *) {
-                return .external(.open)
+                return .allow
             } else {
                 return .unknown
             }

--- a/Core/SchemeHandler.swift
+++ b/Core/SchemeHandler.swift
@@ -77,7 +77,7 @@ public class SchemeHandler {
         switch PlatformScheme(rawValue: schemeString) {
         case .marketKit:
             if #available(iOS 17.4, *) {
-                return .external(.askForConfirmation)
+                return .external(.open)
             } else {
                 return .unknown
             }

--- a/Core/SchemeHandler.swift
+++ b/Core/SchemeHandler.swift
@@ -52,7 +52,7 @@ public class SchemeHandler {
         case shortcuts
         case shortcutsProduction = "shortcuts-production"
         case workflow
-        case marketKit = "marketplace-kit"
+        case marketplaceKit = "marketplace-kit"
     }
 
     private enum BlockedScheme: String {
@@ -76,7 +76,8 @@ public class SchemeHandler {
         }
 
         switch PlatformScheme(rawValue: schemeString) {
-        case .marketKit:
+        case .marketplaceKit:
+            // marketplaceKit urls have to be allowed through without interference
             if #available(iOS 17.4, *) {
                 return .allow
             } else {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1697,19 +1697,6 @@ extension TabViewController: WKNavigationDelegate {
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 
-        if #available(iOS 17.4, *),
-            navigationAction.request.url?.scheme == "marketplace-kit",
-            internalUserDecider.isInternalUser {
-
-            decisionHandler(.allow)
-            let urlString = navigationAction.request.url?.absoluteString ?? "<no url>"
-            ActionMessageView.present(message: "Marketplace Kit URL detected",
-                                      actionTitle: "COPY",
-                                      presentationLocation: .withoutBottomBar, onAction: {
-                UIPasteboard.general.string = urlString
-            })
-            return
-        }
         
         if let url = navigationAction.request.url {
             if !tabURLInterceptor.allowsNavigatingTo(url: url) {

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1887,6 +1887,10 @@ extension TabViewController: WKNavigationDelegate {
         let schemeType = SchemeHandler.schemeType(for: url)
         self.blobDownloadTargetFrame = nil
         switch schemeType {
+        case .allow:
+            completion(.allow)
+            return
+            
         case .navigational:
             performNavigationFor(url: url,
                                  navigationAction: navigationAction,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207138951730082/f
Tech Design URL:
CC:

**Description**:
Allow marketplace URLs to work.

Note that the URL must be from a 'user' request.  So we can't cancel and re-issue the URL otherwise it doesn't work.  This also means that can't handle the case where it doesn't work unless we want to check the user has an EU apple account, which we don't.

**Steps to test this PR**:
1. With an EU Apple ID, visit altstore.io and install their marketplace. Should cause iOS system prompts and then install successfully.
2. With a non-EU Apple ID, visit altstore.io and try to install their marketplace.  Nothing will happen (unfortunately we are unable to catch this case).
