### PR TITLE
[DuckPlayer] Overlay Usage Pixels

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -683,6 +683,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Overlay Usage Pixel handling
         if let url = webView.url {
             duckPlayerOverlayUsagePixels?.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayerMode)
+            lastURLChangeHandling = Date()
         }
         
         // Check if DuckPlayer feature is enabled
@@ -835,6 +836,17 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Reset allowFirstVideo
         duckPlayer.settings.allowFirstVideo = false
         
+        // Overlay Usage Pixel handling for Direct Navigation
+        if let url = webView.url, !url.isYoutube {
+            duckPlayerOverlayUsagePixels?.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayerMode)
+        }
+        // Reset Overlay Last Fired pixel after the page is loaded
+        // A delay is required as Youtube sometimes performs an extra redirect on load
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            self.duckPlayerOverlayUsagePixels?.lastFiredPixel = nil
+        }
+        
+        
     }
     
     /// Resets settings when the web view starts loading a new page.
@@ -892,7 +904,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         guard isDuckPlayerFeatureEnabled else {
             return false
         }
-                
+        
         // Only account for in 'Always' mode
         if duckPlayerMode == .disabled {
             return false

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -575,7 +575,7 @@ final class DuckPlayerNavigationHandler: NSObject {
             // Watch in YT videos always open in new tab
             redirectToYouTubeVideo(url: url, webView: webView, forceNewTab: true)
         }
-    }    
+    }
     
 }
 
@@ -671,16 +671,16 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Update the Referrer based on the first URL change detected
         setReferrer(webView: webView)
         
-        // Overlay Usage Pixel handling
-        if let url = webView.url {
-            duckPlayerOverlayUsagePixels?.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayerMode)
-        }
-        
         // We don't want YouTube redirects happening while default navigation is happening
         // This can be caused by Duplicate Nav events, and quick URL changes
         if let lastTimestamp = lastNavigationHandling,
            Date().timeIntervalSince(lastTimestamp) < lastNavigationHandlingThrottleDuration {
             return .notHandled(.duplicateNavigation)
+        }
+        
+        // Overlay Usage Pixel handling
+        if let url = webView.url {
+            duckPlayerOverlayUsagePixels?.handleNavigationAndFirePixels(url: url, duckPlayerMode: duckPlayerMode)
         }
         
         // Check if DuckPlayer feature is enabled

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -636,7 +636,9 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
                 // Before performing the simulated request
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                     self.performRequest(request: newRequest, webView: webView)
+                    self.duckPlayerOverlayUsagePixels?.handleNavigationAndFirePixels(url: url, duckPlayerMode: self.duckPlayerMode)
                     self.fireDuckPlayerPixels(webView: webView)
+                    
                 }
             } else {
                 redirectToYouTubeVideo(url: url, webView: webView)

--- a/DuckDuckGo/DuckPlayer/DuckPlayerOverlayUsagePixels.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerOverlayUsagePixels.swift
@@ -24,14 +24,7 @@ protocol DuckPlayerOverlayPixelFiring {
     var pixelFiring: PixelFiring.Type { get set }
     var navigationHistory: [URL] { get set }
     
-    func registerNavigation(url: URL?)
-    func navigationBack(duckPlayerMode: DuckPlayerMode)
-    func navigationReload(duckPlayerMode: DuckPlayerMode)
-    func navigationWithinYoutube(duckPlayerMode: DuckPlayerMode)
-    func navigationOutsideYoutube(duckPlayerMode: DuckPlayerMode)
-    func navigationClosed(duckPlayerMode: DuckPlayerMode)
-    func overlayIdle(duckPlayerMode: DuckPlayerMode)
-    
+    func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode)
 }
 
 final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
@@ -55,69 +48,56 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
         idleTimer = nil
     }
 
