### PR TITLE
Add to Dock Onboarding feature flag

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -42,6 +42,7 @@ public enum FeatureFlag: String {
     case syncPromotionBookmarks
     case syncPromotionPasswords
     case onboardingHighlights
+    case onboardingAddToDock
     case autofillSurveys
     case autcompleteTabs
 
@@ -93,6 +94,8 @@ extension FeatureFlag: FeatureFlagSourceProviding {
         case .syncPromotionPasswords:
             return .remoteReleasable(.subfeature(SyncPromotionSubfeature.passwords))
         case .onboardingHighlights:
+            return .internalOnly
+        case .onboardingAddToDock:
             return .internalOnly
         case .autofillSurveys:
             return .remoteReleasable(.feature(.autofillSurveys))

--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -171,7 +171,8 @@ public struct UserDefaultsWrapper<T> {
         // Debug keys
         case debugNewTabPageSectionsEnabledKey = "com.duckduckgo.ios.debug.newTabPageSectionsEnabled"
         case debugOnboardingHighlightsEnabledKey = "com.duckduckgo.ios.debug.onboardingHighlightsEnabled"
-        
+        case debugOnboardingAddToDockEnabledKey = "com.duckduckgo.ios.debug.onboardingAddToDockEnabled"
+
         // Duck Player Pixel Experiment
         case duckPlayerPixelExperimentInstalled = "com.duckduckgo.ios.duckplayer.pixel.experiment.installed.v2"
         case duckPlayerPixelExperimentCohort = "com.duckduckgo.ios.duckplayer.pixel.experiment.cohort.v2"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -725,6 +725,7 @@
 		9F7CFF7D2C89B69A0012833E /* AppIconPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7CFF7C2C89B69A0012833E /* AppIconPickerViewModelTests.swift */; };
 		9F7CFF7F2C8A94F70012833E /* OnboardingView+AddressBarPositionContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7CFF7E2C8A94F70012833E /* OnboardingView+AddressBarPositionContent.swift */; };
 		9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */; };
+		9F8E0F262CC9395D001EA7C5 /* Logger+Onboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E0F252CC9395D001EA7C5 /* Logger+Onboarding.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F96F73B2C9144D5009E45D5 /* Onboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 9F96F73A2C9144D5009E45D5 /* Onboarding */; };
 		9F96F73F2C914C57009E45D5 /* OnboardingGradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F96F73E2C914C57009E45D5 /* OnboardingGradient.swift */; };
@@ -2537,6 +2538,7 @@
 		9F7CFF7C2C89B69A0012833E /* AppIconPickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconPickerViewModelTests.swift; sourceTree = "<group>"; };
 		9F7CFF7E2C8A94F70012833E /* OnboardingView+AddressBarPositionContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddressBarPositionContent.swift"; sourceTree = "<group>"; };
 		9F8007252C5261AF003EDAF4 /* MockPrivacyDataReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataReporter.swift; sourceTree = "<group>"; };
+		9F8E0F252CC9395D001EA7C5 /* Logger+Onboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Onboarding.swift"; sourceTree = "<group>"; };
 		9F96F73E2C914C57009E45D5 /* OnboardingGradient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingGradient.swift; sourceTree = "<group>"; };
 		9F9A922D2C86A56B001D036D /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
 		9F9A92302C86AAE9001D036D /* OnboardingDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDebugView.swift; sourceTree = "<group>"; };
@@ -5699,6 +5701,7 @@
 				85C11E4A209084DE00BFFEB4 /* HomeRow */,
 				F1BE54481E69DD5F00FCF649 /* Onboarding */,
 				F186421A1E94A3F900B2A911 /* Support */,
+				9F8E0F252CC9395D001EA7C5 /* Logger+Onboarding.swift */,
 			);
 			name = Tutorials;
 			sourceTree = "<group>";
