### PR TITLE
TestFlight only release and promotion

### DIFF
--- a/.github/workflows/promote_testflight.yml
+++ b/.github/workflows/promote_testflight.yml
@@ -2,9 +2,6 @@ name: Promote TestFlight to App Store
 
 on: 
   workflow_dispatch: {}
-  push:
-    branches:
-      - kieran/release-changes
 
 jobs:
   promote-testflight-to-appstore:
@@ -34,5 +31,3 @@ jobs:
         git config --global user.name "Dax the Duck"
         git config --global user.email "dax@duckduckgo.com"
         bundle exec fastlane promote_latest_testflight_to_appstore alpha:true
-        bundle exec fastlane promote_latest_testflight_to_appstore
-  

--- a/.github/workflows/promote_testflight.yml
+++ b/.github/workflows/promote_testflight.yml
@@ -1,0 +1,35 @@
+name: Promote TestFlight to App Store
+
+on: 
+  workflow_dispatch: {}
+
+jobs:
+  promote-testflight-to-appstore:
+    runs-on: macos-14
+
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+        sparse-checkout: |
+          .github
+          Gemfile
+          Gemfile.lock
+          fastlane
+          scripts
+
+    - name: Set up fastlane
+      run: bundle install
+
+    - name: Promote TestFlight to App Store
+      env:
+        APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+      run: |
+        git config --global user.name "Dax the Duck"
+        git config --global user.email "dax@duckduckgo.com"
+        bundle exec fastlane promote_latest_testflight_to_appstore alpha:true
+        bundle exec fastlane promote_latest_testflight_to_appstore
+  

--- a/.github/workflows/promote_testflight.yml
+++ b/.github/workflows/promote_testflight.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         git config --global user.name "Dax the Duck"
         git config --global user.email "dax@duckduckgo.com"
-        bundle exec fastlane promote_latest_testflight_to_appstore alpha:true
+        bundle exec fastlane promote_latest_testflight_to_appstore

--- a/.github/workflows/promote_testflight.yml
+++ b/.github/workflows/promote_testflight.yml
@@ -2,6 +2,9 @@ name: Promote TestFlight to App Store
 
 on: 
   workflow_dispatch: {}
+  push:
+    branches:
+      - kieran/release-changes
 
 jobs:
   promote-testflight-to-appstore:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       destination:
         description: "Upload destination (App Store or TestFlight)"
         required: true
-        default: appstore
+        default: testflight
         type: choice
         options:
         - appstore
@@ -36,10 +36,10 @@ jobs:
       id: destination
       run: |
         INPUT_DESTINATION=${{ github.event.inputs.destination }}
-        echo "destination=${INPUT_DESTINATION:-"appstore"}" >> $GITHUB_OUTPUT
+        echo "destination=${INPUT_DESTINATION:-"testflight"}" >> $GITHUB_OUTPUT
 
     - name: Assert release branch
