### PR TITLE
Remove NewTabPage retain cycles

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -128,6 +128,7 @@ class MainViewController: UIViewController {
 
     private lazy var featureFlagger = AppDependencyProvider.shared.featureFlagger
     private lazy var faviconLoader: FavoritesFaviconLoading = FavoritesFaviconLoader()
+    private lazy var faviconsFetcherOnboarding = FaviconsFetcherOnboarding(syncService: syncService, syncBookmarksAdapter: syncDataProviders.bookmarksAdapter)
 
     lazy var menuBookmarksViewModel: MenuBookmarksInteracting = {
         let viewModel = MenuBookmarksViewModel(bookmarksDatabase: bookmarksDatabase, syncService: syncService)
@@ -795,8 +796,6 @@ class MainViewController: UIViewController {
         let controller = NewTabPageViewController(tab: tabModel,
                                                   isNewTabPageCustomizationEnabled: homeTabManager.isNewTabPageSectionsEnabled,
                                                   interactionModel: favoritesViewModel,
-                                                  syncService: syncService,
-                                                  syncBookmarksAdapter: syncDataProviders.bookmarksAdapter,
                                                   homePageMessagesConfiguration: homePageConfiguration,
                                                   privacyProDataReporting: privacyProDataReporter,
                                                   variantManager: variantManager,
@@ -2171,6 +2170,10 @@ extension MainViewController: NewTabPageControllerDelegate {
 
     func newTabPageDidDeleteFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {
         // no-op for now
+    }
+
+    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: NewTabPageViewController) {
+        faviconsFetcherOnboarding.presentOnboardingIfNeeded(from: self)
     }
 }
 

--- a/DuckDuckGo/NewTabPageControllerDelegate.swift
+++ b/DuckDuckGo/NewTabPageControllerDelegate.swift
@@ -24,6 +24,7 @@ protocol NewTabPageControllerDelegate: AnyObject {
     func newTabPageDidOpenFavoriteURL(_ controller: NewTabPageViewController, url: URL)
     func newTabPageDidDeleteFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity)
     func newTabPageDidEditFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity)
+    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: NewTabPageViewController)
 }
 
 protocol NewTabPageControllerShortcutsDelegate: AnyObject {

--- a/DuckDuckGo/NewTabPageSettingsModel.swift
+++ b/DuckDuckGo/NewTabPageSettingsModel.swift
@@ -81,15 +81,15 @@ final class NewTabPageSettingsModel<SettingItem: NewTabPageSettingsStorageItem, 
     private func populateSettings() {
         let allItemsOrder = settingsStorage.itemsOrder
         filteredItemsOrder = allItemsOrder.filter(visibilityFilter)
-
+        
         itemsSettings = filteredItemsOrder.compactMap { item in
             return NTPSetting(item: item,
-                       isEnabled: Binding(get: {
-                self.settingsStorage.isEnabled(item)
-            }, set: { newValue in
-                self.onItemEnabled?(item, newValue)
-                self.settingsStorage.setItem(item, enabled: newValue)
-                self.updatePublishedValues()
+                              isEnabled: Binding(get: { [weak self] in
+                self?.settingsStorage.isEnabled(item) ?? false
+            }, set: { [weak self] newValue in
+                self?.onItemEnabled?(item, newValue)
+                self?.settingsStorage.setItem(item, enabled: newValue)
+                self?.updatePublishedValues()
             }))
         }
 

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -25,13 +25,9 @@ import Core
 
 final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
 
-    private let syncService: DDGSyncing
-    private let syncBookmarksAdapter: SyncBookmarksAdapter
     private let variantManager: VariantManager
     private let newTabDialogFactory: any NewTabDaxDialogProvider
     private let newTabDialogTypeProvider: NewTabDialogSpecProvider
-
-    private(set) lazy var faviconsFetcherOnboarding = FaviconsFetcherOnboarding(syncService: syncService, syncBookmarksAdapter: syncBookmarksAdapter)
 
     private let newTabPageViewModel: NewTabPageViewModel
     private let messagesModel: NewTabPageMessagesModel
@@ -53,8 +49,6 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
     init(tab: Tab,
          isNewTabPageCustomizationEnabled: Bool,
          interactionModel: FavoritesListInteracting,
-         syncService: DDGSyncing,
-         syncBookmarksAdapter: SyncBookmarksAdapter,
          homePageMessagesConfiguration: HomePageMessagesConfiguration,
          privacyProDataReporting: PrivacyProDataReporting? = nil,
          variantManager: VariantManager,
@@ -63,8 +57,6 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
          faviconLoader: FavoritesFaviconLoading) {
 
         self.associatedTab = tab
-        self.syncService = syncService
-        self.syncBookmarksAdapter = syncBookmarksAdapter
         self.variantManager = variantManager
         self.newTabDialogFactory = newTabDialogFactory
         self.newTabDialogTypeProvider = newTabDialogTypeProvider
@@ -145,7 +137,8 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
     private func assignFavoriteModelActions() {
         favoritesModel.onFaviconMissing = { [weak self] in
             guard let self else { return }
-            self.faviconsFetcherOnboarding.presentOnboardingIfNeeded(from: self)
+
+            delegate?.newTabPageDidRequestFaviconsFetcherOnboarding(self)
         }
 
         favoritesModel.onFavoriteURLSelected = { [weak self] url in

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -215,7 +215,10 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
     }
 
     func dismiss() {
-
+        delegate = nil
+        chromeDelegate = nil
+        removeFromParent()
+        view.removeFromSuperview()
     }
 
     func showNextDaxDialog() {

--- a/DuckDuckGoTests/NewTabPageControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/NewTabPageControllerDaxDialogTests.swift
@@ -38,14 +38,7 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         variantManager = CapturingVariantManager()
         dialogFactory = CapturingNewTabDaxDialogProvider()
         specProvider = MockNewTabDialogSpecProvider()
-        let dataProviders = SyncDataProviders(
-            bookmarksDatabase: db,
-            secureVaultFactory: AutofillSecureVaultFactory,
-            secureVaultErrorReporter: SecureVaultReporter(),
-            settingHandlers: [],
-            favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
-            syncErrorHandler: SyncErrorHandler()
-        )
+
         let remoteMessagingClient = RemoteMessagingClient(
             bookmarksDatabase: db,
             appSettings: AppSettingsMock(),
@@ -60,8 +53,6 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             tab: Tab(),
             isNewTabPageCustomizationEnabled: false,
             interactionModel: MockFavoritesListInteracting(),
-            syncService: MockDDGSyncing(authState: .active, isSyncInProgress: false),
-            syncBookmarksAdapter: dataProviders.bookmarksAdapter,
             homePageMessagesConfiguration: homePageConfiguration,
             variantManager: variantManager,
             newTabDialogFactory: dialogFactory,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206226850447395/1208686031091434/f
Tech Design URL:
CC:

**Description**:

Leak 1:
`NewTabPageViewController` was not dismissed properly, this caused it to stay in memory as a child view controller of `MainViewController`.
In effect it was possible to dismiss FaviconFetcherTutorial. Removing the leak required to do additional changes to make it work. I moved it to `MainViewController`, so that it's not dependent on NewTabPage.

Leak 2:
`NewTabPageSettingsModel` was leaking via strong reference present in `NTPSettingItem`.

**Steps to test this PR**:
1. Set up Sync.
2. Add favorite.
3. On another synced device open New Tab Page
4. Favicon Tutorial should appear, see if buttons work, dismissing the tutorial
5. Open and close New Tab Page a few times.
6. Open Memory Graph Debugger, verify only single instance is present for `NewTabPageViewController` and `NewTabPageSettingsModel*` objects.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
