### PR TITLE
Onboarding Add to Dock Refactor for Intro scenario

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -171,7 +171,6 @@ public struct UserDefaultsWrapper<T> {
         // Debug keys
         case debugNewTabPageSectionsEnabledKey = "com.duckduckgo.ios.debug.newTabPageSectionsEnabled"
         case debugOnboardingHighlightsEnabledKey = "com.duckduckgo.ios.debug.onboardingHighlightsEnabled"
-        case debugOnboardingAddToDockEnabledKey = "com.duckduckgo.ios.debug.onboardingAddToDockEnabled"
 
         // Duck Player Pixel Experiment
         case duckPlayerPixelExperimentInstalled = "com.duckduckgo.ios.duckplayer.pixel.experiment.installed.v2"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -710,6 +710,7 @@
 		9F23B8032C2BCD0000950875 /* DaxDialogStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8022C2BCD0000950875 /* DaxDialogStyles.swift */; };
 		9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */; };
 		9F23B8092C2BE9B700950875 /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8082C2BE9B700950875 /* MockURLOpener.swift */; };
+		9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */; };
 		9F4CC5152C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */; };
 		9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */; };
 		9F4CC51B2C48C0C7006A96EB /* MockTabDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51A2C48C0C7006A96EB /* MockTabDelegate.swift */; };
@@ -2508,6 +2509,7 @@
 		9F23B8022C2BCD0000950875 /* DaxDialogStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogStyles.swift; sourceTree = "<group>"; };
 		9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8082C2BE9B700950875 /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
+		9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
 		9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterMock.swift; sourceTree = "<group>"; };
 		9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerDaxDialogTests.swift; sourceTree = "<group>"; };
 		9F4CC51A2C48C0C7006A96EB /* MockTabDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabDelegate.swift; sourceTree = "<group>"; };
@@ -4804,6 +4806,7 @@
 				9F8E0F302CCA6390001EA7C5 /* AddToDockTutorialView.swift */,
 				9F8E0F372CCFAA8A001EA7C5 /* AddToDockPromoView.swift */,
 				9F8E0F3C2CCFD071001EA7C5 /* AddToDockPromoViewModel.swift */,
+				9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */,
 			);
 			path = AddToDock;
 			sourceTree = "<group>";
@@ -7399,6 +7402,7 @@
 				F4E1936625AF722F001D2666 /* HighlightCutOutView.swift in Sources */,
 				1E162605296840D80004127F /* Triangle.swift in Sources */,
 				6FDC64012C92F4A300DB71B3 /* NewTabPageIntroDataStoring.swift in Sources */,
