### PR TITLE
Use WebKit delegate flow for handling opening a new tab from _blank links

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1974,8 +1974,8 @@ extension TabViewController: WKNavigationDelegate {
         }
 
         if isNewTargetBlankRequest(navigationAction: navigationAction) {
-            delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: true, inheritingAttribution: adClickAttributionLogic.state)
-            completion(.cancel)
+            // Continue loading as WKUIDelegate callback will handle opening a new tab in TabViewController.webView(_:createWebViewWith:for:windowFeatures:)
+            completion(.allow)
             return
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208699273169079/f

**Description**:
In https://app.asana.com/0/414709148257752/1208699273169079/f it was identified that opening new tab via links with "_blank" target results in trimming referrer or sometimes broken flows. The previous logic used cancelling the navigation and opening a new tab followed by manual trigger to load target URL.
After investigation this approach was discouraged in favour of allowing the navigation and handling opening the new tab via `WKUIDelegate` callback in `TabViewController.webView(_:createWebViewWith:for:windowFeatures:)`

**Steps to test this PR**:
1. Open https://www.svcbank.com/personal-netbanking
2. Tap `Continue To Login` button
**Expected:** A new tab with the login page should open

1. Open http://miasma13.github.io/downloads.html
2. Tap `What are my headers` link
**Expected:** Check in the summary for referer header to properly list original page

Retest navigation with various means of opening a new tab (including via JS calls)


**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
