### PR TITLE
Increase ratio of complete form saves

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -32,6 +32,7 @@ public enum FeatureFlag: String {
     case autofillFailureReporting
     case autofillOnForExistingUsers
     case autofillUnknownUsernameCategorization
+    case autofillPartialFormSaves
     case incontextSignup
     case autoconsentOnByDefault
     case history
@@ -101,6 +102,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AutofillSubfeature.onForExistingUsers))
         case .autofillUnknownUsernameCategorization:
             return .remoteReleasable(.subfeature(AutofillSubfeature.unknownUsernameCategorization))
+        case .autofillPartialFormSaves:
+            return .internalOnly()
         case .incontextSignup:
             return .remoteReleasable(.feature(.incontextSignup))
         case .autoconsentOnByDefault:

--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -103,7 +103,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .autofillUnknownUsernameCategorization:
             return .remoteReleasable(.subfeature(AutofillSubfeature.unknownUsernameCategorization))
         case .autofillPartialFormSaves:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(AutofillSubfeature.partialFormSaves))
         case .incontextSignup:
             return .remoteReleasable(.feature(.incontextSignup))
         case .autoconsentOnByDefault:

--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -147,6 +147,7 @@ public struct PixelParameters {
 
     // Autofill
     public static let countBucket = "count_bucket"
+    public static let backfilled = "backfilled"
 
     // Privacy Dashboard
     public static let daysSinceInstall = "daysSinceInstall"

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11371,8 +11371,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "graeme/partial-form-save-refactor";
-				kind = branch;
+				kind = exactVersion;
+				version = 219.0.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11371,7 +11371,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "graeme/partial-form-save";
+				branch = "graeme/partial-form-save-refactor";
 				kind = branch;
 			};
 		};

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11371,8 +11371,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 218.0.1;
+				branch = "graeme/partial-form-save";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/partial-form-save-refactor",
-        "revision" : "59198dd08ffd458c148823f81f830c7e29b4539b"
+        "revision" : "ef4db7b7ba39f13eb82c057b6730835e2b5495d5"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "graeme/partial-form-save",
-        "revision" : "6a90b25496e0ca74fab67d87dceb2367c7a3505a"
+        "branch" : "graeme/partial-form-save-refactor",
+        "revision" : "59198dd08ffd458c148823f81f830c7e29b4539b"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "branch" : "dbajpeyi/feature/partial-form-save",
-        "revision" : "716516696e93bad824015d9e1b3d5d9132a5f631"
+        "revision" : "88982a3802ac504e2f1a118a73bfdf2d8f4a7735",
+        "version" : "16.0.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/partial-form-save-refactor",
-        "revision" : "803f4628ecc09d1a15a145442d0d30ecda3c182f"
+        "revision" : "2d9339d4e20353a06d35e7747f1c167db549df5e"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
         "branch" : "dbajpeyi/feature/partial-form-save",
-        "revision" : "e1030b4292f39b18f1e0f0701a6e8d1a68cfa8cd"
+        "revision" : "07db870dc0cfbbac37bebef00231048ee09066b3"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/partial-form-save",
-        "revision" : "655ef65c3873621e1f2e41fcceca0b260fd987e7"
+        "revision" : "37d305dfefcac8a56193bdd249d82e541d16d5ed"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
         "branch" : "dbajpeyi/feature/partial-form-save",
