### PR TITLE
move daily text zoom pixel to same location as count pixel

### DIFF
--- a/DuckDuckGo/TextZoomEditorModel.swift
+++ b/DuckDuckGo/TextZoomEditorModel.swift
@@ -59,11 +59,11 @@ class TextZoomEditorModel: ObservableObject {
         NotificationCenter.default.post(
             name: AppUserDefaults.Notifications.textZoomChange,
             object: nil)
-        DailyPixel.fire(pixel: .textZoomChangedOnPageDaily)
     }
 
     func onDismiss() {
         guard initialValue.rawValue != TextZoomLevel.allCases[value].rawValue else { return }
+        DailyPixel.fire(pixel: .textZoomChangedOnPageDaily)
         Pixel.fire(.textZoomChangedOnPage, withAdditionalParameters: [
             PixelParameters.textZoomInitial: String(initialValue.rawValue),
             PixelParameters.textZoomUpdated: String(TextZoomLevel.allCases[value].rawValue),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208890374564365/f
Tech Design URL:
CC:

**Description**:
Moves pixel to correct fire location

**Steps to test this PR**:
1. Clean install and run the app.  
2. Open the zoom control on a page from browsing menu.
3. Change the value and dismiss the sheet
4. `m.menu.page.zoom.changed.daily` and `m.menu.page.zoom.changed` should fire
5. Repeat but the daily pixel should not fire again
