### PR TITLE
Add launch time pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -159,6 +159,8 @@ public struct PixelParameters {
     // Persistent pixel
     public static let originalPixelTimestamp = "originalPixelTimestamp"
     public static let retriedPixel = "retriedPixel"
+
+    public static let time = "time"
 }
 
 public struct PixelValues {

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -872,9 +872,9 @@ extension Pixel {
         case duckPlayerYouTubeNavigationIdle30
 
         // MARK: Launch time
-        case appDidFinishLaunchingTime
-        case appDidShowUITime
-        case appDidBecomeActiveTime
+        case appDidFinishLaunchingTime(time: BucketAggregation)
+        case appDidShowUITime(time: BucketAggregation)
+        case appDidBecomeActiveTime(time: BucketAggregation)
 
     }
 
@@ -1741,9 +1741,9 @@ extension Pixel.Event {
         case .duckPlayerYouTubeNavigationIdle30: return "duckplayer.youtube.overlay.idle-30"
 
         // MARK: Launch time
-        case .appDidFinishLaunchingTime: return "m_debug_app-did-finish-launching-time"
-        case .appDidShowUITime: return "m_debug_app-did-show-ui-time"
-        case .appDidBecomeActiveTime: return "m_debug_app-did-become-active-time"
+        case .appDidFinishLaunchingTime(let time): return "m_debug_app-did-finish-launching-time-\(time)"
+        case .appDidShowUITime(let time): return "m_debug_app-did-show-ui-time-\(time)"
+        case .appDidBecomeActiveTime(let time): return "m_debug_app-did-become-active-time-\(time)"
 
         }
     }

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -870,6 +870,12 @@ extension Pixel {
         case duckPlayerYouTubeOverlayNavigationOutsideYoutube
         case duckPlayerYouTubeOverlayNavigationClosed
         case duckPlayerYouTubeNavigationIdle30
+
+        // MARK: Launch time
+        case appDidFinishLaunchingTime
+        case appDidShowUITime
+        case appDidBecomeActiveTime
+
     }
 
 }
@@ -1733,6 +1739,11 @@ extension Pixel.Event {
         case .duckPlayerYouTubeOverlayNavigationOutsideYoutube: return "duckplayer.youtube.overlay.navigation.outside-youtube"
         case .duckPlayerYouTubeOverlayNavigationClosed: return "duckplayer.youtube.overlay.navigation.closed"
         case .duckPlayerYouTubeNavigationIdle30: return "duckplayer.youtube.overlay.idle-30"
+
+        // MARK: Launch time
+        case .appDidFinishLaunchingTime: return "m_debug_app-did-finish-launching-time"
+        case .appDidShowUITime: return "m_debug_app-did-show-ui-time"
+        case .appDidBecomeActiveTime: return "m_debug_app-did-become-active-time"
 
         }
     }

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -134,7 +134,7 @@ import os.log
         defer {
             if let didFinishLaunchingStartTime {
                 let launchTime = CFAbsoluteTimeGetCurrent() - didFinishLaunchingStartTime
-                Pixel.fire(pixel: .appDidFinishLaunchingTime,
+                Pixel.fire(pixel: .appDidFinishLaunchingTime(time: Pixel.Event.BucketAggregation(number: launchTime)),
                            withAdditionalParameters: [PixelParameters.time: String(launchTime)])
             }
         }
@@ -577,7 +577,7 @@ import os.log
         defer {
             if let didFinishLaunchingStartTime {
                 let launchTime = CFAbsoluteTimeGetCurrent() - didFinishLaunchingStartTime
-                Pixel.fire(pixel: .appDidBecomeActiveTime,
+                Pixel.fire(pixel: .appDidBecomeActiveTime(time: Pixel.Event.BucketAggregation(number: launchTime)),
                            withAdditionalParameters: [PixelParameters.time: String(launchTime)])
             }
         }
@@ -681,12 +681,6 @@ import os.log
             await refreshShortcuts()
             await vpnWorkaround.removeRedditSessionWorkaround()
         }
-        resetAppStartTime()
-    }
-
-    private func resetAppStartTime() {
-        didFinishLaunchingStartTime = nil
-        mainViewController?.appDidFinishLaunchingStartTime = nil
     }
 
     private func fireAppLaunchPixel() {
@@ -782,6 +776,12 @@ import os.log
         suspendSync()
         syncDataProviders.bookmarksAdapter.cancelFaviconsFetching(application)
         privacyProDataReporter.saveApplicationLastSessionEnded()
+        resetAppStartTime()
+    }
+
+    private func resetAppStartTime() {
+        didFinishLaunchingStartTime = nil
+        mainViewController?.appDidFinishLaunchingStartTime = nil
     }
 
     private func suspendSync() {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -128,6 +128,7 @@ import os.log
     }
 
     // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         didFinishLaunchingStartTime = CFAbsoluteTimeGetCurrent()

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -114,6 +114,9 @@ import os.log
     private let voiceSearchHelper = VoiceSearchHelper()
 
     private let marketplaceAdPostbackManager = MarketplaceAdPostbackManager()
