### PR TITLE
Include inactive tabs statistics in daily tab switcher pixel

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 		6FEC0B882C999961006B4F6E /* FavoritesListInteractingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEC0B872C999961006B4F6E /* FavoritesListInteractingAdapter.swift */; };
 		6FF915822B88E07A0042AC87 /* AdAttributionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF915802B88E0750042AC87 /* AdAttributionFetcherTests.swift */; };
 		6FF9AD3F2CE63DD800C5A406 /* TabSwitcherOpenDailyPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */; };
-		6FF9AD412CE6610F00C5A406 /* TabSwitcherDailyPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD402CE6610600C5A406 /* TabSwitcherDailyPixelTests.swift */; };
+		6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */; };
 		6FF9AD452CE766F700C5A406 /* NewTabPageControllerPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD442CE766F700C5A406 /* NewTabPageControllerPixelTests.swift */; };
 		7B1604E82CB685B400A44EC6 /* Logger+TipKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1604E72CB685B400A44EC6 /* Logger+TipKit.swift */; };
 		7B1604EC2CB68BDA00A44EC6 /* TipKitController+ConvenienceInitializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1604EB2CB68BDA00A44EC6 /* TipKitController+ConvenienceInitializers.swift */; };
@@ -1699,7 +1699,7 @@
 		6FEC0B872C999961006B4F6E /* FavoritesListInteractingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesListInteractingAdapter.swift; sourceTree = "<group>"; };
 		6FF915802B88E0750042AC87 /* AdAttributionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionFetcherTests.swift; sourceTree = "<group>"; };
 		6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherOpenDailyPixel.swift; sourceTree = "<group>"; };
-		6FF9AD402CE6610600C5A406 /* TabSwitcherDailyPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherDailyPixelTests.swift; sourceTree = "<group>"; };
+		6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherOpenDailyPixelTests.swift; sourceTree = "<group>"; };
 		6FF9AD442CE766F700C5A406 /* NewTabPageControllerPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageControllerPixelTests.swift; sourceTree = "<group>"; };
 		7B1604E72CB685B400A44EC6 /* Logger+TipKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+TipKit.swift"; sourceTree = "<group>"; };
 		7B1604EB2CB68BDA00A44EC6 /* TipKitController+ConvenienceInitializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TipKitController+ConvenienceInitializers.swift"; sourceTree = "<group>"; };
@@ -5992,7 +5992,7 @@
 		F13B4BF71F18C9E800814661 /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
-				6FF9AD402CE6610600C5A406 /* TabSwitcherDailyPixelTests.swift */,
+				6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */,
 				85010503292FFB080033978F /* FireproofFaviconUpdaterTests.swift */,
 				8565A34C1FC8DFE400239327 /* LaunchTabNotificationTests.swift */,
 				984D035F24AF49160066CFB8 /* TabPreviewsSourceTests.swift */,
@@ -8153,7 +8153,7 @@
 				C1B7B53428944EFA0098FD6A /* CoreDataTestUtilities.swift in Sources */,
 				859DB81E2CE62766001F7210 /* TextZoomTests.swift in Sources */,
 				1DE384E42BC41E2500871AF6 /* PixelExperimentTests.swift in Sources */,
-				6FF9AD412CE6610F00C5A406 /* TabSwitcherDailyPixelTests.swift in Sources */,
+				6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */,
 				CBDD5DE129A6741300832877 /* MockBundle.swift in Sources */,
 				C158AC7B297AB5DC0008723A /* MockSecureVault.swift in Sources */,
 				569437342BE4E41500C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift in Sources */,

--- a/DuckDuckGoTests/TabSwitcherOpenDailyPixelTests.swift
+++ b/DuckDuckGoTests/TabSwitcherOpenDailyPixelTests.swift
@@ -1,5 +1,5 @@
 //
-//  TabSwitcherDailyPixelTests.swift
+//  TabSwitcherOpenDailyPixelTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
@@ -21,7 +21,7 @@ import XCTest
 import Core
 @testable import DuckDuckGo
 
