### PR TITLE
Post international Privacy Pro launch cleanup

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -58,9 +58,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/0/1208592102886666/1208613627589762/f
     case crashReportOptInStatusResetting
 
-    case isPrivacyProLaunchedROW
-    case isPrivacyProLaunchedROWOverride
-
     /// https://app.asana.com/0/0/1208767141940869/f
     case freeTrials
 }
@@ -71,8 +68,6 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     public var supportsLocalOverriding: Bool {
         switch self {
-        case .isPrivacyProLaunchedROWOverride:
-            return true
         default:
             return false
         }
@@ -140,10 +135,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.adAttributionReporting))
         case .crashReportOptInStatusResetting:
             return .internalOnly()
-        case .isPrivacyProLaunchedROW:
-            return .remoteReleasable(.subfeature(PrivacyProSubfeature.isLaunchedROW))
-        case .isPrivacyProLaunchedROWOverride:
-            return .remoteReleasable(.subfeature(PrivacyProSubfeature.isLaunchedROWOverride))
         case .freeTrials:
             return .remoteDevelopment(.subfeature(PrivacyProSubfeature.freeTrials))
         }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1491,7 +1491,6 @@
 		1E8146A728C8AB3F00D1AF63 /* TrackerAnimationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerAnimationLogicTests.swift; sourceTree = "<group>"; };
 		1E8146A928C8AB8200D1AF63 /* PrivacyIconLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyIconLogicTests.swift; sourceTree = "<group>"; };
 		1E87615828A1517200C7C5CE /* PrivacyDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardViewController.swift; sourceTree = "<group>"; };
-		1E879D352D2F2ECC009CF54D /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../BrowserServicesKit; sourceTree = SOURCE_ROOT; };
 		1E8AD1C627BE9B2900ABA377 /* DownloadsListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsListDataSource.swift; sourceTree = "<group>"; };
 		1E8AD1C827BFAD1500ABA377 /* DirectoryMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryMonitor.swift; sourceTree = "<group>"; };
 		1E8AD1CE27C0009F00ABA377 /* CompleteDownloadRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDownloadRow.swift; sourceTree = "<group>"; };
@@ -4457,7 +4456,6 @@
 		84E341891E2F7EFB00BDBA6F = {
 			isa = PBXGroup;
 			children = (
-				1E879D352D2F2ECC009CF54D /* BrowserServicesKit */,
 				EE3B98EB2A963515002F63A0 /* WidgetsExtensionAlpha.entitlements */,
 				6FB030C7234331B400A10DB9 /* Configuration.xcconfig */,
 				EEB8FDB92A990AEE00EBEDCF /* Configuration-Alpha.xcconfig */,

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11864,8 +11864,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 223.0.0;
+				branch = "michal/international-pp-cleanup";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11864,8 +11864,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "michal/international-pp-cleanup";
-				kind = branch;
+				kind = exactVersion;
+				version = "223.0.0-1";
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1491,6 +1491,7 @@
 		1E8146A728C8AB3F00D1AF63 /* TrackerAnimationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerAnimationLogicTests.swift; sourceTree = "<group>"; };
 		1E8146A928C8AB8200D1AF63 /* PrivacyIconLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyIconLogicTests.swift; sourceTree = "<group>"; };
 		1E87615828A1517200C7C5CE /* PrivacyDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardViewController.swift; sourceTree = "<group>"; };
+		1E879D352D2F2ECC009CF54D /* BrowserServicesKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BrowserServicesKit; path = ../BrowserServicesKit; sourceTree = SOURCE_ROOT; };
 		1E8AD1C627BE9B2900ABA377 /* DownloadsListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsListDataSource.swift; sourceTree = "<group>"; };
 		1E8AD1C827BFAD1500ABA377 /* DirectoryMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryMonitor.swift; sourceTree = "<group>"; };
 		1E8AD1CE27C0009F00ABA377 /* CompleteDownloadRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDownloadRow.swift; sourceTree = "<group>"; };
@@ -4456,6 +4457,7 @@
 		84E341891E2F7EFB00BDBA6F = {
 			isa = PBXGroup;
 			children = (
+				1E879D352D2F2ECC009CF54D /* BrowserServicesKit */,
 				EE3B98EB2A963515002F63A0 /* WidgetsExtensionAlpha.entitlements */,
 				6FB030C7234331B400A10DB9 /* Configuration.xcconfig */,
 				EEB8FDB92A990AEE00EBEDCF /* Configuration-Alpha.xcconfig */,

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "93ea6c3e771bc0b743b38cefbff548c10add9898",
-        "version" : "6.42.0"
+        "revision" : "bc808eb735d9eb72d5c54cf2452b104b6a370e25",
+        "version" : "6.43.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "022c845b06ace6a4aa712a4fa3e79da32193d5c6",
-        "version" : "7.4.0"
+        "revision" : "2e2baf7d31c7d8e158a58bc1cb79498c1c727fd2",
+        "version" : "7.5.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "michal/international-pp-cleanup",
-        "revision" : "84d2f7e4206707f5198a1ba669290d8ff86da22b"
+        "revision" : "a87790835c140e4399ac85bb5b3c39d4c5f4ff03",
+        "version" : "223.0.0-1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
         "revision" : "93ea6c3e771bc0b743b38cefbff548c10add9898",
