### PR TITLE
Fix autofill search authentication looping

### DIFF
--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -228,6 +228,7 @@ final class AutofillLoginSettingsListViewController: UIViewController {
         super.viewDidLoad()
         title = UserText.autofillLoginListTitle
         extendedLayoutIncludesOpaqueBars = true
+        navigationController?.presentationController?.delegate = self
         setupCancellables()
         installSubviews()
         installConstraints()
@@ -447,6 +448,11 @@ final class AutofillLoginSettingsListViewController: UIViewController {
             }
             openSearch = false
         }
+    }
+
+    private func dismissSearchIfRequired() {
+        guard searchController.isActive else { return }
+        searchController.dismiss(animated: false)
     }
 
     private func presentDeleteConfirmation(for title: String, domain: String) {
@@ -1123,6 +1129,16 @@ extension AutofillLoginSettingsListViewController: UISearchBarDelegate {
         viewModel.filterData(with: "")
         tableView.reloadData()
     }
+}
+
+// MARK: UIAdaptivePresentationControllerDelegate
+
+extension AutofillLoginSettingsListViewController: UIAdaptivePresentationControllerDelegate {
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        dismissSearchIfRequired()
+    }
+
 }
 
 // MARK: Keyboard

--- a/DuckDuckGo/AutofillLoginSettingsListViewController.swift
+++ b/DuckDuckGo/AutofillLoginSettingsListViewController.swift
@@ -811,11 +811,11 @@ final class AutofillLoginSettingsListViewController: UIViewController {
         let cell = tableView.dequeueCell(ofType: AutofillBreakageReportTableViewCell.self, for: indexPath)
         let contentView = AutofillBreakageReportCellContentView(onReport: { [weak self] in
 
-            guard let alert = self?.viewModel.createBreakageReporterAlert() else {
+            guard let self = self, let alert = self.viewModel.createBreakageReporterAlert() else {
                 return
             }
 
-            self?.present(controller: alert, fromView: tableView)
+            self.present(controller: alert, fromView: self.tableView)
 
             Pixel.fire(pixel: .autofillLoginsReportConfirmationPromptDisplayed)
         })


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1203822806345703/1208755477452311/f
Tech Design URL:
CC:

**Description**:
Fixes an issue where if the Passwords screen is dismissed while in search mode, UISearchController prevented the Passwords screen from being released from memory. I’ve also found and fixed a memory leak with the autofill breakage reporter. 

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Ensuring you have some passwords saved, go to the Passwords screen via the Settings screen
2. Tap into the search bar and then dismiss the Passwords screen by swiping down
3. In XCode click through to view the debug memory graph, filter on the keyword ‘Autofill’ and confirm  `AutofillLoginSettingsListViewController` has been released from memory
4. This time access the Passwords screen via the overflow menu
5. Repeat Steps 2 & 3
6. Open a tab and visit `https://fill.dev/form/login-simple`
7. Save a login for this site
8. Go back to the Passwords screen, this time via the overflow menu
9. The autofill breakage reporter row should be visible (cell with button titled “Report a problem with autofill”)
10. Dismiss the Passwords screen and again confirm `AutofillLoginSettingsListViewController` and `AutofillBreakageReportTableViewCell` have been released from memory

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Device Testing**:

* [ ] iPhone 14 Pro
* [ ] iPad


—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
