### PR TITLE
Move Maestro test to Robin

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -89,7 +89,7 @@ jobs:
 
     - name: Install Maestro
       run: |
-        export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+        export MAESTRO_VERSION=1.39.1; curl -Ls "https://get.maestro.mobile.dev" | bash
 
     - name: End to End tests
       run: |

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -93,8 +93,8 @@ jobs:
 
     - name: End to End tests
       run: |
-        export PATH="$PATH":"$HOME/.maestro/bin"; maestro cloud --apiKey ${{ secrets.MAESTRO_CLOUD_API_KEY }} -e ONBOARDING_COMPLETED=true --fail-on-timeout=true --fail-on-cancellation=true --timeout=150 --ios-version=17 --include-tags=${{ matrix.test-tag }} DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app .maestro/
-      
+        export PATH="$PATH":"$HOME/.maestro/bin"; maestro cloud --apiKey ${{ secrets.ROBIN_API_KEY }} --project-id ${{ secrets.ROBIN_PROJECT_KEY }} -e ONBOARDING_COMPLETED=true --fail-on-timeout=true --fail-on-cancellation=true --timeout=150 --ios-version=17 --include-tags=${{ matrix.test-tag }} DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app .maestro/
+  
   # notify-failure:
   #   name: Notify on failure
   #   if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -102,7 +102,7 @@ jobs:
         
     - name: Sync e2e tests 
       run: |
-        export PATH="$PATH":"$HOME/.maestro/bin"; maestro cloud --apiKey ${{ secrets.MAESTRO_CLOUD_API_KEY }} -e ONBOARDING_COMPLETED=true --env=CODE=${{ steps.sync-recovery-code.outputs.recovery-code }} --fail-on-timeout=true --fail-on-cancellation=true --timeout=150 --ios-version=${{ matrix.os-version }} --include-tags=sync DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app .maestro/
+        export PATH="$PATH":"$HOME/.maestro/bin"; maestro cloud --apiKey ${{ secrets.ROBIN_API_KEY }} --project-id ${{ secrets.ROBIN_PROJECT_KEY }} -e ONBOARDING_COMPLETED=true --env=CODE=${{ steps.sync-recovery-code.outputs.recovery-code }} --fail-on-timeout=true --fail-on-cancellation=true --timeout=150 --ios-version=${{ matrix.os-version }} --include-tags=sync --app-file DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app --flows .maestro/
 
     - name: Reset config
       run: |

--- a/.github/workflows/sync-end-to-end.yml
+++ b/.github/workflows/sync-end-to-end.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Install Maestro
       run: |
-        export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+        export MAESTRO_VERSION=1.39.1; curl -Ls "https://get.maestro.mobile.dev" | bash
         
     - name: Overwrite default config with sync one
       run: |

--- a/.maestro/setup_ui_tests.sh
+++ b/.maestro/setup_ui_tests.sh
@@ -15,7 +15,7 @@ target_os="iOS-18-1"
 check_maestro() {
 
     local command_name="maestro"
-    local known_version="1.36.0"
+    local known_version="1.39.1"
 
     if command -v $command_name > /dev/null 2>&1; then
       local version_output=$($command_name -v 2>&1 | tail -n 1)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204165176092271/1208804974015522/f
Tech Design URL:
CC:

**Description**:
Move nightly Maestro test runs to Robin. 
Maestro Cloud is being sunset and has proven to be very unreliable for us. Switching tests to its successor which seems to be more reliable. 

Test runs of e2e tests and sync tests were successful: 
https://github.com/duckduckgo/iOS/actions/runs/12065608659
https://github.com/duckduckgo/iOS/actions/runs/12049269866

This PR also updates Maestro to a new-ish version required to run on Robin. 
I'm not updating to the latest 1.39.2 because it looked buggy and sluggish when testing locally. 

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Check CI is green.
2. Verify tests run locally. 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->



---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
