### PR TITLE
Onboarding Add To Dock Pixels

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -143,6 +143,8 @@ extension Pixel {
         
         case brokenSiteReport
         
+        // MARK: - Onboarding
+
         case onboardingIntroShownUnique
         case onboardingIntroComparisonChartShownUnique
         case onboardingIntroChooseBrowserCTAPressed
@@ -172,6 +174,15 @@ extension Pixel {
         case daxDialogsEndOfJourneyTabUnique
         case daxDialogsEndOfJourneyNewTabUnique
         case daxDialogsEndOfJourneyDismissed
+
+        // MARK: - Onboarding Add To Dock
+
+        case onboardingAddToDockPromoImpressionsUnique
+        case onboardingAddToDockPromoShowTutorialCTATapped
+        case onboardingAddToDockPromoDismissCTATapped
+        case onboardingAddToDockTutorialDismissCTATapped
+
+        // MARK: - Onboarding Add To Dock
 
         case widgetsOnboardingCTAPressed
         case widgetsOnboardingDeclineOptionPressed
@@ -1002,6 +1013,11 @@ extension Pixel.Event {
         case .daxDialogsEndOfJourneyTabUnique: return "m_dx_end_tab_unique"
         case .daxDialogsEndOfJourneyNewTabUnique: return "m_dx_end_new_tab_unique"
         case .daxDialogsEndOfJourneyDismissed: return "m_dx_end_dialog_dismissed"
+
+        case .onboardingAddToDockPromoImpressionsUnique: return "m_onboarding_add_to_dock_promo_impressions_unique"
+        case .onboardingAddToDockPromoShowTutorialCTATapped: return "m_onboarding_add_to_dock_promo_show_tutorial_button_tapped"
+        case .onboardingAddToDockPromoDismissCTATapped: return "m_onboarding_add_to_dock_promo_dismiss_button_tapped"
+        case .onboardingAddToDockTutorialDismissCTATapped: return "m_onboarding_add_to_dock_tutorial_dismiss_button_tapped"
 
         case .widgetsOnboardingCTAPressed: return "m_o_w_a"
         case .widgetsOnboardingDeclineOptionPressed: return "m_o_w_d"

--- a/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
+++ b/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
@@ -35,17 +35,20 @@ extension OnboardingView {
         private var animateTitle: Binding<Bool>
         private var animateMessage: Binding<Bool>
         private var showContent: Binding<Bool>
+        private let showTutorialAction: () -> Void
         private let dismissAction: (_ fromAddToDock: Bool) -> Void
 
         init(
             animateTitle: Binding<Bool> = .constant(true),
             animateMessage: Binding<Bool> = .constant(true),
             showContent: Binding<Bool> = .constant(false),
+            showTutorialAction: @escaping () -> Void,
             dismissAction: @escaping (_ fromAddToDock: Bool) -> Void
         ) {
             self.animateTitle = animateTitle
             self.animateMessage = animateMessage
             self.showContent = showContent
+            self.showTutorialAction = showTutorialAction
             self.dismissAction = dismissAction
         }
 
@@ -77,6 +80,7 @@ extension OnboardingView {
                 OnboardingCTAButton(
                     title: UserText.AddToDockOnboarding.Buttons.addToDockTutorial,
                     action: {
+                        showTutorialAction()
                         showAddToDockTutorial = true
                     }
                 )

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -190,6 +190,7 @@ struct OnboardingFinalDialog: View {
     let message: String
     let cta: String
     let canShowAddToDockTutorial: Bool
+    let showAddToDockTutorialAction: () -> Void
     let dismissAction: (_ fromAddToDock: Bool) -> Void
 
     @State private var showAddToDockTutorial = false
@@ -234,6 +235,7 @@ struct OnboardingFinalDialog: View {
                 OnboardingCTAButton(
                     title: UserText.AddToDockOnboarding.Buttons.addToDockTutorial,
                     action: {
+                        showAddToDockTutorialAction()
                         showAddToDockTutorial = true
                     }
                 )
@@ -327,6 +329,7 @@ struct OnboardingAddToDockTutorialContent: View {
         message: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenMessage,
         cta: UserText.DaxOnboardingExperiment.ContextualOnboarding.onboardingFinalScreenButton,
         canShowAddToDockTutorial: false,
+        showAddToDockTutorialAction: {},
         dismissAction: { _ in }
     )
     .padding()
@@ -338,6 +341,7 @@ struct OnboardingAddToDockTutorialContent: View {
         message: UserText.AddToDockOnboarding.EndOfJourney.message,
         cta: UserText.AddToDockOnboarding.Buttons.dismiss,
         canShowAddToDockTutorial: true,
+        showAddToDockTutorialAction: {},
         dismissAction: { _ in }
     )
     .padding()

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -111,20 +111,34 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         }
 
         return FadeInView {
-            OnboardingFinalDialog(logoPosition: .top, message: message, cta: cta, canShowAddToDockTutorial: shouldShowAddToDock) { [weak self] isDismissedFromAddToDock in
-                if isDismissedFromAddToDock {
-                    Logger.onboarding.debug("Dismissed from add to dock")
-                } else {
-                    Logger.onboarding.debug("Dismissed from end of Journey")
-                    self?.onboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
+            OnboardingFinalDialog(
+                logoPosition: .top,
+                message: message,
+                cta: cta,
+                canShowAddToDockTutorial: shouldShowAddToDock,
+                showAddToDockTutorialAction: { [weak self] in
+                    self?.onboardingPixelReporter.trackAddToDockPromoShowTutorialCTAAction()
+                },
+                dismissAction: { [weak self] isDismissedFromAddToDockTutorial in
+                    if isDismissedFromAddToDockTutorial {
+                        self?.onboardingPixelReporter.trackAddToDockTutorialDismissCTAAction()
+                    } else {
+                        self?.onboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
+                        if shouldShowAddToDock {
+                            self?.onboardingPixelReporter.trackAddToDockPromoDismissCTAAction()
+                        }
+                    }
+                    onDismiss()
                 }
-                onDismiss()
-            }
+            )
         }
         .onboardingContextualBackgroundStyle(background: .illustratedGradient(gradientType))
         .onFirstAppear { [weak self] in
             self?.contextualOnboardingLogic.setFinalOnboardingDialogSeen()
             self?.onboardingPixelReporter.trackScreenImpression(event: .daxDialogsEndOfJourneyNewTabUnique)
+            if shouldShowAddToDock {
+                self?.onboardingPixelReporter.trackAddToDockPromoImpression()
+            }
         }
     }
 }

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -110,26 +110,30 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
             )
         }
 
+        let showAddToDockTutorialAction: () -> Void = { [weak self] in
+            self?.onboardingPixelReporter.trackAddToDockPromoShowTutorialCTAAction()
+        }
+
+        let dismissAction = { [weak self] isDismissedFromAddToDockTutorial in
+            if isDismissedFromAddToDockTutorial {
+                self?.onboardingPixelReporter.trackAddToDockTutorialDismissCTAAction()
+            } else {
+                self?.onboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
+                if shouldShowAddToDock {
+                    self?.onboardingPixelReporter.trackAddToDockPromoDismissCTAAction()
+                }
+            }
+            onDismiss()
+        }
+
         return FadeInView {
             OnboardingFinalDialog(
                 logoPosition: .top,
                 message: message,
                 cta: cta,
                 canShowAddToDockTutorial: shouldShowAddToDock,
-                showAddToDockTutorialAction: { [weak self] in
-                    self?.onboardingPixelReporter.trackAddToDockPromoShowTutorialCTAAction()
-                },
-                dismissAction: { [weak self] isDismissedFromAddToDockTutorial in
-                    if isDismissedFromAddToDockTutorial {
-                        self?.onboardingPixelReporter.trackAddToDockTutorialDismissCTAAction()
-                    } else {
-                        self?.onboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
-                        if shouldShowAddToDock {
-                            self?.onboardingPixelReporter.trackAddToDockPromoDismissCTAAction()
-                        }
-                    }
-                    onDismiss()
-                }
+                showAddToDockTutorialAction: showAddToDockTutorialAction,
+                dismissAction: dismissAction
             )
         }
         .onboardingContextualBackgroundStyle(background: .illustratedGradient(gradientType))

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -193,18 +193,32 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
             )
         }
 
-        return OnboardingFinalDialog(logoPosition: .left, message: message, cta: cta, canShowAddToDockTutorial: shouldShowAddToDock, dismissAction: { [weak delegate, weak self] isDismissedFromAddToDock in
-            delegate?.didTapDismissContextualOnboardingAction()
-            if isDismissedFromAddToDock {
-                Logger.onboarding.debug("Dismissed from add to dock")
-            } else {
-                Logger.onboarding.debug("Dismissed from end of Journey")
-                self?.contextualOnboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
+        return OnboardingFinalDialog(
+            logoPosition: .left,
+            message: message,
+            cta: cta,
+            canShowAddToDockTutorial: shouldShowAddToDock,
+            showAddToDockTutorialAction: { [weak self] in
+                self?.contextualOnboardingPixelReporter.trackAddToDockPromoShowTutorialCTAAction()
+            },
+            dismissAction: { [weak delegate, weak self] isDismissedFromAddToDockTutorial in
+                delegate?.didTapDismissContextualOnboardingAction()
+                if isDismissedFromAddToDockTutorial {
+                    self?.contextualOnboardingPixelReporter.trackAddToDockTutorialDismissCTAAction()
+                } else {
+                    self?.contextualOnboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
+                    if shouldShowAddToDock {
+                        self?.contextualOnboardingPixelReporter.trackAddToDockPromoDismissCTAAction()
+                    }
+                }
             }
-        })
+        )
         .onFirstAppear { [weak self] in
             self?.contextualOnboardingLogic.setFinalOnboardingDialogSeen()
             self?.contextualOnboardingPixelReporter.trackScreenImpression(event: pixelName)
+            if shouldShowAddToDock {
+                self?.contextualOnboardingPixelReporter.trackAddToDockPromoImpression()
+            }
         }
     }
 

--- a/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -193,25 +193,29 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
             )
         }
 