-         "version" : "6.42.0"
+        "version" : "6.42.0"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "browserserviceskit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
-      "state" : {
-        "revision" : "e8f94cf597f4a447f86f39f461b736ac9ea280ce",
-        "version" : "223.0.0"
-      }
-    },
-    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
@@ -145,6 +136,24 @@
       }
     },
     {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks.git",
+      "state" : {
+        "revision" : "b9b24b69e2adda099a1fa381cda1eeec272d5b53",
+        "version" : "1.0.5"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
@@ -196,6 +205,15 @@
       "state" : {
         "revision" : "13fd026384b1af11048451061cc1b21434990668",
         "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
+        "version" : "1.4.3"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "browserserviceskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
+      "state" : {
+        "branch" : "michal/international-pp-cleanup",
+        "revision" : "84d2f7e4206707f5198a1ba669290d8ff86da22b"
+      }
+    },
+    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
@@ -136,24 +145,6 @@
       }
     },
     {
-      "identity" : "swift-clocks",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-clocks.git",
-      "state" : {
-        "revision" : "b9b24b69e2adda099a1fa381cda1eeec272d5b53",
-        "version" : "1.0.5"
-      }
-    },
-    {
-      "identity" : "swift-concurrency-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
-      "state" : {
-        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
-        "version" : "1.3.1"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
@@ -205,15 +196,6 @@
       "state" : {
         "revision" : "13fd026384b1af11048451061cc1b21434990668",
         "version" : "1.1.3"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "bc808eb735d9eb72d5c54cf2452b104b6a370e25",
-        "version" : "6.43.0"
+        "revision" : "93ea6c3e771bc0b743b38cefbff548c10add9898",
+         "version" : "6.42.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "2e2baf7d31c7d8e158a58bc1cb79498c1c727fd2",
-        "version" : "7.5.0"
+        "revision" : "022c845b06ace6a4aa712a4fa3e79da32193d5c6",
+        "version" : "7.4.0"
       }
     },
     {

--- a/DuckDuckGo/AppDependencyProvider.swift
+++ b/DuckDuckGo/AppDependencyProvider.swift
@@ -124,28 +124,14 @@ final class AppDependencyProvider: DependencyProvider {
                                                    subscriptionEndpointService: subscriptionService,
                                                    authEndpointService: authService)
 
-        let theFeatureFlagger = featureFlagger
-        let subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags> = FeatureFlaggerMapping { feature in
-            switch feature {
-            case .isLaunchedROW:
-                return theFeatureFlagger.isFeatureOn(.isPrivacyProLaunchedROW)
-            case .isLaunchedROWOverride:
-                return theFeatureFlagger.isFeatureOn(.isPrivacyProLaunchedROWOverride)
-            default:
-                return feature.defaultState
-            }
-        }
-
-        let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionFeatureMappingCache,
-                                                               subscriptionFeatureFlagger: subscriptionFeatureFlagger)
+        let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionFeatureMappingCache)
 
         let subscriptionManager = DefaultSubscriptionManager(storePurchaseManager: storePurchaseManager,
                                                              accountManager: accountManager,
                                                              subscriptionEndpointService: subscriptionService,
                                                              authEndpointService: authService,
                                                              subscriptionFeatureMappingCache: subscriptionFeatureMappingCache,
-                                                             subscriptionEnvironment: subscriptionEnvironment,
-                                                             subscriptionFeatureFlagger: subscriptionFeatureFlagger)
+                                                             subscriptionEnvironment: subscriptionEnvironment)
         accountManager.delegate = subscriptionManager
 
         self.subscriptionManager = subscriptionManager

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -37,7 +37,6 @@ struct SettingsState {
     }
 
     struct Subscription: Codable {
-        var enabled: Bool
         var canPurchase: Bool
         var isSignedIn: Bool
         var hasActiveSubscription: Bool
@@ -136,8 +135,7 @@ struct SettingsState {
             speechRecognitionAvailable: false,
             loginsEnabled: false,
             networkProtectionConnected: false,
-            subscription: Subscription(enabled: false,
-                                       canPurchase: false,
+            subscription: Subscription(canPurchase: false,
                                        isSignedIn: false,
                                        hasActiveSubscription: false,
                                        isRestoring: false,

--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -272,7 +272,7 @@ struct SettingsSubscriptionView: View {
             }
         }
         .onReceive(settingsViewModel.$state) { state in
-            isShowingPrivacyPro = state.subscription.enabled && (state.subscription.isSignedIn || state.subscription.canPurchase)
+            isShowingPrivacyPro = (state.subscription.isSignedIn || state.subscription.canPurchase)
         }
     }
 }

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -757,9 +757,6 @@ extension SettingsViewModel {
             state.subscription = SettingsState.defaults.subscription
         }
 
-        // Update visibility based on Feature flag
-        state.subscription.enabled = subscriptionFeatureAvailability.isFeatureAvailable
-
         // Update if can purchase based on App Store product availability
         state.subscription.canPurchase = subscriptionManager.canPurchase
 

--- a/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -44,8 +44,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         Sections.appstore: "App Store",
         Sections.environment: "Environment",
         Sections.pixels: "Promo Pixel Parameters",
-        Sections.metadata: "StoreKit Metadata",
-        Sections.featureFlags: "Feature flags"
+        Sections.metadata: "StoreKit Metadata"
     ]
 
     enum Sections: Int, CaseIterable {
@@ -55,7 +54,6 @@ final class SubscriptionDebugViewController: UITableViewController {
         case environment
         case pixels
         case metadata
-        case featureFlags
     }
 
     enum AuthorizationRows: Int, CaseIterable {
@@ -86,10 +84,6 @@ final class SubscriptionDebugViewController: UITableViewController {
     enum MetadataRows: Int, CaseIterable {
         case storefrontID
         case countryCode
-    }
-
-    enum FeatureFlagRows: Int, CaseIterable {
-        case isLaunchedROW
     }
 
     private var storefrontID = "Loading"
@@ -184,15 +178,6 @@ final class SubscriptionDebugViewController: UITableViewController {
                 break
             }
 
-        case .featureFlags:
-            switch FeatureFlagRows(rawValue: indexPath.row) {
-            case .isLaunchedROW:
-                cell.textLabel?.text = "isPrivacyProLaunchedROWOverride"
-                cell.accessoryType = featureFlagger.isFeatureOn(.isPrivacyProLaunchedROWOverride) ? .checkmark : .none
-            case .none:
-                break
-            }
-
         case .none:
             break
         }
@@ -208,7 +193,6 @@ final class SubscriptionDebugViewController: UITableViewController {
         case .environment: return EnvironmentRows.allCases.count
         case .pixels: return PixelsRows.allCases.count
         case .metadata: return MetadataRows.allCases.count
-        case .featureFlags: return FeatureFlagRows.allCases.count
         case .none: return 0
         }
     }
@@ -244,11 +228,6 @@ final class SubscriptionDebugViewController: UITableViewController {
             }
         case .metadata:
             break
-        case .featureFlags:
-            switch FeatureFlagRows(rawValue: indexPath.row) {
-            case .isLaunchedROW: toggleIsLaunchedROWFlag()
-            default: break
-            }
         case .none:
             break
         }
