### PR TITLE
Add a debouncer to NavBars animator

### DIFF
--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -384,8 +384,8 @@ class OmniBar: UIView {
             searchStackContainer.setCustomSpacing(13, after: voiceSearchButton)
         }
 
-        UIView.animate(withDuration: 0.0) {
-            self.layoutIfNeeded()
+        UIView.animate(withDuration: 0.0) { [weak self] in
+            self?.layoutIfNeeded()
         }
         
     }

--- a/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -51,10 +51,15 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = 300
         sut.didScroll(in: scrollView)
-        XCTAssertEqual(sut.barsState, .hidden)
+        
+        let expectation = XCTestExpectation(description: "Wait for bars state to update to hidden")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(sut.barsState, .hidden)
+            XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0), .setBarsVisibility(0.0)])
+            expectation.fulfill()
+        }
 
-        XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0),
-                                                   .setBarsVisibility(0.0)])
+        wait(for: [expectation], timeout: 0.2)
     }
 
     func testBarStateHiddenWhenScrollDownKeepsHiddenState() {
@@ -71,14 +76,28 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = 300
         sut.didScroll(in: scrollView)
-        XCTAssertEqual(sut.barsState, .hidden)
+
+        // Add delay before checking hidden state
+        let expectation1 = XCTestExpectation(description: "Wait for bars state to update to hidden")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(sut.barsState, .hidden)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 0.2)
 
         scrollView.contentOffset.y = 100
         sut.didScroll(in: scrollView)
-        XCTAssertEqual(sut.barsState, .hidden)
 
-        XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0),
-                                                   .setBarsVisibility(0.0)])
+        // Add another delay before checking that barsState remains hidden
+        let expectation2 = XCTestExpectation(description: "Wait to confirm bars state remains hidden")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(sut.barsState, .hidden)
+            XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0), .setBarsVisibility(0.0)])
+            expectation2.fulfill()
+        }
+
+        wait(for: [expectation2], timeout: 0.2)
     }
 
     func testBarStateHiddenWhenScrollUpUpdatesToRevealedState() {
@@ -95,7 +114,15 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = 400
         sut.didScroll(in: scrollView)
-        XCTAssertEqual(sut.barsState, .hidden)
+
+        // Add delay before checking hidden state
+        let expectation1 = XCTestExpectation(description: "Wait for bars state to update to hidden")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(sut.barsState, .hidden)
+            expectation1.fulfill()
+        }
+
+        wait(for: [expectation1], timeout: 0.2)
 
         scrollView.contentOffset.y = -100
         sut.didStartScrolling(in: scrollView)
@@ -104,13 +131,21 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = -150
         sut.didScroll(in: scrollView)
-        XCTAssertEqual(sut.barsState, .revealed)
 
-        XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0),
-                                                   .setBarsVisibility(0.0),
-                                                   .setBarsVisibility(1.0),
-                                                   .setBarsVisibility(1.0)])
+        // Add another delay before checking revealed state
+        let expectation2 = XCTestExpectation(description: "Wait for bars state to update to revealed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(sut.barsState, .revealed)
+            XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0),
+                                                       .setBarsVisibility(0.0),
+                                                       .setBarsVisibility(1.0),
+                                                       .setBarsVisibility(1.0)])
+            expectation2.fulfill()
+        }
+
+        wait(for: [expectation2], timeout: 0.2)
     }
+
 
     func testBarStateRevealedWhenScrollUpDoNotChangeCurrentState() {
         let (sut, delegate) = makeSUT()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208671955053442/f
Tech Design URL:
CC:

**Description**:
Fixes a crash related to PDFs and scroll position

This is caused by our navigation bar's hiding animation/visibility triggering a `didScrollEvent`, which causes the app to enter an infinite loop and eventually crash.

The issue does not appear when the navigation bar is at the bottom.  

This adds a debouncer to the method to break the loop while we investigate futher


<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

- Use iOS 18, (preferably on a device) 
- Set the navigation bar to 'top'
- Navigate to https://randomtests.netlify.app/sample3.pdf
- Scroll up and down, zoom, rotate device
- App should not hang or crash

