### PR TITLE
Improve sync e2e reliability

### DIFF
--- a/.github/workflows/ios-sync-end-to-end.yml
+++ b/.github/workflows/ios-sync-end-to-end.yml
@@ -107,7 +107,9 @@ jobs:
         app-file: DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
         workspace: .maestro
         include-tags: sync
-        env: ONBOARDING_COMPLETED=true
+        env: | 
+          ONBOARDING_COMPLETED=true
+          CODE=${{ steps.sync-recovery-code.outputs.recovery-code }}
         ios-version: ${{ matrix.os-version }}
         fail-on-timeout: true
 

--- a/.github/workflows/ios-sync-end-to-end.yml
+++ b/.github/workflows/ios-sync-end-to-end.yml
@@ -69,7 +69,7 @@ jobs:
     name: Sync End To End Tests
     needs: build-for-sync-end-to-end-tests
     runs-on: macos-15
-    timeout-minutes: 240
+    timeout-minutes: 2400
     strategy:
       matrix:
         os-version: [17] #[15, 16, 17]
@@ -92,21 +92,30 @@ jobs:
         name: duckduckgo-ios-app
         path: DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
 
-    - name: Install Maestro
-      run: |
-        export MAESTRO_VERSION=1.39.1; curl -Ls "https://get.maestro.mobile.dev" | bash
-
     - name: Overwrite default config with sync one
       run: |
         cp .maestro/config-sync .maestro/config.yaml
 
     - name: Sync e2e tests
-      run: |
-        export PATH="$PATH":"$HOME/.maestro/bin"; maestro cloud --apiKey ${{ secrets.ROBIN_API_KEY }} --project-id ${{ secrets.ROBIN_PROJECT_KEY }} -e ONBOARDING_COMPLETED=true --env=CODE=${{ steps.sync-recovery-code.outputs.recovery-code }} --fail-on-timeout=true --fail-on-cancellation=true --timeout=150 --ios-version=${{ matrix.os-version }} --include-tags=sync --app-file DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app --flows .maestro/
+      id: upload
+      uses: loremattei/action-maestro-cloud@fix-timeout-handling
+      with:
+        api-key: ${{ secrets.ROBIN_API_KEY }}
+        project-id: ${{ vars.ROBIN_PROJECT_KEY }}
+        name: sync_${{ github.sha }}
+        timeout: 240
+        app-file: DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
+        workspace: .maestro
+        include-tags: sync
+        env: ONBOARDING_COMPLETED=true
+        ios-version: ${{ matrix.os-version }}
+        fail-on-timeout: true
 
     - name: Reset config
       run: |
         git checkout .maestro/config.yaml
+
+    
 
   # notify-failure:
   #   name: Notify on failure

--- a/.github/workflows/ios-sync-end-to-end.yml
+++ b/.github/workflows/ios-sync-end-to-end.yml
@@ -69,7 +69,7 @@ jobs:
     name: Sync End To End Tests
     needs: build-for-sync-end-to-end-tests
     runs-on: macos-15
-    timeout-minutes: 2400
+    timeout-minutes: 240
     strategy:
       matrix:
         os-version: [17] #[15, 16, 17]

--- a/.github/workflows/ios-sync-end-to-end.yml
+++ b/.github/workflows/ios-sync-end-to-end.yml
@@ -2,7 +2,7 @@ name: iOS - Sync-End-to-End tests
 
 on:
   schedule:
-    - cron: '0 5 * * *' # run at 5 AM UTC
+    - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
 
 jobs:
@@ -69,7 +69,7 @@ jobs:
     name: Sync End To End Tests
     needs: build-for-sync-end-to-end-tests
     runs-on: macos-15
-    timeout-minutes: 90
+    timeout-minutes: 240
     strategy:
       matrix:
         os-version: [17] #[15, 16, 17]


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/1204165176092271/1209158713404042/f
Tech Design URL:
CC:

**Description**:
Sync e2e tests were failing randomly, especially during nightly runs, with an error that the server was not reachable.  
After some investigation, I suspect the error is misleading and the actual issue is that the recovery code was invalid when used because the tests got queued or run slower than usual and the GHA timed out, causing the clean up job to run and invalidate the recovery code. 

This PR: 
- Changes the schedule of the test, to avoid it overlaps with the other e2e tests and gets queued. 
- Increases the timeout (needed anyway by the switch to Robin which is much slower than Maestro Cloud)
- Switches to Maestro Action for better reliability of the connection between GHA and Robin (see https://github.com/duckduckgo/iOS/pull/3783 for more context about this)
-
<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run the tests from this branch and validate it's green (you can also check a recent successful run here: https://github.com/duckduckgo/iOS/actions/runs/12828988947 )

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [X] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
