### PR TITLE
Make running the script more explicit

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 mute=">/dev/null 2>&1"
+is_subsequent_release=0
 base_branch="main"
 build_number=0
 
@@ -78,24 +79,28 @@ read_command_line_arguments() {
 		print_usage_and_exit "💥 Error: Missing argument"
 	fi
 
+	shift 1
+
+	while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            -v)
+                mute=
+                ;;
+            -s|--subsequent)
+                is_subsequent_release=1
+                ;;
+            *)
+                print_usage_and_exit "💥 Error: Unknown option '$1'"
+                ;;
+        esac
+        shift
+    done
+
 	if [[ $input =~ $version_regexp ]]; then
 		process_release "$input"
 	else
 		process_hotfix "$input"
 	fi
-
-	shift 1
-
-	while getopts 'v' option; do
-		case "${option}" in
-			v)
-				mute=
-				;;
-			*)
-				print_usage_and_exit "💥 Error: Unknown option '${option}'"
-				;;
-		esac
-	done
 }
 
 process_release() { # expected input e.g. "1.72.0"
@@ -104,9 +109,17 @@ process_release() { # expected input e.g. "1.72.0"
 
 	echo "Processing version number: $version"
 
-	if release_branch_exists; then
-		is_subsequent_release=1
+	if [[ "$is_subsequent_release" -eq 1 ]]; then
+		# check if the release branch exists (it must exist for a subsequent release)
+		if ! release_branch_exists; then
+			die "💥 Error: Release branch does not exist for a subsequent release!"
+		fi
 		base_branch="$release_branch"
+	else
+		# check if the release branch does NOT exist (it must NOT exist for an initial release)
+		if release_branch_exists; then
+			die "💥 Error: Release branch already exists for an initial release!"
+		fi
 	fi
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1207921724970682/f
Tech Design URL:
CC: @THISISDINOSAUR 

**Description**:
Make running the script more explicit, by providing additional argument if it is subsequent release. It will then fail on initial release if the release branch exists and fail on subsequent release if release branch does not.

**Steps to test this PR**:
1. Run the script for the current release ./prepare_release 7.142.0 - it should exit early because release/7.142.0 branch exists.
2. Run the script for some imaginary release ./prepare_release 7.234.0 --subsequent - it should exit early because release/7.234.0 does not exist.
3. Run the script for the current release ./prepare_release 7.142.0 --subsequent, make sure the branch with bumped build number has been created. Remove that branch after you're done with testing.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
