### PR TITLE
Bugfix: Fix Youtube Internal links when 'Watching on Youtube' from Duck Player

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -936,8 +936,19 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
             return false
         }
         
+        // Allow Youtube's internal navigation when DuckPlayer is enabled and user is watching on Youtube
+        // This is to prevent DuckPlayer from interfering with Youtube's internal navigation for search and settings
+        // https://app.asana.com/0/1204099484721401/1208930843675395/f
+        var isYoutubeInternalNavigation = false
+        if let (destinationVideoID, _) = url.youtubeVideoParams,
+           let (originVideoID, _) = webView.url?.youtubeVideoParams,
+            destinationVideoID == originVideoID,
+            duckPlayerMode == .enabled {
+                isYoutubeInternalNavigation = true
+        }
+        
         // Redirect to Duck Player if enabled
-        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) {
+        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) && !isYoutubeInternalNavigation {
             redirectToDuckPlayerVideo(url: url, webView: webView)
             return true
         }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -939,16 +939,15 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Allow Youtube's internal navigation when DuckPlayer is enabled and user is watching on Youtube
         // This is to prevent DuckPlayer from interfering with Youtube's internal navigation for search and settings
         // https://app.asana.com/0/1204099484721401/1208930843675395/f
-        var isYoutubeInternalNavigation = false
         if let (destinationVideoID, _) = url.youtubeVideoParams,
            let (originVideoID, _) = webView.url?.youtubeVideoParams,
             destinationVideoID == originVideoID,
             duckPlayerMode == .enabled {
-                isYoutubeInternalNavigation = true
+                return false
         }
         
         // Redirect to Duck Player if enabled
-        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) && !isYoutubeInternalNavigation {
+        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) {
             redirectToDuckPlayerVideo(url: url, webView: webView)
             return true
         }

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -582,4 +582,24 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         XCTAssertNil(tabNavigator.openedURL, "No new tabs should open")
     }
     
+    @MainActor
+    func testHandleDelegateNavigation_YoutubeWatchURLWithDuckPlayerEnabledAndSameVideoNavigation_ReturnsFalse() async {
+        // Arrange
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc123")!
+        let youtubeInternalURL = URL(string: "https://www.youtube.com/watch?v=abc123&settings")!
+        let request = URLRequest(url: youtubeURL)
+        let mockFrameInfo = MockFrameInfo(isMainFrame: true)
+        let navigationAction = MockNavigationAction(request: request, targetFrame: mockFrameInfo)
+        playerSettings.mode = .enabled
+        featureFlagger.enabledFeatures = [.duckPlayer, .duckPlayerOpenInNewTab]
+
+        mockWebView.setCurrentURL(youtubeInternalURL)
+        
+        // Act
+        let shouldCancel = handler.handleDelegateNavigation(navigationAction: navigationAction, webView: mockWebView)
+
+        // Assert
+        XCTAssertFalse(shouldCancel, "Expected navigation NOT to be cancelled as it's Youtube Internal navigation")
+    }
+    
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208930843675395/f
Tech Design URL:
CC:

**Description**:
Fixes an issue causing Youtube internal links to open Duck Player

**Steps to test this PR**:
- [ ] 1. Set Duck Player mode to 'Always'
- [ ] 2. Go to Youtube.com and open a video in Duck Player
- [ ] 3. Tap "Watch on Youtube"
- [ ] 4. Tap the Youtube "search" icon or the page's three dot menu
- [ ] 5. Confirm Youtube UI shows up and Duck Player does not open.


Demo:
![RocketSim_Recording_iPhone_(18 0)_6 1_2024-12-17_10 02 35](https://github.com/user-attachments/assets/96f0d5fd-f82a-4b67-8c5d-32b47cc5ef2b)

