### PR TITLE
Remove ATB from attribution pixel

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -142,6 +142,7 @@ public struct PixelParameters {
     public static let adAttributionKeywordID = "keyword_id"
     public static let adAttributionAdID = "ad_id"
     public static let adAttributionToken = "attribution_token"
+    public static let adAttributionIsReinstall = "is_reinstall"
 
     // Autofill
     public static let countBucket = "count_bucket"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206226850447395/1208686056380205/f
Tech Design URL:
CC:

**Description**:

Removes ATB cohort information from attribution pixel. Adds information about reinstall (returning user).

**Steps to test this PR**:
1. On a fresh install check if the parameter is included.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