+				9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */,
 				B609D5522862EAFF0088CAC2 /* InlineWKDownloadDelegate.swift in Sources */,
 				BDFF03222BA3D8E200F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */,
 				B652DEFD287BE67400C12A9C /* UserScripts.swift in Sources */,

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -87,5 +87,5 @@ protocol AppSettings: AnyObject, AppDebugSettings {
 
 protocol AppDebugSettings {
     var onboardingHighlightsEnabled: Bool { get set }
-    var onboardingAddToDockEnabled: Bool { get set }
+    var onboardingAddToDockState: OnboardingAddToDockState { get set }
 }

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -84,6 +84,7 @@ public class AppUserDefaults: AppSettings {
     private struct DebugKeys {
         static let inspectableWebViewsEnabledKey = "com.duckduckgo.ios.debug.inspectableWebViewsEnabled"
         static let autofillDebugScriptEnabledKey = "com.duckduckgo.ios.debug.autofillDebugScriptEnabled"
+        static let onboardingAddToDockStateKey = "com.duckduckgo.ios.debug.onboardingAddToDockState"
     }
 
     private var userDefaults: UserDefaults? {
@@ -422,8 +423,15 @@ public class AppUserDefaults: AppSettings {
     @UserDefaultsWrapper(key: .debugOnboardingHighlightsEnabledKey, defaultValue: false)
     var onboardingHighlightsEnabled: Bool
 
-    @UserDefaultsWrapper(key: .debugOnboardingAddToDockEnabledKey, defaultValue: false)
-    var onboardingAddToDockEnabled: Bool
+    var onboardingAddToDockState: OnboardingAddToDockState {
+        get {
+            guard let rawValue = userDefaults?.string(forKey: DebugKeys.onboardingAddToDockStateKey) else { return .disabled }
+            return OnboardingAddToDockState(rawValue: rawValue) ?? .disabled
+        }
+        set {
+            userDefaults?.set(newValue.rawValue, forKey: DebugKeys.onboardingAddToDockStateKey)
+        }
+    }
 }
 
 extension AppUserDefaults: AppConfigurationFetchStatistics {

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -41,6 +41,7 @@ protocol ContextualOnboardingLogic {
     var shouldShowPrivacyButtonPulse: Bool { get }
     var isShowingSearchSuggestions: Bool { get }
     var isShowingSitesSuggestions: Bool { get }
+    var isShowingAddToDockDialog: Bool { get }
 
     func setSearchMessageSeen()
     func setFireEducationMessageSeen()
@@ -211,6 +212,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     private var settings: DaxDialogsSettings
     private var entityProviding: EntityProviding
     private let variantManager: VariantManager
+    private let addToDockManager: OnboardingAddToDockManaging
 
     private var nextHomeScreenMessageOverride: HomeScreenSpec?
     
@@ -222,10 +224,13 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     /// Use singleton accessor, this is only accessible for tests
     init(settings: DaxDialogsSettings = DefaultDaxDialogsSettings(),
          entityProviding: EntityProviding,
-         variantManager: VariantManager = DefaultVariantManager()) {
+         variantManager: VariantManager = DefaultVariantManager(),
+         onboardingManager: OnboardingAddToDockManaging = OnboardingManager()
+    ) {
         self.settings = settings
         self.entityProviding = entityProviding
         self.variantManager = variantManager
+        self.addToDockManager = onboardingManager
     }
 
     private var isNewOnboarding: Bool {
@@ -274,6 +279,11 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     var isShowingSitesSuggestions: Bool {
         guard isNewOnboarding else { return false }
         return lastShownDaxDialogType.flatMap(BrowsingSpec.SpecType.init(rawValue:)) == .visitWebsite || currentHomeSpec == .subsequent
+    }
+
+    var isShowingAddToDockDialog: Bool {
+        guard isNewOnboarding else { return false }
+        return currentHomeSpec == .final && addToDockManager.isAddToDockEnabled
     }
 
     var isEnabled: Bool {
@@ -733,6 +743,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     private func clearOnboardingBrowsingData() {
         removeLastShownDaxDialog()
         removeLastVisitedOnboardingWebsite()
+        currentHomeSpec = nil
     }
 }
 

--- a/DuckDuckGo/DaxDialogs.swift
+++ b/DuckDuckGo/DaxDialogs.swift
@@ -283,7 +283,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 
     var isShowingAddToDockDialog: Bool {
         guard isNewOnboarding else { return false }
-        return currentHomeSpec == .final && addToDockManager.isAddToDockEnabled
+        return currentHomeSpec == .final && addToDockManager.addToDockEnabledState == .contextual
     }
 
     var isEnabled: Bool {

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2672,7 +2672,7 @@ extension MainViewController: AutoClearWorker {
             // Ideally this should happen once data clearing has finished AND the animation is finished
             if showNextDaxDialog {
                 self.newTabPageViewController?.showNextDaxDialog()
-            } else if KeyboardSettings().onNewTab {
+            } else if KeyboardSettings().onNewTab && !self.contextualOnboardingLogic.isShowingAddToDockDialog { // If we're showing the Add to Dock dialog prevent address bar to become first responder. We want to make sure the user focues on the Add to Dock instructions.
                 let showKeyboardAfterFireButton = DispatchWorkItem {
                     self.enterSearch()
                 }

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -314,7 +314,7 @@ extension NewTabPageViewController {
             guard let self else { return }
             dialogProvider.dismiss()
             self.dismissHostingController(didFinishNTPOnboarding: true)
-            // Make the address bar first responder after closing the new tap page final dialog.
+            // Make the address bar first responder after closing the new tab page final dialog.
             self.launchNewSearch()
         }
         let daxDialogView = AnyView(factory.createDaxDialog(for: spec, onDismiss: onDismiss))

--- a/DuckDuckGo/NewTabPageViewController.swift
+++ b/DuckDuckGo/NewTabPageViewController.swift
@@ -310,9 +310,12 @@ extension NewTabPageViewController {
 
         guard let spec = dialogProvider.nextHomeScreenMessageNew() else { return }
 
-        let onDismiss = {
+        let onDismiss = { [weak self] in
+            guard let self else { return }
             dialogProvider.dismiss()
             self.dismissHostingController(didFinishNTPOnboarding: true)
+            // Make the address bar first responder after closing the new tap page final dialog.
+            self.launchNewSearch()
         }
         let daxDialogView = AnyView(factory.createDaxDialog(for: spec, onDismiss: onDismiss))
         let hostingController = UIHostingController(rootView: daxDialogView)

--- a/DuckDuckGo/OnboardingDebugView.swift
+++ b/DuckDuckGo/OnboardingDebugView.swift
@@ -22,6 +22,7 @@ import SwiftUI
 struct OnboardingDebugView: View {
 
     @StateObject private var viewModel = OnboardingDebugViewModel()
+    @State private var isShowingRestDaxDialogsAlert = false
 
     private let newOnboardingIntroStartAction: () -> Void
 
@@ -63,6 +64,18 @@ struct OnboardingDebugView: View {
             }
 
             Section {
+                Button(action: {
+                    viewModel.resetDaxDialogs()
+                    isShowingRestDaxDialogsAlert = true
+                }, label: {
+                    Text(verbatim: "Reset Dax Dialogs State")
+                })
+                .alert(isPresented: $isShowingRestDaxDialogsAlert, content: {
+                    Alert(title: Text(verbatim: "Dax Dialogs reset"), dismissButton: .cancel())
+                })
+            }
+
+            Section {
                 Button(action: newOnboardingIntroStartAction, label: {
                     let onboardingType = viewModel.isOnboardingHighlightsLocalFlagEnabled ? "Highlights" : ""
                     Text(verbatim: "Preview New Onboarding Intro \(onboardingType)")
@@ -86,13 +99,29 @@ final class OnboardingDebugViewModel: ObservableObject {
     }
 
     private let manager: OnboardingHighlightsDebugging & OnboardingAddToDockDebugging
+    private var settings: DaxDialogsSettings
 
-    init(manager: OnboardingHighlightsDebugging & OnboardingAddToDockDebugging = OnboardingManager()) {
+    init(manager: OnboardingHighlightsDebugging & OnboardingAddToDockDebugging = OnboardingManager(), settings: DaxDialogsSettings = DefaultDaxDialogsSettings()) {
         self.manager = manager
+        self.settings = settings
         isOnboardingHighlightsLocalFlagEnabled = manager.isOnboardingHighlightsLocalFlagEnabled
         onboardingAddToDockLocalFlagState = manager.addToDockLocalFlagState
     }
 
+    func resetDaxDialogs() {
+        settings.isDismissed = false
+        settings.homeScreenMessagesSeen = 0
+        settings.browsingAfterSearchShown = false
+        settings.browsingWithTrackersShown = false
+        settings.browsingWithoutTrackersShown = false
+        settings.browsingMajorTrackingSiteShown = false
+        settings.fireMessageExperimentShown = false
+        settings.fireButtonPulseDateShown = nil
+        settings.privacyButtonPulseShown = false
+        settings.browsingFinalDialogShown = false
+        settings.lastVisitedOnboardingWebsiteURLPath = nil
+        settings.lastShownContextualOnboardingDialogType = nil
+    }
 }
 
 #Preview {

--- a/DuckDuckGo/OnboardingDebugView.swift
+++ b/DuckDuckGo/OnboardingDebugView.swift
@@ -45,8 +45,13 @@ struct OnboardingDebugView: View {
             }
 
             Section {
-                Toggle(
-                    isOn: $viewModel.isOnboardingAddToDockLocalFlagEnabled,
+                Picker(
+                    selection: $viewModel.onboardingAddToDockLocalFlagState,
+                    content: {
+                        ForEach(OnboardingAddToDockState.allCases) { state in
+                            Text(verbatim: state.description).tag(state)
+                        }
+                    },
                     label: {
                         Text(verbatim: "Onboarding Add to Dock local setting enabled")
                     }
@@ -74,9 +79,9 @@ final class OnboardingDebugViewModel: ObservableObject {
         }
     }
 
-    @Published var isOnboardingAddToDockLocalFlagEnabled: Bool {
+    @Published var onboardingAddToDockLocalFlagState: OnboardingAddToDockState {
         didSet {
-            manager.isAddToDockLocalFlagEnabled = isOnboardingAddToDockLocalFlagEnabled
+            manager.addToDockLocalFlagState = onboardingAddToDockLocalFlagState
         }
     }
 
@@ -85,11 +90,17 @@ final class OnboardingDebugViewModel: ObservableObject {
     init(manager: OnboardingHighlightsDebugging & OnboardingAddToDockDebugging = OnboardingManager()) {
         self.manager = manager
         isOnboardingHighlightsLocalFlagEnabled = manager.isOnboardingHighlightsLocalFlagEnabled
-        isOnboardingAddToDockLocalFlagEnabled = manager.isAddToDockLocalFlagEnabled
+        onboardingAddToDockLocalFlagState = manager.addToDockLocalFlagState
     }
 
 }
 
 #Preview {
     OnboardingDebugView(onNewOnboardingIntroStartAction: {})
+}
+
+extension OnboardingAddToDockState: Identifiable {
+    var id: OnboardingAddToDockState {
+        self
+    }
 }

--- a/DuckDuckGo/OnboardingDebugView.swift
+++ b/DuckDuckGo/OnboardingDebugView.swift
@@ -22,7 +22,7 @@ import SwiftUI
 struct OnboardingDebugView: View {
 
     @StateObject private var viewModel = OnboardingDebugViewModel()
-    @State private var isShowingRestDaxDialogsAlert = false
+    @State private var isShowingResetDaxDialogsAlert = false
 
     private let newOnboardingIntroStartAction: () -> Void
 
@@ -66,11 +66,11 @@ struct OnboardingDebugView: View {
             Section {
                 Button(action: {
                     viewModel.resetDaxDialogs()
-                    isShowingRestDaxDialogsAlert = true
+                    isShowingResetDaxDialogsAlert = true
                 }, label: {
                     Text(verbatim: "Reset Dax Dialogs State")
                 })
-                .alert(isPresented: $isShowingRestDaxDialogsAlert, content: {
+                .alert(isPresented: $isShowingResetDaxDialogsAlert, content: {
                     Alert(title: Text(verbatim: "Dax Dialogs reset"), dismissButton: .cancel())
                 })
             }

--- a/DuckDuckGo/OnboardingExperiment/AddToDock/AddToDockTutorialView.swift
+++ b/DuckDuckGo/OnboardingExperiment/AddToDock/AddToDockTutorialView.swift
@@ -32,6 +32,7 @@ struct AddToDockTutorialView: View {
 
     private let title: String
     private let message: String
+    private let cta: String
     private let action: () -> Void
 
     @State private var animateTitle = true
@@ -44,10 +45,12 @@ struct AddToDockTutorialView: View {
     init(
         title: String,
         message: String,
+        cta: String,
         action: @escaping () -> Void
     ) {
         self.title = title
         self.message = message
+        self.cta = cta
         self.action = action
     }
 
@@ -81,7 +84,7 @@ struct AddToDockTutorialView: View {
                 }
             
             Button(action: action) {
-                Text(UserText.AddToDockOnboarding.Buttons.dismiss)
+                Text(cta)
             }
             .buttonStyle(PrimaryButtonStyle())
             .visibility(showContent ? .visible : .invisible)
@@ -110,6 +113,7 @@ struct AddToDockTutorial_Previews: PreviewProvider {
             AddToDockTutorialView(
                 title: UserText.AddToDockOnboarding.Tutorial.title,
                 message: UserText.AddToDockOnboarding.Tutorial.message,
+                cta: UserText.AddToDockOnboarding.Buttons.dismiss,
                 action: {}
             )
             .padding()

--- a/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
+++ b/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
@@ -32,12 +32,6 @@ extension OnboardingView {
 
         @State private var showAddToDockTutorial = false
 
-        private let title = "Want to add me to your Dock?"
-        private let message = "I can paddle into the Dock and perch there until you need me."
-        private let nextCTA = "Skip"
-        private let tutotialShowCTA = UserText.AddToDockOnboarding.Buttons.addToDockTutorial
-        private let tutorialDismissCTA = "Got It"
-
         private var animateTitle: Binding<Bool>
         private var animateMessage: Binding<Bool>
         private var showContent: Binding<Bool>
@@ -57,14 +51,14 @@ extension OnboardingView {
 
         var body: some View {
             if showAddToDockTutorial {
-                OnboardingAddToDockTutorialContent(cta: tutorialDismissCTA) {
+                OnboardingAddToDockTutorialContent(cta: UserText.AddToDockOnboarding.Intro.tutorialDismissCTA) {
                     dismissAction(true)
                 }
             } else {
                 ContextualDaxDialogContent(
-                    title: title,
+                    title: UserText.AddToDockOnboarding.Intro.title,
                     titleFont: Font(UIFont.daxTitle3()),
-                    message: NSAttributedString(string: message),
+                    message: NSAttributedString(string: UserText.AddToDockOnboarding.Intro.message),
                     messageFont: Font.system(size: 16),
                     customView: AnyView(addToDockPromoView),
                     customActionView: AnyView(customActionView)
@@ -81,14 +75,14 @@ extension OnboardingView {
         private var customActionView: some View {
             VStack {
                 OnboardingCTAButton(
-                    title: tutotialShowCTA,
+                    title: UserText.AddToDockOnboarding.Buttons.addToDockTutorial,
                     action: {
                         showAddToDockTutorial = true
                     }
                 )
 
                 OnboardingCTAButton(
-                    title: nextCTA,
+                    title: UserText.AddToDockOnboarding.Intro.skipCTA,
                     buttonStyle: .ghost,
                     action: {
                         dismissAction(false)

--- a/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
+++ b/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
@@ -1,0 +1,102 @@
+//
+//  OnboardingView+AddToDockContent.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import Onboarding
+
+extension OnboardingView {
+
+    struct AddToDockPromoContentState {
+        var animateTitle = true
+        var animateMessage = false
+        var showContent = false
+    }
+
+    struct AddToDockPromoContent: View {
+
+        @State private var showAddToDockTutorial = false
+
+        private let title = "Want to add me to your Dock?"
+        private let message = "I can paddle into the Dock and perch there until you need me."
+        private let nextCTA = "Skip"
+        private let tutotialShowCTA = UserText.AddToDockOnboarding.Buttons.addToDockTutorial
+        private let tutorialDismissCTA = "Got It"
+
+        private var animateTitle: Binding<Bool>
+        private var animateMessage: Binding<Bool>
+        private var showContent: Binding<Bool>
+        private let dismissAction: (_ fromAddToDock: Bool) -> Void
+
+        init(
+            animateTitle: Binding<Bool> = .constant(true),
+            animateMessage: Binding<Bool> = .constant(true),
+            showContent: Binding<Bool> = .constant(false),
+            dismissAction: @escaping (_ fromAddToDock: Bool) -> Void
+        ) {
+            self.animateTitle = animateTitle
+            self.animateMessage = animateMessage
+            self.showContent = showContent
+            self.dismissAction = dismissAction
+        }
+
+        var body: some View {
+            if showAddToDockTutorial {
+                OnboardingAddToDockTutorialContent(cta: tutorialDismissCTA) {
+                    dismissAction(true)
+                }
+            } else {
+                ContextualDaxDialogContent(
+                    title: title,
+                    titleFont: Font(UIFont.daxTitle3()),
+                    message: NSAttributedString(string: message),
+                    messageFont: Font.system(size: 16),
+                    customView: AnyView(addToDockPromoView),
+                    customActionView: AnyView(customActionView)
+                )
+            }
+        }
+
+        private var addToDockPromoView: some View {
+            AddToDockPromoView()
+                .aspectRatio(contentMode: .fit)
+                .padding(.vertical)
+        }
+
+        private var customActionView: some View {
+            VStack {
+                OnboardingCTAButton(
+                    title: tutotialShowCTA,
+                    action: {
+                        showAddToDockTutorial = true
+                    }
+                )
+
+                OnboardingCTAButton(
+                    title: nextCTA,
+                    buttonStyle: .ghost,
+                    action: {
+                        dismissAction(false)
+                    }
+                )
+            }
+        }
+
+    }
+
+}

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -198,7 +198,7 @@ struct OnboardingFinalDialog: View {
         ScrollView(.vertical, showsIndicators: false) {
             DaxDialogView(logoPosition: logoPosition) {
                 if showAddToDockTutorial {
-                    OnboardingAddToDockTutorialContent {
+                    OnboardingAddToDockTutorialContent(cta:  UserText.AddToDockOnboarding.Buttons.dismiss) {
                         dismissAction(true)
                     }
                 } else {
@@ -278,15 +278,17 @@ struct OnboardingCTAButton: View {
 struct OnboardingAddToDockTutorialContent: View {
     let title = UserText.AddToDockOnboarding.Tutorial.title
     let message = UserText.AddToDockOnboarding.Tutorial.message
-    let cta = UserText.AddToDockOnboarding.Buttons.dismiss
 
+    let cta: String
     let dismissAction: () -> Void
 
     var body: some View {
         AddToDockTutorialView(
             title: title,
             message: message,
-            action: dismissAction)
+            cta: cta,
+            action: dismissAction
+        )
     }
 }
 
@@ -356,11 +358,11 @@ struct OnboardingAddToDockTutorialContent: View {
 }
 
 #Preview("Add To Dock Tutorial - Light") {
-    OnboardingAddToDockTutorialContent(dismissAction: {})
+    OnboardingAddToDockTutorialContent(cta:  UserText.AddToDockOnboarding.Buttons.dismiss, dismissAction: {})
         .preferredColorScheme(.light)
 }
 
 #Preview("Add To Dock Tutorial - Dark") {
-    OnboardingAddToDockTutorialContent(dismissAction: {})
+    OnboardingAddToDockTutorialContent(cta:  UserText.AddToDockOnboarding.Buttons.dismiss, dismissAction: {})
         .preferredColorScheme(.dark)
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -206,6 +206,7 @@ struct OnboardingFinalDialog: View {
                         title: title,
                         titleFont: Font(UIFont.daxTitle3()),
                         message: NSAttributedString(string: message),
+                        messageFont: Font.system(size: 16),
                         customView: AnyView(customView),
                         customActionView: AnyView(customActionView)
                     )

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -198,7 +198,7 @@ struct OnboardingFinalDialog: View {
         ScrollView(.vertical, showsIndicators: false) {
             DaxDialogView(logoPosition: logoPosition) {
                 if showAddToDockTutorial {
-                    OnboardingAddToDockTutorialContent(cta:  UserText.AddToDockOnboarding.Buttons.dismiss) {
+                    OnboardingAddToDockTutorialContent(cta: UserText.AddToDockOnboarding.Buttons.dismiss) {
                         dismissAction(true)
                     }
                 } else {
@@ -358,11 +358,11 @@ struct OnboardingAddToDockTutorialContent: View {
 }
 
 #Preview("Add To Dock Tutorial - Light") {
-    OnboardingAddToDockTutorialContent(cta:  UserText.AddToDockOnboarding.Buttons.dismiss, dismissAction: {})
+    OnboardingAddToDockTutorialContent(cta: UserText.AddToDockOnboarding.Buttons.dismiss, dismissAction: {})
         .preferredColorScheme(.light)
 }
 
 #Preview("Add To Dock Tutorial - Dark") {
-    OnboardingAddToDockTutorialContent(cta:  UserText.AddToDockOnboarding.Buttons.dismiss, dismissAction: {})
+    OnboardingAddToDockTutorialContent(cta: UserText.AddToDockOnboarding.Buttons.dismiss, dismissAction: {})
         .preferredColorScheme(.dark)
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -185,10 +185,10 @@ struct OnboardingTrackersDoneDialog: View {
 
 struct OnboardingFinalDialog: View {
     let title = UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenTitle
-    let cta = UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenButton
 
     let logoPosition: DaxDialogLogoPosition
     let message: String
+    let cta: String
     let canShowAddToDockTutorial: Bool
     let dismissAction: (_ fromAddToDock: Bool) -> Void
 
@@ -322,6 +322,7 @@ struct OnboardingAddToDockTutorialContent: View {
     OnboardingFinalDialog(
         logoPosition: .top,
         message: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage,
+        cta: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenButton,
         canShowAddToDockTutorial: false,
         dismissAction: { _ in }
     )
@@ -332,6 +333,7 @@ struct OnboardingAddToDockTutorialContent: View {
     OnboardingFinalDialog(
         logoPosition: .left,
         message: UserText.AddToDockOnboarding.EndOfJourney.message,
+        cta: UserText.AddToDockOnboarding.Buttons.dismiss,
         canShowAddToDockTutorial: true,
         dismissAction: { _ in }
     )

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -99,7 +99,9 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     }
 
     private func createFinalDialog(onDismiss: @escaping () -> Void) -> some View {
-        let (message, cta) = if onboardingManager.isAddToDockEnabled {
+        let shouldShowAddToDock = onboardingManager.addToDockEnabledState == .contextual
+
+        let (message, cta) = if shouldShowAddToDock {
             (UserText.AddToDockOnboarding.EndOfJourney.message, UserText.AddToDockOnboarding.Buttons.dismiss)
         } else {
             (
@@ -109,7 +111,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         }
 
         return FadeInView {
-            OnboardingFinalDialog(logoPosition: .top, message: message, cta: cta, canShowAddToDockTutorial: onboardingManager.isAddToDockEnabled) { [weak self] isDismissedFromAddToDock in
+            OnboardingFinalDialog(logoPosition: .top, message: message, cta: cta, canShowAddToDockTutorial: shouldShowAddToDock) { [weak self] isDismissedFromAddToDock in
                 if isDismissedFromAddToDock {
                     Logger.onboarding.debug("Dismissed from add to dock")
                 } else {

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -99,14 +99,17 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
     }
 
     private func createFinalDialog(onDismiss: @escaping () -> Void) -> some View {
-        let message = if onboardingManager.isAddToDockEnabled {
-            UserText.AddToDockOnboarding.EndOfJourney.message
+        let (message, cta) = if onboardingManager.isAddToDockEnabled {
+            (UserText.AddToDockOnboarding.EndOfJourney.message, UserText.AddToDockOnboarding.Buttons.dismiss)
         } else {
-            onboardingManager.isOnboardingHighlightsEnabled ? UserText.HighlightsOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage : UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage
+            (
+                onboardingManager.isOnboardingHighlightsEnabled ?  UserText.HighlightsOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage : UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage,
+                UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenButton
+            )
         }
 
         return FadeInView {
-            OnboardingFinalDialog(logoPosition: .top, message: message, canShowAddToDockTutorial: onboardingManager.isAddToDockEnabled) { [weak self] isDismissedFromAddToDock in
+            OnboardingFinalDialog(logoPosition: .top, message: message, cta: cta, canShowAddToDockTutorial: onboardingManager.isAddToDockEnabled) { [weak self] isDismissedFromAddToDock in
                 if isDismissedFromAddToDock {
                     Logger.onboarding.debug("Dismissed from add to dock")
                 } else {

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -182,7 +182,9 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     }
 
     private func endOfJourneyDialog(delegate: ContextualOnboardingDelegate, pixelName: Pixel.Event) -> some View {
-        let (message, cta) = if onboardingManager.isAddToDockEnabled {
+        let shouldShowAddToDock = onboardingManager.addToDockEnabledState == .contextual
+
+        let (message, cta) = if shouldShowAddToDock {
             (UserText.AddToDockOnboarding.EndOfJourney.message, UserText.AddToDockOnboarding.Buttons.dismiss)
         } else {
             (
@@ -191,7 +193,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
             )
         }
 
-        return OnboardingFinalDialog(logoPosition: .left, message: message, cta: cta, canShowAddToDockTutorial: onboardingManager.isAddToDockEnabled, dismissAction: { [weak delegate, weak self] isDismissedFromAddToDock in
+        return OnboardingFinalDialog(logoPosition: .left, message: message, cta: cta, canShowAddToDockTutorial: shouldShowAddToDock, dismissAction: { [weak delegate, weak self] isDismissedFromAddToDock in
             delegate?.didTapDismissContextualOnboardingAction()
             if isDismissedFromAddToDock {
                 Logger.onboarding.debug("Dismissed from add to dock")

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -182,13 +182,16 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     }
 
     private func endOfJourneyDialog(delegate: ContextualOnboardingDelegate, pixelName: Pixel.Event) -> some View {
-        let message = if onboardingManager.isAddToDockEnabled {
-            UserText.AddToDockOnboarding.EndOfJourney.message
+        let (message, cta) = if onboardingManager.isAddToDockEnabled {
+            (UserText.AddToDockOnboarding.EndOfJourney.message, UserText.AddToDockOnboarding.Buttons.dismiss)
         } else {
-            onboardingManager.isOnboardingHighlightsEnabled ? UserText.HighlightsOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage : UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage
+            (
+                onboardingManager.isOnboardingHighlightsEnabled ? UserText.HighlightsOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage : UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage,
+                UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenButton
+            )
         }
 
-        return OnboardingFinalDialog(logoPosition: .left, message: message, canShowAddToDockTutorial: onboardingManager.isAddToDockEnabled, dismissAction: { [weak delegate, weak self] isDismissedFromAddToDock in
+        return OnboardingFinalDialog(logoPosition: .left, message: message, cta: cta, canShowAddToDockTutorial: onboardingManager.isAddToDockEnabled, dismissAction: { [weak delegate, weak self] isDismissedFromAddToDock in
             delegate?.didTapDismissContextualOnboardingAction()
             if isDismissedFromAddToDock {
                 Logger.onboarding.debug("Dismissed from add to dock")

--- a/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -20,6 +20,23 @@
 import BrowserServicesKit
 import Core
 
+enum OnboardingAddToDockState: String, Equatable, CaseIterable, CustomStringConvertible {
+    case disabled
+    case intro
+    case contextual
+
+    var description: String {
+        switch self {
+        case .disabled:
+            "Disabled"
+        case .intro:
+            "Onboarding Intro"
+        case .contextual:
+            "Dax Dialogs"
+        }
+    }
+}
+
 final class OnboardingManager {
     private var appDefaults: AppDebugSettings
     private let featureFlagger: FeatureFlagger
@@ -75,27 +92,33 @@ extension OnboardingManager: OnboardingHighlightsManaging, OnboardingHighlightsD
 // MARK: - Add to Dock
 
 protocol OnboardingAddToDockManaging: AnyObject {
-    var isAddToDockEnabled: Bool { get }
+    var addToDockEnabledState: OnboardingAddToDockState { get }
 }
 
 protocol OnboardingAddToDockDebugging: AnyObject {
-    var isAddToDockLocalFlagEnabled: Bool { get set }
+    var addToDockLocalFlagState: OnboardingAddToDockState { get set }
     var isAddToDockFeatureFlagEnabled: Bool { get }
 }
 
 extension OnboardingManager: OnboardingAddToDockManaging, OnboardingAddToDockDebugging {
 
-    var isAddToDockEnabled: Bool {
-        // TODO: Add variant condition once the experiment is setup
-        isIphone && isAddToDockLocalFlagEnabled && isAddToDockFeatureFlagEnabled
+    var addToDockEnabledState: OnboardingAddToDockState {
+        // TODO: Add variant condition OR local conditions
+        if isAddToDockFeatureFlagEnabled && isIphone && addToDockLocalFlagState == .contextual {
+            return .contextual
+        } else if isAddToDockFeatureFlagEnabled && isIphone && addToDockLocalFlagState == .intro {
+            return .intro
+        } else {
+            return .disabled
+        }
     }
 
-    var isAddToDockLocalFlagEnabled: Bool {
+    var addToDockLocalFlagState: OnboardingAddToDockState {
         get {
-            appDefaults.onboardingAddToDockEnabled
+            appDefaults.onboardingAddToDockState
         }
         set {
-            appDefaults.onboardingAddToDockEnabled = newValue
+            appDefaults.onboardingAddToDockState = newValue
         }
     }
 

--- a/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -104,13 +104,9 @@ extension OnboardingManager: OnboardingAddToDockManaging, OnboardingAddToDockDeb
 
     var addToDockEnabledState: OnboardingAddToDockState {
         // TODO: Add variant condition OR local conditions
-        if isAddToDockFeatureFlagEnabled && isIphone && addToDockLocalFlagState == .contextual {
-            return .contextual
-        } else if isAddToDockFeatureFlagEnabled && isIphone && addToDockLocalFlagState == .intro {
-            return .intro
-        } else {
-            return .disabled
-        }
+        guard isAddToDockFeatureFlagEnabled && isIphone else { return .disabled }
+
+        return addToDockLocalFlagState
     }
 
     var addToDockLocalFlagState: OnboardingAddToDockState {

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -31,7 +31,7 @@ final class OnboardingIntroViewModel: ObservableObject {
     private var introSteps: [OnboardingIntroStep]
 
     private let pixelReporter: OnboardingIntroPixelReporting
-    private let onboardingManager: OnboardingHighlightsManaging
+    private let onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging
     private let isIpad: Bool
     private let urlOpener: URLOpener
     private let appIconProvider: () -> AppIcon
@@ -39,7 +39,7 @@ final class OnboardingIntroViewModel: ObservableObject {
 
     init(
         pixelReporter: OnboardingIntroPixelReporting,
-        onboardingManager: OnboardingHighlightsManaging = OnboardingManager(),
+        onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging = OnboardingManager(),
         isIpad: Bool = UIDevice.current.userInterfaceIdiom == .pad,
         urlOpener: URLOpener = UIApplication.shared,
         appIconProvider: @escaping () -> AppIcon = { AppIconManager.shared.appIcon },
@@ -52,7 +52,9 @@ final class OnboardingIntroViewModel: ObservableObject {
         self.appIconProvider = appIconProvider
         self.addressBarPositionProvider = addressBarPositionProvider
 
-        introSteps = if onboardingManager.isOnboardingHighlightsEnabled {
+        introSteps = if onboardingManager.isOnboardingHighlightsEnabled && onboardingManager.isAddToDockEnabled {
+            isIpad ? OnboardingIntroStep.highlightsIPadFlow : OnboardingIntroStep.highlightsAddToDockIphoneFlow
+        } else if onboardingManager.isOnboardingHighlightsEnabled {
             isIpad ? OnboardingIntroStep.highlightsIPadFlow : OnboardingIntroStep.highlightsIPhoneFlow
         } else {
             OnboardingIntroStep.defaultFlow
@@ -83,6 +85,10 @@ final class OnboardingIntroViewModel: ObservableObject {
 
     func cancelSetDefaultBrowserAction() {
         handleSetDefaultBrowserAction()
+    }
+
+    func addToDockContinueAction() {
+        state = makeViewState(for: .appIconSelection)
     }
 
     func appIconPickerContinueAction() {
@@ -130,6 +136,8 @@ private extension OnboardingIntroViewModel {
             OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog, step: .hidden))
         case .browserComparison:
             OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog, step: stepInfo()))
+        case .addToDockPromo:
+            OnboardingView.ViewState.onboarding(.init(type: .addToDockPromoDialog, step: stepInfo()))
         case .appIconSelection:
             OnboardingView.ViewState.onboarding(.init(type: .chooseAppIconDialog, step: stepInfo()))
         case .addressBarPositionSelection:
@@ -140,7 +148,9 @@ private extension OnboardingIntroViewModel {
     }
 
     func handleSetDefaultBrowserAction() {
-        if onboardingManager.isOnboardingHighlightsEnabled {
+        if onboardingManager.isAddToDockEnabled && onboardingManager.isOnboardingHighlightsEnabled {
+            state = makeViewState(for: .addToDockPromo)
+        } else if onboardingManager.isOnboardingHighlightsEnabled {
             state = makeViewState(for: .appIconSelection)
             pixelReporter.trackChooseAppIconImpression()
         } else {
@@ -157,8 +167,10 @@ private enum OnboardingIntroStep {
     case browserComparison
     case appIconSelection
     case addressBarPositionSelection
+    case addToDockPromo
 
     static let defaultFlow: [OnboardingIntroStep] = [.introDialog, .browserComparison]
     static let highlightsIPhoneFlow: [OnboardingIntroStep] = [.introDialog, .browserComparison, .appIconSelection, .addressBarPositionSelection]
     static let highlightsIPadFlow: [OnboardingIntroStep] = [.introDialog, .browserComparison, .appIconSelection]
+    static let highlightsAddToDockIphoneFlow: [OnboardingIntroStep] = [.introDialog, .browserComparison, .addToDockPromo, .appIconSelection, .addressBarPositionSelection]
 }

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -52,7 +52,7 @@ final class OnboardingIntroViewModel: ObservableObject {
         self.appIconProvider = appIconProvider
         self.addressBarPositionProvider = addressBarPositionProvider
 
-        introSteps = if onboardingManager.isOnboardingHighlightsEnabled && onboardingManager.isAddToDockEnabled {
+        introSteps = if onboardingManager.isOnboardingHighlightsEnabled && onboardingManager.addToDockEnabledState == .intro {
             isIpad ? OnboardingIntroStep.highlightsIPadFlow : OnboardingIntroStep.highlightsAddToDockIphoneFlow
         } else if onboardingManager.isOnboardingHighlightsEnabled {
             isIpad ? OnboardingIntroStep.highlightsIPadFlow : OnboardingIntroStep.highlightsIPhoneFlow
@@ -148,7 +148,7 @@ private extension OnboardingIntroViewModel {
     }
 
     func handleSetDefaultBrowserAction() {
-        if onboardingManager.isAddToDockEnabled && onboardingManager.isOnboardingHighlightsEnabled {
+        if onboardingManager.addToDockEnabledState == .intro && onboardingManager.isOnboardingHighlightsEnabled {
             state = makeViewState(for: .addToDockPromo)
         } else if onboardingManager.isOnboardingHighlightsEnabled {
             state = makeViewState(for: .appIconSelection)

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -40,6 +40,7 @@ struct OnboardingView: View {
 
     @State private var appIconPickerContentState = AppIconPickerContentState()
     @State private var addressBarPositionContentState = AddressBarPositionContentState()
+    @State private var addToDockPromoContentState = AddToDockPromoContentState()
 
     init(model: OnboardingIntroViewModel) {
         self.model = model
@@ -75,6 +76,10 @@ struct OnboardingView: View {
                             case .browsersComparisonDialog:
                                 showComparisonButton = true
                                 animateComparisonText = false
+                            case .addToDockPromoDialog:
+                                addToDockPromoContentState.animateTitle = false
+                                addToDockPromoContentState.animateMessage = false
+                                addToDockPromoContentState.showContent = true
                             case .chooseAppIconDialog:
                                 appIconPickerContentState.animateTitle = false
                                 appIconPickerContentState.animateMessage = false
@@ -90,6 +95,8 @@ struct OnboardingView: View {
                                 introView
                             case .browsersComparisonDialog:
                                 browsersComparisonView
+                            case .addToDockPromoDialog:
+                                addToDockPromoView
                             case .chooseAppIconDialog:
                                 appIconPickerView
                             case .chooseAddressBarPositionDialog:
@@ -149,6 +156,11 @@ struct OnboardingView: View {
             }
         )
         .onboardingDaxDialogStyle()
+    }
+
+    private var addToDockPromoView: some View {
+        AddToDockPromoContent(dismissAction: { _ in model.addToDockContinueAction()
+        })
     }
 
     private var appIconPickerView: some View {
@@ -231,6 +243,7 @@ extension OnboardingView.ViewState.Intro {
     enum IntroType: Equatable {
         case startOnboardingDialog
         case browsersComparisonDialog
+        case addToDockPromoDialog
         case chooseAppIconDialog
         case chooseAddressBarPositionDialog
     }

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -1427,5 +1427,12 @@ But if you *do* want a peek under the hood, you can find more information about 
             static let title = NSLocalizedString("contextual.onboarding.addToDock.tutorial.title", value: "Adding me to your Dock is easy.", comment: "The title of the onboarding dialog popup that explains how to add the DDG browser icon to the dock.")
             static let message = NSLocalizedString("contextual.onboarding.addToDock.tutorial.message", value: "Find or search for the DuckDuckGo icon on your home screen. Then press and drag into place. That’s it!", comment: "The message of the onboarding dialog popup that explains how to add the DDG browser icon to the dock.")
         }
+
+        public enum Intro {
+            static let title = NSLocalizedString("onboarding.addToDock.title", value: "Want to add me to your Dock?", comment: "The title of the onboarding dialog popup informing the user on the benefits of adding the DDG browser icon to the dock.")
+            static let message = NSLocalizedString("onboarding.addToDock.message", value: "I can paddle into the Dock and perch there until you need me.", comment: "The message of the onboarding dialog popup informing the user on the benefits of adding the DDG browser icon to the dock.")
+            static let skipCTA = NSLocalizedString("onboarding.addToDock.cta", value: "Skip", comment: "The title of the dialog button CTA to skip adding the DDB browser icon to the dock.")
+            static let tutorialDismissCTA =  NSLocalizedString("onboarding.addToDock.tutorial.cta", value: "Got It", comment: "Button on the Add to Dock tutorial screen of the onboarding, it will dismiss the screen and proceed to the next step.")
+        }
     }
 }

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -1856,6 +1856,18 @@ https://duckduckgo.com/mac";
 /* Text displayed on notification appearing in the address bar when the browser  hides a cookie popup */
 "omnibar.notification.popup-hidden" = "Pop-up Hidden";
 
+/* The title of the dialog button CTA to skip adding the DDB browser icon to the dock. */
+"onboarding.addToDock.cta" = "Skip";
+
+/* The message of the onboarding dialog popup informing the user on the benefits of adding the DDG browser icon to the dock. */
+"onboarding.addToDock.message" = "I can paddle into the Dock and perch there until you need me.";
+
+/* The title of the onboarding dialog popup informing the user on the benefits of adding the DDG browser icon to the dock. */
+"onboarding.addToDock.title" = "Want to add me to your Dock?";
+
+/* Button on the Add to Dock tutorial screen of the onboarding, it will dismiss the screen and proceed to the next step. */
+"onboarding.addToDock.tutorial.cta" = "Got It";
+
 /* Button to change the default browser */
 "onboarding.browsers.cta" = "Choose Your Browser";
 

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -95,6 +95,6 @@ class AppSettingsMock: AppSettings {
     var newTabPageIntroMessageSeenCount: Int = 0
 
     var onboardingHighlightsEnabled: Bool = false
-    var onboardingAddToDockEnabled: Bool = false
-    
+    var onboardingAddToDockState: OnboardingAddToDockState = .disabled
+
 }

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -28,6 +28,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
     private var delegate: ContextualOnboardingDelegateMock!
     private var settingsMock: ContextualOnboardingSettingsMock!
     private var pixelReporterMock: OnboardingPixelReporterMock!
+    private var onboardingManagerMock: OnboardingManagerMock!
     private var window: UIWindow!
 
     override func setUpWithError() throws {
@@ -35,10 +36,12 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         delegate = ContextualOnboardingDelegateMock()
         settingsMock = ContextualOnboardingSettingsMock()
         pixelReporterMock = OnboardingPixelReporterMock()
+        onboardingManagerMock = OnboardingManagerMock()
         sut = ExperimentContextualDaxDialogsFactory(
             contextualOnboardingLogic: ContextualOnboardingLogicMock(),
             contextualOnboardingSettings: settingsMock,
-            contextualOnboardingPixelReporter: pixelReporterMock
+            contextualOnboardingPixelReporter: pixelReporterMock,
+            onboardingManager: onboardingManagerMock
         )
         window = UIWindow(frame: UIScreen.main.bounds)
         window.makeKeyAndVisible()
@@ -50,6 +53,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         delegate = nil
         settingsMock = nil
         pixelReporterMock = nil
+        onboardingManagerMock = nil
         sut = nil
         try super.tearDownWithError()
     }
@@ -334,6 +338,36 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(pixelReporterMock.didCallTrackEndOfJourneyDialogDismiss)
+    }
+
+    // MARK: - Add To Dock
+
+    func testWhenEndOfJourneyDialogAndAddToDockIsContextualThenReturnExpectedCopy() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = sut.makeView(for: spec, delegate: delegate, onSizeUpdate: {})
+
+        // WHEN
+        let result = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+
+        // THEN
+        XCTAssertEqual(result.message, UserText.AddToDockOnboarding.EndOfJourney.message)
+        XCTAssertEqual(result.cta, UserText.AddToDockOnboarding.Buttons.dismiss)
+    }
+
+    func testWhenEndOfJourneyDialogAndAddToDockIsContextualThenCanShowAddToDockTutorialIsTrue() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = sut.makeView(for: spec, delegate: delegate, onSizeUpdate: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+
+        // WHEN
+        let result = view.canShowAddToDockTutorial
+
+        // THEN
+        XCTAssertTrue(result)
     }
 }
 

--- a/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -29,6 +29,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
     var mockDelegate: CapturingOnboardingNavigationDelegate!
     var contextualOnboardingLogicMock: ContextualOnboardingLogicMock!
     var pixelReporterMock: OnboardingPixelReporterMock!
+    var onboardingManagerMock: OnboardingManagerMock!
     var onDismissCalled: Bool!
     var window: UIWindow!
 
@@ -36,9 +37,15 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         super.setUp()
         mockDelegate = CapturingOnboardingNavigationDelegate()
         contextualOnboardingLogicMock = ContextualOnboardingLogicMock()
+        onboardingManagerMock = OnboardingManagerMock()
         onDismissCalled = false
         pixelReporterMock = OnboardingPixelReporterMock()
-        factory = NewTabDaxDialogFactory(delegate: mockDelegate, contextualOnboardingLogic: contextualOnboardingLogicMock, onboardingPixelReporter: pixelReporterMock)
+        factory = NewTabDaxDialogFactory(
+            delegate: mockDelegate,
+            contextualOnboardingLogic: contextualOnboardingLogicMock,
+            onboardingPixelReporter: pixelReporterMock,
+            onboardingManager: onboardingManagerMock
+        )
         window = UIWindow(frame: UIScreen.main.bounds)
         window.makeKeyAndVisible()
     }
@@ -51,6 +58,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         onDismissCalled = nil
         contextualOnboardingLogicMock = nil
         pixelReporterMock = nil
+        onboardingManagerMock = nil
         super.tearDown()
     }
 
@@ -161,6 +169,36 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(pixelReporterMock.didCallTrackEndOfJourneyDialogDismiss)
+    }
+
+    // MARK: - Add To Dock
+
+    func testWhenEndOfJourneyDialogAndAddToDockIsContextualThenReturnExpectedCopy() throws {
+        // GIVEN
+        let spec = DaxDialogs.HomeScreenSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+
+        // WHEN
+        let result = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+
+        // THEN
+        XCTAssertEqual(result.message, UserText.AddToDockOnboarding.EndOfJourney.message)
+        XCTAssertEqual(result.cta, UserText.AddToDockOnboarding.Buttons.dismiss)
+    }
+
+    func testWhenEndOfJourneyDialogAndAddToDockIsContextualThenCanShowAddToDockTutorialIsTrue() throws {
+        // GIVEN
+        let spec = DaxDialogs.HomeScreenSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+
+        // WHEN
+        let result = view.canShowAddToDockTutorial
+
+        // THEN
+        XCTAssertTrue(result)
     }
 
 }

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -1100,6 +1100,52 @@ final class DaxDialog: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    // MARK: - States
+
+    func testWhenIsShowingAddToDockDialogCalledAndHomeSpecIsFinalAndAddToDockIsEnabledThenReturnTrue() {
+        // GIVEN
+        let onboardingManagerMock = OnboardingManagerMock()
+        onboardingManagerMock.isAddToDockEnabled = true
+        settings.fireMessageExperimentShown = true
+        let sut = makeExperimentSUT(settings: settings, onboardingManager: onboardingManagerMock)
+        _ = sut.nextHomeScreenMessageNew()
+
+        // WHEN
+        let result = sut.isShowingAddToDockDialog
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenIsShowingAddToDockDialogCalledAndHomeSpecIsNotFinalThenReturnFalse() {
+        // GIVEN
+        let onboardingManagerMock = OnboardingManagerMock()
+        onboardingManagerMock.isAddToDockEnabled = true
+        let sut = makeExperimentSUT(settings: settings, onboardingManager: onboardingManagerMock)
+        _ = sut.nextHomeScreenMessageNew()
+
+        // WHEN
+        let result = sut.isShowingAddToDockDialog
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenIsShowingAddToDockDialogCalledAndHomeSpeciIsFinalAndAddToDockIsNotEnabledReturnFalse() {
+        // GIVEN
+        let onboardingManagerMock = OnboardingManagerMock()
+        onboardingManagerMock.isAddToDockEnabled = false
+        settings.fireMessageExperimentShown = true
+        let sut = makeExperimentSUT(settings: settings, onboardingManager: onboardingManagerMock)
+        _ = sut.nextHomeScreenMessageNew()
+
+        // WHEN
+        let result = sut.isShowingAddToDockDialog
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
     private func detectedTrackerFrom(_ url: URL, pageUrl: String) -> DetectedRequest {
         let entity = entityProvider.entity(forHost: url.host!)
         return DetectedRequest(url: url.absoluteString,
@@ -1123,11 +1169,11 @@ final class DaxDialog: XCTestCase {
                            protectionStatus: protectionStatus)
     }
 
-    private func makeExperimentSUT(settings: DaxDialogsSettings) -> DaxDialogs {
+    private func makeExperimentSUT(settings: DaxDialogsSettings, onboardingManager: OnboardingAddToDockManaging = OnboardingManagerMock()) -> DaxDialogs {
         var mockVariantManager = MockVariantManager()
         mockVariantManager.isSupportedBlock = { feature in
             feature == .contextualDaxDialogs
         }
-        return DaxDialogs(settings: settings, entityProviding: entityProvider, variantManager: mockVariantManager)
+        return DaxDialogs(settings: settings, entityProviding: entityProvider, variantManager: mockVariantManager, onboardingManager: onboardingManager)
     }
 }

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -1105,7 +1105,7 @@ final class DaxDialog: XCTestCase {
     func testWhenIsShowingAddToDockDialogCalledAndHomeSpecIsFinalAndAddToDockIsEnabledThenReturnTrue() {
         // GIVEN
         let onboardingManagerMock = OnboardingManagerMock()
-        onboardingManagerMock.isAddToDockEnabled = true
+        onboardingManagerMock.addToDockEnabledState = .contextual
         settings.fireMessageExperimentShown = true
         let sut = makeExperimentSUT(settings: settings, onboardingManager: onboardingManagerMock)
         _ = sut.nextHomeScreenMessageNew()
@@ -1120,7 +1120,7 @@ final class DaxDialog: XCTestCase {
     func testWhenIsShowingAddToDockDialogCalledAndHomeSpecIsNotFinalThenReturnFalse() {
         // GIVEN
         let onboardingManagerMock = OnboardingManagerMock()
-        onboardingManagerMock.isAddToDockEnabled = true
+        onboardingManagerMock.addToDockEnabledState = .contextual
         let sut = makeExperimentSUT(settings: settings, onboardingManager: onboardingManagerMock)
         _ = sut.nextHomeScreenMessageNew()
 
@@ -1134,7 +1134,7 @@ final class DaxDialog: XCTestCase {
     func testWhenIsShowingAddToDockDialogCalledAndHomeSpeciIsFinalAndAddToDockIsNotEnabledReturnFalse() {
         // GIVEN
         let onboardingManagerMock = OnboardingManagerMock()
-        onboardingManagerMock.isAddToDockEnabled = false
+        onboardingManagerMock.addToDockEnabledState = .disabled
         settings.fireMessageExperimentShown = true
         let sut = makeExperimentSUT(settings: settings, onboardingManager: onboardingManagerMock)
         _ = sut.nextHomeScreenMessageNew()

--- a/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -475,4 +475,34 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(result, UserText.HighlightsOnboardingExperiment.BrowsersComparison.title)
     }
 
+    // MARK: - Add To Dock
+
+    func testWhenSetDefaultBrowserActionIsCalledAndIsHighlightsIphoneFlowThenViewStateChangesToAddToDockPromoDialogAndProgressIs2Of4() {
+        // GIVEN
+        onboardingManager.isOnboardingHighlightsEnabled = true
+        onboardingManager.addToDockEnabledState = .intro
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingPixelReporterMock(), onboardingManager: onboardingManager, isIpad: false, urlOpener: MockURLOpener())
+        XCTAssertEqual(sut.state, .landing)
+
+        // WHEN
+        sut.setDefaultBrowserAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .addToDockPromoDialog, step: .init(currentStep: 2, totalSteps: 4))))
+    }
+
+    func testWhenAddtoDockContinueActionIsCalledAndIsHighlightsIphoneFlowThenThenViewStateChangesToChooseAppIconAndProgressIs3of4() {
+        // GIVEN
+        onboardingManager.isOnboardingHighlightsEnabled = true
+        onboardingManager.addToDockEnabledState = .intro
+        let sut = OnboardingIntroViewModel(pixelReporter: OnboardingPixelReporterMock(), onboardingManager: onboardingManager, isIpad: false)
+        XCTAssertEqual(sut.state, .landing)
+
+        // WHEN
+        sut.addToDockContinueAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .chooseAppIconDialog, step: .init(currentStep: 3, totalSteps: 4))))
+    }
+
 }

--- a/DuckDuckGoTests/OnboardingManagerMock.swift
+++ b/DuckDuckGoTests/OnboardingManagerMock.swift
@@ -22,5 +22,5 @@ import Foundation
 
 final class OnboardingManagerMock: OnboardingHighlightsManaging, OnboardingAddToDockManaging {
     var isOnboardingHighlightsEnabled: Bool = false
-    var isAddToDockEnabled: Bool = false
+    var addToDockEnabledState: OnboardingAddToDockState = .disabled
 }

--- a/DuckDuckGoTests/OnboardingManagerMock.swift
+++ b/DuckDuckGoTests/OnboardingManagerMock.swift
@@ -20,6 +20,7 @@
 import Foundation
 @testable import DuckDuckGo
 
-final class OnboardingManagerMock: OnboardingHighlightsManaging {
+final class OnboardingManagerMock: OnboardingHighlightsManaging, OnboardingAddToDockManaging {
     var isOnboardingHighlightsEnabled: Bool = false
+    var isAddToDockEnabled: Bool = false
 }

--- a/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -155,26 +155,37 @@ final class OnboardingManagerTests: XCTestCase {
 
     // MARK: - Add to Dock
 
-    func testWhenIsAddToDockLocalFlagEnabledCalledAndAppDefaultsOnboardingAddToDockEnabledIsTrueThenReturnTrue() {
+    func testWhenAddToDockLocalFlagStateCalledAndAppDefaultsOnboardingAddToDockStateIsIntroThenReturnIntro() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = true
+        appSettingsMock.onboardingAddToDockState = .intro
 
         // WHEN
-        let result = sut.isAddToDockLocalFlagEnabled
+        let result = sut.addToDockLocalFlagState
 
         // THEN
-        XCTAssertTrue(result)
+        XCTAssertEqual(result, .intro)
     }
 
-    func testWhenIsAddToDockLocalFlagEnabledCalledAndAppDefaultsOnboardingAddToDockEnabledIsFalseThenReturnFalse() {
+    func testWhenAddToDockLocalFlagStateCalledAndAppDefaultsOnboardingAddToDockStateIsContextualThenReturnContextual() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = false
+        appSettingsMock.onboardingAddToDockState = .contextual
 
         // WHEN
-        let result = sut.isAddToDockLocalFlagEnabled
+        let result = sut.addToDockLocalFlagState
 
         // THEN
-        XCTAssertFalse(result)
+        XCTAssertEqual(result, .contextual)
+    }
+
+    func testWhenAddToDockLocalFlagStateCalledAndAppDefaultsOnboardingAddToDockStateIsDisabledThenReturnDisabled() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockState = .disabled
+
+        // WHEN
+        let result = sut.addToDockLocalFlagState
+
+        // THEN
+        XCTAssertEqual(result, .disabled)
     }
 
     func testWhenIsAddToDockFeatureFlagEnabledCalledAndFeaturFlaggerFeatureIsOnThenReturnTrue() {
@@ -199,65 +210,102 @@ final class OnboardingManagerTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    func testWhenIsAddToDockEnabledCalledAndLocalFlagEnabledIsFalseAndFeatureFlagIsFalseThenReturnFalse() {
+    func testWhenAddToDockStateCalledAndLocalFlagStateIsDisabledAndFeatureFlagIsFalseThenReturnDisabled() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = false
+        appSettingsMock.onboardingAddToDockState = .disabled
         featureFlaggerMock.enabledFeatureFlags = []
 
         // WHEN
-        let result = sut.isAddToDockEnabled
+        let result = sut.addToDockEnabledState
 
         // THEN
-        XCTAssertFalse(result)
+        XCTAssertEqual(result, .disabled)
     }
 
-    func testWhenIsAddToDockEnabledCalledAndLocalFlagEnabledIsTrueAndFeatureFlagIsFalseThenReturnFalse() {
+    func testWhenAddToDockStateCalledAndLocalFlagStateIsIntroAndFeatureFlagIsFalseThenReturnDisabled() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = true
+        appSettingsMock.onboardingAddToDockState = .intro
         featureFlaggerMock.enabledFeatureFlags = []
 
         // WHEN
-        let result = sut.isAddToDockEnabled
+        let result = sut.addToDockEnabledState
 
         // THEN
-        XCTAssertFalse(result)
+        XCTAssertEqual(result, .disabled)
     }
 
-    func testWhenIsAddToDockEnabledCalledAndLocalFlagEnabledIsFalseAndFeatureFlagEnabledIsTrueThenReturnFalse() {
+    func testWhenAddToDockStateCalledAndLocalFlagStateIsContextualAndFeatureFlagIsFalseThenReturnDisabled() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = false
+        appSettingsMock.onboardingAddToDockState = .contextual
+        featureFlaggerMock.enabledFeatureFlags = []
+
+        // WHEN
+        let result = sut.addToDockEnabledState
+
+        // THEN
+        XCTAssertEqual(result, .disabled)
+    }
+
+    func testWhenAddToDockStateCalledAndLocalFlagStateIsDisabledAndFeatureFlagEnabledIsTrueThenReturnDisabled() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockState = .disabled
         featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
 
         // WHEN
-        let result = sut.isAddToDockEnabled
+        let result = sut.addToDockEnabledState
 
         // THEN
-        XCTAssertFalse(result)
+        XCTAssertEqual(result, .disabled)
     }
 
-    func testWhenIsAddToDockEnabledAndLocalFlagEnabledIsTrueAndFeatureFlagEnabledIsTrueThenReturnTrue() {
+    func testWhenAddToDockStateAndLocalFlagStateIsIntroAndFeatureFlagEnabledIsTrueThenReturnIntro() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = true
+        appSettingsMock.onboardingAddToDockState = .intro
         featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
 
         // WHEN
-        let result = sut.isAddToDockEnabled
+        let result = sut.addToDockEnabledState
 
         // THEN
-        XCTAssertTrue(result)
+        XCTAssertEqual(result, .intro)
     }
 
-    func testWhenIsAddToDockEnabledAndLocalAndFeatureFlagsAreEnabledAndDeviceIsIpadReturnFalse() {
+    func testWhenAddToDockStateAndLocalFlagStateIsContextualAndFeatureFlagEnabledIsTrueThenReturnContextual() {
         // GIVEN
-        appSettingsMock.onboardingAddToDockEnabled = true
+        appSettingsMock.onboardingAddToDockState = .contextual
+        featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
+
+        // WHEN
+        let result = sut.addToDockEnabledState
+
+        // THEN
+        XCTAssertEqual(result, .contextual)
+    }
+
+    func testWhenAddToDockStateAndLocalFlagStateIsIntroAndFeatureFlagsIsEnabledAndDeviceIsIpadReturnDisabled() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockState = .intro
         featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
         sut = OnboardingManager(appDefaults: appSettingsMock, featureFlagger: featureFlaggerMock, variantManager: variantManagerMock, isIphone: false)
 
         // WHEN
-        let result = sut.isAddToDockEnabled
+        let result = sut.addToDockEnabledState
 
         // THEN
-        XCTAssertFalse(result)
+        XCTAssertEqual(result, .disabled)
+    }
+
+    func testWhenAddToDockStateAndLocalFlagStateIsContextualAndFeatureFlagsIsEnabledAndDeviceIsIpadReturnDisabled() {
+        // GIVEN
+        appSettingsMock.onboardingAddToDockState = .contextual
+        featureFlaggerMock.enabledFeatureFlags = [.onboardingAddToDock]
+        sut = OnboardingManager(appDefaults: appSettingsMock, featureFlagger: featureFlaggerMock, variantManager: variantManagerMock, isIphone: false)
+
+        // WHEN
+        let result = sut.addToDockEnabledState
+
+        // THEN
+        XCTAssertEqual(result, .disabled)
     }
 
 }

--- a/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -242,6 +242,7 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
     var shouldShowPrivacyButtonPulse: Bool = false
     var isShowingSearchSuggestions: Bool = false
     var isShowingSitesSuggestions: Bool = false
+    var isShowingAddToDockDialog: Bool = false
 
     func setFireEducationMessageSeen() {
         didCallSetFireEducationMessageSeen = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208648960421864/f

**Description**:

Refactor the logic to show Add to Dock from the Onboarding Intro or the end of the contextual flow.

This PR also contains:
* Prevent showing the keyboard on the contextual end of journey dialog when it shows the Add to Dock instructions.
* SH1/ Design review fix that caused the copy to be broken on multiple lines at the wrong spot.

**Steps to test this PR**:
_Prerequisites:_
1.  Ensure that `isOnboardingHighlightsEnabled` returns `true` in OnboardingManager.
2. Add `return VariantIOS(name: "mx", weight: 1, isIncluded: VariantIOS.When.always, features: [.newOnboardingIntroHighlights, .contextualDaxDialogs])` in `DefaultVariantManager` -> `selectVariant()` at line 156.

**Scenario 1 - Add to Dock is presented from linear onboarding**
1. Ensure that `addToDockEnabledState` returns `.intro` in OnboardingManager.
2. Launch the App.
3. Ensure that Add to Dock Dax dialog is presented after "Set Default Browser" dialog.
4. Continue with the flow and ensure that the Add to Dock promo is not presented in the final contextual dialog.

Repeat the test and ensure that the “Show me how” button in the Add to Dock promo dialog shows the video tutorial and that the onboarding flow continues upon tapping on “Got It".

**Scenario 2 - Add to Dock is presented from contextual onboarding**
1. Ensure that `addToDockEnabledState` returns `.contextual` in OnboardingManager.
2. Launch the App.
3. Ensure that Add to Dock Dax dialog is not presented after "Set Default Browser" dialog.
4. Continue with the flow and ensure that the Add to Dock promo is presented in the final contextual dialog.

Repeat the test and ensure that the “Show me how” button in the Add to Dock contextual dialog shows the video tutorial and that the dialog is dismissed upon tapping “Start Browsing".

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
