### PR TITLE
Do not refresh cookie on config update

### DIFF
--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -438,7 +438,6 @@ import os.log
                 Task { [weak self] in
                     if isEnabled {
                         self?.subscriptionCookieManager.enableSettingSubscriptionCookie()
-                        await self?.subscriptionCookieManager.refreshSubscriptionCookie()
                     } else {
                         await self?.subscriptionCookieManager.disableSettingSubscriptionCookie()
                     }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -431,7 +431,7 @@ import os.log
         // Keep track of feature flag changes
         subscriptionCookieManagerFeatureFlagCancellable = privacyConfigurationManager.updatesPublisher
             .sink { [weak self, weak privacyConfigurationManager] in
-                guard let self, let privacyConfigurationManager else { return }
+                guard let self, !self.appIsLaunching, let privacyConfigurationManager else { return }
 
                 let isEnabled = privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(PrivacyProSubfeature.setAccessTokenCookieForSubscriptionDomains)
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -430,6 +430,7 @@ import os.log
 
         // Keep track of feature flag changes
         subscriptionCookieManagerFeatureFlagCancellable = privacyConfigurationManager.updatesPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self, weak privacyConfigurationManager] in
                 guard let self, !self.appIsLaunching, let privacyConfigurationManager else { return }
 

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -435,7 +435,7 @@ import os.log
 
                 let isEnabled = privacyConfigurationManager.privacyConfig.isSubfeatureEnabled(PrivacyProSubfeature.setAccessTokenCookieForSubscriptionDomains)
 
-                Task { [weak self] in
+                Task { @MainActor [weak self] in
                     if isEnabled {
                         self?.subscriptionCookieManager.enableSettingSubscriptionCookie()
                     } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208829922317861/f
CC: @bwaresiak 

**Description**:
- Do not refresh the cookie on config change when flag was detected enabled
- Guard the code not to execute while the app is still launching / has not completed launching
- Make the task for interaction with `subscriptionCookieManager` use main actor

**Steps to test this PR**:
Test enabling and disabling the `setAccessTokenCookieForSubscriptionDomains` feature flag.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
