### PR TITLE
Add padding for iOS 16 favorites widget

### DIFF
--- a/Widgets/WidgetViews.swift
+++ b/Widgets/WidgetViews.swift
@@ -190,8 +190,9 @@ struct FavoritesWidgetView: View {
                 } else {
                     FavoritesGridView(entry: entry)
                 }
-
-            }.padding(.bottom, 8)
+            }
+            .padding(hasSystemPadding ? 0 : 16)
+            .padding(.bottom, 8)
 
             VStack(spacing: 4) {
                 Text(UserText.noFavoritesMessage)
@@ -217,6 +218,15 @@ struct FavoritesWidgetView: View {
 
         }
         .widgetContainerBackground(color: Color(designSystemColor: .backgroundSheets))
+    }
+
+    /// iOS 17+ automatically added extra padding for the views inside the widget.
+    private var hasSystemPadding: Bool {
+        if #available(iOS 17, *) {
+            return true
+        } else {
+            return false
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1209170939020827/f

**Description**:
Add padding for iOS 16 favorites widget

**Steps to test this PR**:
1. Add the favorites widget (medium and large) 
2. Verify that the margin looks good
3. Test this on iOS 16, iOS 17 and iOS 18
4. See Asana task to see the screenshot with the margin problem