-        "revision" : "07db870dc0cfbbac37bebef00231048ee09066b3"
+        "revision" : "716516696e93bad824015d9e1b3d5d9132a5f631"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "bbcb41c87c5788718a43883b5b10eb3b4f54aff3",
-        "version" : "218.0.1"
+        "branch" : "graeme/partial-form-save",
+        "revision" : "655ef65c3873621e1f2e41fcceca0b260fd987e7"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "c992041d16ec10d790e6204dce9abf9966d1363c",
-        "version" : "15.1.0"
+        "branch" : "dbajpeyi/feature/partial-form-save",
+        "revision" : "e1030b4292f39b18f1e0f0701a6e8d1a68cfa8cd"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/partial-form-save-refactor",
-        "revision" : "ef4db7b7ba39f13eb82c057b6730835e2b5495d5"
+        "revision" : "803f4628ecc09d1a15a145442d0d30ecda3c182f"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "graeme/partial-form-save",
-        "revision" : "37d305dfefcac8a56193bdd249d82e541d16d5ed"
+        "revision" : "6a90b25496e0ca74fab67d87dceb2367c7a3505a"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "graeme/partial-form-save-refactor",
-        "revision" : "2d9339d4e20353a06d35e7747f1c167db549df5e"
+        "revision" : "20df9e22d5a69acfc25204fb0228a9d6f79b721f",
+        "version" : "219.0.0"
       }
     },
     {

--- a/DuckDuckGo/EmailSignupViewController.swift
+++ b/DuckDuckGo/EmailSignupViewController.swift
@@ -64,6 +64,7 @@ class EmailSignupViewController: UIViewController {
 
     lazy private var vaultManager: SecureVaultManager = {
         let manager = SecureVaultManager(includePartialAccountMatches: true,
+                                         shouldAllowPartialFormSaves: featureFlagger.isFeatureOn(.autofillPartialFormSaves),
                                          tld: AppDependencyProvider.shared.storageCache.tld)
         manager.delegate = self
         return manager

--- a/DuckDuckGo/SaveAutofillLoginManager.swift
+++ b/DuckDuckGo/SaveAutofillLoginManager.swift
@@ -29,6 +29,7 @@ protocol SaveAutofillLoginManagerProtocol {
     var isPasswordOnlyAccount: Bool { get }
     var hasOtherCredentialsOnSameDomain: Bool { get }
     var hasSavedMatchingPasswordWithoutUsername: Bool { get }
+    var hasSavedMatchingUsernameWithoutPassword: Bool { get }
     var hasSavedMatchingUsername: Bool { get }
     
     static func saveCredentials(_ credentials: SecureVaultModels.WebsiteCredentials, with factory: AutofillVaultFactory) throws -> Int64
@@ -85,7 +86,15 @@ final class SaveAutofillLoginManager: SaveAutofillLoginManagerProtocol {
     var hasSavedMatchingUsername: Bool {
         savedMatchingUsernameCredential != nil
     }
-    
+
+    var hasSavedMatchingUsernameWithoutPassword: Bool {
+        if let savedMatchingUsernameCredential {
+            return savedMatchingUsernameCredential.password.flatMap { String(data: $0, encoding: .utf8) }.isNilOrEmpty
+        } else {
+            return false
+        }
+    }
+
     func prepareData(completion: @escaping () -> Void) {
         fetchDomainStoredCredentials { [weak self] credentials in
             self?.domainStoredCredentials = credentials
@@ -112,7 +121,7 @@ final class SaveAutofillLoginManager: SaveAutofillLoginManagerProtocol {
         let credentialsWithSameUsername = domainStoredCredentials.filter { $0.account.username == credentials.account.username }
         return credentialsWithSameUsername.first
     }
-    
+
     private func fetchDomainStoredCredentials(completion: @escaping ([SecureVaultModels.WebsiteCredentials]) -> Void) {
         DispatchQueue.global(qos: .userInteractive).async {
             var result = [SecureVaultModels.WebsiteCredentials]()

--- a/DuckDuckGo/SaveLoginView.swift
+++ b/DuckDuckGo/SaveLoginView.swift
@@ -264,6 +264,7 @@ private enum Const {
 
 struct SaveLoginView_Previews: PreviewProvider {
     private struct MockManager: SaveAutofillLoginManagerProtocol {
+        var hasSavedMatchingUsernameWithoutPassword: Bool { false }
 
         var username: String { "dax@duck.com" }
         var visiblePassword: String { "supersecurepasswordquack" }

--- a/DuckDuckGo/SaveLoginViewController.swift
+++ b/DuckDuckGo/SaveLoginViewController.swift
@@ -77,9 +77,11 @@ class SaveLoginViewController: UIViewController {
         case .savePassword:
             Pixel.fire(pixel: .autofillLoginsSavePasswordModalDismissed)
         case .updateUsername:
-            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDismissed)
+            let isBackfilled = viewModel.isUpdatingEmptyUsername
+            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDismissed, withAdditionalParameters: [PixelParameters.backfilled: String(describing: isBackfilled)])
         case .updatePassword:
-            Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalDismissed)
+            let isBackfilled = viewModel.isUpdatingEmptyPassword
+            Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalDismissed, withAdditionalParameters: [PixelParameters.backfilled: String(describing: isBackfilled)])
         }
         
         viewModel.viewControllerDidDisappear()
@@ -103,9 +105,11 @@ class SaveLoginViewController: UIViewController {
         case .savePassword:
             Pixel.fire(pixel: .autofillLoginsSavePasswordModalDisplayed)
         case .updateUsername:
-            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDisplayed)
+            let isBackfilled = saveViewModel.isUpdatingEmptyUsername
+            Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalDisplayed, withAdditionalParameters: [PixelParameters.backfilled: String(describing: isBackfilled)])
         case .updatePassword:
-            Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalDisplayed)
+            let isBackfilled = saveViewModel.isUpdatingEmptyPassword
+            Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalDisplayed, withAdditionalParameters: [PixelParameters.backfilled: String(describing: isBackfilled)])
         }
     }
 }
@@ -124,9 +128,11 @@ extension SaveLoginViewController: SaveLoginViewModelDelegate {
             delegate?.saveLoginViewController(self, didSaveCredentials: credentialManager.credentials)
         case .updatePassword, .updateUsername:
             if viewModel.layoutType == .updatePassword {
-                Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalConfirmed)
+                let isBackfilled = viewModel.isUpdatingEmptyPassword
+                Pixel.fire(pixel: .autofillLoginsUpdatePasswordModalConfirmed, withAdditionalParameters: [PixelParameters.backfilled: String(describing: isBackfilled)])
             } else {
-                Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalConfirmed)
+                let isBackfilled = viewModel.isUpdatingEmptyUsername
+                Pixel.fire(pixel: .autofillLoginsUpdateUsernameModalConfirmed, withAdditionalParameters: [PixelParameters.backfilled: String(describing: isBackfilled)])
             }
             delegate?.saveLoginViewController(self, didUpdateCredentials: credentialManager.credentials)
         }