+        let showAddToDockTutorialAction: () -> Void = { [weak self] in
+            self?.contextualOnboardingPixelReporter.trackAddToDockPromoShowTutorialCTAAction()
+        }
+
+        let dismissAction = { [weak delegate, weak self] isDismissedFromAddToDockTutorial in
+            delegate?.didTapDismissContextualOnboardingAction()
+            if isDismissedFromAddToDockTutorial {
+                self?.contextualOnboardingPixelReporter.trackAddToDockTutorialDismissCTAAction()
+            } else {
+                self?.contextualOnboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
+                if shouldShowAddToDock {
+                    self?.contextualOnboardingPixelReporter.trackAddToDockPromoDismissCTAAction()
+                }
+            }
+        }
+
         return OnboardingFinalDialog(
             logoPosition: .left,
             message: message,
             cta: cta,
             canShowAddToDockTutorial: shouldShowAddToDock,
-            showAddToDockTutorialAction: { [weak self] in
-                self?.contextualOnboardingPixelReporter.trackAddToDockPromoShowTutorialCTAAction()
-            },
-            dismissAction: { [weak delegate, weak self] isDismissedFromAddToDockTutorial in
-                delegate?.didTapDismissContextualOnboardingAction()
-                if isDismissedFromAddToDockTutorial {
-                    self?.contextualOnboardingPixelReporter.trackAddToDockTutorialDismissCTAAction()
-                } else {
-                    self?.contextualOnboardingPixelReporter.trackEndOfJourneyDialogCTAAction()
-                    if shouldShowAddToDock {
-                        self?.contextualOnboardingPixelReporter.trackAddToDockPromoDismissCTAAction()
-                    }
-                }
-            }
+            showAddToDockTutorialAction: showAddToDockTutorialAction,
+            dismissAction: dismissAction
         )
         .onFirstAppear { [weak self] in
             self?.contextualOnboardingLogic.setFinalOnboardingDialogSeen()

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -30,7 +30,7 @@ final class OnboardingIntroViewModel: ObservableObject {
     var onCompletingOnboardingIntro: (() -> Void)?
     private var introSteps: [OnboardingIntroStep]
 
-    private let pixelReporter: OnboardingIntroPixelReporting
+    private let pixelReporter: OnboardingIntroPixelReporting & OnboardingAddToDockReporting
     private let onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging
     private let isIpad: Bool
     private let urlOpener: URLOpener
@@ -38,7 +38,7 @@ final class OnboardingIntroViewModel: ObservableObject {
     private let addressBarPositionProvider: () -> AddressBarPosition
 
     init(
-        pixelReporter: OnboardingIntroPixelReporting,
+        pixelReporter: OnboardingIntroPixelReporting & OnboardingAddToDockReporting,
         onboardingManager: OnboardingHighlightsManaging & OnboardingAddToDockManaging = OnboardingManager(),
         isIpad: Bool = UIDevice.current.userInterfaceIdiom == .pad,
         urlOpener: URLOpener = UIApplication.shared,
@@ -87,8 +87,17 @@ final class OnboardingIntroViewModel: ObservableObject {
         handleSetDefaultBrowserAction()
     }
 
-    func addToDockContinueAction() {
+    func addToDockContinueAction(isShowingAddToDockTutorial: Bool) {
         state = makeViewState(for: .appIconSelection)
+        if isShowingAddToDockTutorial {
+            pixelReporter.trackAddToDockTutorialDismissCTAAction()
+        } else {
+            pixelReporter.trackAddToDockPromoDismissCTAAction()
+        }
+    }
+
+    func addtoDockShowTutorialAction() {
+        pixelReporter.trackAddToDockPromoShowTutorialCTAAction()
     }
 
     func appIconPickerContinueAction() {
@@ -150,6 +159,7 @@ private extension OnboardingIntroViewModel {
     func handleSetDefaultBrowserAction() {
         if onboardingManager.addToDockEnabledState == .intro && onboardingManager.isOnboardingHighlightsEnabled {
             state = makeViewState(for: .addToDockPromo)
+            pixelReporter.trackAddToDockPromoImpression()
         } else if onboardingManager.isOnboardingHighlightsEnabled {
             state = makeViewState(for: .appIconSelection)
             pixelReporter.trackChooseAppIconImpression()

--- a/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -159,8 +159,14 @@ struct OnboardingView: View {
     }
 
     private var addToDockPromoView: some View {
-        AddToDockPromoContent(dismissAction: { _ in model.addToDockContinueAction()
-        })
+        AddToDockPromoContent(
+            showTutorialAction: {
+                model.addtoDockShowTutorialAction()
+            },
+            dismissAction: { fromAddToDockTutorial in
+                model.addToDockContinueAction(isShowingAddToDockTutorial: fromAddToDockTutorial)
+            }
+        )
     }
 
     private var appIconPickerView: some View {

--- a/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -67,7 +67,14 @@ protocol OnboardingDaxDialogsReporting {
     func trackEndOfJourneyDialogCTAAction()
 }
 
-typealias OnboardingPixelReporting = OnboardingIntroImpressionReporting & OnboardingIntroPixelReporting & OnboardingSearchSuggestionsPixelReporting & OnboardingSiteSuggestionsPixelReporting & OnboardingCustomInteractionPixelReporting & OnboardingDaxDialogsReporting
+protocol OnboardingAddToDockReporting {
+    func trackAddToDockPromoImpression()
+    func trackAddToDockPromoShowTutorialCTAAction()
+    func trackAddToDockPromoDismissCTAAction()
+    func trackAddToDockTutorialDismissCTAAction()
+}
+
+typealias OnboardingPixelReporting = OnboardingIntroImpressionReporting & OnboardingIntroPixelReporting & OnboardingSearchSuggestionsPixelReporting & OnboardingSiteSuggestionsPixelReporting & OnboardingCustomInteractionPixelReporting & OnboardingDaxDialogsReporting & OnboardingAddToDockReporting
 
 // MARK: - Implementation
 
@@ -228,6 +235,28 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
 
     func trackEndOfJourneyDialogCTAAction() {
         fire(event: .daxDialogsEndOfJourneyDismissed, unique: false)
+    }
+
+}
+
+// MARK: - OnboardingPixelReporter + Add To Dock
+
+extension OnboardingPixelReporter: OnboardingAddToDockReporting {
+   
+    func trackAddToDockPromoImpression() {
+        fire(event: .onboardingAddToDockPromoImpressionsUnique, unique: true)
+    }
+    
+    func trackAddToDockPromoShowTutorialCTAAction() {
+        fire(event: .onboardingAddToDockPromoShowTutorialCTATapped, unique: false)
+    }
+    
+    func trackAddToDockPromoDismissCTAAction() {
+        fire(event: .onboardingAddToDockPromoDismissCTATapped, unique: false)
+    }
+    
+    func trackAddToDockTutorialDismissCTAAction() {
+        fire(event: .onboardingAddToDockTutorialDismissCTATapped, unique: false)
     }
 
 }

--- a/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -369,11 +369,76 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         // THEN
         XCTAssertTrue(result)
     }
+
+    // MARK: - Add To Dock Pixels
+
+    func testWhenEndOfJourneyAddToDockPromoDialogAppearForTheFirstTimeThenFireExpectedPixel() throws {
+        // GIVEN
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let spec = DaxDialogs.BrowsingSpec.final
+        // TEST
+        waitForDialogDefinedBy(spec: spec) {
+            XCTAssertTrue(self.pixelReporterMock.didCallTrackAddToDockPromoImpression)
+        }
+    }
+
+    func testWhenEndOfJourneyAndAddToDockPromoShowTutorialButtonActionThenFireExpectedPixel() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = sut.makeView(for: spec, delegate: ContextualOnboardingDelegateMock(), onSizeUpdate: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoShowTutorialCTAAction)
+
+        // WHEN
+        view.showAddToDockTutorialAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoShowTutorialCTAAction)
+    }
+
+    func testWhenEndOfJourneyAndAddToDockPromoDismissButtonActionThenFireExpectedPixel() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = sut.makeView(for: spec, delegate: ContextualOnboardingDelegateMock(), onSizeUpdate: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoDismissCTAAction)
+
+        // WHEN
+        view.dismissAction(false)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoDismissCTAAction)
+    }
+
+    func testWhenEndOfJourneyAndAddToDockTutorialDismissButtonActionThenFireExpectedPixel() throws {
+        // GIVEN
+        let spec = DaxDialogs.BrowsingSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = sut.makeView(for: spec, delegate: ContextualOnboardingDelegateMock(), onSizeUpdate: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockTutorialDismissCTAAction)
+
+        // WHEN
+        view.dismissAction(true)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockTutorialDismissCTAAction)
+    }
 }
 
 extension ContextualDaxDialogsFactoryTests {
 
     func testDialogDefinedBy(spec: DaxDialogs.BrowsingSpec, firesEvent event: Pixel.Event) {
+        waitForDialogDefinedBy(spec: spec) {
+            // THEN
+            XCTAssertTrue(self.pixelReporterMock.didCallTrackScreenImpressionCalled)
+            XCTAssertEqual(self.pixelReporterMock.capturedScreenImpression, event)
+        }
+    }
+
+    func waitForDialogDefinedBy(spec: DaxDialogs.BrowsingSpec, completionHandler: @escaping () -> Void) {
         // GIVEN
         let expectation = self.expectation(description: #function)
         XCTAssertFalse(pixelReporterMock.didCallTrackScreenImpressionCalled)
@@ -388,8 +453,7 @@ extension ContextualDaxDialogsFactoryTests {
 
         // THEN
         waitForExpectations(timeout: 2.0)
-        XCTAssertTrue(pixelReporterMock.didCallTrackScreenImpressionCalled)
-        XCTAssertEqual(pixelReporterMock.capturedScreenImpression, event)
+        completionHandler()
     }
 
 }

--- a/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -201,11 +201,76 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    // MARK: - Add To Dock Pixels
+
+    func testWhenEndOfJourneyAddToDockPromoDialogAppearForTheFirstTimeThenFireExpectedPixel() throws {
+        // GIVEN
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let spec = DaxDialogs.HomeScreenSpec.final
+        // TEST
+        waitForDialogDefinedBy(spec: spec) {
+            XCTAssertTrue(self.pixelReporterMock.didCallTrackAddToDockPromoImpression)
+        }
+    }
+
+    func testWhenEndOfJourneyAndAddToDockPromoShowTutorialButtonActionThenFireExpectedPixel() throws {
+        // GIVEN
+        let spec = DaxDialogs.HomeScreenSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoShowTutorialCTAAction)
+
+        // WHEN
+        view.showAddToDockTutorialAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoShowTutorialCTAAction)
+    }
+
+    func testWhenEndOfJourneyAndAddToDockPromoDismissButtonActionThenFireExpectedPixel() throws {
+        // GIVEN
+        let spec = DaxDialogs.HomeScreenSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoDismissCTAAction)
+
+        // WHEN
+        view.dismissAction(false)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoDismissCTAAction)
+    }
+
+    func testWhenEndOfJourneyAndAddToDockTutorialDismissButtonActionThenFireExpectedPixel() throws {
+        // GIVEN
+        let spec = DaxDialogs.HomeScreenSpec.final
+        onboardingManagerMock.addToDockEnabledState = .contextual
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockTutorialDismissCTAAction)
+
+        // WHEN
+        view.dismissAction(true)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockTutorialDismissCTAAction)
+    }
+
 }
 
 private extension ContextualOnboardingNewTabDialogFactoryTests {
 
     func testDialogDefinedBy(spec: DaxDialogs.HomeScreenSpec, firesEvent event: Pixel.Event) {
+        waitForDialogDefinedBy(spec: spec) {
+            // THEN
+            XCTAssertTrue(self.pixelReporterMock.didCallTrackScreenImpressionCalled)
+            XCTAssertEqual(self.pixelReporterMock.capturedScreenImpression, event)
+        }
+    }
+
+    func waitForDialogDefinedBy(spec: DaxDialogs.HomeScreenSpec, completionHandler: @escaping () -> Void) {
         // GIVEN
         let expectation = self.expectation(description: #function)
         XCTAssertFalse(pixelReporterMock.didCallTrackScreenImpressionCalled)
@@ -220,8 +285,7 @@ private extension ContextualOnboardingNewTabDialogFactoryTests {
 
         // THEN
         waitForExpectations(timeout: 2.0)
-        XCTAssertTrue(pixelReporterMock.didCallTrackScreenImpressionCalled)
-        XCTAssertEqual(pixelReporterMock.capturedScreenImpression, event)
+        completionHandler()
     }
 
 }

--- a/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -241,7 +241,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         // THEN
         XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog, step: .hidden)))
     }
