### PR TITLE
Update NetP tests to use Swift concurrency waiter

### DIFF
--- a/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
+++ b/DuckDuckGoTests/NetworkProtectionStatusViewModelTests.swift
@@ -36,7 +36,6 @@ final class NetworkProtectionStatusViewModelTests: XCTestCase {
     }
 
     override func setUpWithError() throws {
-        throw XCTSkip("Potentially flaky")
         try super.setUpWithError()
         tunnelController = MockTunnelController()
         statusObserver = MockConnectionStatusObserver()
@@ -57,12 +56,12 @@ final class NetworkProtectionStatusViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func testStatusUpdate_connected_setsIsNetPEnabledToTrue() throws {
-        whenStatusUpdate_connected()
+    func testStatusUpdate_connected_setsIsNetPEnabledToTrue() async throws {
+        await whenStatusUpdate_connected()
     }
 
-    func testStatusUpdate_notConnected_setsIsNetPEnabledToFalse() throws {
-        whenStatusUpdate_notConnected()
+    func testStatusUpdate_notConnected_setsIsNetPEnabledToFalse() async throws {
+        await whenStatusUpdate_notConnected()
     }
 
     func testDidToggleNetPToTrue_setsTunnelControllerStateToTrue() async {
@@ -75,27 +74,27 @@ final class NetworkProtectionStatusViewModelTests: XCTestCase {
         XCTAssertEqual(self.tunnelController.didCallStart, false)
     }
 
-    func testStatusUpdate_connected_setsHeaderTitleToOn() {
+    func testStatusUpdate_connected_setsHeaderTitleToOn() async {
         viewModel.headerTitle = ""
-        whenStatusUpdate_connected()
+        await whenStatusUpdate_connected()
         XCTAssertEqual(self.viewModel.headerTitle, UserText.netPStatusHeaderTitleOn)
     }
 
-    func testStatusUpdate_notconnected_setsHeaderTitleToOff() {
+    func testStatusUpdate_notconnected_setsHeaderTitleToOff() async {
         viewModel.headerTitle = ""
-        whenStatusUpdate_notConnected()
+        await whenStatusUpdate_notConnected()
         XCTAssertEqual(self.viewModel.headerTitle, UserText.netPStatusHeaderTitleOff)
     }
 
-    func testStatusUpdate_connected_setsStatusImageIDToVPN() {
+    func testStatusUpdate_connected_setsStatusImageIDToVPN() async {
         viewModel.statusImageID = ""
-        whenStatusUpdate_connected()
+        await whenStatusUpdate_connected()
         XCTAssertEqual(self.viewModel.statusImageID, "VPN")
     }
 
-    func testStatusUpdate_disconnected_setsStatusImageIDToVPNDisabled() {
+    func testStatusUpdate_disconnected_setsStatusImageIDToVPNDisabled() async {
         viewModel.statusImageID = ""
-        whenStatusUpdate_notConnected()
+        await whenStatusUpdate_notConnected()
         XCTAssertEqual(self.viewModel.statusImageID, "VPNDisabled")
     }
 
@@ -183,25 +182,25 @@ final class NetworkProtectionStatusViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func whenStatusUpdate_connected() {
+    private func whenStatusUpdate_connected() async {
         statusObserver.subject.send(.connected(connectedDate: Date()))
-        waitFor(condition: self.viewModel.isNetPEnabled)
+        await waitFor(condition: self.viewModel.isNetPEnabled)
     }
 
-    private func whenStatusUpdate_notConnected() {
+    private func whenStatusUpdate_notConnected() async {
         let nonConnectedCases: [ConnectionStatus] = [.disconnected, .disconnecting, .notConfigured, .reasserting]
         for current in nonConnectedCases {
             statusObserver.subject.send(current)
-            waitFor(condition: !self.viewModel.isNetPEnabled)
+            await waitFor(condition: !self.viewModel.isNetPEnabled)
         }
     }
 
-    private func waitFor(condition: @escaping @autoclosure () -> Bool) {
+    private func waitFor(condition: @escaping @autoclosure () -> Bool) async {
         let predicate = NSPredicate { _, _ in
             condition()
         }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
-        wait(for: [expectation], timeout: 20)
+        await fulfillment(of: [expectation], timeout: 20)
     }
 
     private func serverAttributes() -> NetworkProtectionServerInfo.ServerAttributes {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208837629360139/f

**Description**:

Tests were using `waitForExpectations` while the underlying calls spawn Tasks - we should not mix structured concurrency with that API as it could produce unexpected deadlocks. Updating to use `await fulfillmentOfExpectations`

**Steps to test this PR**:
Green CI

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