-    func registerNavigation(url: URL?) {
+    func handleNavigationAndFirePixels(url: URL?, duckPlayerMode: DuckPlayerMode) {
         guard let url = url else { return }
-        navigationHistory.append(url)
-        
+        let comparisonURL = url.forComparison()
+
+        // Only append the URL if it's different from the last entry in normalized form
+        navigationHistory.append(comparisonURL)
+
+        // DuckPlayer is in Ask Mode, there's navigation history, and last URL is a YouTube Watch Video
+        guard duckPlayerMode == .alwaysAsk,
+              navigationHistory.count > 1,
+              let currentURL = navigationHistory.last,
+              let previousURL = navigationHistory.dropLast().last,
+              previousURL.isYoutubeWatch else { return }
+
+        var isReload = false
+        // Check for a reload condition: when current videoID is the same as Previous
+        if let currentVideoID = currentURL.youtubeVideoParams?.videoID,
+           let previousVideoID = previousURL.youtubeVideoParams?.videoID {
+            isReload = currentVideoID == previousVideoID
+        }
+
+        // Fire the reload pixel if this is a reload navigation
+        if isReload {
+            pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationRefresh, withAdditionalParameters: [:])
+        } else {
+            // Determine if it’s a back navigation by looking further back in history
+            let isBackNavigation = navigationHistory.count > 2 &&
+                                   navigationHistory[navigationHistory.count - 3].forComparison() == currentURL.forComparison()
+
+            // Fire the appropriate pixel based on navigation type
+            if isBackNavigation {
+                pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationBack, withAdditionalParameters: [:])
+            } else if previousURL.isYoutubeWatch && currentURL.isYoutube {
+                // Forward navigation within YouTube (including non-video URLs)
+                pixelFiring.fire(.duckPlayerYouTubeNavigationWithinYouTube, withAdditionalParameters: [:])
+            } else if previousURL.isYoutubeWatch && !currentURL.isYoutube {
+                // Navigation outside YouTube
+                pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationOutsideYoutube, withAdditionalParameters: [:])
+            }
+        }
+
+        // Refined truncation logic:
+        if let lastOccurrenceIndex = (0..<navigationHistory.count - 1).last(where: { navigationHistory[$0].forComparison() == comparisonURL }) {
+            // Truncate history to keep only up to the last occurrence of the current URL in normalized form
+            navigationHistory = Array(navigationHistory.prefix(upTo: lastOccurrenceIndex + 1))
+        }
+
         // Cancel and reset the idle timer whenever a new navigation occurs
         resetIdleTimer()
     }
 
-    func navigationBack(duckPlayerMode: DuckPlayerMode) {
-        guard duckPlayerMode == .alwaysAsk,
-              let lastURL = navigationHistory.last,
-              lastURL.isYoutubeWatch else { return }
 
-        pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationBack, withAdditionalParameters: [:])
-    }
-
-    func navigationReload(duckPlayerMode: DuckPlayerMode) {
-        guard duckPlayerMode == .alwaysAsk,
-              let lastURL = navigationHistory.last,
-              lastURL.isYoutubeWatch else { return }
-
-        pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationRefresh, withAdditionalParameters: [:])
-    }
-
-    func navigationWithinYoutube(duckPlayerMode: DuckPlayerMode) {
-        guard duckPlayerMode == .alwaysAsk,
-              navigationHistory.count > 1,
-              let currentURL = navigationHistory.last,
-              let previousURL = navigationHistory.dropLast().last,
-              previousURL.isYoutubeWatch,
-              currentURL.isYoutube else { return }
-
-        pixelFiring.fire(.duckPlayerYouTubeNavigationWithinYouTube, withAdditionalParameters: [:])
-    }
-
-    func navigationOutsideYoutube(duckPlayerMode: DuckPlayerMode) {
-        guard duckPlayerMode == .alwaysAsk,
-              navigationHistory.count > 1,
-              let currentURL = navigationHistory.last,
-              let previousURL = navigationHistory.dropLast().last,
-              previousURL.isYoutubeWatch,
-              !currentURL.isYoutube else { return }
-
-        pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationOutsideYoutube, withAdditionalParameters: [:])
-    }
-
-    func navigationClosed(duckPlayerMode: DuckPlayerMode) {
-        
-        guard duckPlayerMode == .alwaysAsk,
-              let lastURL = navigationHistory.last,
-              lastURL.isYoutubeWatch else { return }
-        
-        pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationClosed, withAdditionalParameters: [:])
-        
-    }
-
-    func overlayIdle(duckPlayerMode: DuckPlayerMode) {
-        guard duckPlayerMode == .alwaysAsk,
-              let lastURL = navigationHistory.last,
-              lastURL.isYoutubeWatch else { return }
-
-        idleTimer = Timer.scheduledTimer(withTimeInterval: idleTimeInterval, repeats: false) { [weak self] _ in
-            self?.pixelFiring.fire(.duckPlayerYouTubeNavigationIdle30, withAdditionalParameters: [:])
-        }
-    }
 }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerOverlayUsagePixels.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerOverlayUsagePixels.swift