-    //
+
     func testWhenStartOnboardingActionIsCalledAndIsHighlightsIpadFlowThenViewStateChangesToBrowsersComparisonDialogAndProgressIs1Of3() {
         // GIVEN
         onboardingManager.isOnboardingHighlightsEnabled = true
@@ -499,10 +499,72 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .landing)
 
         // WHEN
-        sut.addToDockContinueAction()
+        sut.addToDockContinueAction(isShowingAddToDockTutorial: false)
 
         // THEN
         XCTAssertEqual(sut.state, .onboarding(.init(type: .chooseAppIconDialog, step: .init(currentStep: 3, totalSteps: 4))))
+    }
+
+    // MARK: - Pixel Add To Dock
+
+    func testWhenStateChangesToAddToDockPromoThenPixelReporterTrackAddToDockPromoImpression() {
+        // GIVEN
+        onboardingManager.isOnboardingHighlightsEnabled = true
+        onboardingManager.addToDockEnabledState = .intro
+        let pixelReporterMock = OnboardingPixelReporterMock()
+        let sut = OnboardingIntroViewModel(pixelReporter: pixelReporterMock, onboardingManager: onboardingManager, urlOpener: MockURLOpener())
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoImpression)
+
+        // WHEN
+        sut.setDefaultBrowserAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoImpression)
+    }
+
+    func testWhenAddToDockShowTutorialActionIsCalledThenPixelReporterTrackAddToDockPromoShowTutorialCTA() {
+        // GIVEN
+        onboardingManager.isOnboardingHighlightsEnabled = true
+        onboardingManager.addToDockEnabledState = .intro
+        let pixelReporterMock = OnboardingPixelReporterMock()
+        let sut = OnboardingIntroViewModel(pixelReporter: pixelReporterMock, onboardingManager: onboardingManager, urlOpener: MockURLOpener())
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoShowTutorialCTAAction)
+
+        // WHEN
+        sut.addtoDockShowTutorialAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoShowTutorialCTAAction)
+    }
+
+    func testWhenAddToDockContinueActionIsCalledAndIsShowingFromAddToDockTutorialIsTrueThenPixelReporterTrackAddToDockTutorialDismissCTA() {
+        // GIVEN
+        onboardingManager.isOnboardingHighlightsEnabled = true
+        onboardingManager.addToDockEnabledState = .intro
+        let pixelReporterMock = OnboardingPixelReporterMock()
+        let sut = OnboardingIntroViewModel(pixelReporter: pixelReporterMock, onboardingManager: onboardingManager, urlOpener: MockURLOpener())
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockTutorialDismissCTAAction)
+
+        // WHEN
+        sut.addToDockContinueAction(isShowingAddToDockTutorial: true)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockTutorialDismissCTAAction)
+    }
+
+    func testWhenAddToDockContinueActionIsCalledAndIsShowingFromAddToDockTutorialIsFalseThenPixelReporterTrackAddToDockTutorialDismissCTA() {
+        // GIVEN
+        onboardingManager.isOnboardingHighlightsEnabled = true
+        onboardingManager.addToDockEnabledState = .intro
+        let pixelReporterMock = OnboardingPixelReporterMock()
+        let sut = OnboardingIntroViewModel(pixelReporter: pixelReporterMock, onboardingManager: onboardingManager, urlOpener: MockURLOpener())
+        XCTAssertFalse(pixelReporterMock.didCallTrackAddToDockPromoDismissCTAAction)
+
+        // WHEN
+        sut.addToDockContinueAction(isShowingAddToDockTutorial: false)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallTrackAddToDockPromoDismissCTAAction)
     }
 
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -22,8 +22,7 @@ import Core
 import Onboarding
 @testable import DuckDuckGo
 
