### PR TITLE
BSK Bump - Defaults internal Privacy Pro links to /subscriptions

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11940,8 +11940,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = exactVersion;
-				version = 224.6.2;
+				kind = revision;
+				revision = aba14e440b42ade0111da01b7579b28a22c3c027;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11940,8 +11940,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				kind = revision;
-				revision = aba14e440b42ade0111da01b7579b28a22c3c027;
+				kind = exactVersion;
+				version = 224.7.1;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "aba14e440b42ade0111da01b7579b28a22c3c027"
+        "revision" : "5acb297db5c0edabe13c79efa33b1d0e545d6bff",
+        "version" : "224.7.1"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "revision" : "a2a5a32d111aadac6316db4cc629e5dd635939ba",
-        "version" : "224.6.2"
+        "revision" : "aba14e440b42ade0111da01b7579b28a22c3c027"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209009315184468/f

**Description**:
Previously, default Privacy Pro links were sent to `/subscriptions/welcome`, and the frontend redirected to `/subscriptions`.

Currently, this will still result in a redirect to `/subscriptions/welcome` for subscribed users—effectively a no-op. After an upcoming frontend release, this will show `/subscriptions` with a link to `/subscriptions/welcome`.

**Steps to test this PR**:
1. TBD

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