@@ -89,9 +89,8 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
             }
         }
 
-        // Refined truncation logic:
+        // Truncation logic: Remove all URLs up to the last occurrence of the current URL in normalized form
         if let lastOccurrenceIndex = (0..<navigationHistory.count - 1).last(where: { navigationHistory[$0].forComparison() == comparisonURL }) {
-            // Truncate history to keep only up to the last occurrence of the current URL in normalized form
             navigationHistory = Array(navigationHistory.prefix(upTo: lastOccurrenceIndex + 1))
         }
 

--- a/DuckDuckGo/DuckPlayer/DuckPlayerOverlayUsagePixels.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerOverlayUsagePixels.swift
@@ -65,7 +65,8 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
         var isReload = false
         // Check for a reload condition: when current videoID is the same as Previous
         if let currentVideoID = currentURL.youtubeVideoParams?.videoID,
-           let previousVideoID = previousURL.youtubeVideoParams?.videoID {
+           let previousVideoID = previousURL.youtubeVideoParams?.videoID,
+           !previousURL.isDuckPlayer, !currentURL.isDuckPlayer {
             isReload = currentVideoID == previousVideoID
         }
 
@@ -83,7 +84,7 @@ final class DuckPlayerOverlayUsagePixels: DuckPlayerOverlayPixelFiring {
             } else if previousURL.isYoutubeWatch && currentURL.isYoutube {
                 // Forward navigation within YouTube (including non-video URLs)
                 pixelFiring.fire(.duckPlayerYouTubeNavigationWithinYouTube, withAdditionalParameters: [:])
-            } else if previousURL.isYoutubeWatch && !currentURL.isYoutube {
+            } else if previousURL.isYoutubeWatch && !currentURL.isYoutube && !currentURL.isDuckPlayer {
                 // Navigation outside YouTube
                 pixelFiring.fire(.duckPlayerYouTubeOverlayNavigationOutsideYoutube, withAdditionalParameters: [:])
             }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -867,7 +867,7 @@ class TabViewController: UIViewController {
         }
 
         if webView.canGoBack {
-            webView.goBack()            
+            webView.goBack()
             chromeDelegate?.omniBar.resignFirstResponder()
             return
         }

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -867,7 +867,7 @@ class TabViewController: UIViewController {
         }
 
         if webView.canGoBack {
-            webView.goBack()
+            webView.goBack()            
             chromeDelegate?.omniBar.resignFirstResponder()
             return
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208739766555300/f

**Description**:
- Unifies navigation tracking and pixel firing in a single method
- Adds temporary Overlay usage pixels

**Steps to test this PR**:

- [x] Set DuckPlayer to Always ask
- [x] Filter console messages with `duckplayer.youtube.overlay`
- [x] Go to Youtube.com, search for 'Metallica' and open a video ([link](https://m.youtube.com/results?sp=mAEA&search_query=Metallica))
- [x] While seeing the overlay, tap 'Back'
- [x] **Confirm `duckplayer.youtube.overlay.navigation.back` is fired.**
- [x] Select another from the list
- [x] While seeing the overlay, tap 'Reload'
- [x] **Confirm `duckplayer.youtube.overlay.navigation.refresh` is fired.**
- [x] Scroll down to the recommended videos, and tap another video or a playlist
- [x] **Confirm `duckplayer.youtube.overlay.navigation.within-youtube` is fired.**
- [x] Tap the "Watch in Duck Player" button
- [ ] **Confirm No pixels are fired**
- [ ] Go back
- [ ] Tap the URL bar and enter a URL that's not Youtube, such as https://www.example.com
- [ ] **Confirm `duckplayer.youtube.overlay.navigation.outside-youtube` is fired.**

Notes: 
- `duckplayer.youtube.overlay.navigation.back` is only fired when navigating directly to a video.  Further back navigation will `duckplayer.youtube.overlay.navigation.within-youtube`.  This is fine as we only want to track bounces on overlay after navigating directly to a video.
- All the pixels above include unit tests
