### PR TITLE
adding impression pixels for duckplayer in landscape mode

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -788,6 +788,7 @@ extension Pixel {
         case duckPlayerViewFromSERP
         case duckPlayerViewFromOther
         case duckPlayerOverlayYoutubeImpressions
+        case duckPlayerLandscapeLayoutImpressions
         case duckPlayerOverlayYoutubeWatchHere
         case duckPlayerSettingAlwaysDuckPlayer
         case duckPlayerSettingAlwaysSettings
@@ -1654,6 +1655,9 @@ extension Pixel.Event {
             
         // MARK: - WebView Error Page shown
         case .webViewErrorPageShown: return "m_errorpageshown"
+
+        // MARK: - DuckPlayer FE Application Telemetry
+        case .duckPlayerLandscapeLayoutImpressions: return "duckplayer_landscape_layout_impressions"
         }
     }
 }

--- a/DuckDuckGo/DuckPlayer/YoutubePlayerUserScript.swift
+++ b/DuckDuckGo/DuckPlayer/YoutubePlayerUserScript.swift
@@ -37,6 +37,7 @@ final class YoutubePlayerUserScript: NSObject, Subfeature {
         static let initialSetup = "initialSetup"
         static let openSettings = "openSettings"
         static let openInfo = "openInfo"
+        static let telemetryEvent = "telemetryEvent"
     }
     
     init(duckPlayer: DuckPlayerProtocol) {
@@ -79,6 +80,8 @@ final class YoutubePlayerUserScript: NSObject, Subfeature {
             return duckPlayer.openDuckPlayerSettings
         case Handlers.openInfo:
             return duckPlayer.openDuckPlayerInfo
+        case Handlers.telemetryEvent:
+            return duckPlayer.telemetryEvent
         default:
             assertionFailure("YoutubePlayerUserScript: Failed to parse User Script message: \(methodName)")
             return nil

--- a/DuckDuckGoTests/DuckPlayerMocks.swift
+++ b/DuckDuckGoTests/DuckPlayerMocks.swift
@@ -118,6 +118,11 @@ final class MockDuckPlayerSettings: DuckPlayerSettings {
 
 final class MockDuckPlayer: DuckPlayerProtocol {
     
+    func telemetryEvent(params: Any, message: WKScriptMessage) async -> (any Encodable)? {
+        nil
+    }
+    
+    
     var hostView: UIViewController?
     
     func openDuckPlayerSettings(params: Any, message: WKScriptMessage) async -> (any Encodable)? {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201141132935289/1208637202774549/f
Tech Design URL:
CC:

**Description**:

the DuckPlayer frontend will start sending a generic 'telemetry' events soon - this PR adds support for the first one, but in a format that can be expanded later without needing new handlers.

> [!NOTE]
> Please see https://deploy-preview-1164--content-scope-scripts.netlify.app/interfaces/duckplayer_messages.telemetryevent - there's only 1 event right now, but under `attributes` it gives us scope to expand if needed.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Link BSK to CSS branch `pr-releases/pr-1164`
2. Load DuckPlayer, rotate to landscape
3. Observe 1 pixel is sent per page load (not multiple)

Note: This change is backwards compatible with the existing application

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
