### PR TITLE
Update BSK with AI Chat deeplink feature flag

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -49,6 +49,7 @@ public enum FeatureFlag: String {
     case textZoom
     case adAttributionReporting
     case aiChat
+    case aiChatDeepLink
 
     /// https://app.asana.com/0/72649045549333/1208231259093710/f
     case networkProtectionUserTips
@@ -140,6 +141,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteDevelopment(.subfeature(PrivacyProSubfeature.privacyProFreeTrialJan25))
         case .aiChat:
             return .remoteReleasable(.feature(.aiChat))
+        case .aiChatDeepLink:
+            return .remoteReleasable(.subfeature(AIChatSubfeature.deepLink))
         }
     }
 }

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11901,7 +11901,7 @@
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
 				kind = exactVersion;
-				version = 224.5.0;
+				version = 224.6.0;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "1700c54067b6676974676ca9a81d654317a093f1",
-        "version" : "224.5.0"
+        "revision" : "20316b105d8874e10cf544a9c97e97237441ae01",
+        "version" : "224.6.0"
       }
     },
     {

--- a/DuckDuckGo/TabURLInterceptor.swift
+++ b/DuckDuckGo/TabURLInterceptor.swift
@@ -53,7 +53,7 @@ final class TabURLInterceptorDefault: TabURLInterceptor {
     ]
     
     func allowsNavigatingTo(url: URL) -> Bool {
-        if url.isDuckAIURL {
+        if featureFlagger.isFeatureOn(.aiChatDeepLink), url.isDuckAIURL {
             return handleURLInterception(interceptedURL: .aiChat, queryItems: nil)
         }
 
@@ -102,7 +102,7 @@ extension TabURLInterceptorDefault {
                 return false
             }
         case .aiChat:
-            if featureFlagger.isFeatureOn(.aiChat) {
+            if featureFlagger.isFeatureOn(.aiChatDeepLink) {
                 NotificationCenter.default.post(
                     name: .urlInterceptAIChat,
                     object: nil,

--- a/DuckDuckGoTests/TabURLInterceptorTests.swift
+++ b/DuckDuckGoTests/TabURLInterceptorTests.swift
@@ -103,7 +103,7 @@ class TabURLInterceptorDefaultTests: XCTestCase {
     }
 
     func testNotificationForInterceptedAIChatPathWhenFeatureFlagIsOn() {
-        urlInterceptor = TabURLInterceptorDefault(featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.aiChat]), canPurchase: { true })
+        urlInterceptor = TabURLInterceptorDefault(featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.aiChatDeepLink]), canPurchase: { true })
 
         _ = self.expectation(forNotification: .urlInterceptAIChat, object: nil, handler: nil)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1209108545833453/f

**Description**:
Update BSK with AI Chat deeplink feature flag

**Steps to test this PR**:
1. This was already tested on https://github.com/duckduckgo/iOS/pull/3775, the change is the feature flag that's being used. Instead of the core .aichat feature flag, we changed to a subfeature specific just for deeplink
2. If you want to validate, check the instructions from the PR above, you can also use the config files bellow to validate it against live config files

aichat enabled, deeplink disabled -> http://jsonblob.com/api/1327200110144315392
aichat enabled, deeplink enabled -> http://jsonblob.com/api/1327200251714658304

