### PR TITLE
Update BSK with autofill 16.0.0

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11363,16 +11363,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 210.0.1;
+				kind = revision;
+				revision = 6a5642a07acc85af9e1b165066e5b9d9716b7a09;
 			};
 		};
 		98A16C2928A11BDE00A6C003 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 218.0.0;
+				kind = revision;
+				revision = 6a5642a07acc85af9e1b165066e5b9d9716b7a09;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11371,8 +11371,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = 6a5642a07acc85af9e1b165066e5b9d9716b7a09;
+				kind = exactVersion;
+				version = 218.1.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "a404b05cc0ec6b7b3e346804c1e0970dd91c0634",
-        "version" : "218.0.2"
+        "revision" : "a82c14b991f8cbef46d4b7d8e613762f1592fcd2",
+        "version" : "218.1.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "c992041d16ec10d790e6204dce9abf9966d1363c",
-        "version" : "15.1.0"
+        "revision" : "88982a3802ac504e2f1a118a73bfdf2d8f4a7735",
+        "version" : "16.0.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208923931185505/1208923931185505
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.0.0
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/1122

## Description
Updates Autofill to version [16.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.0.0).

### Autofill 16.0.0 release notes
## What's Changed
This PR introduces breaking changes for Android/Windows causing save autofill prompt to get triggered in username only fields.
* Upgrade to shared eslint config + Adopt Prettier by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/695
* Ignore lint PR in git blame by @muodov in https://github.com/duckduckgo/duckduckgo-autofill/pull/699
* Update password-related json files (2024-11-18) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/706
* [Form] Always scan shadow elements when categorizing the form inputs by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/703
* Bump ts-to-zod from 3.1.3 to 3.14.0 by @dependabot in https://github.com/duckduckgo/duckduckgo-autofill/pull/710
* [FormAnalyzer] Fix paperlesspost.com login form by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/711
* [FormAnalyzer] Tweak regex to match forgot password attribute by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/712
* [Form] Trigger partialSave on username/email only form submit by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/702


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/15.1.0...16.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).