### PR TITLE
Disable asana reporting on test failures

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -95,17 +95,17 @@ jobs:
       run: |
         export PATH="$PATH":"$HOME/.maestro/bin"; maestro cloud --apiKey ${{ secrets.MAESTRO_CLOUD_API_KEY }} -e ONBOARDING_COMPLETED=true --fail-on-timeout=true --fail-on-cancellation=true --timeout=150 --ios-version=17 --include-tags=${{ matrix.test-tag }} DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app .maestro/
       
-  notify-failure:
-    name: Notify on failure
-    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}
-    needs: [build-end-to-end-tests, end-to-end-tests]
-    runs-on: ubuntu-latest
+  # notify-failure:
+  #   name: Notify on failure
+  #   if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}
+  #   needs: [build-end-to-end-tests, end-to-end-tests]
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - name: Create Asana task when workflow failed
-      run: |
-        curl -s "https://app.asana.com/api/1.0/tasks" \
-          --header "Accept: application/json" \
-          --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
-          --header "Content-Type: application/json" \
-          --data ' { "data": { "name": "GH Workflow Failure - End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'
+  #   steps:
+  #   - name: Create Asana task when workflow failed
+  #     run: |
+  #       curl -s "https://app.asana.com/api/1.0/tasks" \
+  #         --header "Accept: application/json" \
+  #         --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
+  #         --header "Content-Type: application/json" \
+  #         --data ' { "data": { "name": "GH Workflow Failure - End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}. For instructions on how to handle the failure(s), check https://app.asana.com/0/0/1206423571874502/f" } }'

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        os-version: [15, 16, 17]
+        os-version: [17] #[15, 16, 17]
       max-parallel: 1 # Uncomment this line to run tests sequentially. 
       fail-fast: false
     

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -108,20 +108,20 @@ jobs:
       run: |
         git checkout .maestro/config.yaml
     
-  notify-failure:
-    name: Notify on failure
-    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}
-    needs: [build-for-sync-end-to-end-tests, sync-end-to-end-tests]
-    runs-on: ubuntu-latest
+  # notify-failure:
+  #   name: Notify on failure
+  #   if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}
+  #   needs: [build-for-sync-end-to-end-tests, sync-end-to-end-tests]
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Create Asana task when workflow failed
-        run: |
-          curl -s "https://app.asana.com/api/1.0/tasks" \
-            --header "Accept: application/json" \
-            --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
-            --header "Content-Type: application/json" \
-            --data ' { "data": { "name": "GH Workflow Failure - Sync End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}" } }'
+  #   steps:
+  #     - name: Create Asana task when workflow failed
+  #       run: |
+  #         curl -s "https://app.asana.com/api/1.0/tasks" \
+  #           --header "Accept: application/json" \
+  #           --header "Authorization: Bearer ${{ secrets.ASANA_ACCESS_TOKEN }}" \
+  #           --header "Content-Type: application/json" \
+  #           --data ' { "data": { "name": "GH Workflow Failure - Sync End to end tests", "workspace": "${{ vars.GH_ASANA_WORKSPACE_ID }}", "projects": [ "${{ vars.GH_ASANA_IOS_APP_PROJECT_ID }}" ], "notes" : "The end to end workflow has failed. See https://github.com/duckduckgo/iOS/actions/runs/${{ github.run_id }}" } }'
 
     
     


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/0/1208804974015521/f
Tech Design URL:
CC:

**Description**:
We have experienced issues with e2e tests reliability due to CI instability for quite a long time now and we are at a point where we don't investigate failures anymore. Because of this, reporting test failures in Asana only adds noise for the maintenance DRI. 
This PR disables reporting, while we work to stabilise the tests. 

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Verify CI is green.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
