### PR TITLE
Fix Youtube Player Links

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -438,11 +438,11 @@ final class DuckPlayerNavigationHandler: NSObject {
         let referrerValue = queryItems.first(where: { $0.name == Constants.duckPlayerReferrerParameter })?.value
         let allowFirstVideoValue = queryItems.first(where: { $0.name == Constants.allowFirstVideoParameter })?.value
         let isNewTabValue = queryItems.first(where: { $0.name == Constants.newTabParameter })?.value
-        let youtubeEmbedURI = queryItems.first(where: { $0.name == Constants.youtubeEmbedURI })?.value
+        let youtubeEmbedURI = queryItems.first(where: { $0.name == Constants.youtubeEmbedURI })?.value ?? ""
         
         // Use the from(string:) method to parse referrer
         let referrer = DuckPlayerReferrer(string: referrerValue ?? "")
-        let allowFirstVideo = allowFirstVideoValue == "1" || youtubeEmbedURI.map(\.isEmpty) ?? false
+        let allowFirstVideo = allowFirstVideoValue == "1" || !youtubeEmbedURI.isEmpty
         let isNewTab = isNewTabValue == "1"
         
         return DuckPlayerParameters(referrer: referrer, isNewTap: isNewTab, allowFirstVideo: allowFirstVideo)
@@ -720,16 +720,19 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         
         guard videoID != lastWatchInYoutubeVideo else {
             lastURLChangeHandling = Date()
-            return .handled
+            return .handled(.newVideo)
         }
         
         let parameters = getDuckPlayerParameters(url: url)
+        
+        // If this is an internal Youtube Link (i.e Clicking in youtube logo in the player)
+        // Do not handle it
         
         // If the URL has the allow first video, we just don't handle it
         if parameters.allowFirstVideo {
             lastWatchInYoutubeVideo = videoID
             lastURLChangeHandling = Date()
-            return .handled
+            return .handled(.allowFirstVideo)
         }
         
         guard duckPlayerMode == .enabled else {
@@ -743,7 +746,7 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
             })
             lastURLChangeHandling = Date()
             Logger.duckPlayer.debug("Handling URL change for \(webView.url?.absoluteString ?? "")")
-            return .handled
+            return .handled(.duckPlayerEnabled)
         } else {
             
         }

--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandling.swift
@@ -42,7 +42,7 @@ extension DuckPlayerReferrer {
 enum DuckPlayerNavigationHandlerURLChangeResult {
     
     /// Possible reasons for not handling a URL change.
-    enum HandlingResult {
+    enum NotHandledResult {
         case featureOff
         case invalidURL
         case duckPlayerDisabled
@@ -50,9 +50,16 @@ enum DuckPlayerNavigationHandlerURLChangeResult {
         case disabledForVideo
         case duplicateNavigation
     }
+    
+    /// Possible reasons for handling a URL change.
+    enum HandledResult {
+        case newVideo
+        case allowFirstVideo
+        case duckPlayerEnabled
+    }
 
-    case handled
-    case notHandled(HandlingResult)
+    case handled(HandledResult)
+    case notHandled(NotHandledResult)
 }
 
 /// Represents the direction of navigation in the Duck Player.

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -283,7 +283,7 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         let result2 = handler.handleURLChange(webView: mockWebView)
 
         // Assert
-        if case .handled = result1 {
+        if case .handled(.duckPlayerEnabled) = result1 {
             // Success
         } else {
             XCTFail("Expected first call to return .handled")
@@ -370,6 +370,26 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
             XCTFail("Expected .unhandled when feature flag is disabled")
         }
     }
+    
+    @MainActor
+    func testHandleURLChange_WithYoutubeEmbedURIParam_ReturnsHandled() async {
+        // Arrange
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc123&&embeds_referring_euri=true")!
+        mockWebView.setCurrentURL(youtubeURL)
+        playerSettings.mode = .enabled
+        featureFlagger.enabledFeatures = [.duckPlayer, .duckPlayerOpenInNewTab]
+
+        // Act
+        let result = handler.handleURLChange(webView: mockWebView)
+        
+        // Assert
+        if case .handled(.allowFirstVideo) = result {
+            // Success
+        } else {
+            XCTFail("Expected first call to return .handled")
+        }
+    }
+
     
     @MainActor
     func testHandleDelegateNavigation_NotToMainFrame_ReturnsFalse() async {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208847473290835/f
Tech Design URL:
CC:

**Description**:
Fixes issue causing taps on Youtube Logo in the player to open multiple tabs, when just one is required.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:

- [ ] Set Duck Player mode to “Always”.  (Settings > Duck Player > Open Videos in Duck Player)
- [ ] In the same screen, enable “Open Duck Player in a New Tab” if not enabled already
- [ ] Go to youtube.com, find a video and open it, so it opens in Duck Player [Or paste `duck://player/tAGnKpE4NCI`]
- [ ] Once in Duck Player, tap the Youtube logo in the player (See screenshot)
- [ ] Confirm, a new single tab opens, and the video opens in Youtube. 

![12-23 at 17 35](https://github.com/user-attachments/assets/3b9db8e3-95f3-42e9-972a-6d9bb8a7b644)
