### PR TITLE
Limits TipKit availability to iOS 18+

### DIFF
--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -256,7 +256,7 @@ struct NetworkProtectionStatusView: View {
         .listRowBackground(Color(designSystemColor: .surface))
 
         Section {
-            if #available(iOS 17.8, *) {
+            if #available(iOS 18.0, *) {
                 geoswitchingTipView()
                     .tipImageSize(Self.defaultImageSize)
                     .padding(.horizontal, 3)

--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -148,13 +148,13 @@ struct NetworkProtectionStatusView: View {
         .listRowBackground(Color(designSystemColor: .surface))
 
         Section {
-            if #available(iOS 17.0, *) {
+            if #available(iOS 18.0, *) {
                 widgetTipView()
                     .tipImageSize(Self.defaultImageSize)
                     .padding(.horizontal, 3)
             }
 
-            if #available(iOS 17.0, *) {
+            if #available(iOS 18.0, *) {
                 snoozeTipView()
                     .tipImageSize(Self.defaultImageSize)
                     .padding(.horizontal, 3)
@@ -256,7 +256,7 @@ struct NetworkProtectionStatusView: View {
         .listRowBackground(Color(designSystemColor: .surface))
 
         Section {
-            if #available(iOS 17.0, *) {
+            if #available(iOS 17.8, *) {
                 geoswitchingTipView()
                     .tipImageSize(Self.defaultImageSize)
                     .padding(.horizontal, 3)
@@ -351,7 +351,7 @@ struct NetworkProtectionStatusView: View {
 
     // MARK: - Tips
 
-    @available(iOS 17.0, *)
+    @available(iOS 18.0, *)
     @ViewBuilder
     private func geoswitchingTipView() -> some View {
         if statusModel.canShowTips {
@@ -363,7 +363,7 @@ struct NetworkProtectionStatusView: View {
         }
     }
 
-    @available(iOS 17.0, *)
+    @available(iOS 18.0, *)
     @ViewBuilder
     private func snoozeTipView() -> some View {
         if statusModel.canShowTips,
@@ -376,7 +376,7 @@ struct NetworkProtectionStatusView: View {
         }
     }
 
-    @available(iOS 17.0, *)
+    @available(iOS 18.0, *)
     @ViewBuilder
     private func widgetTipView() -> some View {
         if statusModel.canShowTips,


### PR DESCRIPTION
### Important: this is open for review, but DO NOT MERGE until we can point at the internal release branch.

Task/Issue URL: https://app.asana.com/0/1206580121312550/1208786321276837/f

## Description

Two changes are introduces here:
- We're improving how we handle the TipKit remote feature flag to include the `setup` call at startup.
- We're limiting TipKit support to iOS 18+ because of the high amount of crashes we saw on iOS 17.

**Steps to test this PR**:

Test our tips work well.
Remember you can reset TipKit at the bottom of our debug menu.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