-      if: steps.destination.outputs.destination == 'appstore'
+      if: steps.destination.outputs.destination == 'appstore' || steps.destination.outputs.destination == 'testflight'
       run: |
         case "${{ github.ref }}" in
           *release/*) ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         echo "destination=${INPUT_DESTINATION:-"testflight"}" >> $GITHUB_OUTPUT
 
     - name: Assert release branch
-      if: steps.destination.outputs.destination == 'appstore' || steps.destination.outputs.destination == 'testflight'
       run: |
         case "${{ github.ref }}" in
           *release/*) ;;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,7 +175,7 @@ lane :promote_latest_testflight_to_appstore do |options|
 
   app_identifier = options[:alpha] ? "com.duckduckgo.mobile.ios.alpha" : "com.duckduckgo.mobile.ios"
 
-  latest_build_info = latest_testflight_build_number(
+  latest_testflight_build_number(
     api_key: get_api_key,
     username: get_username(options),
     platform: 'ios',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,7 +220,8 @@ desc 'Updates App Store metadata'
 lane :upload_metadata do |options|
   deliver(common_deliver_arguments.merge(options).merge({
     skip_binary_upload: true,
-    skip_metadata: false
+    skip_metadata: false,
+    version_check_wait_retry_limit: 0
   }))
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,7 +185,6 @@ lane :promote_latest_testflight_to_appstore do |options|
       api_key: get_api_key,
       username: get_username(options),
       platform: 'ios'
-      # No app_identifier for non-alpha
     )
   end
 
@@ -194,10 +193,10 @@ lane :promote_latest_testflight_to_appstore do |options|
 
   UI.message("The latest build number #{latest_build_number} of the latest version: #{latest_build_version}")
 
-  # upload_metadata(options.merge({
-  #   build_number: latest_build_number.to_s,
-  #   app_version: latest_build_version.to_s,
-  # }))
+  upload_metadata(options.merge({
+    build_number: latest_build_number.to_s,
+    app_version: latest_build_version.to_s,
+  }))
 end
 
 desc 'Makes App Store release build and uploads it to App Store Connect'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -173,30 +173,25 @@ end
 desc 'Promotes the latest TestFlight build to App Store without submitting for review'
 lane :promote_latest_testflight_to_appstore do |options|
 
-  if options[:alpha]
-    latest_build_info = latest_testflight_build_number(
-      api_key: get_api_key,
-      username: get_username(options),
-      platform: 'ios',
-      app_identifier: "com.duckduckgo.mobile.ios.alpha"
-    )
-  else
-    latest_build_info = latest_testflight_build_number(
-      api_key: get_api_key,
-      username: get_username(options),
-      platform: 'ios'
-    )
-  end
+  app_identifier = options[:alpha] ? "com.duckduckgo.mobile.ios.alpha" : "com.duckduckgo.mobile.ios"
+
+  latest_build_info = latest_testflight_build_number(
+    api_key: get_api_key,
+    username: get_username(options),
+    platform: 'ios',
+    app_identifier: app_identifier
+  )
 
   latest_build_number = lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER]   
   latest_build_version = lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION]
 
-  UI.message("The latest build number #{latest_build_number} of the latest version: #{latest_build_version}")
+  UI.message("The latest build number #{latest_build_number} of the latest version: #{latest_build_version} for app identifier: #{app_identifier}")
 
-  upload_metadata(options.merge({
+  upload_metadata({
     build_number: latest_build_number.to_s,
     app_version: latest_build_version.to_s,
-  }))
+    app_identifier: app_identifier 
+  })
 end
 
 desc 'Makes App Store release build and uploads it to App Store Connect'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -168,15 +168,27 @@ lane :alpha_adhoc do |options|
   end
 end
 
+
+
 desc 'Promotes the latest TestFlight build to App Store without submitting for review'
 lane :promote_latest_testflight_to_appstore do |options|
 
-  latest_build_info = latest_testflight_build_number(
-    api_key: get_api_key,
-    username: get_username(options),
-    platform: 'ios'
-  )
-  
+  if options[:alpha]
+    latest_build_info = latest_testflight_build_number(
+      api_key: get_api_key,
+      username: get_username(options),
+      platform: 'ios',
+      app_identifier: "com.duckduckgo.mobile.ios.alpha"
+    )
+  else
+    latest_build_info = latest_testflight_build_number(
+      api_key: get_api_key,
+      username: get_username(options),
+      platform: 'ios'
+      # No app_identifier for non-alpha
+    )
+  end
+
   latest_build_number = lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER]   
   latest_build_version = lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION]
 
@@ -186,7 +198,6 @@ lane :promote_latest_testflight_to_appstore do |options|
   #   build_number: latest_build_number.to_s,
   #   app_version: latest_build_version.to_s,
   # }))
-
 end
 
 desc 'Makes App Store release build and uploads it to App Store Connect'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -168,6 +168,27 @@ lane :alpha_adhoc do |options|
   end
 end
 
+desc 'Promotes the latest TestFlight build to App Store without submitting for review'
+lane :promote_latest_testflight_to_appstore do |options|
+
+  latest_build_info = latest_testflight_build_number(
+    api_key: get_api_key,
+    username: get_username(options),
+    platform: 'ios'
+  )
+  
+  latest_build_number = lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER]   
+  latest_build_version = lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION]
+
+  UI.message("The latest build number #{latest_build_number} of the latest version: #{latest_build_version}")
+
+  # upload_metadata(options.merge({
+  #   build_number: latest_build_number.to_s,
+  #   app_version: latest_build_version.to_s,
+  # }))
+
+end
+
 desc 'Makes App Store release build and uploads it to App Store Connect'
 lane :release_appstore do |options|
   build_release(options)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1208234424227124/f
Tech Design URL:
CC:  @ayoy 

**Description**:
- Changes nightly builds to release to TestFlight only
- Adds promote TestFlight to appstore (mirroring MacOS) which gets the latest test flight build and uploads the meta data for that version. Currently only tested with Alpha. 

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
-  [Initial test flow](https://github.com/duckduckgo/iOS/actions/runs/11491500989/job/31983979375) (without upload meta data).
   - This iteration of the flow only checked the version and build number to upload without doing the upload
   - For Alpha it found `Latest upload for version 7.142.0 on ios platform is build: 1`
   - For Stable it found `Latest upload for version 7.142.0 on ios platform is build: 0`
- The nightly job ran (conveniently) to update the alpha build in TestFlight, and a rerun of the [promote flow](https://github.com/duckduckgo/iOS/actions/runs/11491747964/job/31984649252)  showed it found updated build number of 2 which we expect
- [Final run](https://github.com/duckduckgo/iOS/actions/runs/11492279658) failed due to Alpha not quite setup to accept submissions due to metadata conflicts with stable, but it did successfully update the version and some of the metadata, so confident this will work for stable builds.

Before 
![image](https://github.com/user-attachments/assets/a4e47883-f1bf-4256-9425-a3870a0d9be9)


After promotion run
![image](https://github.com/user-attachments/assets/1d23ea75-e26e-41de-a976-6052068f6b15)



<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
