### PR TITLE
DuckPlayer: Don’t open new tabs or DuckPlayer at launch when in alwaysAsk mode

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -936,8 +936,19 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
             return false
         }
         
+        // Allow Youtube's internal navigation when DuckPlayer is enabled and user is watching on Youtube
+        // This is to prevent DuckPlayer from interfering with Youtube's internal navigation for search and settings
+        // https://app.asana.com/0/1204099484721401/1208930843675395/f
+        var isYoutubeInternalNavigation = false
+        if let (destinationVideoID, _) = url.youtubeVideoParams,
+           let (originVideoID, _) = webView.url?.youtubeVideoParams,
+            destinationVideoID == originVideoID,
+            duckPlayerMode == .enabled {
+                isYoutubeInternalNavigation = true
+        }
+        
         // Redirect to Duck Player if enabled
-        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) {
+        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) && !isYoutubeInternalNavigation {
             redirectToDuckPlayerVideo(url: url, webView: webView)
             return true
         }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -939,16 +939,15 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Allow Youtube's internal navigation when DuckPlayer is enabled and user is watching on Youtube
         // This is to prevent DuckPlayer from interfering with Youtube's internal navigation for search and settings
         // https://app.asana.com/0/1204099484721401/1208930843675395/f
-        var isYoutubeInternalNavigation = false
         if let (destinationVideoID, _) = url.youtubeVideoParams,
            let (originVideoID, _) = webView.url?.youtubeVideoParams,
             destinationVideoID == originVideoID,
             duckPlayerMode == .enabled {
-                isYoutubeInternalNavigation = true
+                return false
         }
         
         // Redirect to Duck Player if enabled
-        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) && !isYoutubeInternalNavigation {
+        if url.isYoutubeWatch && duckPlayerMode == .enabled && !isDuckPlayerRedirect(url: url) {
             redirectToDuckPlayerVideo(url: url, webView: webView)
             return true
         }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -954,7 +954,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         
         // Redirect to Youtube + DuckPlayer Overlay if Ask Mode
         if url.isYoutubeWatch && duckPlayerMode == .alwaysAsk && !isDuckPlayerRedirect(url: url) {
-            redirectToYouTubeVideo(url: url, webView: webView, allowFirstVideo: false)
+            redirectToYouTubeVideo(url: url, webView: webView, allowFirstVideo: false, disableNewTab: true)
             return true
         }
         

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -582,4 +582,24 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         XCTAssertNil(tabNavigator.openedURL, "No new tabs should open")
     }
     
+    @MainActor
+    func testHandleDelegateNavigation_YoutubeWatchURLWithDuckPlayerEnabledAndSameVideoNavigation_ReturnsFalse() async {
+        // Arrange
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc123")!
+        let youtubeInternalURL = URL(string: "https://www.youtube.com/watch?v=abc123&settings")!
+        let request = URLRequest(url: youtubeURL)
+        let mockFrameInfo = MockFrameInfo(isMainFrame: true)
+        let navigationAction = MockNavigationAction(request: request, targetFrame: mockFrameInfo)
+        playerSettings.mode = .enabled
+        featureFlagger.enabledFeatures = [.duckPlayer, .duckPlayerOpenInNewTab]
+
+        mockWebView.setCurrentURL(youtubeInternalURL)
+        
+        // Act
+        let shouldCancel = handler.handleDelegateNavigation(navigationAction: navigationAction, webView: mockWebView)
+
+        // Assert
+        XCTAssertFalse(shouldCancel, "Expected navigation NOT to be cancelled as it's Youtube Internal navigation")
+    }
+    
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208896356321073/f
Tech Design URL:
CC:

**Description**:
Bugfix: When launching the app after a crash or force close with DuckPlayer in 'Ask' mode, the app automatically opened `youtube.com/watch` pages (videos) in DuckPlayer when it shouldn't.

This was caused by DuckPlayer's 'open in new tab' feature.  When the app was first launched, a new tab opened for every `youtube.com/watch` page, which triggered DuckPlayer by default.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

- [x] Set Duck Player to "always ask", in Settings
- [x] Visit [youtube.com](https://youtube.com/) and select a video to have the overlay displayed
- [x] Open a new tab and navigate to other URL
- [x] Go back to the Youtube Tab
- [x] Force kill the app and relaunch (if on the simulator, re-run from Xcode)
- [x] Confirm no new (empty) tabs are opened 
- [x] Confirm the YouTube video page shows the DuckPlayer overlay.

Demo:
![ScreenRecording_12-18-2024 6-54-04 PM_1](https://github.com/user-attachments/assets/3bad94e9-7141-4ea4-a125-5f807a689d67)

