### PR TITLE
Aligning Privacy Dashboard EventMapping with macOS

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11952,7 +11952,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "mgurgel/improved-breakage-form";
+				branch = "jacek/new-breakage-form";
 				kind = branch;
 			};
 		};

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -11952,7 +11952,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "jacek/new-breakage-form";
+				branch = "mgurgel/improved-breakage-form-pixel";
 				kind = branch;
 			};
 		};

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "mgurgel/improved-breakage-form",
-        "revision" : "c77e36efe790bc01af9b152fc0ef0fbb35a32f82"
+        "branch" : "jacek/new-breakage-form",
+        "revision" : "9f5a4af0c16522251d3f578aba61099afab3b254"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "3f58e008d4e9d1b56ab12dbb95bd891045cf2758",
-        "version" : "8.0.0"
+        "branch" : "pr-releases/pr-196",
+        "revision" : "1c355be4c27d067b8f3b7435274865a02d949f52"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "jacek/new-breakage-form",
-        "revision" : "9f5a4af0c16522251d3f578aba61099afab3b254"
+        "branch" : "mgurgel/improved-breakage-form-pixel",
+        "revision" : "89cdcdc2e18e8a4df5ee69c48b1b2ace828ae929"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "branch" : "pr-releases/pr-196",
-        "revision" : "1c355be4c27d067b8f3b7435274865a02d949f52"
+        "branch" : "pr-releases/pr-302",
+        "revision" : "05d04de7505117b32949b2007e5a56ba2d39469b"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "mgurgel/improved-breakage-form-pixel",
-        "revision" : "6a2da92ab10011097a4eab63df846e5f14374675"
+        "revision" : "f85a4199ba4251921ecff6d110527c8d5c44e329"
       }
     },
     {

--- a/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "mgurgel/improved-breakage-form-pixel",
-        "revision" : "89cdcdc2e18e8a4df5ee69c48b1b2ace828ae929"
+        "revision" : "6a2da92ab10011097a4eab63df846e5f14374675"
       }
     },
     {

--- a/DuckDuckGo/MainViewController+Segues.swift
+++ b/DuckDuckGo/MainViewController+Segues.swift
@@ -108,10 +108,6 @@ extension MainViewController {
             return
         }
 
-        if entryPoint == .report {
-            fireBrokenSiteReportShown()
-        }
-
         let storyboard = UIStoryboard(name: "PrivacyDashboard", bundle: nil)
         let controller = storyboard.instantiateInitialViewController { coder in
             PrivacyDashboardViewController(coder: coder,
@@ -139,13 +135,6 @@ extension MainViewController {
         }
         
         present(controller, animated: true)
-    }
-
-    private func fireBrokenSiteReportShown() {
-        let parameters = [
-            PrivacyDashboardEvents.Parameters.source: BrokenSiteReport.Source.appMenu.rawValue
-        ]
-        Pixel.fire(pixel: .reportBrokenSiteShown, withAdditionalParameters: parameters)
     }
 
     func segueToNegativeFeedbackForm() {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1206594217596623/1209173355503842/f

**Description**:

Removes automatic firing of `BrokenSiteReportShown` pixel to align with macOS. The firing of that pixel is now actively requested by the Privacy Dashboard (see https://github.com/duckduckgo/BrowserServicesKit/pull/1167)

This PR contains a fix for on https://github.com/duckduckgo/iOS/pull/3802 which is why it is stacked on it. Please let me know if this is not the best way to have this code reviewed.

**Steps to test this PR**:

1. Invoke the breakage form in the two possible ways:
Open the Privacy Dashboard and click on "Report a problem with this site"
Open the app menu ••• and click on "Report Broken Site” (iOS)

2. Confirm that the pixel `m_report-broken-site_shown` was fired
3. Submit a report
4. Confirm that the pixels `epbf` and `m_report-broken-site_sent` were fired

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
