### PR TITLE
add daily pixel for deleting suggestions

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -137,6 +137,7 @@ extension Pixel {
         case autocompleteDisplayedLocalHistory
         case autocompleteDisplayedOpenedTab
         case autocompleteSwipeToDelete
+        case autocompleteSwipeToDeleteDaily
 
         case feedbackPositive
         case feedbackNegativePrefix(category: String)
@@ -962,6 +963,7 @@ extension Pixel.Event {
         case .autocompleteDisplayedLocalHistory: return "m_autocomplete_display_local_history"
         case .autocompleteDisplayedOpenedTab: return "m_autocomplete_display_switch_to_tab"
         case .autocompleteSwipeToDelete: return "m_autocomplete_result_deleted"
+        case .autocompleteSwipeToDeleteDaily: return "m_autocomplete_result_deleted_daily"
 
         case .feedbackPositive: return "mfbs_positive_submit"
         case .feedbackNegativePrefix(category: let category): return "mfbs_negative_\(category)"

--- a/DuckDuckGo/AutocompleteViewController.swift
+++ b/DuckDuckGo/AutocompleteViewController.swift
@@ -274,6 +274,7 @@ extension AutocompleteViewController: AutocompleteViewModelDelegate {
             Task {
                 await historyManager.deleteHistoryForURL(url)
                 Pixel.fire(pixel: .autocompleteSwipeToDelete)
+                DailyPixel.fireDaily(.autocompleteSwipeToDeleteDaily)
                 requestSuggestions(query: self.query)
             }
         default:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208397572815368/f
Tech Design URL:
CC:

**Description**:
adds daily pixel for deleting suggestions 

**Steps to test this PR**:
1. Run the app and delete a suggestion.  Observe daily pixel.
2. Delete another suggestion.  No daily pixel is fired.
