### PR TITLE
Fix Maestro opening tabs test

### DIFF
--- a/.maestro/browser_features/opening_tabs.yaml
+++ b/.maestro/browser_features/opening_tabs.yaml
@@ -43,8 +43,6 @@ tags:
 - tapOn: "Browse Back"
 - assertVisible: "A link that opens in a new window"
 
-# Workaround - for some reason Tab Switcher button is not found by maestro at this point.
-- tapOn: "Refresh Page"
 - runFlow:
     file: ../shared/check_number_of_tabs.yaml
     env:

--- a/.maestro/shared/check_number_of_tabs.yaml
+++ b/.maestro/shared/check_number_of_tabs.yaml
@@ -1,6 +1,9 @@
 appId: com.duckduckgo.mobile.ios
 ---
 
+# Workaround - for some reason Tab Switcher button is not found by maestro at this point.
+- tapOn: "Refresh Page"
+
 - assertVisible: "Tab Switcher"
 - tapOn: "Tab Switcher"
 - assertVisible: ${TITLE}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204165176092271/1209100870139900/f
Tech Design URL:
CC:

**Description**:
Fixes an issue with the test where Maestro can't find the accessibility ID of the Tab Switcher button in certain cases. 
This PR isn't fixing the actual accessibility issue, but more simply expanding the work around that's already in place to cover all cases where the issue can happen. 

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the tab_tabs.yaml test and verify it passes. 

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
