### PR TITLE
better guards on access tab index

### DIFF
--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -125,8 +125,7 @@ class TabManager {
 
     @MainActor
     func current(createIfNeeded: Bool = false) -> TabViewController? {
-        let index = model.currentIndex
-        let tab = model.tabs[index]
+        guard let tab = model.currentTab else { return nil }
 
         if let controller = controller(for: tab) {
             return controller

--- a/DuckDuckGo/TabsModel.swift
+++ b/DuckDuckGo/TabsModel.swift
@@ -75,7 +75,7 @@ public class TabsModel: NSObject, NSCoding {
 
     var currentTab: Tab? {
         let index = currentIndex
-        return tabs[index]
+        return tabs.indices.contains(index) ? tabs[index] : nil
     }
 
     var count: Int {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1209158320724215/f
Tech Design URL:
CC:

**Description**:
Speculative fix for a crash. Checks index is available in indices before accessing the array.

**Steps to test this PR**:
Smoke test tab manager on iPhone and iPad
1.  Grid and list mode
2. Add new tabs 
3. Delete tabs
4. Reorder tabs
5. Close and re-open the app
