### PR TITLE
Add pixel when the error page is shown

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -827,6 +827,9 @@ extension Pixel {
         case duckplayerExperimentDailySearch
         case duckplayerExperimentWeeklySearch
         case duckplayerExperimentYoutubePageView
+
+        // MARK: WebView Error Page Shown
+        case webViewErrorPageShown
     }
 
 }
@@ -1649,6 +1652,8 @@ extension Pixel.Event {
         case .duckplayerExperimentWeeklySearch: return "duckplayer_experiment_weekly_search_v2"
         case .duckplayerExperimentYoutubePageView: return "duckplayer_experiment_youtube_page_view_v2"
             
+        // MARK: - WebView Error Page shown
+        case .webViewErrorPageShown: return "m_errorpageshown"
         }
     }
 }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -2063,6 +2063,7 @@ extension TabViewController: WKNavigationDelegate {
         if !(error.failedUrl?.isCustomURLScheme() ?? false) {
             url = error.failedUrl
             showError(message: error.localizedDescription)
+            Pixel.fire(pixel: .webViewErrorPageShown)
         }
 
         webpageDidFailToLoad()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1176956903599313/1208602127384124/f

**Description**:

Fire a pixel when we show the error page in the WebView. 

**Steps to test this PR**:
1. Run the app and navigate to `http://invalid.url`
2. Ensure that the console log prints `Pixel fired m.errorpageshown`

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
