### PR TITLE
Validate Webview URL before reloading

### DIFF
--- a/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
+++ b/DuckDuckGo/DuckPlayer/DuckPlayerNavigationHandler.swift
@@ -813,13 +813,13 @@ extension DuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         
         // Reset DuckPlayer status
         duckPlayer.settings.allowFirstVideo = false
-        
-        guard isDuckPlayerFeatureEnabled else {
-            webView.reload()
+                
+        guard let url = webView.url else {
             return
         }
         
-        guard let url = webView.url else {
+        guard isDuckPlayerFeatureEnabled else {
+            webView.reload()
             return
         }
         


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1208801010014872/f
Tech Design URL:
CC:

**Description**:
Attempt to fix [webView Reload crash on a terminated webview](https://errors.duckduckgo.com/organizations/ddg/issues/191825/?project=8&query=is%3Aunresolved+firstSeen%3A-9d&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=0).

If the webviewContent is terminated and fails to restart, calling reload on an invalid URL may cause a the crash.  This ensures there’s still a valid URL before attempting a reload.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. CI should be 🥬

