### PR TITLE
Fix updating OmniBar constraints on iOS18

### DIFF
--- a/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -308,14 +308,15 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
 
         if !isEnabled || tabsModel.currentIndex == indexPath.row {
             cell.omniBar = coordinator.omniBar
+            cell.setNeedsUpdateConstraints()
         } else {
             // Strong reference while we use the omnibar
             let omniBar = OmniBar.loadFromXib(voiceSearchHelper: voiceSearchHelper)
 
             cell.omniBar = omniBar
             cell.omniBar?.translatesAutoresizingMaskIntoConstraints = false
-            cell.updateConstraints()
-            
+            cell.setNeedsUpdateConstraints()
+
             cell.omniBar?.showSeparator()
             if self.appSettings.currentAddressBarPosition.isBottom {
                 cell.omniBar?.moveSeparatorToTop()
@@ -343,7 +344,7 @@ class OmniBarCell: UICollectionViewCell {
             subviews.forEach { $0.removeFromSuperview() }
             if let omniBar {
                 addSubview(omniBar)
-                
+
                 NSLayoutConstraint.activate([
                     constrainView(omniBar, by: .leadingMargin),
                     constrainView(omniBar, by: .trailingMargin),
@@ -354,14 +355,14 @@ class OmniBarCell: UICollectionViewCell {
             }
         }
     }
-    
+
     override func updateConstraints() {
-        super.updateConstraints()
         let left = superview?.safeAreaInsets.left ?? 0
         let right = superview?.safeAreaInsets.right ?? 0
         omniBar?.updateOmniBarPadding(left: left, right: right)
+
+        super.updateConstraints()
     }
-    
 }
 
 extension TabsModel {

--- a/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -308,14 +308,12 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
 
         if !isEnabled || tabsModel.currentIndex == indexPath.row {
             cell.omniBar = coordinator.omniBar
-            cell.setNeedsUpdateConstraints()
         } else {
             // Strong reference while we use the omnibar
             let omniBar = OmniBar.loadFromXib(voiceSearchHelper: voiceSearchHelper)
 
             cell.omniBar = omniBar
             cell.omniBar?.translatesAutoresizingMaskIntoConstraints = false
-            cell.setNeedsUpdateConstraints()
 
             cell.omniBar?.showSeparator()
             if self.appSettings.currentAddressBarPosition.isBottom {
@@ -331,7 +329,9 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
             }
 
         }
-        
+
+        cell.setNeedsUpdateConstraints()
+
         return cell
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208602903372806/f
Tech Design URL:
CC:

**Description**:

Addresses an issue when OmniBar was not sized properly on phones after rotating to landscape and back to portrait.

Seems like root cause was some "optimization" in iOS 18 layout system which changed when `updateConstraints` is being called. Solution was to use `setNeedsUpdateConstraints()` while preparing cell for both "real" and "fake" OmniBar.

Additionally call to `super.updateConstraints()` was moved to the end of the override as highlighted in [documentation](https://developer.apple.com/documentation/uikit/uiview/1622512-updateconstraints#discussion).

**Steps to test this PR**:
1. Rotate to landscape and back to portrait with single and multiple tabs for both bar position settings (top and bottom).
2. Repeat for iPad

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone 8
* [x] iPhone 16
* [x] iPad

**OS Testing**:

* [x] iOS 15
* [x] iOS 17
* [x] iOS 18

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