-final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting {
-    
+final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting, OnboardingAddToDockReporting {
     private(set) var didCallTrackOnboardingIntroImpression = false
     private(set) var didCallTrackBrowserComparisonImpression = false
     private(set) var didCallTrackChooseBrowserCTAAction = false
@@ -45,6 +44,11 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
     private(set) var capturedScreenImpression: Pixel.Event?
     private(set) var didCallTrackPrivacyDashboardOpenedForFirstTime = false
     private(set) var didCallTrackEndOfJourneyDialogDismiss = false
+
+    private(set) var didCallTrackAddToDockPromoImpression = false
+    private(set) var didCallTrackAddToDockPromoShowTutorialCTAAction = false
+    private(set) var didCallTrackAddToDockPromoDismissCTAAction = false
+    private(set) var didCallTrackAddToDockTutorialDismissCTAAction = false
 
     func trackOnboardingIntroImpression() {
         didCallTrackOnboardingIntroImpression = true
@@ -105,5 +109,21 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     func trackPrivacyDashboardOpenedForFirstTime() {
         didCallTrackPrivacyDashboardOpenedForFirstTime = true
+    }
+
+    func trackAddToDockPromoImpression() {
+        didCallTrackAddToDockPromoImpression = true
+    }
+
+    func trackAddToDockPromoShowTutorialCTAAction() {
+        didCallTrackAddToDockPromoShowTutorialCTAAction = true
+    }
+
+    func trackAddToDockPromoDismissCTAAction() {
+        didCallTrackAddToDockPromoDismissCTAAction = true
+    }
+
+    func trackAddToDockTutorialDismissCTAAction() {
+        didCallTrackAddToDockTutorialDismissCTAAction = true
     }
 }

--- a/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -401,4 +401,74 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion])
     }
 
