### PR TITLE
Temporary disable use of subscription cookie to share subscription access token

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -88,7 +88,8 @@ import os.log
     private var autofillUsageMonitor = AutofillUsageMonitor()
 
     private(set) var subscriptionFeatureAvailability: SubscriptionFeatureAvailability!
-    private var subscriptionCookieManager: SubscriptionCookieManaging!
+    // Temporary disable, see: https://app.asana.com/0/0/1208249142369975/1208659372053914/f
+//    private var subscriptionCookieManager: SubscriptionCookieManaging!
     var privacyProDataReporter: PrivacyProDataReporting!
 
     // MARK: - Feature specific app event handlers
@@ -314,16 +315,17 @@ import os.log
             privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
             purchasePlatform: .appStore)
         
-        subscriptionCookieManager = SubscriptionCookieManager(subscriptionManager: AppDependencyProvider.shared.subscriptionManager,
-                                                              currentCookieStore: { [weak self] in
-            guard self?.mainViewController?.tabManager.model.hasActiveTabs ?? false else {
-                // We shouldn't interact with WebKit's cookie store unless we have a WebView,
-                // eventually the subscription cookie will be refreshed on opening the first tab
-                return nil
-            }
-            
-            return WKWebsiteDataStore.current().httpCookieStore
-        }, eventMapping: SubscriptionCookieManageEventPixelMapping())
+        // Temporary disable, see: https://app.asana.com/0/0/1208249142369975/1208659372053914/f
+//        subscriptionCookieManager = SubscriptionCookieManager(subscriptionManager: AppDependencyProvider.shared.subscriptionManager,
+//                                                              currentCookieStore: { [weak self] in
+//            guard self?.mainViewController?.tabManager.model.hasActiveTabs ?? false else {
+//                // We shouldn't interact with WebKit's cookie store unless we have a WebView,
+//                // eventually the subscription cookie will be refreshed on opening the first tab
+//                return nil
+//            }
+//            
+//            return WKWebsiteDataStore.current().httpCookieStore
+//        }, eventMapping: SubscriptionCookieManageEventPixelMapping())
 
         homePageConfiguration = HomePageConfiguration(variantManager: AppDependencyProvider.shared.variantManager,
                                                       remoteMessagingClient: remoteMessagingClient,
@@ -362,8 +364,7 @@ import os.log
                                           contextualOnboardingLogic: daxDialogs,
                                           contextualOnboardingPixelReporter: onboardingPixelReporter,
                                           subscriptionFeatureAvailability: subscriptionFeatureAvailability,
-                                          voiceSearchHelper: voiceSearchHelper,
-                                          subscriptionCookieManager: subscriptionCookieManager)
+                                          voiceSearchHelper: voiceSearchHelper)
 
             main.loadViewIfNeeded()
             syncErrorHandler.alertPresenter = main
@@ -587,9 +588,10 @@ import os.log
             }
         }
 
