### PR TITLE
Read underlying errors recursively

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -302,18 +302,37 @@ private extension Pixel.Event {
 }
 
 extension Dictionary where Key == String, Value == String {
+
     mutating func appendErrorPixelParams(error: Error) {
         let nsError = error as NSError
 
         self[PixelParameters.errorCode] = "\(nsError.code)"
         self[PixelParameters.errorDomain] = nsError.domain
 
-        if let underlyingError = nsError.userInfo["NSUnderlyingError"] as? NSError {
-            self[PixelParameters.underlyingErrorCode] = "\(underlyingError.code)"
-            self[PixelParameters.underlyingErrorDomain] = underlyingError.domain
-        } else if let sqlErrorCode = nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {
-            self[PixelParameters.underlyingErrorCode] = "\(sqlErrorCode.intValue)"
-            self[PixelParameters.underlyingErrorDomain] = "NSSQLiteErrorDomain"
-        }
+        let underlyingErrorParameters = underlyingErrorParameters(for: error as NSError)
+        self.merge(underlyingErrorParameters) { first, _ in first }
     }
+
+    private func underlyingErrorParameters(for nsError: NSError, level: Int = 0) -> [String: String] {
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+            let errorCodeParameterName = PixelParameters.underlyingErrorCode + (level == 0 ? "" : String(level + 1))
+            let errorDomainParameterName = PixelParameters.underlyingErrorDomain + (level == 0 ? "" : String(level + 1))
+
+            let currentUnderlyingErrorParameters = [
+                errorCodeParameterName: "\(underlyingError.code)",
+                errorDomainParameterName: underlyingError.domain
+            ]
+
+            let additionalParameters = underlyingErrorParameters(for: underlyingError, level: level + 1)
+            return currentUnderlyingErrorParameters.merging(additionalParameters) { first, _ in first }
+        } else if let sqlErrorCode = nsError.userInfo["NSSQLiteErrorDomain"] as? NSNumber {
+            return [
+                PixelParameters.underlyingErrorCode: "\(sqlErrorCode.intValue)",
+                PixelParameters.underlyingErrorDomain: "NSSQLiteErrorDomain"
+            ]
+        }
+
+        return [:]
+    }
+
 }

--- a/DuckDuckGoTests/PixelTests.swift
+++ b/DuckDuckGoTests/PixelTests.swift
@@ -193,4 +193,38 @@ class PixelTests: XCTestCase {
         wait(for: [firstFireExpectation, thirdFireExpectation], timeout: Double(debounceInterval + 4))
     }
 
+    func testWhenDefiningUnderlyingErrorParametersThenNestedErrorsAreIncluded() {
+        let underlyingError4 = NSError(domain: "underlyingError4", code: 5, userInfo: [:])
+        let underlyingError3 = NSError(domain: "underlyingError3", code: 4, userInfo: [NSUnderlyingErrorKey: underlyingError4])
+        let underlyingError2 = NSError(domain: "underlyingError2", code: 3, userInfo: [NSUnderlyingErrorKey: underlyingError3])
+        let underlyingError1 = NSError(domain: "underlyingError1", code: 2, userInfo: [NSUnderlyingErrorKey: underlyingError2])
+        let error = NSError(domain: "error", code: 1, userInfo: [NSUnderlyingErrorKey: underlyingError1])
+
+        var parameters: [String: String] = [:]
+        parameters.appendErrorPixelParams(error: error)
+
+        XCTAssertEqual(parameters.count, 10)
+        XCTAssertEqual(parameters["d"], error.domain)
+        XCTAssertEqual(parameters["e"], String(error.code))
+        XCTAssertEqual(parameters["ud"], underlyingError1.domain)
+        XCTAssertEqual(parameters["ue"], String(underlyingError1.code))
+        XCTAssertEqual(parameters["ud2"], underlyingError2.domain)
+        XCTAssertEqual(parameters["ue2"], String(underlyingError2.code))
+        XCTAssertEqual(parameters["ud3"], underlyingError3.domain)
+        XCTAssertEqual(parameters["ue3"], String(underlyingError3.code))
+        XCTAssertEqual(parameters["ud4"], underlyingError4.domain)
+        XCTAssertEqual(parameters["ue4"], String(underlyingError4.code))
+    }
+
+    func testWhenDefiningUnderlyingErrorParametersAndThereIsNoUnderlyingErrorThenOnlyTopLevelParametersAreIncluded() {
+        let error = NSError(domain: "error", code: 1, userInfo: [:])
+
+        var parameters: [String: String] = [:]
+        parameters.appendErrorPixelParams(error: error)
+
+        XCTAssertEqual(parameters.count, 2)
+        XCTAssertEqual(parameters["d"], error.domain)
+        XCTAssertEqual(parameters["e"], String(error.code))
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1208811744276031/f
Tech Design URL:
CC:

**Description**:

This PR updates the pixel error handling to read underlying errors recursively.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check that the test suite changes cover everything correctly and that no pixel behavior is otherwise changing
2. Next, we can check that this works with a pixel by adding a test call that uses many underlying errors. Add the following to the bottom of `applicationDidBecomeActive`:

```
let underlyingError4 = NSError(domain: "underlyingError4", code: 5, userInfo: [:])
let underlyingError3 = NSError(domain: "underlyingError3", code: 4, userInfo: [NSUnderlyingErrorKey: underlyingError4])
let underlyingError2 = NSError(domain: "underlyingError2", code: 3, userInfo: [NSUnderlyingErrorKey: underlyingError3])
let underlyingError1 = NSError(domain: "underlyingError1", code: 2, userInfo: [NSUnderlyingErrorKey: underlyingError2])
let error = NSError(domain: "error", code: 1, userInfo: [NSUnderlyingErrorKey: underlyingError1])

Pixel.fire(pixel: .networkProtectionRekeyFailure, error: error)
```

Then, run the app and filter for `rekey`, and check that the parameters look good.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
