### PR TITLE
Properly set state when user cancelled the purchase

### DIFF
--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -183,7 +183,7 @@ final class SubscriptionFlowViewModel: ObservableObject {
             isBackendError = true
             state.transactionError = .hasActiveSubscription
         case .cancelledByUser:
-            state.transactionError = nil
+            state.transactionError = .cancelledByUser
         case .accountCreationFailed:
             DailyPixel.fireDailyAndCount(pixel: .privacyProPurchaseFailureAccountNotCreated,
                                          pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1208967366086507/f

**Description**:
Do not trigger 'm_privacy-pro_app_subscription-purchase_failure_other' pixel when cancelling the purchase.

**Steps to test this PR**:
_(Since steps do not involve purchase it can be verified on simulator)_
1. Ensure no Privacy Pro is on the device
2. Open Settings -> "Get Privacy Pro"
3. Select one of the two options (monthly or annual)
4. Select "Subscribe" to confirm ToS
5. When iOS shows alert prompting to confirm purchase and/or to sign into Apple ID account tap "Cancel" to stop the purchase flow.
6. Ensure that the cancel action is not triggering `m_privacy-pro_app_subscription-purchase_failure_other` pixel to be fired

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
