### PR TITLE
DuckPlayer: Youtube internal navigation fix

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -596,6 +596,13 @@ final class DuckPlayerNavigationHandler: NSObject {
         duckPlayerModeCancellable = nil
     }
     
+    /// Checks if a URL contains a hash
+    ///
+    /// - Parameter url: The `URL` used to determine the tab type.
+    private func urlContainsHash(_ url: URL) -> Bool {
+        return url.fragment != nil && !url.fragment!.isEmpty
+    }
+    
 }
 
 extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
@@ -937,13 +944,10 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         }
         
         // Allow Youtube's internal navigation when DuckPlayer is enabled and user is watching on Youtube
-        // This is to prevent DuckPlayer from interfering with Youtube's internal navigation for search and settings
-        // https://app.asana.com/0/1204099484721401/1208930843675395/f
-        if let (destinationVideoID, _) = url.youtubeVideoParams,
-           let (originVideoID, _) = webView.url?.youtubeVideoParams,
-            destinationVideoID == originVideoID,
-            duckPlayerMode == .enabled {
-                return false
+        // Youtube uses hashes to navigate within some settings
+        // This allows any navigation that includes a hash # (#searching, #bottom-sheet, etc)
+        if urlContainsHash(url), url.isYoutubeWatch {
+            return false
         }
         
         // Redirect to Duck Player if enabled

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -583,20 +583,37 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
     }
     
     @MainActor
-    func testHandleDelegateNavigation_YoutubeWatchURLWithDuckPlayerEnabledAndSameVideoNavigation_ReturnsFalse() async {
+    func testHandleDelegateNavigation_YoutubeInternalNavigation_ReturnsFalse() async {
         // Arrange
-        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc123")!
-        let youtubeInternalURL = URL(string: "https://www.youtube.com/watch?v=abc123&settings")!
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc123#searching")!
         let request = URLRequest(url: youtubeURL)
         let mockFrameInfo = MockFrameInfo(isMainFrame: true)
         let navigationAction = MockNavigationAction(request: request, targetFrame: mockFrameInfo)
         playerSettings.mode = .enabled
         featureFlagger.enabledFeatures = [.duckPlayer, .duckPlayerOpenInNewTab]
 
-        mockWebView.setCurrentURL(youtubeInternalURL)
+        mockWebView.setCurrentURL(youtubeURL)
         
         // Act
-        let shouldCancel = handler.handleDelegateNavigation(navigationAction: navigationAction, webView: mockWebView)
+        var shouldCancel = handler.handleDelegateNavigation(navigationAction: navigationAction, webView: mockWebView)
+
+        // Assert
+        XCTAssertFalse(shouldCancel, "Expected navigation NOT to be cancelled as it's Youtube Internal navigation")
+        
+        // Arrange
+        playerSettings.mode = .disabled
+        
+        // Act
+        shouldCancel = handler.handleDelegateNavigation(navigationAction: navigationAction, webView: mockWebView)
+
+        // Assert
+        XCTAssertFalse(shouldCancel, "Expected navigation NOT to be cancelled as it's Youtube Internal navigation")
+        
+        // Arrange
+        featureFlagger.enabledFeatures = [.duckPlayer]
+        
+        // Act
+        shouldCancel = handler.handleDelegateNavigation(navigationAction: navigationAction, webView: mockWebView)
 
         // Assert
         XCTAssertFalse(shouldCancel, "Expected navigation NOT to be cancelled as it's Youtube Internal navigation")


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL:  https://app.asana.com/0/1204099484721401/1209009420882148/f
Tech Design URL:
CC:

**Description**:
Bugfix:  When watching a Youtube video (/watch/ page), tapping the buttons in Youtube's top navbar caused the page to reload or DuckPlayer to show, and users were not able to access Youtube's settings.

Since Youtube uses hashes for internal navigation, this allows internal Youtube navigation for all DuckPlayer modes by ignoring URL changes that include a hash (#)


**Steps to test this PR**:
1. Set DuckPlayer to 'Always Ask' mode
2. Go to youtube.com and navigate to a video
3. Tap the 'Search' or 'Three dot menu' icon at the sites' top navbar
4. Confirm Youtube's UI is presented and page does not reload or DuckPlayer opens

Demo:
![RocketSim_Recording_iPhone_(18 0)_6 1_2024-12-19_16 43 47](https://github.com/user-attachments/assets/9a236c24-af69-406d-914d-e3ecf2e59529)



<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
