### PR TITLE
Duckplayer: Bugfix: Update referrer from URL

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -603,6 +603,17 @@ final class DuckPlayerNavigationHandler: NSObject {
         return url.fragment != nil && !url.fragment!.isEmpty
     }
     
+    /// Checks a URL and updates the referer if present
+    ///
+    /// - Parameter url: The 'URL' with referrer parameters (current URL)
+    private func updateReferrerIfNeeded(url: URL) {
+        // Get the referrer from the URL if present
+        let urlReferrer = getDuckPlayerParameters(url: url).referrer
+        if urlReferrer != .other && urlReferrer != .undefined {
+            referrer = urlReferrer
+        }
+    }
+    
 }
 
 extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
@@ -642,6 +653,9 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         
         // Determine navigation type
         let shouldOpenInNewTab = isOpenInNewTabEnabled && !isNewTab(navigationAction)
+        
+        // Update referrer if needed
+        updateReferrerIfNeeded(url: url)
         
         // Handle duck:// scheme URLs (Or direct navigation to duck player)
         if url.isDuckURLScheme {

--- a/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/YoutublePlayerNavigationHandlerTests.swift
@@ -241,6 +241,23 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
     }
     
     @MainActor
+    func testHandleNavigation_WithReferrerInURL_UpdatesDuckPlayerReferrer() async {
+        // Arrange
+        let youtubeURL = URL(string: "https://www.youtube.com/watch?v=abc123&dp_referrer=serp")!
+        let navigationAction = MockNavigationAction(request: URLRequest(url: youtubeURL))
+        playerSettings.mode = .alwaysAsk
+        playerSettings.openInNewTab = true
+        featureFlagger.enabledFeatures = [.duckPlayer, .duckPlayerOpenInNewTab]
+
+        // Act
+        handler.handleDuckNavigation(navigationAction, webView: mockWebView)
+        
+        // Assert
+        XCTAssertEqual(handler.referrer, .serp)
+        
+    }
+    
+    @MainActor
     func testHandleDelegateNavigation_DuckPlayerURL_CancelNavigationAndLoadsDuckPlayerWithParamsInTab() async {
         // Arrange
         let duckPlayerURL = URL(string: "duck://player/abc123")!


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208861142284498/f
Tech Design URL:
CC:

**Description**:
When using Duckplayer in “New tab” mode, the video Referer pixel was not being sent correctly.   This updates the handler to update it properly.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Go to Settings > Duck Player
2. Set Open Youtube videos in DuckPlayer to  ‘Always’
3. Enable “Open Duck Player in a new tab"
4. Search for ‘metallica’ and go to the “videos” section
5. Tap on a video result
6. Observe the pixel `duckplayer.view-from.serp` is fired when DuckPlayer opens

**Note**: Change is also covered by a new test, so make sure tests are 🥬



