### PR TITLE
pixels for bookmarks > favorites tab

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -207,6 +207,9 @@ extension Pixel {
         case bookmarkAddFavoriteBySwipe
         case bookmarkDeletedFromBookmark
 
+        case bookmarksUIFavoritesAction
+        case bookmarksUIFavoritesManage
+
         case bookmarkImportSuccess
         case bookmarkImportFailure
         case bookmarkImportFailureParsingDL
@@ -964,6 +967,9 @@ extension Pixel.Event {
         case .bookmarkRemoveFavoriteFromBookmark: return "m_remove_favorite_from_bookmark"
         case .bookmarkAddFavoriteBySwipe: return "m_add_favorite_by_swipe"
         case .bookmarkDeletedFromBookmark: return "m_bookmark_deleted_from_bookmark"
+
+        case .bookmarksUIFavoritesAction: return "m_bookmarks_ui_favorites_action_daily"
+        case .bookmarksUIFavoritesManage: return "m_bookmarks_ui_favorites_manage_daily"
 
         case .homeScreenShown: return "mh"
         case .homeScreenEditFavorite: return "mh_ef"

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -787,6 +787,10 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
         changeEditButtonToDone()
         configureToolbarMoreItem()
         refreshFooterView()
+
+        if !favoritesContainer.isHidden {
+            DailyPixel.fireDaily(.bookmarksUIFavoritesManage)
+        }
     }
 
     private func finishEditing() {

--- a/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -274,7 +274,7 @@ class FavoritesHomeViewSectionRenderer {
               let dragItem = coordinator.items.first?.dragItem,
               let sourcePath = coordinator.items.first?.sourceIndexPath,
               let destinationPath = coordinator.destinationIndexPath,
-              let cell = self.collectionView(collectionView, cellForItemAt: sourcePath) as? FavoriteHomeCell,
+              let cell = collectionView.cellForItem(at: sourcePath) as? FavoriteHomeCell,
               let favorite = cell.favorite
         else { return }
 
@@ -291,7 +291,7 @@ class FavoritesHomeViewSectionRenderer {
     }
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        guard let cell = self.collectionView(collectionView, cellForItemAt: indexPath) as? FavoriteHomeCell else { return [] }
+        guard let cell = collectionView.cellForItem(at: indexPath) as? FavoriteHomeCell else { return [] }
 
         if let size = cell.iconImage.image?.size.width, size <= 32 {
             cell.iconBackground.backgroundColor = ThemeManager.shared.currentTheme.backgroundColor

--- a/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -156,6 +156,7 @@ class FavoritesHomeViewSectionRenderer {
         guard let indexPath = collectionView.indexPath(for: cell),
         let favorite = viewModel.favorite(at: indexPath.row) else { return }
         Pixel.fire(pixel: .homeScreenDeleteFavorite)
+        fireActionPixel()
         viewModel.removeFavorite(favorite)
         WidgetCenter.shared.reloadAllTimelines()
         collectionView.performBatchUpdates {
@@ -168,6 +169,7 @@ class FavoritesHomeViewSectionRenderer {
         guard let indexPath = collectionView.indexPath(for: cell),
               let favorite = viewModel.favorite(at: indexPath.row) else { return }
         Pixel.fire(pixel: .homeScreenEditFavorite)
+        fireActionPixel()
         controller?.favoritesRenderer(self, didRequestEdit: favorite)
     }
     
@@ -285,6 +287,7 @@ class FavoritesHomeViewSectionRenderer {
 
         coordinator.drop(dragItem, toItemAt: destinationPath)
 
+        fireActionPixel()
     }
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
@@ -312,6 +315,11 @@ class FavoritesHomeViewSectionRenderer {
         }
 
         return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+    }
+
+    /// Actions are only available from the bookmarks UI, so this is safe to send from here.
+    func fireActionPixel() {
+        DailyPixel.fire(pixel: .bookmarksUIFavoritesAction)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208733952836859/f
Tech Design URL:
CC:

**Description**:
Pixels for bookmarks > favorites tab.

**Steps to test this PR**:
1. Change DailyPixel.swift so that `hasBeenFiredToday` returns false
2. Add some favorites
3. Go to the bookmarks UI and tap on the favourites tab
4. Tap on manage -> pixel should fire `m_bookmarks_ui_favorites_manage_daily`
6. Exit edit mode
7. Edit a favorite -> pixel should fire `m_bookmarks_ui_favorites_action_daily`
8. Move a favorite -> pixel should fire `m_bookmarks_ui_favorites_action_daily`
9. Remove a favorite -> pixel should fire `m_bookmarks_ui_favorites_action_daily`
10. Check that actions on the new tab page do not fire the above pixels
11. Check the overlay does not trigger these pixels to fire
