### PR TITLE
Revert "pixels for bookmarks > favorites tab (#3572)"

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -216,9 +216,6 @@ extension Pixel {
         case bookmarkAddFavoriteBySwipe
         case bookmarkDeletedFromBookmark
 
-        case bookmarksUIFavoritesAction
-        case bookmarksUIFavoritesManage
-
         case bookmarkImportSuccess
         case bookmarkImportFailure
         case bookmarkImportFailureParsingDL
@@ -1110,9 +1107,6 @@ extension Pixel.Event {
         case .bookmarkRemoveFavoriteFromBookmark: return "m_remove_favorite_from_bookmark"
         case .bookmarkAddFavoriteBySwipe: return "m_add_favorite_by_swipe"
         case .bookmarkDeletedFromBookmark: return "m_bookmark_deleted_from_bookmark"
-
-        case .bookmarksUIFavoritesAction: return "m_bookmarks_ui_favorites_action_daily"
-        case .bookmarksUIFavoritesManage: return "m_bookmarks_ui_favorites_manage_daily"
 
         case .homeScreenShown: return "mh"
         case .homeScreenEditFavorite: return "mh_ef"

--- a/DuckDuckGo/BookmarksViewController.swift
+++ b/DuckDuckGo/BookmarksViewController.swift
@@ -787,10 +787,6 @@ class BookmarksViewController: UIViewController, UITableViewDelegate {
         changeEditButtonToDone()
         configureToolbarMoreItem()
         refreshFooterView()
-
-        if !favoritesContainer.isHidden {
-            DailyPixel.fireDaily(.bookmarksUIFavoritesManage)
-        }
     }
 
     private func finishEditing() {

--- a/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -156,7 +156,6 @@ class FavoritesHomeViewSectionRenderer {
         guard let indexPath = collectionView.indexPath(for: cell),
         let favorite = viewModel.favorite(at: indexPath.row) else { return }
         Pixel.fire(pixel: .homeScreenDeleteFavorite)
-        fireActionPixel()
         viewModel.removeFavorite(favorite)
         WidgetCenter.shared.reloadAllTimelines()
         collectionView.performBatchUpdates {
@@ -169,7 +168,6 @@ class FavoritesHomeViewSectionRenderer {
         guard let indexPath = collectionView.indexPath(for: cell),
               let favorite = viewModel.favorite(at: indexPath.row) else { return }
         Pixel.fire(pixel: .homeScreenEditFavorite)
-        fireActionPixel()
         controller?.favoritesRenderer(self, didRequestEdit: favorite)
     }
     
@@ -274,7 +272,7 @@ class FavoritesHomeViewSectionRenderer {
               let dragItem = coordinator.items.first?.dragItem,
               let sourcePath = coordinator.items.first?.sourceIndexPath,
               let destinationPath = coordinator.destinationIndexPath,
-              let cell = collectionView.cellForItem(at: sourcePath) as? FavoriteHomeCell,
+              let cell = self.collectionView(collectionView, cellForItemAt: sourcePath) as? FavoriteHomeCell,
               let favorite = cell.favorite
         else { return }
 
@@ -287,11 +285,10 @@ class FavoritesHomeViewSectionRenderer {
 
         coordinator.drop(dragItem, toItemAt: destinationPath)
 
-        fireActionPixel()
     }
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? FavoriteHomeCell else { return [] }
+        guard let cell = self.collectionView(collectionView, cellForItemAt: indexPath) as? FavoriteHomeCell else { return [] }
 
         if let size = cell.iconImage.image?.size.width, size <= 32 {
             cell.iconBackground.backgroundColor = ThemeManager.shared.currentTheme.backgroundColor
@@ -315,11 +312,6 @@ class FavoritesHomeViewSectionRenderer {
         }
 
         return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
-    }
-
-    /// Actions are only available from the bookmarks UI, so this is safe to send from here.
-    func fireActionPixel() {
-        DailyPixel.fire(pixel: .bookmarksUIFavoritesAction)
     }
 
 }

--- a/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -288,7 +288,7 @@ class FavoritesHomeViewSectionRenderer {
     }
 
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        guard let cell = self.collectionView(collectionView, cellForItemAt: indexPath) as? FavoriteHomeCell else { return [] }
+        guard let cell = collectionView.cellForItem(at: indexPath) as? FavoriteHomeCell else { return [] }
 
         if let size = cell.iconImage.image?.size.width, size <= 32 {
             cell.iconBackground.backgroundColor = ThemeManager.shared.currentTheme.backgroundColor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208736944745857/f
Tech Design URL:
CC:

**Description**:
This reverts commit 95897a71d6c75ed877c1baad334df8a902083f17 as the pixels are no longer required.

**Steps to test this PR**:
1. Build and run the app.
2. Open bookmarks manager and tap on favorites view and smoke test it.
