### PR TITLE
Improvements to AutofillSettingStatus to remove unnecessary LAContext() calls

### DIFF
--- a/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -469,10 +469,10 @@ final class AutofillLoginListViewModel: ObservableObject {
     private func updateViewState() {
         var newViewState: AutofillLoginListViewModel.ViewState
         
-        if authenticator.state == .loggedOut && !authenticationNotRequired {
-            newViewState = .authLocked
-        } else if authenticator.state == .notAvailable {
+        if !authenticator.canAuthenticate() {
             newViewState = .noAuthAvailable
+        } else if authenticator.state == .loggedOut && !authenticationNotRequired {
+            newViewState = .authLocked
         } else if isSearching {
             if sections.count == 0 {
                 newViewState = .searchingNoResults

--- a/DuckDuckGo/AutofillSettingStatus.swift
+++ b/DuckDuckGo/AutofillSettingStatus.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import LocalAuthentication
-import os.log
 import UIKit
 
 struct AutofillSettingStatus {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1201462886803403/1208801010014864/f
Tech Design URL:
CC:

**Description**:
AutofillSettingStatus refactored to cache a users device authentication status (i.e. do they have a passcode set on their device which is a requirement for the autofill feature) while the app is in foreground instead of constantly querying every time a check is required. 
- This should greatly reduce the number of times `LAcontext().canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)` is called which is currently the source of a steady number of ongoing crashes. 
- I’ve also explicitly set the `LAcontext()` call to run on main which should prevent future crashes.
While testing I also discovered that the incorrect UI state was being presented on the Passwords screen for users who do not have any device security enabled, which I’ve fixed here also

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Testing on device which has (at a minimum) a passcode set 
2. Ensure there are some passwords saved and that `Save and autofill passwords` enabled
3. In `AutofillSettingStatus` set a breakpoint at line 48 `result = LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)`
4. Launch the app and load a webpage. Confirm the breakpoint only hits once 
5. Visit `[fill.dev](https://fill.dev/form/login-simple)`, enter new credentials and save them when prompted
6. Minimise the app, go to system Settings and disable the passcode on the device 
7. Reload the tab and go back to the fill.dev login screen. Confirm the breakpoint hits again (but just once)
8. Confirm that you are not prompted to fill the login that was saved in step 5 and that there is no key icon in the login fields
9. Go to the Passwords screen and confirm you are presented with a screen stating that a passcode is required (and no passwords are visible)
10. Re-enable a passcode on your device and return to the app
11. Reload the `fill.dev` login webpage and confirm that autofill prompts are back 

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
