### PR TITLE
Re-prompt for crash reporting

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -53,6 +53,9 @@ public enum FeatureFlag: String {
 
     /// https://app.asana.com/0/72649045549333/1208617860225199/f
     case networkProtectionEnforceRoutes
+    
+    /// https://app.asana.com/0/1208592102886666/1208613627589762/f
+    case crashReportOptInStatusResetting
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -118,6 +121,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteDevelopment(.subfeature(NetworkProtectionSubfeature.enforceRoutes))
         case .adAttributionReporting:
             return .remoteReleasable(.feature(.adAttributionReporting))
+        case .crashReportOptInStatusResetting:
+            return .internalOnly
         }
     }
 }

--- a/DuckDuckGo/AppSettings.swift
+++ b/DuckDuckGo/AppSettings.swift
@@ -79,6 +79,7 @@ protocol AppSettings: AnyObject, AppDebugSettings {
     var autoconsentEnabled: Bool { get set }
 
     var crashCollectionOptInStatus: CrashCollectionOptInStatus { get set }
+    var crashCollectionShouldRevertOptedInStatusTrigger: Int { get set }
     
     var duckPlayerMode: DuckPlayerMode { get set }
     var duckPlayerAskModeOverlayHidden: Bool { get set }

--- a/DuckDuckGo/AppUserDefaults.swift
+++ b/DuckDuckGo/AppUserDefaults.swift
@@ -75,6 +75,7 @@ public class AppUserDefaults: AppSettings {
         static let favoritesDisplayMode = "com.duckduckgo.ios.favoritesDisplayMode"
 
         static let crashCollectionOptInStatus = "com.duckduckgo.ios.crashCollectionOptInStatus"
+        static let crashCollectionShouldRevertOptedInStatusTrigger = "com.duckduckgo.ios.crashCollectionShouldRevertOptedInStatusTrigger"
         
         static let duckPlayerMode = "com.duckduckgo.ios.duckPlayerMode"
         static let duckPlayerAskModeOverlayHidden = "com.duckduckgo.ios.duckPlayerAskModeOverlayHidden"
@@ -396,6 +397,19 @@ public class AppUserDefaults: AppSettings {
         }
         set {
             userDefaults?.setValue(newValue.rawValue, forKey: Keys.crashCollectionOptInStatus)
+        }
+    }
+    
+    var crashCollectionShouldRevertOptedInStatusTrigger: Int {
+        get {
+            if let resetTrigger = userDefaults?.integer(forKey: Keys.crashCollectionShouldRevertOptedInStatusTrigger) {
+                return resetTrigger
+            } else {
+                return 0
+            }
+        }
+        set {
+            userDefaults?.setValue(newValue, forKey: Keys.crashCollectionShouldRevertOptedInStatusTrigger)
         }
     }
     

--- a/DuckDuckGo/CrashCollectionOnboarding.swift
+++ b/DuckDuckGo/CrashCollectionOnboarding.swift
@@ -50,10 +50,6 @@ final class CrashCollectionOnboarding: NSObject {
     func presentOnboardingIfNeeded(for payloads: [Data], from viewController: UIViewController, sendReport: @escaping () -> Void) {
         let isCurrentlyPresenting = viewController.presentedViewController != nil
         
-#if DEBUG
-        appSettings.crashCollectionShouldRevertOptedInStatusTrigger = 0
-#endif
-        
         if appSettings.crashCollectionOptInStatus == .optedIn &&
             appSettings.crashCollectionShouldRevertOptedInStatusTrigger < crashCollectionShouldRevertOptedInStatusTriggerTargetValue {
             debugPrint("Resettting crash report opt in status from \(appSettings.crashCollectionOptInStatus) to .undetermined")

--- a/DuckDuckGo/CrashCollectionOnboarding.swift
+++ b/DuckDuckGo/CrashCollectionOnboarding.swift
@@ -58,7 +58,6 @@ final class CrashCollectionOnboarding: NSObject {
         if featureFlagger.isFeatureOn(.crashReportOptInStatusResetting) {
             if appSettings.crashCollectionOptInStatus == .optedIn &&
                 appSettings.crashCollectionShouldRevertOptedInStatusTrigger < crashCollectionShouldRevertOptedInStatusTriggerTargetValue {
-                debugPrint("Resettting crash report opt in status from \(appSettings.crashCollectionOptInStatus) to .undetermined")
                 appSettings.crashCollectionOptInStatus = .undetermined
                 appSettings.crashCollectionShouldRevertOptedInStatusTrigger = crashCollectionShouldRevertOptedInStatusTriggerTargetValue
             }

--- a/DuckDuckGo/CrashCollectionOnboarding.swift
+++ b/DuckDuckGo/CrashCollectionOnboarding.swift
@@ -55,10 +55,6 @@ final class CrashCollectionOnboarding: NSObject {
     func presentOnboardingIfNeeded(for payloads: [Data], from viewController: UIViewController, sendReport: @escaping () -> Void) {
         let isCurrentlyPresenting = viewController.presentedViewController != nil
         
-#if DEBUG
-        appSettings.crashCollectionShouldRevertOptedInStatusTrigger = 0
-#endif
-        
         if featureFlagger.isFeatureOn(.crashReportOptInStatusResetting) {
             if appSettings.crashCollectionOptInStatus == .optedIn &&
                 appSettings.crashCollectionShouldRevertOptedInStatusTrigger < crashCollectionShouldRevertOptedInStatusTriggerTargetValue {

--- a/DuckDuckGoTests/AppSettingsMock.swift
+++ b/DuckDuckGoTests/AppSettingsMock.swift
@@ -82,6 +82,8 @@ class AppSettingsMock: AppSettings {
     var autoconsentEnabled = true
 
     var crashCollectionOptInStatus: CrashCollectionOptInStatus = .undetermined
+    
+    var crashCollectionShouldRevertOptedInStatusTrigger: Int = 0
 
     var newTabPageSectionsEnabled: Bool = false
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208592102886666/1208630312625695/f
Tech Design URL: https://app.asana.com/0/1208592102886666/1208660326715650/f
CC: @loremattei 

**Description**:
- Introduce a feature flag for use with this project overall, currently set to internal only
- Introduce a new UserDefaults value (```crashCollectionShouldRevertOptedInStatusTrigger```) that can be used to force the client to revert the existing ```crashCollectionOptInStatus```  to .unknown, only if the value is currently .optedIn.  This new trigger is implemented as an Int, so that we can ensure the user’s Opt-In state will be reverted only once after the feature is turned on.  In the future if we need this functionality again, we’d simply bump the garget value and the opt-in state would be reset again.

See asana task for specific requirements, and the parent project for more context if necessary.

**Steps to test this PR**:
**Preconditions**
- Start with a fresh install of the iOS browser _**without the changes in this PR**_.
- Crash reporting and submitting works only on a physical device, so testing cannot be done in the simulator

**Testing Steps**
1. Create a crash log: Launch the app, and navigate to “…” -> Settings -> All debug options -> Crash (any one of the 4 crash types)
2. Re-launch the app and see that you are prompted to submit a crash report.  Select “Always Send Crash Reports”.
3. Perform step 1 again to produce another crash.  Do not launch the app again yet.
4. _**Install the new build of the app with this PR’s changes included**_
5. Run the app, and you should be prompted again to submit crash reports (or not), same screen as from step 2.
6. Cause another crash via the settings menu
7. Run the app _again_ and ensure that you are NOT prompted yet another time (your opt-in choice with the new version should now be respected)

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?
* Note: I don’t believe there is any automation around existing crash reporting (I couldn’t find any).  If it exists, or if you think there is a straight foward way to add some, please point me in the right direction :)

**Copy Testing**:

* [N/A] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

Note: I have tested on the devices and configurations I have available at home currently.  These changes are not UI related, nor are they likely to depend on particular OS version functionality, so exhaustive coverage is likely not critical.  If you’re able to test with a different configuration than I used that would be helpful :)

* [X] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [X] iPhone 15 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17
* [X] iOS 18

**Theme Testing**:

* [ ] Light theme
* [X] Dark theme
