### PR TITLE
Fix button shapes on New Tab Page

### DIFF
--- a/DuckDuckGo/EditableShortcutsView.swift
+++ b/DuckDuckGo/EditableShortcutsView.swift
@@ -37,6 +37,7 @@ struct EditableShortcutsView: View {
                     ShortcutItemView(shortcut: setting.item, accessoryType: isEnabled ? .selected : .add)
                         .frame(width: NewTabPageGrid.Item.edgeSize)
                 }
+                .buttonStyle(.plain)
                 .padding([.horizontal, .top], 6) // Adjust for the accessory being cut-off when lifting for preview
                 .previewShape()
             } preview: { setting in

--- a/DuckDuckGo/FavoritesView.swift
+++ b/DuckDuckGo/FavoritesView.swift
@@ -108,6 +108,7 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
                 .background(.clear)
                 .frame(width: NewTabPageGrid.Item.edgeSize)
             })
+            .buttonStyle(.plain)
         case .addFavorite:
             Button(action: {
                 isAddingFavorite = true

--- a/DuckDuckGo/ShortcutsView.swift
+++ b/DuckDuckGo/ShortcutsView.swift
@@ -33,6 +33,7 @@ struct ShortcutsView: View {
                 } label: {
                     ShortcutItemView(shortcut: shortcut, accessoryType: nil)
                 }
+                .buttonStyle(.plain)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206226850447395/1208777193348112/f
Tech Design URL:
CC:

**Description**:

Default button style in SwiftUI is defining a border shape which is visible when "Button Shapes" are enabled in _Accessibility -> Display & Text Size_. This sets custom button styles to plain in order to prevent them from appearing.

**Steps to test this PR**:
1. Enable _Accessibility -> Display & Text Size -> Button Shapes_
2. Make sure there is no gray-ish shape around Favorites
3. Enable NTP Sections in Debug settings
4. Check there's no border around shortcuts on New Tab Page and in Customize view.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
