### PR TITLE
OmniBar.refreshState: Don't layoutIfNeeded if... not needed

### DIFF
--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -82,7 +82,7 @@ class OmniBar: UIView {
     static func loadFromXib(voiceSearchHelper: VoiceSearchHelperProtocol) -> OmniBar {
         let omniBar = OmniBar.load(nibName: "OmniBar")
         omniBar.state = SmallOmniBarState.HomeNonEditingState(voiceSearchHelper: voiceSearchHelper, isLoading: false)
-        omniBar.refreshState(omniBar.state)
+        omniBar.refreshState(omniBar.state, layOutIfNeeded: false)
 
         return omniBar
     }
@@ -359,7 +359,7 @@ class OmniBar: UIView {
         textField.selectedTextRange = textField.textRange(from: fromPosition, to: textField.endOfDocument)
     }
 
-    fileprivate func refreshState(_ newState: any OmniBarState) {
+    fileprivate func refreshState(_ newState: any OmniBarState, layOutIfNeeded: Bool = true) {
         if state.requiresUpdate(transitioningInto: newState) {
             Logger.general.debug("OmniBar entering \(newState.description) from \(self.state.description)")
 
@@ -399,10 +399,11 @@ class OmniBar: UIView {
             searchStackContainer.setCustomSpacing(13, after: voiceSearchButton)
         }
 
-        UIView.animate(withDuration: 0.0) { [weak self] in
-            self?.layoutIfNeeded()
+        if layOutIfNeeded {
+            UIView.animate(withDuration: 0.0) { [weak self] in
+                self?.layoutIfNeeded()
+            }
         }
-        
     }
 
     func updateOmniBarPadding(left: CGFloat, right: CGFloat) {

--- a/DuckDuckGo/OmniBar.swift
+++ b/DuckDuckGo/OmniBar.swift
@@ -399,6 +399,7 @@ class OmniBar: UIView {
             searchStackContainer.setCustomSpacing(13, after: voiceSearchButton)
         }
 
+        // Attempting to fix crash: https://app.asana.com/0/414709148257752/1208881366194997/f
         if layOutIfNeeded {
             UIView.animate(withDuration: 0.0) { [weak self] in
                 self?.layoutIfNeeded()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208881366194997/f

**Description**:

`OmniBar.refreshState` is crashing when called as part of setting up the initial UI stack. It's specifically the `layoutIfNeeded` call that is crashing so I'm going to see if removing this when initially creating the views has an effect. After all, it shouldn't be needed in that case.

**Steps to test this PR**:
1. Launch the app a few times, altering the text in the OmniBar each time.
2. Generally try breaking this. 

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
