### PR TITLE
Malicious Site Protection - Pixels

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -168,6 +168,9 @@ public struct PixelParameters {
     public static let appEvent = "event"
 
     public static let didCallWillEnterForeground = "didCallWillEnterForeground"
+
+    // Background Tasks
+    public static let backgroundTaskCategory = "category"
 }
 
 public struct PixelValues {

--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -1545,7 +1545,7 @@ extension Pixel.Event {
         case .webKitWarmupUnexpectedDidFinish: return "m_d_webkit-warmup-unexpected-did-finish"
         case .webKitWarmupUnexpectedDidTerminate: return "m_d_webkit-warmup-unexpected-did-terminate"
 
-        case .backgroundTaskSubmissionFailed: return "m_bt_rf"
+        case .backgroundTaskSubmissionFailed: return "m_background-task_submission-failed"
             
         case .blankOverlayNotDismissed: return "m_d_ovs"
             

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -843,6 +843,7 @@
 		9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */; };
 		9F6933212C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */; };
 		9F72FE272CD223A000BA35F5 /* add-to-dock-promo.json in Resources */ = {isa = PBXBuildFile; fileRef = 9F72FE262CD223A000BA35F5 /* add-to-dock-promo.json */; };
+		9F74B7922D49E43A00A7F174 /* MaliciousSiteProtection+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F74B7912D49E42D00A7F174 /* MaliciousSiteProtection+Pixel.swift */; };
 		9F7CFF762C86BB8F0012833E /* OnboardingView+AppIconPickerContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7CFF752C86BB8F0012833E /* OnboardingView+AppIconPickerContent.swift */; };
 		9F7CFF782C86E3E10012833E /* OnboardingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7CFF772C86E3E10012833E /* OnboardingManagerTests.swift */; };
 		9F7CFF7D2C89B69A0012833E /* AppIconPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7CFF7C2C89B69A0012833E /* AppIconPickerViewModelTests.swift */; };
@@ -2767,6 +2768,7 @@
 		9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
 		9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHostingControllerMock.swift; sourceTree = "<group>"; };
 		9F72FE262CD223A000BA35F5 /* add-to-dock-promo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "add-to-dock-promo.json"; sourceTree = "<group>"; };
+		9F74B7912D49E42D00A7F174 /* MaliciousSiteProtection+Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MaliciousSiteProtection+Pixel.swift"; sourceTree = "<group>"; };
 		9F7CFF752C86BB8F0012833E /* OnboardingView+AppIconPickerContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AppIconPickerContent.swift"; sourceTree = "<group>"; };
 		9F7CFF772C86E3E10012833E /* OnboardingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManagerTests.swift; sourceTree = "<group>"; };
 		9F7CFF7C2C89B69A0012833E /* AppIconPickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconPickerViewModelTests.swift; sourceTree = "<group>"; };
@@ -5321,6 +5323,7 @@
 		9F254AA92CF47CD30063B308 /* MaliciousSiteProtection */ = {
 			isa = PBXGroup;
 			children = (
+				9F74B7902D49E42100A7F174 /* Events */,
 				9F0949A32D3898DD0079291B /* UserPreferences */,
 				9F0949A22D3898C20079291B /* Services */,
 				9F06EB882D0D737500905426 /* Settings */,
@@ -5411,6 +5414,14 @@
 				9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */,
 			);
 			path = ContextualOnboarding;
+			sourceTree = "<group>";
+		};
+		9F74B7902D49E42100A7F174 /* Events */ = {
+			isa = PBXGroup;
+			children = (
+				9F74B7912D49E42D00A7F174 /* MaliciousSiteProtection+Pixel.swift */,
+			);
+			path = Events;
 			sourceTree = "<group>";
 		};
 		9F8E0F282CCA577E001EA7C5 /* AddToDock */ = {
@@ -8567,6 +8578,7 @@
 				F1D796F01E7B07610019D451 /* BookmarksViewControllerCells.swift in Sources */,
 				9F9EE4D42C37BB1300D4118E /* OnboardingView+Landing.swift in Sources */,
 				85058369219F424500ED4EDB /* UIColorExtension.swift in Sources */,
+				9F74B7922D49E43A00A7F174 /* MaliciousSiteProtection+Pixel.swift in Sources */,
 				BDE219E62C406D19005D5884 /* PrivacyProDataReporting.swift in Sources */,
 				D6E83C312B1EA309006C8AFB /* SettingsCell.swift in Sources */,
 				1DEAADEE2BA45DFE00E25A97 /* SettingsDataClearingView.swift in Sources */,

--- a/DuckDuckGo/AppConfigurationFetch.swift
+++ b/DuckDuckGo/AppConfigurationFetch.swift
@@ -161,7 +161,7 @@ class AppConfigurationFetch {
         do {
             try BGTaskScheduler.shared.submit(task)
         } catch {
-            Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error)
+            Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error, withAdditionalParameters: [PixelParameters.backgroundTaskCategory: "appConfiguration"])
         }
         #endif
     }

