### PR TITLE
Update to subscription cookie

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -710,8 +710,8 @@ extension Pixel {
         case privacyProKeychainAccessError
         case privacyProSubscriptionCookieMissingTokenOnSignIn
         case privacyProSubscriptionCookieMissingCookieOnSignOut
-        case privacyProSubscriptionCookieRefreshedWithUpdate
-        case privacyProSubscriptionCookieRefreshedWithDelete
+        case privacyProSubscriptionCookieRefreshedWithAccessToken
+        case privacyProSubscriptionCookieRefreshedWithEmptyValue
         case privacyProSubscriptionCookieFailedToSetSubscriptionCookie
 
         // MARK: Pixel Experiment
@@ -1527,8 +1527,8 @@ extension Pixel.Event {
         case .privacyProKeychainAccessError: return "m_privacy-pro_keychain_access_error"
         case .privacyProSubscriptionCookieMissingTokenOnSignIn: return "m_privacy-pro_subscription-cookie-missing_token_on_sign_in"
         case .privacyProSubscriptionCookieMissingCookieOnSignOut: return "m_privacy-pro_subscription-cookie-missing_cookie_on_sign_out"
-        case .privacyProSubscriptionCookieRefreshedWithUpdate: return "m_privacy-pro_subscription-cookie-refreshed_with_update"
-        case .privacyProSubscriptionCookieRefreshedWithDelete: return "m_privacy-pro_subscription-cookie-refreshed_with_delete"
+        case .privacyProSubscriptionCookieRefreshedWithAccessToken: return "m_privacy-pro_subscription-cookie-refreshed_with_access_token"
+        case .privacyProSubscriptionCookieRefreshedWithEmptyValue: return "m_privacy-pro_subscription-cookie-refreshed_with_empty_value"
         case .privacyProSubscriptionCookieFailedToSetSubscriptionCookie: return "m_privacy-pro_subscription-cookie-failed_to_set_subscription_cookie"
 
         // MARK: Pixel Experiment

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11009,8 +11009,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "michal/update-subs-cookie";
-				kind = branch;
+				kind = exactVersion;
+				version = "201.0.0-1";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11009,8 +11009,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 201.0.0;
+				branch = "michal/update-subs-cookie";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "michal/update-subs-cookie",
-        "revision" : "9506581ae99273681073f9993fc6d881d3edaa7f"
+        "revision" : "9506581ae99273681073f9993fc6d881d3edaa7f",
+        "version" : "201.0.0-1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "e5946eee6af859690cc1cc5e51daef3c8368981b",
-        "version" : "201.0.0"
+        "branch" : "michal/update-subs-cookie",
+        "revision" : "9506581ae99273681073f9993fc6d881d3edaa7f"
       }
     },
     {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -124,7 +124,7 @@ import os.log
         }
     }
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
 #if targetEnvironment(simulator)

--- a/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
+++ b/DuckDuckGo/Subscription/SubscriptionCookieManageEventPixelMapping.swift
@@ -30,12 +30,10 @@ public final class SubscriptionCookieManageEventPixelMapping: EventMapping<Subsc
                 switch event {
                 case .errorHandlingAccountDidSignInTokenIsMissing:
                     return .privacyProSubscriptionCookieMissingTokenOnSignIn
-                case .errorHandlingAccountDidSignOutCookieIsMissing:
-                    return .privacyProSubscriptionCookieMissingCookieOnSignOut
-                case .subscriptionCookieRefreshedWithUpdate:
-                    return .privacyProSubscriptionCookieRefreshedWithUpdate
-                case .subscriptionCookieRefreshedWithDelete:
-                    return .privacyProSubscriptionCookieRefreshedWithDelete
+                case .subscriptionCookieRefreshedWithAccessToken:
+                    return .privacyProSubscriptionCookieRefreshedWithAccessToken
+                case .subscriptionCookieRefreshedWithEmptyValue:
+                    return .privacyProSubscriptionCookieRefreshedWithEmptyValue
                 case .failedToSetSubscriptionCookie:
                     return .privacyProSubscriptionCookieFailedToSetSubscriptionCookie
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1108686900785972/1208264562025859/f

**Description**:
Initial PR -> https://github.com/duckduckgo/iOS/pull/3488
Update to how the subscription cookie operates:
- constraint the cookie to `subscriptions.duckduckgo.com`
- on sign out do not fully remove the cookie - just clear the value
- gate the feature behind the `setAccessTokenCookieForSubscriptionDomains` privacy config feature flag 

**Steps to test this PR**:
To inspect website cookies use "Cookies" in the debug menu. Please mind that cookies may appear empty with no WebView being instantiated (no tabs), ensure there is at least tab with webpage open (unless required not to).
To test purchase use the real device and test the Alpha target.

1. Verify that feature flag gates the operation ([JSON BLOB](https://jsonblob.com/api/jsonBlob/1301685977817669632) and its [editor](https://jsonblob.com/1301685977817669632))
2. Ensure that cookie is set properly for the new domain
3. Test that when feature flag is enabled after the purchase the token is set in the cookie
4.Test that when feature flag is enabled after signing out of the subscription the cookie is updated with empty value 
5. Test that when feature flag is turned to disabled the cookie independent of its value is cleared

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