+
+    private var didFinishLaunchingStartTime: CFAbsoluteTime?
+
     override init() {
         super.init()
 
@@ -126,6 +129,16 @@ import os.log
 
     // swiftlint:disable:next function_body_length
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        didFinishLaunchingStartTime = CFAbsoluteTimeGetCurrent()
+        defer {
+            if let didFinishLaunchingStartTime {
+                let launchTime = CFAbsoluteTimeGetCurrent() - didFinishLaunchingStartTime
+                Pixel.fire(pixel: .appDidFinishLaunchingTime,
+                           withAdditionalParameters: [PixelParameters.time: String(launchTime)])
+            }
+        }
+
 
 #if targetEnvironment(simulator)
         if ProcessInfo.processInfo.environment["UITESTING"] == "true" {
@@ -560,6 +573,14 @@ import os.log
     func applicationDidBecomeActive(_ application: UIApplication) {
         guard !testing else { return }
 
+        defer {
+            if let didFinishLaunchingStartTime {
+                let launchTime = CFAbsoluteTimeGetCurrent() - didFinishLaunchingStartTime
+                Pixel.fire(pixel: .appDidBecomeActiveTime,
+                           withAdditionalParameters: [PixelParameters.time: String(launchTime)])
+            }
+        }
+
         StorageInconsistencyMonitor().didBecomeActive(isProtectedDataAvailable: application.isProtectedDataAvailable)
         syncService.initializeIfNeeded()
         syncDataProviders.setUpDatabaseCleanersIfNeeded(syncService: syncService)
@@ -659,6 +680,12 @@ import os.log
             await refreshShortcuts()
             await vpnWorkaround.removeRedditSessionWorkaround()
         }
+        resetAppStartTime()
+    }
+
+    private func resetAppStartTime() {
+        didFinishLaunchingStartTime = nil
+        mainViewController?.appDidFinishLaunchingStartTime = nil
     }
 
     private func fireAppLaunchPixel() {

--- a/DuckDuckGo/AppDelegate.swift
+++ b/DuckDuckGo/AppDelegate.swift
@@ -371,7 +371,8 @@ import os.log
                                           voiceSearchHelper: voiceSearchHelper,
                                           featureFlagger: AppDependencyProvider.shared.featureFlagger,
                                           subscriptionCookieManager: subscriptionCookieManager,
-                                          textZoomCoordinator: makeTextZoomCoordinator())
+                                          textZoomCoordinator: makeTextZoomCoordinator(),
+                                          appDidFinishLaunchingStartTime: didFinishLaunchingStartTime)
 
             main.loadViewIfNeeded()
             syncErrorHandler.alertPresenter = main

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -183,6 +183,8 @@ class MainViewController: UIViewController {
     var historyManager: HistoryManaging
     var viewCoordinator: MainViewCoordinator!
 
+    var appDidFinishLaunchingStartTime: CFAbsoluteTime?
+
     init(
         bookmarksDatabase: CoreDataDatabase,
         bookmarksDatabaseCleaner: BookmarkDatabaseCleaner,
@@ -206,7 +208,8 @@ class MainViewController: UIViewController {
         featureFlagger: FeatureFlagger,
         fireproofing: Fireproofing = UserDefaultsFireproofing.shared,
         subscriptionCookieManager: SubscriptionCookieManaging,
-        textZoomCoordinator: TextZoomCoordinating
+        textZoomCoordinator: TextZoomCoordinating,
+        appDidFinishLaunchingStartTime: CFAbsoluteTime
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner
@@ -246,6 +249,7 @@ class MainViewController: UIViewController {
         self.fireproofing = fireproofing
         self.subscriptionCookieManager = subscriptionCookieManager
         self.textZoomCoordinator = textZoomCoordinator
+        self.appDidFinishLaunchingStartTime = appDidFinishLaunchingStartTime
 
         super.init(nibName: nil, bundle: nil)
         
@@ -337,7 +341,14 @@ class MainViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+        defer {
+            if let appDidFinishLaunchingStartTime {
+                let launchTime = CFAbsoluteTimeGetCurrent() - appDidFinishLaunchingStartTime
+                Pixel.fire(pixel: .appDidShowUITime,
+                           withAdditionalParameters: [PixelParameters.time: String(launchTime)])
+            }
+        }
+
         // Needs to be called here because sometimes the frames are not the expected size during didLoad
         refreshViewsBasedOnAddressBarPosition(appSettings.currentAddressBarPosition)
 

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -344,7 +344,7 @@ class MainViewController: UIViewController {
         defer {
             if let appDidFinishLaunchingStartTime {
                 let launchTime = CFAbsoluteTimeGetCurrent() - appDidFinishLaunchingStartTime
-                Pixel.fire(pixel: .appDidShowUITime,
+                Pixel.fire(pixel: .appDidShowUITime(time: Pixel.Event.BucketAggregation(number: launchTime)),
                            withAdditionalParameters: [PixelParameters.time: String(launchTime)])
             }
         }

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -209,7 +209,7 @@ class MainViewController: UIViewController {
         fireproofing: Fireproofing = UserDefaultsFireproofing.shared,
         subscriptionCookieManager: SubscriptionCookieManaging,
         textZoomCoordinator: TextZoomCoordinating,
-        appDidFinishLaunchingStartTime: CFAbsoluteTime
+        appDidFinishLaunchingStartTime: CFAbsoluteTime?
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner

--- a/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
+++ b/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
@@ -83,7 +83,8 @@ final class OnboardingDaxFavouritesTests: XCTestCase {
             voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true),
             featureFlagger: MockFeatureFlagger(),
             subscriptionCookieManager: SubscriptionCookieManagerMock(),
-            textZoomCoordinator: MockTextZoomCoordinator()
+            textZoomCoordinator: MockTextZoomCoordinator(),
+            appDidFinishLaunchingStartTime: nil
         )
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -81,7 +81,8 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true),
             featureFlagger: MockFeatureFlagger(),
             subscriptionCookieManager: SubscriptionCookieManagerMock(),
-            textZoomCoordinator: MockTextZoomCoordinator())
+            textZoomCoordinator: MockTextZoomCoordinator(),
+            appDidFinishLaunchingStartTime: nil)
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208832732122368/f

**Description**:
We want to measure our app’s launch speed to establish a baseline for future improvements.

**Steps to test this PR**:
1. Launch the app and check if three m.debug.app-did-* pixels fired.
2. Launch the app and quickly go into background - the pixel related to showing the UI likely shouldn’t be triggered.