### PR TITLE
For BLOB downloads make sure the file is not preview-able before triggering the download

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2171,7 +2171,7 @@ extension TabViewController {
                     return
                 }
 
-                if self.shouldTriggerDownloadAction(for: navigationResponse) {
+                if self.shouldTriggerDownloadAction(for: navigationResponse) && !FilePreviewHelper.canAutoPreviewMIMEType(downloadMetadata.mimeType) {
                     // Show alert to the file download
                     self.presentSaveToDownloadsAlert(with: downloadMetadata) {
                         callback(self.transfer(download,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1207504349745342/f

**Description**:
When wallet passes are served as BLOB type downloads they just trigger the download prompt instead of directly open their preview allowing adding them to Wallet app.

**Steps to test this PR**:
1. Open http://lu.ma/
2. (register with email - not sure if necessary)
3. Find a free event
4. Join the event
5. Tap the small wallet icon
6. Wallet pass should open directly in modal preview allowing adding it to wallet

![Simulator Screenshot - iPhone 15 - 2024-10-23 at 19 27 37](https://github.com/user-attachments/assets/eb95af68-bced-44a9-a5a2-8a380221fb61)

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