+    // MARK: Add To Dock Experiment
+
+    func testWhenTrackAddToDockPromoImpressionsIsCalledThenOnboardingAddToDockPromoImpressionsPixelFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingAddToDockPromoImpressionsUnique
+        XCTAssertFalse(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingUniquePixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackAddToDockPromoImpression()
+
+        // THEN
+        XCTAssertTrue(OnboardingUniquePixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, expectedPixel.name)
+        XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackAddToDockPromoShowTutorialCTAActionIsCalledThenOnboardingAddToDockPromoShowTutorialCTAPixelFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingAddToDockPromoShowTutorialCTATapped
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingPixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackAddToDockPromoShowTutorialCTAAction()
+
+        // THEN
+        XCTAssertTrue(OnboardingPixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, expectedPixel.name)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackAddToDockPromoDismissCTAActionThenOnboardingAddToDockPromoDismissCTAPixelFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingAddToDockPromoDismissCTATapped
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingPixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackAddToDockPromoDismissCTAAction()
+
+        // THEN
+        XCTAssertTrue(OnboardingPixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, expectedPixel.name)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    func testWhenTrackAddToDockTutorialDismissCTAActionIsCalledThenonboardingAddToDockTutorialDismissCTAPixelFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingAddToDockTutorialDismissCTATapped
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingPixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.trackAddToDockTutorialDismissCTAAction()
+
+        // THEN
+        XCTAssertTrue(OnboardingPixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, expectedPixel.name)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208590665790272/f

**Description**:

Add pixels for "Add To Dock" experiment.

**Steps to test this PR**:
_Prerequisites:_
1.  Ensure that `isOnboardingHighlightsEnabled` returns `true` in OnboardingManager.
2. Add `return VariantIOS(name: "mx", weight: 1, isIncluded: VariantIOS.When.always, features: [.newOnboardingIntroHighlights, .contextualDaxDialogs])` in `DefaultVariantManager` -> `selectVariant()` at line 156.

**Scenario 1 - Add to Dock is presented from linear onboarding**
1. Ensure that `addToDockEnabledState` returns `.intro` in OnboardingManager.
2. Launch the App.
3. Wait for the Add to Dock Promo screen is presented.
4. Ensure that “m_onboarding_add_to_dock_promo_impressions_unique” is fired.
5. Tap “Skip” button and ensure that “m_onboarding_add_to_dock_promo_dismiss_button_tapped” is fired.

Repeat the test and when Add to Dock Promo screen is presented:
1. Tap the “Show me how” button and ensure that “m_onboarding_add_to_dock_promo_show_tutorial_button_tapped” is fired.
2. Tap the “Got It” button and ensure that “m_onboarding_add_to_dock_tutorial_dismiss_button_tapped” is fired.

**Scenario 2 - Add to Dock is presented from contextual onboarding**
1. Ensure that `addToDockEnabledState` returns `.contextual` in OnboardingManager.
2. Launch the App.
3. Complete the contextual onboarding till the end of journey dialog.
4. Ensure that “m_onboarding_add_to_dock_promo_impressions_unique” is fired.
5. Tap the “Start Browsing” button and ensure that “m_onboarding_add_to_dock_promo_dismiss_button_tapped” is fired.

Repeat the test and when Add to Dock Promo contextual dialog  is presented:
1. Tap the “Show me how” button and ensure that “m_onboarding_add_to_dock_promo_show_tutorial_button_tapped” is fired.
2. Tap the “Start Browsing” button and ensure that “m_onboarding_add_to_dock_tutorial_dismiss_button_tapped” is fired.

Repeat the test and instead of showing the End of journey dialog from NTP, show it from contextual dialog.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
