### PR TITLE
Only attempt to refresh auth token when user is authenticated

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11723,7 +11723,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 221.0.0;
+				version = "221.0.0-1";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -138,7 +138,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
         "version" : "1.4.0"

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "9975e63265e617ce9c25ae1be6d531f6de5e6592",
-        "version" : "221.0.0"
+        "revision" : "276754fc1efab85c39a77da64e68439e7f105de3",
+        "version" : "221.0.0-1"
       }
     },
     {

--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -196,16 +196,12 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
     func getSubscription(params: Any, original: WKScriptMessage) async -> Encodable? {
         guard accountManager.isUserAuthenticated else { return [Constants.token: Constants.empty] }
 
-        let authToken: String
-
         switch await appStoreAccountManagementFlow.refreshAuthTokenIfNeeded() {
-        case .success(let refreshedToken):
-            authToken = refreshedToken
+        case .success(let currentAuthToken):
+            return [Constants.token: currentAuthToken]
         case .failure:
-            authToken = Constants.empty
+            return [Constants.token: Constants.empty]
         }
-
-        return [Constants.token: authToken]
     }
     
     func getSubscriptionOptions(params: Any, original: WKScriptMessage) async -> Encodable? {

--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -194,8 +194,16 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
     // MARK: Broker Methods (Called from WebView via UserScripts)
     
     func getSubscription(params: Any, original: WKScriptMessage) async -> Encodable? {
-        await appStoreAccountManagementFlow.refreshAuthTokenIfNeeded()
-        let authToken = accountManager.authToken ?? Constants.empty
+        guard accountManager.isUserAuthenticated else { return [Constants.token: Constants.empty] }
+
+        let authToken: String
+
+        switch await appStoreAccountManagementFlow.refreshAuthTokenIfNeeded() {
+        case .success(let refreshedToken):
+            authToken = refreshedToken
+        case .failure:
+            authToken = Constants.empty
+        }
 
         return [Constants.token: authToken]
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208966018277167/f

**Description**:
Following [Increase of 401s in auth api - Darwin](https://app.asana.com/0/0/1208959507432558) we found that the refreshAuthTokenIfNeeded is being called without a proper check if user is authenticated (and tokens are present).

It also includes BSK check -> https://github.com/duckduckgo/BrowserServicesKit/commit/fb809edc28e809aba8a17aaf3e1c4b37086d9cd4 

**Steps to test this PR**:
1. Ensure no PP is on the device
2. Open PP purchase page
3. Check if `refreshAuthTokenIfNeeded` was not called and no calls to `validate_token` endpoint were made.
4. Purchase or activate subscription
5. Open add/edit email page
6. Check if `refreshAuthTokenIfNeeded` was properly called with a call to `validate_token` endpoint.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