@@ -7464,6 +7467,7 @@
 				F4D9C4FA25117A0F00814B71 /* HomeMessageStorage.swift in Sources */,
 				D69FBF762B28BE3600B505F1 /* SettingsSubscriptionView.swift in Sources */,
 				D664C7CC2B289AA200CBFA76 /* SubscriptionPagesUserScript.swift in Sources */,
+				9F8E0F262CC9395D001EA7C5 /* Logger+Onboarding.swift in Sources */,
 				AA3D854523D9942200788410 /* AppIconSettingsViewController.swift in Sources */,
 				85C297042476C1FD0063A335 /* DaxDialogsSettings.swift in Sources */,
 				8505836F219F424500ED4EDB /* UIViewExtension.swift in Sources */,

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -87,4 +87,5 @@ protocol AppSettings: AnyObject, AppDebugSettings {
 
 protocol AppDebugSettings {
     var onboardingHighlightsEnabled: Bool { get set }
+    var onboardingAddToDockEnabled: Bool { get set }
 }

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -418,10 +418,12 @@ public class AppUserDefaults: AppSettings {
     
     @UserDefaultsWrapper(key: .duckPlayerOpenInNewTab, defaultValue: true)
     var duckPlayerOpenInNewTab: Bool
-    
 
     @UserDefaultsWrapper(key: .debugOnboardingHighlightsEnabledKey, defaultValue: false)
     var onboardingHighlightsEnabled: Bool
+
+    @UserDefaultsWrapper(key: .debugOnboardingAddToDockEnabledKey, defaultValue: false)
+    var onboardingAddToDockEnabled: Bool
 }
 
 extension AppUserDefaults: AppConfigurationFetchStatistics {

--- a/DuckDuckGo/Logger+Onboarding.swift
+++ b/DuckDuckGo/Logger+Onboarding.swift
@@ -1,0 +1,25 @@
+//
+//  Logger+Onboarding.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@_exported import os.log
+
+extension Logger {
+    static var onboarding = { Logger(subsystem: "Onboarding", category: "") }()
+}

--- a/DuckDuckGo/OnboardingDebugView.swift
+++ b/DuckDuckGo/OnboardingDebugView.swift
@@ -45,6 +45,19 @@ struct OnboardingDebugView: View {
             }
 
             Section {
+                Toggle(
+                    isOn: $viewModel.isOnboardingAddToDockLocalFlagEnabled,
+                    label: {
+                        Text(verbatim: "Onboarding Add to Dock local setting enabled")
+                    }
+                )
+            } header: {
+                Text(verbatim: "Onboarding Add to Dock settings")
+            } footer: {
+                Text(verbatim: "Requires internal user flag set to have an effect.")
+            }
+
+            Section {
                 Button(action: newOnboardingIntroStartAction, label: {
                     let onboardingType = viewModel.isOnboardingHighlightsLocalFlagEnabled ? "Highlights" : ""
                     Text(verbatim: "Preview New Onboarding Intro \(onboardingType)")
@@ -61,11 +74,18 @@ final class OnboardingDebugViewModel: ObservableObject {
         }
     }
 
-    private let manager: OnboardingHighlightsDebugging
+    @Published var isOnboardingAddToDockLocalFlagEnabled: Bool {
+        didSet {
+            manager.isAddToDockLocalFlagEnabled = isOnboardingAddToDockLocalFlagEnabled
+        }
+    }
 
-    init(manager: OnboardingHighlightsDebugging = OnboardingManager()) {
+    private let manager: OnboardingHighlightsDebugging & OnboardingAddToDockDebugging
+
+    init(manager: OnboardingHighlightsDebugging & OnboardingAddToDockDebugging = OnboardingManager()) {
         self.manager = manager
         isOnboardingHighlightsLocalFlagEnabled = manager.isOnboardingHighlightsLocalFlagEnabled
+        isOnboardingAddToDockLocalFlagEnabled = manager.isAddToDockLocalFlagEnabled
     }
 
 }

--- a/DuckDuckGo/OnboardingDebugView.swift
+++ b/DuckDuckGo/OnboardingDebugView.swift
@@ -33,7 +33,7 @@ struct OnboardingDebugView: View {
         List {
             Section {
                 Toggle(
-                    isOn: $viewModel.isLocalFlagEnabled,
+                    isOn: $viewModel.isOnboardingHighlightsLocalFlagEnabled,
                     label: {
                         Text(verbatim: "Onboarding Highlights local setting enabled")
                     }
@@ -46,7 +46,7 @@ struct OnboardingDebugView: View {
 
             Section {
                 Button(action: newOnboardingIntroStartAction, label: {
-                    let onboardingType = viewModel.isLocalFlagEnabled ? "Highlights" : ""
+                    let onboardingType = viewModel.isOnboardingHighlightsLocalFlagEnabled ? "Highlights" : ""
                     Text(verbatim: "Preview New Onboarding Intro \(onboardingType)")
                 })
             }
@@ -55,9 +55,9 @@ struct OnboardingDebugView: View {
 }
 
 final class OnboardingDebugViewModel: ObservableObject {
-    @Published var isLocalFlagEnabled: Bool {
+    @Published var isOnboardingHighlightsLocalFlagEnabled: Bool {
         didSet {
-            manager.isLocalFlagEnabled = isLocalFlagEnabled
+            manager.isOnboardingHighlightsLocalFlagEnabled = isOnboardingHighlightsLocalFlagEnabled
         }
     }
 
@@ -65,7 +65,7 @@ final class OnboardingDebugViewModel: ObservableObject {
 
     init(manager: OnboardingHighlightsDebugging = OnboardingManager()) {
         self.manager = manager
-        isLocalFlagEnabled = manager.isLocalFlagEnabled
+        isOnboardingHighlightsLocalFlagEnabled = manager.isOnboardingHighlightsLocalFlagEnabled
     }
 
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -30,7 +30,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     private var delegate: OnboardingNavigationDelegate?
     private let contextualOnboardingLogic: ContextualOnboardingLogic
     private let onboardingPixelReporter: OnboardingPixelReporting
-    private let onboardingManager: OnboardingHighlightsManaging
+    private let onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging
 
     private var gradientType: OnboardingGradientType {
         onboardingManager.isOnboardingHighlightsEnabled ? .highlights : .default
@@ -40,7 +40,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         delegate: OnboardingNavigationDelegate?,
         contextualOnboardingLogic: ContextualOnboardingLogic,
         onboardingPixelReporter: OnboardingPixelReporting,
-        onboardingManager: OnboardingHighlightsManaging = OnboardingManager()
+        onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging = OnboardingManager()
     ) {
         self.delegate = delegate
         self.contextualOnboardingLogic = contextualOnboardingLogic
@@ -99,6 +99,13 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     }
 
     private func createFinalDialog(onDismiss: @escaping () -> Void) -> some View {
+        // TODO: Update views
+        if onboardingManager.isAddToDockEnabled {
+            Logger.onboarding.debug("Present Final Dialog with Add To Dock updates")
+        } else {
+            Logger.onboarding.debug("Present Final Dialog without Add To Dock updates")
+        }
+
         let message = onboardingManager.isOnboardingHighlightsEnabled ? UserText.HighlightsOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage : UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage
 
         return FadeInView {

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -48,7 +48,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     private let contextualOnboardingSettings: ContextualOnboardingSettings
     private let contextualOnboardingPixelReporter: OnboardingPixelReporting
     private let contextualOnboardingSiteSuggestionsProvider: OnboardingSuggestionsItemsProviding
-    private let onboardingManager: OnboardingHighlightsManaging
+    private let onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging
 
     private var gradientType: OnboardingGradientType {
         onboardingManager.isOnboardingHighlightsEnabled ? .highlights : .default
@@ -59,7 +59,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         contextualOnboardingSettings: ContextualOnboardingSettings = DefaultDaxDialogsSettings(),
         contextualOnboardingPixelReporter: OnboardingPixelReporting,
         contextualOnboardingSiteSuggestionsProvider: OnboardingSuggestionsItemsProviding = OnboardingSuggestedSitesProvider(surpriseItemTitle: UserText.DaxOnboardingExperiment.ContextualOnboarding.tryASearchOptionSurpriseMeTitle),
-        onboardingManager: OnboardingHighlightsManaging = OnboardingManager()
+        onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging = OnboardingManager()
     ) {
         self.contextualOnboardingSettings = contextualOnboardingSettings
         self.contextualOnboardingLogic = contextualOnboardingLogic
@@ -182,6 +182,13 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     }
 
     private func endOfJourneyDialog(delegate: ContextualOnboardingDelegate, pixelName: Pixel.Event) -> some View {
+        // TODO: Update views
+        if onboardingManager.isAddToDockEnabled {
+            Logger.onboarding.debug("Present Contextual Final Dialog with Add To Dock updates")
+        } else {
+            Logger.onboarding.debug("Present Contextual Final Dialog without Add To Dock updates")
+        }
+
         let message = onboardingManager.isOnboardingHighlightsEnabled ? UserText.HighlightsOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage : UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage
 
         return OnboardingFinalDialog(message: message, highFiveAction: { [weak delegate, weak self] in

--- a/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -75,7 +75,7 @@ protocol OnboardingAddToDockManaging: AnyObject {
     var isAddToDockEnabled: Bool { get }
 }
 
-protocol OnboardingAddToDockDebugging {
+protocol OnboardingAddToDockDebugging: AnyObject {
     var isAddToDockLocalFlagEnabled: Bool { get set }
     var isAddToDockFeatureFlagEnabled: Bool { get }
 }

--- a/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -20,16 +20,7 @@
 import BrowserServicesKit
 import Core
 
-protocol OnboardingHighlightsManaging: AnyObject {
-    var isOnboardingHighlightsEnabled: Bool { get }
-}
-
-protocol OnboardingHighlightsDebugging: OnboardingHighlightsManaging {
-    var isLocalFlagEnabled: Bool { get set }
-    var isFeatureFlagEnabled: Bool { get }
-}
-
-final class OnboardingManager: OnboardingHighlightsManaging, OnboardingHighlightsDebugging {
+final class OnboardingManager {
     private var appDefaults: AppDebugSettings
     private let featureFlagger: FeatureFlagger
     private let variantManager: VariantManager
@@ -43,12 +34,27 @@ final class OnboardingManager: OnboardingHighlightsManaging, OnboardingHighlight
         self.featureFlagger = featureFlagger
         self.variantManager = variantManager
     }
+}
+
+// MARK: - Onboarding Highlights
+
+protocol OnboardingHighlightsManaging: AnyObject {
+    var isOnboardingHighlightsEnabled: Bool { get }
+}
+
+protocol OnboardingHighlightsDebugging: OnboardingHighlightsManaging {
+    var isOnboardingHighlightsLocalFlagEnabled: Bool { get set }
+    var isOnboardingHighlightsFeatureFlagEnabled: Bool { get }
+}
+
+
+extension OnboardingManager: OnboardingHighlightsManaging, OnboardingHighlightsDebugging {
 
     var isOnboardingHighlightsEnabled: Bool {
-        variantManager.isOnboardingHighlightsExperiment || (isLocalFlagEnabled && isFeatureFlagEnabled)
+        variantManager.isOnboardingHighlightsExperiment || (isOnboardingHighlightsLocalFlagEnabled && isOnboardingHighlightsFeatureFlagEnabled)
     }
 
-    var isLocalFlagEnabled: Bool {
+    var isOnboardingHighlightsLocalFlagEnabled: Bool {
         get {
             appDefaults.onboardingHighlightsEnabled
         }
@@ -57,7 +63,41 @@ final class OnboardingManager: OnboardingHighlightsManaging, OnboardingHighlight
         }
     }
 
-    var isFeatureFlagEnabled: Bool {
+    var isOnboardingHighlightsFeatureFlagEnabled: Bool {
         featureFlagger.isFeatureOn(.onboardingHighlights)
     }
+
+}
+
+// MARK: - Add to Dock
+
+protocol OnboardingAddToDockManaging: AnyObject {
+    var isAddToDockEnabled: Bool { get }
+}
+
+protocol OnboardingAddToDockDebugging {
+    var isAddToDockLocalFlagEnabled: Bool { get set }
+    var isAddToDockFeatureFlagEnabled: Bool { get }
+}
+
+extension OnboardingManager: OnboardingAddToDockManaging, OnboardingAddToDockDebugging {
+
+    var isAddToDockEnabled: Bool {
+        // TODO: Add variant condition once the experiment is setup
+        isAddToDockLocalFlagEnabled && isAddToDockFeatureFlagEnabled
+    }
+
+    var isAddToDockLocalFlagEnabled: Bool {
+        get {
+            appDefaults.onboardingAddToDockEnabled
+        }
+        set {
+            appDefaults.onboardingAddToDockEnabled = newValue
+        }
+    }
+
+    var isAddToDockFeatureFlagEnabled: Bool {
+        featureFlagger.isFeatureOn(.onboardingAddToDock)
+    }
+
 }

--- a/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -24,15 +24,18 @@ final class OnboardingManager {
     private var appDefaults: AppDebugSettings
     private let featureFlagger: FeatureFlagger
     private let variantManager: VariantManager
+    private let isIphone: Bool
 
     init(
         appDefaults: AppDebugSettings = AppDependencyProvider.shared.appSettings,
         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-        variantManager: VariantManager = DefaultVariantManager()
+        variantManager: VariantManager = DefaultVariantManager(),
+        isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone
     ) {
         self.appDefaults = appDefaults
         self.featureFlagger = featureFlagger
         self.variantManager = variantManager
+        self.isIphone = isIphone
     }
 }
 
@@ -84,7 +87,7 @@ extension OnboardingManager: OnboardingAddToDockManaging, OnboardingAddToDockDeb
 
     var isAddToDockEnabled: Bool {
         // TODO: Add variant condition once the experiment is setup
-        isAddToDockLocalFlagEnabled && isAddToDockFeatureFlagEnabled
+        isIphone && isAddToDockLocalFlagEnabled && isAddToDockFeatureFlagEnabled
     }
 
     var isAddToDockLocalFlagEnabled: Bool {

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -95,6 +95,6 @@ class AppSettingsMock: AppSettings {
     var newTabPageIntroMessageSeenCount: Int = 0
 
     var onboardingHighlightsEnabled: Bool = false
-    
+    var onboardingAddToDockEnabled: Bool = false
     
 }

--- a/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -43,45 +43,47 @@ final class OnboardingManagerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testWhenIsLocalFlagEnabledIsCalledAndAppDefaultsOnboardingHiglightsEnabledIsTrueThenReturnTrue() {
+    // MARK: - Onboarding Highlights
+
+    func testWhenIsOnboardingHighlightsLocalFlagEnabledCalledAndAppDefaultsOnboardingHiglightsEnabledIsTrueThenReturnTrue() {
         // GIVEN
         appSettingsMock.onboardingHighlightsEnabled = true
 
         // WHEN
-        let result = sut.isLocalFlagEnabled
+        let result = sut.isOnboardingHighlightsLocalFlagEnabled
 
         // THEN
         XCTAssertTrue(result)
     }
 
-    func testWhenIsLocalFlagEnabledIsCalledAndAppDefaultsOnboardingHiglightsEnabledIsFalseThenReturnFalse() {
+    func testWhenIsOnboardingHighlightsLocalFlagEnabledCalledAndAppDefaultsOnboardingHiglightsEnabledIsFalseThenReturnFalse() {
         // GIVEN
         appSettingsMock.onboardingHighlightsEnabled = false
 
         // WHEN
-        let result = sut.isLocalFlagEnabled
+        let result = sut.isOnboardingHighlightsLocalFlagEnabled
 
         // THEN
         XCTAssertFalse(result)
     }
 
-    func testWhenIsFeatureFlagEnabledIsCalledAndFeaturFlaggerFeatureIsOnThenReturnTrue() {
+    func testWhenIsOnboardingHighlightsFeatureFlagEnabledCalledAndFeaturFlaggerFeatureIsOnThenReturnTrue() {
         // GIVEN
         featureFlaggerMock.enabledFeatureFlags = [FeatureFlag.onboardingHighlights]
 
         // WHEN
-        let result = sut.isFeatureFlagEnabled
+        let result = sut.isOnboardingHighlightsFeatureFlagEnabled
 
         // THEN
         XCTAssertTrue(result)
     }
 
-    func testWhenIsFeatureFlagEnabledIsCalledAndFeaturFlaggerFeatureIsOffThenReturnFalse() {
+    func testWhenIsOnboardingHighlightsFeatureFlagEnabledCalledAndFeaturFlaggerFeatureIsOffThenReturnFalse() {
         // GIVEN
         featureFlaggerMock.enabledFeatureFlags = []
 
         // WHEN
-        let result = sut.isFeatureFlagEnabled
+        let result = sut.isOnboardingHighlightsFeatureFlagEnabled
 
         // THEN
         XCTAssertFalse(result)
@@ -150,4 +152,99 @@ final class OnboardingManagerTests: XCTestCase {
         // THEN
         XCTAssertFalse(result)
     }
+
+    // MARK: - Add to Dock
+
+    func testWhenIsAddToDockLocalFlagEnabledCalledAndAppDefaultsOnboardingAddToDockEnabledIsTrueThenReturnTrue() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = true
+
+        // WHEN
+        let result = sut.isAddToDockLocalFlagEnabled
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenIsAddToDockLocalFlagEnabledCalledAndAppDefaultsOnboardingAddToDockEnabledIsFalseThenReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = false
+
+        // WHEN
+        let result = sut.isAddToDockLocalFlagEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsAddToDockFeatureFlagEnabledCalledAndFeaturFlaggerFeatureIsOnThenReturnTrue() {
+        // GIVEN
+        featureFlaggerMock.enabledFeatureFlags = [FeatureFlag.onboardingAddToDock]
+
+        // WHEN
+        let result = sut.isAddToDockFeatureFlagEnabled
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenIsAddToDockFeatureFlagEnabledCalledAndFeaturFlaggerFeatureIsOffThenReturnFalse() {
+        // GIVEN
+        featureFlaggerMock.enabledFeatureFlags = []
+
+        // WHEN
+        let result = sut.isAddToDockFeatureFlagEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsAddToDockEnabledCalledAndLocalFlagEnabledIsFalseAndFeatureFlagIsFalseThenReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = false
+        featureFlaggerMock.enabledFeatureFlags = []
+
+        // WHEN
+        let result = sut.isAddToDockEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsAddToDockEnabledCalledAndLocalFlagEnabledIsTrueAndFeatureFlagIsFalseThenReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = true
+        featureFlaggerMock.enabledFeatureFlags = []
+
+        // WHEN
+        let result = sut.isAddToDockEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsAddToDockEnabledCalledAndLocalFlagEnabledIsFalseAndFeatureFlagEnabledIsTrueThenReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = false
+        featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
+
+        // WHEN
+        let result = sut.isAddToDockEnabled
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsAddToDockEnabledAndLocalFlagEnabledIsTrueAndFeatureFlagEnabledIsTrueThenReturnTrue() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = true
+        featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
+
+        // WHEN
+        let result = sut.isAddToDockEnabled
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
 }

--- a/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -32,7 +32,7 @@ final class OnboardingManagerTests: XCTestCase {
         appSettingsMock = AppSettingsMock()
         featureFlaggerMock = MockFeatureFlagger()
         variantManagerMock = MockVariantManager()
-        sut = OnboardingManager(appDefaults: appSettingsMock, featureFlagger: featureFlaggerMock, variantManager: variantManagerMock)
+        sut = OnboardingManager(appDefaults: appSettingsMock, featureFlagger: featureFlaggerMock, variantManager: variantManagerMock, isIphone: true)
     }
 
     override func tearDownWithError() throws {
@@ -245,6 +245,19 @@ final class OnboardingManagerTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(result)
+    }
+
+    func testWhenIsAddToDockEnabledAndLocalAndFeatureFlagsAreEnabledAndDeviceIsIpadReturnFalse() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockEnabled = true
+        featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
+        sut = OnboardingManager(appDefaults: appSettingsMock, featureFlagger: featureFlaggerMock, variantManager: variantManagerMock, isIphone: false)
+
+        // WHEN
+        let result = sut.isAddToDockEnabled
+
+        // THEN
+        XCTAssertFalse(result)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1208577512136639/f

**Description**:

Add a feature flag used to show Add to Dock during the onboarding flow.
Note that the feature will be available only for iPhone

**Steps to test this PR**:

_Prerequisites:_

Add `return VariantIOS(name: "mu", weight: 1, isIncluded: When.always, features: [.newOnboardingIntro, .contextualDaxDialogs])` in `DefaultVariantManager -> selectVariant()` line 156.

**Scenario 1 — When the End of Journey Dialog is presented from NTP and Add to Dock flag is enabled then log Add to Dock**
1. Complete onboarding intro.
2. Wait for Contextual Dax dialogs to appear.
3. Login as internal user.
4. In the Debug menu -> New Onboarding -> enable Onboarding Add to Dock local setting.
5. Progress with the contextual onboarding and use the fire button till seeing end of journey dialog.
6. Ensure the Console log prints “Present Final Dialog with Add To Dock updates” (you need to enable subsystem in the metadata filter and set it to Onboarding) 

**Scenario 2 — When the End of Journey Dialog is presented from NTP and Add to Dock flag is disabled then log Add to Dock**
1. Complete onboarding intro.
2. Wait for Contextual Dax dialogs to appear.
4. In the Debug menu -> New Onboarding -> disable Onboarding Add to Dock local setting.
5. Progress with the contextual onboarding and use the fire button till seeing end of journey dialog.
6. Ensure the Console log prints “Present Final Dialog without Add To Dock updates” (you need to enable subsystem in the metadata filter and set it to Onboarding) 

**Scenario 3 — When the End of Journey Dialog is presented from in context and Add to Dock flag is enabled then log Add to Dock**
1. Complete onboarding intro.
2. Wait for Contextual Dax dialogs to appear.
3. Login as internal user.
4. In the Debug menu -> New Onboarding -> enable Onboarding Add to Dock local setting.
5. Progress with the contextual onboarding tille the fire dialog. Don’t use the fire dialog.
6. Navigate to another website and wait for the contextual end of journey dialog is presented.
6. Ensure the Console log prints “Present Contextual Final Dialog with Add To Dock updates” (you need to enable subsystem in the metadata filter and set it to Onboarding) 

**Scenario 4 — When the End of Journey Dialog is presented from  in context and Add to Dock flag is disabled then log Add to Dock**
1. Complete onboarding intro.
2. Wait for Contextual Dax dialogs to appear.
3. Login as internal user.
4. In the Debug menu -> New Onboarding -> enable Onboarding Add to Dock local setting.
5. Progress with the contextual onboarding tille the fire dialog. Don’t use the fire dialog.
6. Navigate to another website and wait for the contextual end of journey dialog is presented.
6. Ensure the Console log prints “Present Contextual Final Dialog without Add To Dock updates” (you need to enable subsystem in the metadata filter and set it to Onboarding) 

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