-        Task { @MainActor in
-            await subscriptionCookieManager.refreshSubscriptionCookie()
-        }
+        // Temporary disable, see: https://app.asana.com/0/0/1208249142369975/1208659372053914/f
+//        Task { @MainActor in
+//            await subscriptionCookieManager.refreshSubscriptionCookie()
+//        }
 
         let importPasswordsStatusHandler = ImportPasswordsStatusHandler(syncService: syncService)
         importPasswordsStatusHandler.checkSyncSuccessStatus()

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -123,7 +123,6 @@ class MainViewController: UIViewController {
     private var feedbackCancellable: AnyCancellable?
 
     let subscriptionFeatureAvailability: SubscriptionFeatureAvailability
-    private let subscriptionCookieManager: SubscriptionCookieManaging
     let privacyProDataReporter: PrivacyProDataReporting
 
     private lazy var featureFlagger = AppDependencyProvider.shared.featureFlagger
@@ -196,8 +195,7 @@ class MainViewController: UIViewController {
         tutorialSettings: TutorialSettings = DefaultTutorialSettings(),
         statisticsStore: StatisticsStore = StatisticsUserDefaults(),
         subscriptionFeatureAvailability: SubscriptionFeatureAvailability,
-        voiceSearchHelper: VoiceSearchHelperProtocol,
-        subscriptionCookieManager: SubscriptionCookieManaging
+        voiceSearchHelper: VoiceSearchHelperProtocol
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner
@@ -219,8 +217,7 @@ class MainViewController: UIViewController {
                                      privacyProDataReporter: privacyProDataReporter,
                                      contextualOnboardingPresenter: contextualOnboardingPresenter,
                                      contextualOnboardingLogic: contextualOnboardingLogic,
-                                     onboardingPixelReporter: contextualOnboardingPixelReporter,
-                                     subscriptionCookieManager: subscriptionCookieManager)
+                                     onboardingPixelReporter: contextualOnboardingPixelReporter)
         self.syncPausedStateManager = syncPausedStateManager
         self.privacyProDataReporter = privacyProDataReporter
         self.homeTabManager = NewTabPageManager()
@@ -231,7 +228,6 @@ class MainViewController: UIViewController {
         self.statisticsStore = statisticsStore
         self.subscriptionFeatureAvailability = subscriptionFeatureAvailability
         self.voiceSearchHelper = voiceSearchHelper
-        self.subscriptionCookieManager = subscriptionCookieManager
 
         super.init(nibName: nil, bundle: nil)
         

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -42,7 +42,6 @@ class TabManager {
     private let contextualOnboardingPresenter: ContextualOnboardingPresenting
     private let contextualOnboardingLogic: ContextualOnboardingLogic
     private let onboardingPixelReporter: OnboardingPixelReporting
-    private let subscriptionCookieManager: SubscriptionCookieManaging
 
     weak var delegate: TabDelegate?
 
@@ -59,8 +58,7 @@ class TabManager {
          privacyProDataReporter: PrivacyProDataReporting,
          contextualOnboardingPresenter: ContextualOnboardingPresenting,
          contextualOnboardingLogic: ContextualOnboardingLogic,
-         onboardingPixelReporter: OnboardingPixelReporting,
-         subscriptionCookieManager: SubscriptionCookieManaging) {
+         onboardingPixelReporter: OnboardingPixelReporting) {
         self.model = model
         self.previewsSource = previewsSource
         self.bookmarksDatabase = bookmarksDatabase
@@ -71,7 +69,6 @@ class TabManager {
         self.contextualOnboardingPresenter = contextualOnboardingPresenter
         self.contextualOnboardingLogic = contextualOnboardingLogic
         self.onboardingPixelReporter = onboardingPixelReporter
-        self.subscriptionCookieManager = subscriptionCookieManager
         registerForNotifications()
     }
 
@@ -93,8 +90,7 @@ class TabManager {
                                                               contextualOnboardingPresenter: contextualOnboardingPresenter,
                                                               contextualOnboardingLogic: contextualOnboardingLogic,
                                                               onboardingPixelReporter: onboardingPixelReporter,
-                                                              featureFlagger: AppDependencyProvider.shared.featureFlagger,
-                                                              subscriptionCookieManager: subscriptionCookieManager)
+                                                              featureFlagger: AppDependencyProvider.shared.featureFlagger)
         controller.applyInheritedAttribution(inheritedAttribution)
         controller.attachWebView(configuration: configuration,
                                  andLoadRequest: url == nil ? nil : URLRequest.userInitiated(url!),
@@ -172,8 +168,7 @@ class TabManager {
                                                               contextualOnboardingPresenter: contextualOnboardingPresenter,
                                                               contextualOnboardingLogic: contextualOnboardingLogic,
                                                               onboardingPixelReporter: onboardingPixelReporter,
-                                                              featureFlagger: AppDependencyProvider.shared.featureFlagger,
-                                                              subscriptionCookieManager: subscriptionCookieManager)
+                                                              featureFlagger: AppDependencyProvider.shared.featureFlagger)
         controller.attachWebView(configuration: configCopy,
                                  andLoadRequest: request,
                                  consumeCookies: !model.hasActiveTabs,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -93,7 +93,6 @@ class TabViewController: UIViewController {
     let appSettings: AppSettings
 
     var featureFlagger: FeatureFlagger
-    let subscriptionCookieManager: SubscriptionCookieManaging
     private lazy var internalUserDecider = AppDependencyProvider.shared.internalUserDecider
 
     private lazy var autofillNeverPromptWebsitesManager = AppDependencyProvider.shared.autofillNeverPromptWebsitesManager
@@ -323,8 +322,7 @@ class TabViewController: UIViewController {
                                    contextualOnboardingLogic: ContextualOnboardingLogic,
                                    onboardingPixelReporter: OnboardingCustomInteractionPixelReporting,
                                    urlCredentialCreator: URLCredentialCreating = URLCredentialCreator(),
-                                   featureFlagger: FeatureFlagger,
-                                   subscriptionCookieManager: SubscriptionCookieManaging) -> TabViewController {
+                                   featureFlagger: FeatureFlagger) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
             TabViewController(coder: coder,
@@ -339,8 +337,7 @@ class TabViewController: UIViewController {
                               contextualOnboardingLogic: contextualOnboardingLogic,
                               onboardingPixelReporter: onboardingPixelReporter,
                               urlCredentialCreator: urlCredentialCreator,
-                              featureFlagger: featureFlagger,
-                              subscriptionCookieManager: subscriptionCookieManager
+                              featureFlagger: featureFlagger
             )
         })
         return controller
@@ -373,8 +370,7 @@ class TabViewController: UIViewController {
                    contextualOnboardingLogic: ContextualOnboardingLogic,
                    onboardingPixelReporter: OnboardingCustomInteractionPixelReporting,
                    urlCredentialCreator: URLCredentialCreating = URLCredentialCreator(),
-                   featureFlagger: FeatureFlagger,
-                   subscriptionCookieManager: SubscriptionCookieManaging) {
+                   featureFlagger: FeatureFlagger) {
         self.tabModel = tabModel
         self.appSettings = appSettings
         self.bookmarksDatabase = bookmarksDatabase
@@ -393,7 +389,6 @@ class TabViewController: UIViewController {
         self.onboardingPixelReporter = onboardingPixelReporter
         self.urlCredentialCreator = urlCredentialCreator
         self.featureFlagger = featureFlagger
-        self.subscriptionCookieManager = subscriptionCookieManager
         super.init(coder: aDecoder)
     }
 
@@ -642,8 +637,9 @@ class TabViewController: UIViewController {
             await webView.configuration.websiteDataStore.dataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes())
             let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
             await WebCacheManager.shared.consumeCookies(httpCookieStore: cookieStore)
-            subscriptionCookieManager.resetLastRefreshDate()
-            await subscriptionCookieManager.refreshSubscriptionCookie()
+            // Temporary disable, see: https://app.asana.com/0/0/1208249142369975/1208659372053914/f
+//            subscriptionCookieManager.resetLastRefreshDate()
+//            await subscriptionCookieManager.refreshSubscriptionCookie()
             doLoad()
         }
     }

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -111,8 +111,7 @@ extension TabViewController {
                                                                  contextualOnboardingPresenter: contextualOnboardingPresenter,
                                                                  contextualOnboardingLogic: contextualOnboardingLogic,
                                                                  onboardingPixelReporter: onboardingPixelReporter,
-                                                                 featureFlagger: AppDependencyProvider.shared.featureFlagger,
-                                                                 subscriptionCookieManager: subscriptionCookieManager)
+                                                                 featureFlagger: AppDependencyProvider.shared.featureFlagger)
         tabController.isLinkPreview = true
         let configuration = WKWebViewConfiguration.nonPersistent()
         tabController.attachWebView(configuration: configuration, andLoadRequest: URLRequest.userInitiated(url), consumeCookies: false)

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -136,8 +136,7 @@ extension TabViewController {
             contextualOnboardingLogic: contextualOnboardingLogic,
             onboardingPixelReporter: contextualOnboardingPixelReporter,
             urlCredentialCreator: MockCredentialCreator(),
-            featureFlagger: featureFlagger,
-            subscriptionCookieManager: SubscriptionCookieManagerMock()
+            featureFlagger: featureFlagger
         )
         tab.attachWebView(configuration: .nonPersistent(), andLoadRequest: nil, consumeCookies: false, customWebView: customWebView)
         return tab

--- a/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
+++ b/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
@@ -79,8 +79,7 @@ final class OnboardingDaxFavouritesTests: XCTestCase {
             contextualOnboardingPixelReporter: OnboardingPixelReporterMock(),
             tutorialSettings: tutorialSettingsMock,
             subscriptionFeatureAvailability: SubscriptionFeatureAvailabilityMock.enabled,
-            voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true),
-            subscriptionCookieManager: SubscriptionCookieManagerMock()
+            voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true)
         )
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -77,8 +77,7 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             contextualOnboardingLogic: ContextualOnboardingLogicMock(),
             contextualOnboardingPixelReporter: onboardingPixelReporter,
             subscriptionFeatureAvailability: SubscriptionFeatureAvailabilityMock.enabled,
-            voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true),
-            subscriptionCookieManager: SubscriptionCookieManagerMock())
+            voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true))
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414235014887631/1208264562025859/f

**Description**:
Based on https://app.asana.com/0/0/1208249142369975/1208659372053914/f we decided to temporary disable the mechanism waiting for a refined approach.

**Steps to test this PR**:
Ensure that `SubscriptionCookieManager` is not instantiated anywhere. 

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