@@ -355,16 +334,6 @@ final class SubscriptionDebugViewController: UITableViewController {
                 Randomized: \(reportedParameters.joined(separator: ", "))
                 """
         showAlert(title: "", message: message)
-    }
-
-    private func toggleIsLaunchedROWFlag() {
-        let flag = FeatureFlag.isPrivacyProLaunchedROWOverride
-        if featureFlagger.localOverrides?.override(for: flag) == nil {
-            featureFlagger.localOverrides?.toggleOverride(for: flag)
-        } else {
-            featureFlagger.localOverrides?.clearOverride(for: flag)
-        }
-        tableView.reloadData()
     }
 
     private func syncAppleIDAccount() {

--- a/DuckDuckGoTests/Subscription/SubscriptionFeatureAvailabilityMock.swift
+++ b/DuckDuckGoTests/Subscription/SubscriptionFeatureAvailabilityMock.swift
@@ -22,15 +22,13 @@ import Foundation
 
 public final class SubscriptionFeatureAvailabilityMock: SubscriptionFeatureAvailability {
     static var enabled: SubscriptionFeatureAvailabilityMock {
-        return SubscriptionFeatureAvailabilityMock(isFeatureAvailable: true, isSubscriptionPurchaseAllowed: true, usesUnifiedFeedbackForm: true)
+        return SubscriptionFeatureAvailabilityMock(isSubscriptionPurchaseAllowed: true, usesUnifiedFeedbackForm: true)
     }
 
-    public var isFeatureAvailable: Bool
     public var isSubscriptionPurchaseAllowed: Bool
     public var usesUnifiedFeedbackForm: Bool
 
-    public init(isFeatureAvailable: Bool, isSubscriptionPurchaseAllowed: Bool, usesUnifiedFeedbackForm: Bool) {
-        self.isFeatureAvailable = isFeatureAvailable
+    public init(isSubscriptionPurchaseAllowed: Bool, usesUnifiedFeedbackForm: Bool) {
         self.isSubscriptionPurchaseAllowed = isSubscriptionPurchaseAllowed
         self.usesUnifiedFeedbackForm = usesUnifiedFeedbackForm
     }

--- a/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -82,7 +82,6 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
     var subscriptionEnvironment: SubscriptionEnvironment!
 
     var subscriptionFeatureMappingCache: SubscriptionFeatureMappingCacheMock!
-    var subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags>!
 
     var appStorePurchaseFlow: AppStorePurchaseFlow!
     var appStoreRestoreFlow: AppStoreRestoreFlow!
@@ -134,7 +133,6 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
                                                              settings: UserDefaultsCacheSettings(defaultExpirationInterval: .minutes(20)))
 
         subscriptionFeatureMappingCache = SubscriptionFeatureMappingCacheMock()
-        subscriptionFeatureFlagger = FeatureFlaggerMapping<SubscriptionFeatureFlags>(mapping: { $0.defaultState })
 
         // Real AccountManager
         accountManager = DefaultAccountManager(storage: accountStorage,
@@ -164,8 +162,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
                                                          subscriptionEndpointService: subscriptionService,
                                                          authEndpointService: authService,
                                                          subscriptionFeatureMappingCache: subscriptionFeatureMappingCache,
-                                                         subscriptionEnvironment: subscriptionEnvironment,
-                                                         subscriptionFeatureFlagger: subscriptionFeatureFlagger)
+                                                         subscriptionEnvironment: subscriptionEnvironment)
 
         feature = SubscriptionPagesUseSubscriptionFeature(subscriptionManager: subscriptionManager,
                                                           subscriptionFeatureAvailability: subscriptionFeatureAvailability,

--- a/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -315,7 +315,6 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
     func testGetSubscriptionOptionsReturnsEmptyOptionsWhenPurchaseNotAllowed() async throws {
         // Given
         let subscriptionFeatureAvailabilityWithoutPurchaseAllowed = SubscriptionFeatureAvailabilityMock(
-            isFeatureAvailable: true,
             isSubscriptionPurchaseAllowed: false,
             usesUnifiedFeedbackForm: true
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1208836865988474/f

CC: @federicocappelli 

**Description**:
Post launch remove isLaunchedROW and isLaunchedROWOverride  feature flags and clean related business logic

**Steps to test this PR**:
- Verify purchase paths for both US and non-US Privacy Pro variants work correctly (no functional changes expected)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
