### PR TITLE
Add to Dock: Fix copy size for onboarding dialogs

### DIFF
--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -34,6 +34,7 @@ struct OnboardingTrySearchDialog: View {
                     title: title,
                     titleFont: Font(UIFont.daxTitle3()),
                     message: NSAttributedString(string: message),
+                    messageFont: Font.system(size: 16),
                     list: viewModel.itemsList,
                     listAction: viewModel.listItemPressed
                 )
@@ -67,6 +68,7 @@ struct OnboardingTryVisitingSiteDialogContent: View {
             title: viewModel.title,
             titleFont: Font(UIFont.daxTitle3()),
             message: message,
+            messageFont: Font.system(size: 16),
             list: viewModel.itemsList,
             listAction: viewModel.listItemPressed)
     }
@@ -90,7 +92,9 @@ struct OnboardingFireButtonDialogContent: View {
 
     var body: some View {
         ContextualDaxDialogContent(
-            message: attributedMessage)
+            message: attributedMessage,
+            messageFont: Font.system(size: 16)
+        )
     }
 }
 
@@ -113,6 +117,7 @@ struct OnboardingFirstSearchDoneDialog: View {
                     } else {
                         ContextualDaxDialogContent(
                             message: message,
+                            messageFont: Font.system(size: 16),
                             customActionView: AnyView(
                                 OnboardingCTAButton(title: cta) {
                                     gotItAction()
@@ -164,6 +169,7 @@ struct OnboardingTrackersDoneDialog: View {
                     } else {
                         ContextualDaxDialogContent(
                             message: message,
+                            messageFont: Font.system(size: 16),
                             customActionView: AnyView(
                                 OnboardingCTAButton(title: cta) {
                                     blockedTrackersCTAAction()

--- a/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -89,7 +89,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         FadeInView {
             ScrollView(.vertical) {
                 DaxDialogView(logoPosition: .top) {
-                    ContextualDaxDialogContent(message: NSAttributedString(string: message))
+                    ContextualDaxDialogContent(message: NSAttributedString(string: message), messageFont: Font.system(size: 16))
                 }
                 .padding()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208923319582846/f

**Description**:

This PR fixes the copy size of the Dax dialogs body in the onboarding flow as per [Asana conversation](https://app.asana.com/0/0/1208577512136710/1208923319582843/f). 

**Steps to test this PR**:
-

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