-final class TabSwitcherDailyPixelTests: XCTestCase {
+final class TabSwitcherOpenDailyPixelTests: XCTestCase {
     func testPopulatesParameters() {
         let tabs = [Tab(), Tab(), Tab()]
         let pixel = TabSwitcherOpenDailyPixel()

--- a/DuckDuckGoTests/TabSwitcherOpenDailyPixelTests.swift
+++ b/DuckDuckGoTests/TabSwitcherOpenDailyPixelTests.swift
@@ -85,15 +85,173 @@ final class TabSwitcherOpenDailyPixelTests: XCTestCase {
             }
         }
     }
+
+    // - MARK: Inactive tabs aggregation tests
+
+    func testTabsWithoutLastVisitValueArentIncludedInBuckets() throws {
+        let tabs = [Tab.mock(), .mock()]
+
+        let parameters = TabSwitcherOpenDailyPixel().parameters(with: tabs)
+
+        try testBucketParameters(parameters, expectedCount: 0)
+    }
+
+    func testEdgeCaseBucketParameterForInactiveTabs() throws {
+        let now = Date()
+
+        let tabs: [Tab] = [
+            .mock(lastViewedDate: now.daysAgo(7)),
+            .mock(lastViewedDate: now.daysAgo(14)),
+            .mock(lastViewedDate: now.daysAgo(21)),
+            .mock(lastViewedDate: now.daysAgo(22))
+        ]
+
+        let pixelParametersForSecondInterval = TabSwitcherOpenDailyPixel().parameters(with: tabs, referenceDate: now)
+
+        try testBucketParameters(pixelParametersForSecondInterval, expectedCount: 1)
+    }
+
+    func testBucketParametersForInactiveTabs() throws {
+        let now = Date()
+
+        let tabsSecondInterval = Tab.stubCollectionForSecondInterval(baseDate: now)
+        let parametersForSecondInterval = TabSwitcherOpenDailyPixel().parameters(with: tabsSecondInterval, referenceDate: now)
+
+        let tabsThirdInterval = Tab.stubCollectionForThirdInterval(baseDate: now)
+        let parametersForThirdInterval = TabSwitcherOpenDailyPixel().parameters(with: tabsThirdInterval, referenceDate: now)
+
+        try testBucketParameters(parametersForSecondInterval, expectedCount: 5)
+        try testBucketParameters(parametersForThirdInterval, expectedCount: 6)
+    }
+
+    func testBucketNamingForInactiveTabs() throws {
+        let now = Date()
+        let expectedBuckets = [
+            0...0: "0",
+            1...5: "1-5",
+            6...10: "6-10",
+            11...20: "11-20",
+            21...40: "21+"
+        ]
+
+        // How many days need to pass for each interval bucket
+        let parameterDaysOffsetMapping = [
+            ParameterName.tabActive7dCount: 0,
+            ParameterName.tabInactive1wCount: 8,
+            ParameterName.tabInactive2wCount: 15,
+            ParameterName.tabInactive3wCount: 22
+        ]
+
+        for bucket in expectedBuckets {
+            let count = bucket.key.lowerBound
+
+            for parameter in parameterDaysOffsetMapping {
+                let daysOffset = parameter.value
+                // Create tabs based on expected count for bucket, using proper days offset
+                let tabs = Array(repeating: Tab.mock(lastViewedDate: now.daysAgo(daysOffset)), count: count)
+
+                let parameters = TabSwitcherOpenDailyPixel().parameters(with: tabs, referenceDate: now)
+
+                XCTAssertEqual(parameters[parameter.key], bucket.value, "Failed for bucket: \(bucket.key) with parameter: \(parameter.key)")
+            }
+        }
+    }
+
+    // MARK: - Test helper methods
+
+    private func testBucketParameters(_ parameters: [String: String], expectedCount: Int) throws {
+        let parameterNames = [
+            ParameterName.tabActive7dCount,
+            ParameterName.tabInactive1wCount,
+            ParameterName.tabInactive2wCount,
+            ParameterName.tabInactive3wCount
+        ]
+
+        let expectedBucket = try XCTUnwrap(Buckets.inactiveTabs.first { $0.key.contains(expectedCount) }).value
+        for parameterName in parameterNames {
+            let bucketValue = parameters[parameterName]
+
+            XCTAssertEqual(bucketValue, expectedBucket, "Failed for parameter: \(parameterName)")
+        }
+    }
 }
 
 private extension Tab {
-    static func mock() -> Tab {
-        Tab(link: Link(title: nil, url: URL("https://example.com")!))
+    static func mock(lastViewedDate: Date? = nil) -> Tab {
+        Tab(link: Link(title: nil, url: URL("https://example.com")!), lastViewedDate: lastViewedDate)
+    }
+
+    static func stubCollectionForSecondInterval(baseDate: Date) -> [Tab] {
+        [
+            // MARK: First week
+            .mock(lastViewedDate: baseDate),
+            .mock(lastViewedDate: baseDate.daysAgo(3)),
+            .mock(lastViewedDate: baseDate.daysAgo(4)),
+            .mock(lastViewedDate: baseDate.daysAgo(5)),
+            .mock(lastViewedDate: baseDate.daysAgo(7)),
+
+            // MARK: >1 week
+            .mock(lastViewedDate: baseDate.daysAgo(8)),
+            .mock(lastViewedDate: baseDate.daysAgo(10)),
+            .mock(lastViewedDate: baseDate.daysAgo(11)),
+            .mock(lastViewedDate: baseDate.daysAgo(12)),
+            .mock(lastViewedDate: baseDate.daysAgo(14)),
+
+            // MARK: >2 weeks
+            .mock(lastViewedDate: baseDate.daysAgo(15)),
+            .mock(lastViewedDate: baseDate.daysAgo(16)),
+            .mock(lastViewedDate: baseDate.daysAgo(17)),
+            .mock(lastViewedDate: baseDate.daysAgo(18)),
+            .mock(lastViewedDate: baseDate.daysAgo(21)),
+
+            // MARK: >3 weeks
+            .mock(lastViewedDate: baseDate.daysAgo(22)),
+            .mock(lastViewedDate: baseDate.daysAgo(23)),
+            .mock(lastViewedDate: baseDate.daysAgo(24)),
+            .mock(lastViewedDate: baseDate.daysAgo(100)),
+            .mock(lastViewedDate: Date.distantPast),
+        ]
+    }
+    static func stubCollectionForThirdInterval(baseDate: Date) -> [Tab] {
+        stubCollectionForSecondInterval(baseDate: baseDate) +
+        [
+            // MARK: First week
+            .mock(lastViewedDate: baseDate.daysAgo(4)),
+
+            // MARK: >1 week
+            .mock(lastViewedDate: baseDate.daysAgo(14)),
+
+            // MARK: >2 weeks
+            .mock(lastViewedDate: baseDate.daysAgo(15)),
+
+            // MARK: >3 weeks
+            .mock(lastViewedDate: baseDate.daysAgo(22))
+        ]
     }
 }
 
 private enum ParameterName {
     static let newTabCount = "new_tab_count"
     static let tabCount = "tab_count"
+
+    static let tabActive7dCount = "tab_active_7d"
+    static let tabInactive1wCount = "tab_inactive_1w"
+    static let tabInactive2wCount = "tab_inactive_2w"
+    static let tabInactive3wCount = "tab_inactive_3w"
+}
+
+private enum Buckets {
+    static let inactiveTabs = [
+        0...0: "0",
+        1...5: "1-5",
+        6...10: "6-10",
+        11...20: "11-20",
+        21...40: "21+"
+    ]
+}
+
+private extension Date {
+    func daysAgo(_ days: Int) -> Date {
+        addingTimeInterval(TimeInterval(-days * 86400))
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208778471392233/f
Tech Design URL:
CC:

**Description**:

Adds statistics information about inactive tabs to `m_tab_manager_clicked_daily` pixel. Although Tab model has been changed, migration is not necessary. New property is optional and is defaulting to `nil` in case no value has been found.
Pixel details can be found in [this task](https://app.asana.com/0/0/1208778471392225/f).

**Steps to test this PR**:

Prerequisite: Change `DailyPixel.hasBeenFiredToday` to return `false`.

1. Build and run current public version (can be any recent one) or make sure you already have a few tabs opened.
2. Build and run this code.
3. Observe pixel after opening tab switcher:
    1. There should be 0 inactive tabs reported (as they don't have last activity date stored)
    2. Go to a few of opened tabs, on next pixel fire they should be counted as inactive tabs in respective bucket (`tab_active_7d`).
4. Open a bunch of new tabs.
5. Observe pixel parameters include new tabs in counts after opening tab switcher.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
