### PR TITLE
Fix running BoolFileMarkerTest on device

### DIFF
--- a/Core/BoolFileMarkerTests.swift
+++ b/Core/BoolFileMarkerTests.swift
@@ -41,7 +41,11 @@ final class BoolFileMarkerTests: XCTestCase {
         let fileURL = try XCTUnwrap(testFileURL)
 
         let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+#if targetEnvironment(simulator)
         XCTAssertNil(attributes[.protectionKey])
+#else
+        XCTAssertEqual(attributes[.protectionKey] as? FileProtectionType, FileProtectionType.none)
+#endif
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
         XCTAssertEqual(marker.isPresent, true)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208808387106647/f
Tech Design URL:
CC:

**Description**:

`BoolFileMarkerTests` test failed when run on device. This PR fixes it.

**Steps to test this PR**:
1. Check `BoolFileMarkerTests` pass when run on a device.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