--- a/DuckDuckGo/MaliciousSiteProtection/Events/MaliciousSiteProtection+Pixel.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Events/MaliciousSiteProtection+Pixel.swift
@@ -1,5 +1,5 @@
 //
-//  Logger+MaliciousSiteProtection.swift
+//  MaliciousSiteProtection+Pixel.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -18,11 +18,14 @@
 //
 
 import Foundation
-import os.log
+import Core
+import MaliciousSiteProtection
 
-extension Logger {
-    enum MaliciousSiteProtection {
-        static let datasetsFetcher = Logger(subsystem: "MaliciousSite", category: "DatasetsFetcher")
-        static let manager = Logger(subsystem: "MaliciousSite", category: "Manager")
+extension Pixel {
+
+    static func fire(_ event: MaliciousSiteProtection.Event) {
+        guard let convertedPixelEvent = Event.MaliciousSiteProtectionEvent(event) else { return }
+        Pixel.fire(.maliciousSiteProtection(event: convertedPixelEvent), withAdditionalParameters: convertedPixelEvent.parameters)
     }
+
 }

--- a/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -20,7 +20,7 @@
 import Foundation
 import MaliciousSiteProtection
 import Common
-import PixelKit
+import Core
 
 typealias MaliciousSiteProtectionManaging = MaliciousSiteDetecting & MaliciousSiteProtectionDatasetsFetching
 
@@ -31,7 +31,19 @@ final class MaliciousSiteProtectionManager {
     private let maliciousSiteProtectionFeatureFlagger: MaliciousSiteProtectionFeatureFlagger
 
     private static let debugEvents = EventMapping<MaliciousSiteProtection.Event> { event, _, _, _ in
-        PixelKit.fire(event)
+        switch event {
+        case .errorPageShown,
+             .visitSite,
+             .iframeLoaded,
+             .settingToggled,
+             .matchesApiTimeout:
+            Pixel.fire(event)
+        case .matchesApiFailure(let error):
+            Logger.MaliciousSiteProtection.manager.error("Error fetching matches from API: \(error)")
+        case .failedToDownloadInitialDataSets:
+            // `.failedToDownloadInitialDataSets` Pixel is sent within the BSK library
+            break
+        }
     }
 
     init(

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -231,7 +231,7 @@ extension MaliciousSiteProtectionDatasetsFetcher {
                 try backgroundTaskScheduler.submit(task)
             } catch {
                 Logger.MaliciousSiteProtection.datasetsFetcher.error("Failed scheduling background task for \(datasetType.rawValue)")
-                Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error)
+                Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error, withAdditionalParameters: [PixelParameters.backgroundTaskCategory: "maliciousSiteProtection"])
             }
         }
 

--- a/DuckDuckGo/MaliciousSiteProtection/Settings/MaliciousSiteProtectionSettingsViewModel.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Settings/MaliciousSiteProtectionSettingsViewModel.swift
@@ -21,6 +21,7 @@ import Foundation
 import Combine
 import Core
 import SwiftUI
+import PixelKit
 import MaliciousSiteProtection
 
 final class MaliciousSiteProtectionSettingsViewModel: ObservableObject {
@@ -51,4 +52,8 @@ final class MaliciousSiteProtectionSettingsViewModel: ObservableObject {
         urlOpener.open(URL.maliciousSiteProtectionLearnMore)
     }
 
+    private func updateMaliciousSiteProtection(enabled isEnabled: Bool) {
+        isMaliciousSiteProtectionOn = isEnabled
+        PixelKit.fire(MaliciousSiteProtection.Event.settingToggled(to: isEnabled))
+    }
 }

--- a/DuckDuckGo/MaliciousSiteProtection/Settings/MaliciousSiteProtectionSettingsViewModel.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Settings/MaliciousSiteProtectionSettingsViewModel.swift
@@ -21,14 +21,13 @@ import Foundation
 import Combine
 import Core
 import SwiftUI
-import PixelKit
 import MaliciousSiteProtection
 
 final class MaliciousSiteProtectionSettingsViewModel: ObservableObject {
-    @Published var shouldShowMaliciousSiteProtectionSection = false
-    @Published var isMaliciousSiteProtectionOn: Bool = false {
+    @Published var shouldShowMaliciousSiteProtectionSection: Bool
+    @Published var isMaliciousSiteProtectionOn: Bool {
         didSet {
-            manager.isMaliciousSiteProtectionOn = isMaliciousSiteProtectionOn
+            updateMaliciousSiteProtection(enabled: isMaliciousSiteProtectionOn)
         }
     }
 
@@ -53,7 +52,7 @@ final class MaliciousSiteProtectionSettingsViewModel: ObservableObject {
     }
 
     private func updateMaliciousSiteProtection(enabled isEnabled: Bool) {
-        isMaliciousSiteProtectionOn = isEnabled
-        PixelKit.fire(MaliciousSiteProtection.Event.settingToggled(to: isEnabled))
+        manager.isMaliciousSiteProtectionOn = isEnabled
+        Pixel.fire(MaliciousSiteProtection.Event.settingToggled(to: isEnabled))
     }
 }

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
@@ -23,7 +23,6 @@ import Core
 import SpecialErrorPages
 import WebKit
 import MaliciousSiteProtection
-import PixelKit
 
 enum MaliciousSiteProtectionNavigationResult: Equatable {
     case navigationHandled(NavigationType)
@@ -110,7 +109,7 @@ extension MaliciousSiteProtectionNavigationHandler: MaliciousSiteProtectionNavig
                 let response = MaliciousSiteDetectionNavigationResponse(navigationAction: navigationAction, errorData: errorData)
                 return .navigationHandled(.mainFrame(response))
             } else {
-                PixelKit.fire(MaliciousSiteProtection.Event.iframeLoaded(category: threatKind))
+                Pixel.fire(MaliciousSiteProtection.Event.iframeLoaded(category: threatKind))
                 // Extract the URL of the source frame (the iframe) that initiated the navigation action
                 let iFrameTopURL = navigationAction.sourceFrame.safeRequest?.url ?? url
                 let errorData = SpecialErrorData.maliciousSite(kind: threatKind, url: iFrameTopURL)
@@ -146,7 +145,7 @@ extension MaliciousSiteProtectionNavigationHandler: SpecialErrorPageActionHandle
         maliciousURLExemptions[url] = threatKind
         bypassedMaliciousSiteThreatKind = threatKind
 
-        PixelKit.fire(MaliciousSiteProtection.Event.visitSite(category: threatKind))
+        Pixel.fire(MaliciousSiteProtection.Event.visitSite(category: threatKind))
     }
 
     func leaveSite() { }

--- a/DuckDuckGo/WaitlistExtensions.swift
+++ b/DuckDuckGo/WaitlistExtensions.swift
@@ -34,7 +34,7 @@ extension Waitlist {
 
     var onBackgroundTaskSubmissionError: ((Error) -> Void)? {
         { error in
-            Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error)
+            Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error, withAdditionalParameters: [PixelParameters.backgroundTaskCategory: "waitlist"])
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1207169456840072/f

**Description**:

This PR adds the pixel events for the malicious site protection feature.

[Pixels definition](https://app.asana.com/0/1208717418466383/1208808591364106/f)

Note that iframes handling is descoped for the time being.

**Steps to test this PR**:

**Prerequisites**
Ensure that `isMaliciousSiteProtectionEnabled` and `shouldDetectMaliciousThreat(forDomain domain: String?) -> Bool` defined in `MaliciousSiteProtectionFeatureFlags.swift` -> return `true`

**Scenario 1 - Navigate to a Malicious site - Phishing**
1. Navigate to http://privacy-test-pages.site/security/badware/phishing.html
2. Ensure that Pixel `malicious-site-protection_error-page-shown` is fired with category `phishing`.

 **Scenario 2 - Navigate to a Malicious site - Malware**
1. Navigate to http://privacy-test-pages.site/security/badware/malware.html
2. Ensure that Pixel `malicious-site-protection_error-page-shown` is fired with category `malware`.

**Scenario 3 - Visit Malicious Site - Phishing**
1. Navigate to http://privacy-test-pages.site/security/badware/phishing.html
2. Tap the “Advanced” button. 
3. Tap the “Accept risk and visit site” button.
4. Ensure that Pixel `malicious-site-protection_visit-site` is fired with category `phishing`.

**Scenario 4 - Visit Malicious Site - Malware**
1. Navigate to http://privacy-test-pages.site/security/badware/malware.html
2. Tap the “Advanced” button. 
3. Tap the “Accept risk and visit site” button.
4. Ensure that Pixel `malicious-site-protection_visit-site` is fired with category `malware`.

**Scenario 3 - Enable/Disable feature in App settings**
1. Go to App Settings -> General.
2. Enable/Disable Malicious Site Protection.
3. Ensure that Pixel `malicious-site-protection_feature-toggled` is fired with parameter `newState` true / false depending on the setting value. 

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
