### PR TITLE
Fix favorites grid layout issues on New Tab Page

### DIFF
--- a/DuckDuckGo/EditableShortcutsView.swift
+++ b/DuckDuckGo/EditableShortcutsView.swift
@@ -28,7 +28,7 @@ struct EditableShortcutsView: View {
     private let haptics = UIImpactFeedbackGenerator()
 
     var body: some View {
-        NewTabPageGridView(geometry: geometry) { _ in
+        NewTabPageGridView(geometry: geometry, isUsingDynamicSpacing: true) { _ in
             ReorderableForEach(model.itemsSettings, id: \.item.id, isReorderingEnabled: true) { setting in
                 let isEnabled = model.enabledItems.contains(setting.item)
                 Button {

--- a/DuckDuckGo/FavoritesView.swift
+++ b/DuckDuckGo/FavoritesView.swift
@@ -36,10 +36,12 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
     var body: some View {
         VStack(alignment: .center, spacing: 24) {
 
-            let columns = NewTabPageGrid.columnsCount(for: horizontalSizeClass, isLandscape: isLandscape)
+            let columns = NewTabPageGrid.columnsCount(for: horizontalSizeClass,
+                                                      isLandscape: isLandscape,
+                                                      isDynamic: model.isNewTabPageCustomizationEnabled)
             let result = model.prefixedFavorites(for: columns)
 
-            NewTabPageGridView(geometry: geometry) { _ in
+            NewTabPageGridView(geometry: geometry, isUsingDynamicSpacing: model.isNewTabPageCustomizationEnabled) { _ in
                 ReorderableForEach(result.items) { item in
                     viewFor(item)
                         .previewShape()

--- a/DuckDuckGo/FavoritesViewModel.swift
+++ b/DuckDuckGo/FavoritesViewModel.swift
@@ -54,7 +54,8 @@ class FavoritesViewModel: ObservableObject {
     private let favoriteDataSource: NewTabPageFavoriteDataSource
     private let pixelFiring: PixelFiring.Type
     private let dailyPixelFiring: DailyPixelFiring.Type
-    private let isNewTabPageCustomizationEnabled: Bool
+
+    let isNewTabPageCustomizationEnabled: Bool
 
     var isEmpty: Bool {
         allFavorites.filter(\.isFavorite).isEmpty

--- a/DuckDuckGo/NewTabPageGridView.swift
+++ b/DuckDuckGo/NewTabPageGridView.swift
@@ -91,8 +91,19 @@ enum NewTabPageGrid {
             let usesWideLayout = isLandscape || sizeClass == .regular
             return usesWideLayout ? ColumnCount.regular : ColumnCount.compact
         } else {
-            return UIDevice.current.userInterfaceIdiom == .pad ? ColumnCount.iPadStaticLayout : ColumnCount.compact
+            return staticGridColumnsCount(for: sizeClass)
         }
+    }
+
+    static func staticGridWidth(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        let columnsCount = CGFloat(staticGridColumnsCount(for: sizeClass))
+        return columnsCount * Item.edgeSize + (columnsCount - 1) * Item.staticSpacing
+    }
+
+    private static func staticGridColumnsCount(for sizeClass: UserInterfaceSizeClass?) -> Int {
+        let isPad = UIDevice.current.userInterfaceIdiom == .pad
+
+        return isPad && sizeClass == .regular ? ColumnCount.staticWideLayout : ColumnCount.compact
     }
 
     enum Item {
@@ -104,7 +115,7 @@ private extension NewTabPageGrid {
     enum ColumnCount {
         static let compact = 4
         static let regular = 6
-        static let iPadStaticLayout = 5
+        static let staticWideLayout = 5
     }
 }
 

--- a/DuckDuckGo/ShortcutsView.swift
+++ b/DuckDuckGo/ShortcutsView.swift
@@ -26,7 +26,7 @@ struct ShortcutsView: View {
     let proxy: GeometryProxy?
 
     var body: some View {
-        NewTabPageGridView(geometry: proxy) { _ in
+        NewTabPageGridView(geometry: proxy, isUsingDynamicSpacing: true) { _ in
             ForEach(shortcuts) { shortcut in
                 Button {
                     model.openShortcut(shortcut)

--- a/DuckDuckGo/SimpleNewTabPageView.swift
+++ b/DuckDuckGo/SimpleNewTabPageView.swift
@@ -81,7 +81,7 @@ private extension SimpleNewTabPageView {
 
                     favoritesSectionView(proxy: proxy)
                 }
-                .padding(Metrics.largePadding)
+                .padding(sectionsViewPadding(in: proxy))
             }
             .withScrollKeyboardDismiss()
         }
@@ -99,7 +99,7 @@ private extension SimpleNewTabPageView {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
-        .padding(Metrics.largePadding)
+        .padding(Metrics.regularPadding)
     }
 
     private var messagesSectionView: some View {
@@ -114,6 +114,11 @@ private extension SimpleNewTabPageView {
         FavoritesView(model: favoritesViewModel,
                       isAddingFavorite: .constant(false),
                       geometry: proxy)
+    }
+
+    private func sectionsViewPadding(in geometry: GeometryProxy) -> CGFloat {
+        let requiredWidth = NewTabPageGrid.staticGridWidth(for: horizontalSizeClass) + Metrics.regularPadding
+        return geometry.frame(in: .local).width >= requiredWidth ? Metrics.regularPadding : Metrics.smallPadding
     }
 }
 
@@ -130,8 +135,8 @@ private extension View {
 
 private struct Metrics {
 
-    static let regularPadding = 16.0
-    static let largePadding = 24.0
+    static let smallPadding = 12.0
+    static let regularPadding = 24.0
     static let sectionSpacing = 32.0
     static let nonGridSectionTopPadding = -8.0
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1206226850447395/1208709136086082/f
Tech Design URL:
CC:

**Description**:

Addresses feedback around updated favorites grid layout on New Tab Page.
* Uses static column setup with 4 columns on iPhone and 5 on iPad when NTP customization is turned off.
* Reduces the width of grid and makes it centered.
* A special case handled for smaller screens so the static layout does not exceed margins.

**Steps to test this PR**:
For best baseline run 7.142.1 or earlier.
1. Add at least 5 favorites
2. Verify number of columns shown and their count does not change when rotated to landscape:
    a. 4 on iPhone
    b. 5 on iPad (unless in compact-sized Split View)

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Orientation Testing**:

* [x] Portrait
* [x] Landscape

**Device Testing**:

* [x] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [x] iPhone 16 Pro
* [x] iPad

**OS Testing**:

* [x] iOS 15
* [ ] iOS 16
* [x] iOS 18

**Theme Testing**:

* [x] Light theme
* [x] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
