### PR TITLE
Fix sending pixel when dismissing keyboard on NTP

### DIFF
--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -515,6 +515,7 @@ class MainViewController: UIViewController {
 
 
     var keyboardShowing = false
+    private var didSendGestureDismissPixel: Bool = false
 
     @objc
     private func keyboardDidShow() {
@@ -523,14 +524,16 @@ class MainViewController: UIViewController {
 
     @objc
     private func keyboardWillHide() {
-        if newTabPageViewController?.isDragging == true, keyboardShowing {
+        if !didSendGestureDismissPixel, newTabPageViewController?.isDragging == true, keyboardShowing {
             Pixel.fire(pixel: .addressBarGestureDismiss)
+            didSendGestureDismissPixel = true
         }
     }
 
     @objc
     private func keyboardDidHide() {
         keyboardShowing = false
+        didSendGestureDismissPixel = false
     }
 
     private func registerForPageRefreshPatterns() {

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -154,6 +154,8 @@ private extension NewTabPageView {
                 EmptyView()
             }
         }
+        // Prevent recreating geomery reader when keyboard is shown/hidden.
+        .ignoresSafeArea(.keyboard)
     }
 
     @ViewBuilder

--- a/DuckDuckGo/NewTabPageView.swift
+++ b/DuckDuckGo/NewTabPageView.swift
@@ -76,7 +76,7 @@ struct NewTabPageView: View {
                 .simultaneousGesture(
                     DragGesture()
                         .onChanged({ value in
-                            if value.translation.height > 0 {
+                            if value.translation.height != 0 {
                                 viewModel.beginDragging()
                             }
                         })

--- a/DuckDuckGo/SimpleNewTabPageView.swift
+++ b/DuckDuckGo/SimpleNewTabPageView.swift
@@ -85,6 +85,8 @@ private extension SimpleNewTabPageView {
             }
             .withScrollKeyboardDismiss()
         }
+        // Prevent recreating geomery reader when keyboard is shown/hidden.
+        .ignoresSafeArea(.keyboard)
     }
 
     @ViewBuilder

--- a/DuckDuckGo/SimpleNewTabPageView.swift
+++ b/DuckDuckGo/SimpleNewTabPageView.swift
@@ -49,7 +49,7 @@ struct SimpleNewTabPageView: View {
                 .simultaneousGesture(
                     DragGesture()
                         .onChanged({ value in
-                            if value.translation.height > 0 {
+                            if value.translation.height != 0.0 {
                                 viewModel.beginDragging()
                             }
                         })


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206226850447395/1208763673835126/f
Tech Design URL:
CC:

**Description**:

Fixed a few issues with sending pixel while dismissing keyboard with a swipe gesture:
1. Prevented sending pixel twice with a long gesture.
2. Fixed `isDragging` to set when swiping upwards.
3. Prevented stuttering of view while doing the scroll gesture with keyboard present.

**Steps to test this PR**:
Observe a **single** `m.addressbar.focus.dismiss.gesture` being sent while on a NTP with favorites and:
1. Dismissing keyboard by scrolling up
1. Dismissing keyboard by scrolling down
1. Dismissing keyboard by scrolling continuously up and down

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