--- a/DuckDuckGo/SaveLoginViewModel.swift
+++ b/DuckDuckGo/SaveLoginViewModel.swift
@@ -88,8 +88,12 @@ final class SaveLoginViewModel: ObservableObject {
         credentialManager.hasSavedMatchingUsername
     }
     
-    var isUpdatingUsername: Bool {
+    var isUpdatingEmptyUsername: Bool {
         credentialManager.hasSavedMatchingPasswordWithoutUsername
+    }
+
+    var isUpdatingEmptyPassword: Bool {
+        credentialManager.hasSavedMatchingUsernameWithoutPassword
     }
 
     var hiddenPassword: String {
@@ -132,7 +136,7 @@ final class SaveLoginViewModel: ObservableObject {
             return .savePassword
         }
         
-        if isUpdatingUsername {
+        if isUpdatingEmptyUsername {
             return .updateUsername
         }
         

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -270,6 +270,7 @@ class TabViewController: UIViewController {
 
     lazy var vaultManager: SecureVaultManager = {
         let manager = SecureVaultManager(includePartialAccountMatches: true,
+                                         shouldAllowPartialFormSaves: featureFlagger.isFeatureOn(.autofillPartialFormSaves),
                                          tld: AppDependencyProvider.shared.storageCache.tld)
         manager.delegate = self
         return manager


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206048666874235/f

**Description**:

Increase ratio of complete credentials saves (i.e. that include the username) by checking for recently filled emails/usernames when a form save event is incomplete.

Approach is to have a new form save events for username/email-only forms that stays in memory for 3 minutes. If a password-only form save is detected for the same domain, we can complete the form with the previous partial data. This would also cover mobile where we don't have identities autofill – and in general in all cases where the user inputs data manually. 

**Steps to test this PR**:
https://app.asana.com/0/1202926619870900/1208866651723703/f

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
