### PR TITLE
Prevent showing favorites suggestion tray when opening DuckPlayer

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -1814,7 +1814,7 @@ extension MainViewController: OmniBarDelegate {
 
     func onOmniQueryUpdated(_ updatedQuery: String) {
         if updatedQuery.isEmpty {
-            if newTabPageViewController != nil {
+            if newTabPageViewController != nil || !omniBar.textField.isEditing {
                 hideSuggestionTray()
             } else {
                 let didShow = tryToShowSuggestionTray(.favorites)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203249713006009/1208838384448084/f
Tech Design URL:
CC:

**Description**:

When opening DuckPlayer in New Tab, we're going through multiple states of OmniBar, one of which is attempting to clear the URL field. This is causing the controller to show up. However it should not appear, since the URL Text Field is not being edited.

⚠️ I wasn't able to reproduce this on Simulator 100%. Had more luck on a device.

**Steps to test this PR**:
1. Add at least one Favorite.
1. Search for YouTube video in the SERP (e.g. "youtube duck").
2. Make sure DuckPlayer is set to "ask every time".
3. When prompted open video in DuckPlayer.
4. DP should open in new tab (if the setting is enabled), favorites should not.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
