### PR TITLE
Remove an unnecessary step when stopping the tunnel

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11250,8 +11250,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = cab867b50a4ae91b7616decb2a2d20be6c5dc621;
+				kind = exactVersion;
+				version = 212.1.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11250,8 +11250,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 212.0.0;
+				kind = revision;
+				revision = cab867b50a4ae91b7616decb2a2d20be6c5dc621;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "a3d5a2fc45ce000515b04666aa2fa7ad2d30e288",
-        "version" : "212.1.0"
+        "revision" : "db9c29a429896138fab29da987981a5f4a8d6712",
+        "version" : "212.1.1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "5a24a885425dcb5626353bf5a8ca6af79c44c1cb",
-        "version" : "212.0.0"
+        "revision" : "cab867b50a4ae91b7616decb2a2d20be6c5dc621"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "cab867b50a4ae91b7616decb2a2d20be6c5dc621"
+        "revision" : "a3d5a2fc45ce000515b04666aa2fa7ad2d30e288",
+        "version" : "212.1.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1208865941226621/f

BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/1102
macOS PR: https://github.com/duckduckgo/macos-browser/pull/3608

## Description

Removes a duplicated step from the tunnel stop logic that was causing some trouble in the logs.

## Testing

The change should be completely transparent, but you can try stopping the tunnel and seeing that you spot the tunnel stop success or failure pixels.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
