### PR TITLE
Malicious site protection - Datasets fetch + Background Tasks

### DIFF
--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -791,10 +791,6 @@
 		9F0949A02D372AE60079291B /* MaliciousSiteProtectionDatasetsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */; };
 		9F0949A52D3898FF0079291B /* MaliciousSiteProtectionPreferencesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */; };
 		9F0949A72D389F1E0079291B /* MaliciousSiteProtectionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */; };
-		9F0949A92D3A01D40079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */; };
-		9F0949AC2D3A08300079291B /* MaliciousSiteProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */; };
-		9F14C1DF2D3E366F00C12DB0 /* TimeTraveller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */; };
-		9F14C1E12D3E374500C12DB0 /* MaliciousSiteProtectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F14C1E02D3E373A00C12DB0 /* MaliciousSiteProtectionManagerTests.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8002C2BC94400950875 /* OnboardingBackground.swift */; };
@@ -834,6 +830,10 @@
 		9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */; };
 		9F4CC5242C4A4F0D006A96EB /* SwiftUITestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */; };
 		9F4CC5272C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */; };
+		9F5BEA7C2D4382430045E484 /* MaliciousSiteProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA762D4382430045E484 /* MaliciousSiteProtectionMocks.swift */; };
+		9F5BEA7D2D4382430045E484 /* TimeTraveller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA772D4382430045E484 /* TimeTraveller.swift */; };
+		9F5BEA7E2D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */; };
+		9F5BEA7F2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */; };
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
@@ -2718,10 +2718,6 @@
 		9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcher.swift; sourceTree = "<group>"; };
 		9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionPreferencesManager.swift; sourceTree = "<group>"; };
 		9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionAPI.swift; sourceTree = "<group>"; };
-		9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcherTests.swift; sourceTree = "<group>"; };
-		9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionMocks.swift; sourceTree = "<group>"; };
-		9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveller.swift; sourceTree = "<group>"; };
-		9F14C1E02D3E373A00C12DB0 /* MaliciousSiteProtectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionManagerTests.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8002C2BC94400950875 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
@@ -2755,6 +2751,10 @@
 		9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactoryTests.swift; sourceTree = "<group>"; };
 		9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITestUtilities.swift; sourceTree = "<group>"; };
 		9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyIconContextualOnboardingAnimator.swift; sourceTree = "<group>"; };
+		9F5BEA762D4382430045E484 /* MaliciousSiteProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionMocks.swift; sourceTree = "<group>"; };
+		9F5BEA772D4382430045E484 /* TimeTraveller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveller.swift; sourceTree = "<group>"; };
+		9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcherTests.swift; sourceTree = "<group>"; };
+		9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionManagerTests.swift; sourceTree = "<group>"; };
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
@@ -5238,16 +5238,6 @@
 			name = Themes;
 			sourceTree = "<group>";
 		};
-		9F06EB7A2D09EC2000905426 /* MaliciousSiteProtection */ = {
-			isa = PBXGroup;
-			children = (
-				9F0949AA2D3A08210079291B /* Mocks */,
-				9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */,
-				9F14C1E02D3E373A00C12DB0 /* MaliciousSiteProtectionManagerTests.swift */,
-			);
-			path = MaliciousSiteProtection;
-			sourceTree = "<group>";
-		};
 		9F0949A22D3898C20079291B /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -5264,15 +5254,6 @@
 				9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */,
 			);
 			path = UserPreferences;
-			sourceTree = "<group>";
-		};
-		9F0949AA2D3A08210079291B /* Mocks */ = {
-			isa = PBXGroup;
-			children = (
-				9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */,
-				9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */,
-			);
-			path = Mocks;
 			sourceTree = "<group>";
 		};
 		9F23B7FF2C2BABE000950875 /* OnboardingIntro */ = {
@@ -5388,6 +5369,25 @@
 				9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */,
 			);
 			name = ContextualOnboarding;
+			sourceTree = "<group>";
+		};
+		9F5BEA782D4382430045E484 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				9F5BEA762D4382430045E484 /* MaliciousSiteProtectionMocks.swift */,
+				9F5BEA772D4382430045E484 /* TimeTraveller.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		9F5BEA7B2D4382430045E484 /* MaliciousSiteProtection */ = {
+			isa = PBXGroup;
+			children = (
+				9F5BEA782D4382430045E484 /* Mocks */,
+				9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */,
+				9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */,
+			);
+			path = MaliciousSiteProtection;
 			sourceTree = "<group>";
 		};
 		9F5E5AAA2C3D0FAA00165F54 /* ContextualOnboarding */ = {
@@ -6429,6 +6429,7 @@
 				85D2186E24BF24BA004373D2 /* Favicons */,
 				83134D7F20E2E013006CE65D /* Feedback */,
 				8588026724E4249800C24AB6 /* iPad */,
+				9F5BEA7B2D4382430045E484 /* MaliciousSiteProtection */,
 				851DFD88212C5ED600D95F20 /* Main */,
 				EE56DE3A2A6038F500375C41 /* NetworkProtection */,
 				6F03CAFF2C32ED22004179A8 /* NewTabPage */,
@@ -8748,7 +8749,6 @@
 				8590CB632684F10F0089F6BF /* ContentBlockerProtectionStoreTests.swift in Sources */,
 				83EDCC411F86B89C005CDFCD /* StatisticsLoaderTests.swift in Sources */,
 				564DE4572C4150E600D23241 /* NewTabPageControllerDaxDialogTests.swift in Sources */,
-				9F14C1DF2D3E366F00C12DB0 /* TimeTraveller.swift in Sources */,
 				C14882E327F20D9A00D59F0C /* BookmarksExporterTests.swift in Sources */,
 				85C29708247BDD060063A335 /* DaxDialogsBrowsingSpecTests.swift in Sources */,
 				9FE05CF12C36468A00D9046B /* OnboardingPixelReporterTests.swift in Sources */,
@@ -8803,7 +8803,6 @@
 				9FDEC7B62C8FDFD600C7A692 /* OnboardingManagerMock.swift in Sources */,
 				F198D78E1E39762C0088DA8A /* StringExtensionTests.swift in Sources */,
 				9FDEC7BA2C9006E000C7A692 /* BrowserComparisonModelTests.swift in Sources */,
-				9F0949A92D3A01D40079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */,
 				31B1FA87286EFC5C00CA3C1C /* XCTestCaseExtension.swift in Sources */,
 				D62EC3BC2C2470E000FC9D04 /* DuckPlayerTests.swift in Sources */,
 				1E8146AE28C8ABF400D1AF63 /* PrivacyIconLogicTests.swift in Sources */,
@@ -8814,13 +8813,11 @@
 				310E79BD2949CAA5007C49E8 /* FireButtonReferenceTests.swift in Sources */,
 				4B62C4BA25B930DD008912C6 /* AppConfigurationFetchTests.swift in Sources */,
 				31C7D71C27515A6300A95D0A /* MockVoiceSearchHelper.swift in Sources */,
-				9F14C1E12D3E374500C12DB0 /* MaliciousSiteProtectionManagerTests.swift in Sources */,
 				9F254ACE2CF5D3540063B308 /* SpecialErrorPageNavigationHandlerIntegrationTests.swift in Sources */,
 				8519526C2CE256BC00578553 /* AutocompleteSuggestionsDataSourceTests.swift in Sources */,
 				6F395BBB2CD2C87D00B92FC3 /* BoolFileMarkerTests.swift in Sources */,
 				8598F67B2405EB8D00FBC70C /* KeyboardSettingsTests.swift in Sources */,
 				98AAF8E4292EB46000DBDF06 /* BookmarksMigrationTests.swift in Sources */,
-				9F0949AC2D3A08300079291B /* MaliciousSiteProtectionMocks.swift in Sources */,
 				85D2187224BF24F2004373D2 /* NotFoundCachingDownloaderTests.swift in Sources */,
 				C1935A242C89CC6D001AD72D /* AutofillHeaderViewFactoryTests.swift in Sources */,
 				C111B26927F579EF006558B1 /* BookmarkOrFolderTests.swift in Sources */,
@@ -8897,6 +8894,10 @@
 				6F3529FF2CDCEDFF00A59170 /* OmniBarLoadingStateBearerTests.swift in Sources */,
 				564DE45E2C45218500D23241 /* OnboardingNavigationDelegateTests.swift in Sources */,
 				C14E2F7729DE14EA002AC515 /* AutofillInterfaceUsernameTruncatorTests.swift in Sources */,
+				9F5BEA7C2D4382430045E484 /* MaliciousSiteProtectionMocks.swift in Sources */,
+				9F5BEA7D2D4382430045E484 /* TimeTraveller.swift in Sources */,
+				9F5BEA7E2D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */,
+				9F5BEA7F2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift in Sources */,
 				9F7CFF782C86E3E10012833E /* OnboardingManagerTests.swift in Sources */,
 				4B27FBB12C9252F4007E21A7 /* DefaultPersistentPixelStorageTests.swift in Sources */,
 				564DE45A2C450BE600D23241 /* DaxDialogsNewTabTests.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -825,6 +825,7 @@
 		9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */; };
 		9F38A28C2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */; };
 		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
+		9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */; };
 		9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */; };
 		9F4CC5152C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */; };
 		9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */; };
@@ -2745,6 +2746,7 @@
 		9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorModel.swift; sourceTree = "<group>"; };
 		9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageThreatProvider.swift; sourceTree = "<group>"; };
 		9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+MaliciousSiteProtection.swift"; sourceTree = "<group>"; };
+		9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionService.swift; sourceTree = "<group>"; };
 		9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
 		9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterMock.swift; sourceTree = "<group>"; };
 		9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerDaxDialogTests.swift; sourceTree = "<group>"; };
@@ -5986,6 +5988,7 @@
 		CBAD0F0E2D006291006267B8 /* AppServices */ = {
 			isa = PBXGroup;
 			children = (
+				9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */,
 				CBAD0F0F2D0062A3006267B8 /* UIService.swift */,
 				CBAD0F112D00F1C8006267B8 /* UNService.swift */,
 				CBAD0F132D01EE40006267B8 /* SubscriptionService.swift */,
@@ -8371,6 +8374,7 @@
 				857EEB752095FFAC008A005C /* HomeRowInstructionsViewController.swift in Sources */,
 				D63FF8952C1B67E9006DE24D /* YoutubePlayerUserScript.swift in Sources */,
 				4BF3E4AF2C06A85200ED5D57 /* VPNRedditSessionWorkaround.swift in Sources */,
+				9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */,
 				6F40D15B2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift in Sources */,
 				311BD1AF2836BB4200AEF6C1 /* AutofillItemsLockedView.swift in Sources */,
 				85DE681A2B6A8BB000DED4FE /* MainViewCoordinator.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12093,7 +12093,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "alessandro/malicious-site-protection-ios";
+				branch = "alessandro/malicious-site-protection-update-changes";
 				kind = branch;
 			};
 		};

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -788,6 +788,7 @@
 		98F3A1D8217B37010011A0D4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F3A1D7217B37010011A0D4 /* Theme.swift */; };
 		98F6EA472863124100720957 /* ContentBlockerRulesLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F6EA462863124100720957 /* ContentBlockerRulesLists.swift */; };
 		98F78B8E22419093007CACF4 /* ThemableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F78B8D22419093007CACF4 /* ThemableNavigationController.swift */; };
+		9F0949A52D3898FF0079291B /* MaliciousSiteProtectionPreferencesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8002C2BC94400950875 /* OnboardingBackground.swift */; };
@@ -2706,6 +2707,7 @@
 		98F3A1D7217B37010011A0D4 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		98F6EA462863124100720957 /* ContentBlockerRulesLists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerRulesLists.swift; sourceTree = "<group>"; };
 		98F78B8D22419093007CACF4 /* ThemableNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemableNavigationController.swift; sourceTree = "<group>"; };
+		9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionPreferencesManager.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8002C2BC94400950875 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
@@ -5220,6 +5222,21 @@
 			name = Themes;
 			sourceTree = "<group>";
 		};
+		9F06EB7A2D09EC2000905426 /* MaliciousSiteProtection */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = MaliciousSiteProtection;
+			sourceTree = "<group>";
+		};
+		9F0949A32D3898DD0079291B /* UserPreferences */ = {
+			isa = PBXGroup;
+			children = (
+				9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */,
+			);
+			path = UserPreferences;
+			sourceTree = "<group>";
+		};
 		9F23B7FF2C2BABE000950875 /* OnboardingIntro */ = {
 			isa = PBXGroup;
 			children = (
@@ -5274,6 +5291,7 @@
 		9F254AA92CF47CD30063B308 /* MaliciousSiteProtection */ = {
 			isa = PBXGroup;
 			children = (
+				9F0949A32D3898DD0079291B /* UserPreferences */,
 				9F254AAA2CF47DD50063B308 /* MaliciousSiteProtectionManager.swift */,
 			);
 			path = MaliciousSiteProtection;
@@ -8528,6 +8546,7 @@
 				0283A2012C6E46E300508FBD /* BrokenSitePromptLimiterStore.swift in Sources */,
 				85DFEDF924CF3D0E00973FE7 /* TabsBarCell.swift in Sources */,
 				851672D32BED23FE00592F24 /* AutocompleteViewModel.swift in Sources */,
+				9F0949A52D3898FF0079291B /* MaliciousSiteProtectionPreferencesManager.swift in Sources */,
 				8562CE152B9B645C00E1D399 /* CachedBookmarkSuggestions.swift in Sources */,
 				C13F3F682B7F88100083BE40 /* AuthConfirmationPromptView.swift in Sources */,
 				F1617C191E573EA800DEDCAF /* TabSwitcherDelegate.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -791,6 +791,9 @@
 		9F0949A02D372AE60079291B /* MaliciousSiteProtectionDatasetsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */; };
 		9F0949A52D3898FF0079291B /* MaliciousSiteProtectionPreferencesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */; };
 		9F0949A72D389F1E0079291B /* MaliciousSiteProtectionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */; };
+		9F0949A92D3A01D40079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */; };
+		9F0949AC2D3A08300079291B /* MaliciousSiteProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */; };
+		9F14C1DF2D3E366F00C12DB0 /* TimeTraveller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8002C2BC94400950875 /* OnboardingBackground.swift */; };
@@ -2712,6 +2715,9 @@
 		9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcher.swift; sourceTree = "<group>"; };
 		9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionPreferencesManager.swift; sourceTree = "<group>"; };
 		9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionAPI.swift; sourceTree = "<group>"; };
+		9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcherTests.swift; sourceTree = "<group>"; };
+		9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionMocks.swift; sourceTree = "<group>"; };
+		9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveller.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8002C2BC94400950875 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
@@ -5229,6 +5235,8 @@
 		9F06EB7A2D09EC2000905426 /* MaliciousSiteProtection */ = {
 			isa = PBXGroup;
 			children = (
+				9F0949AA2D3A08210079291B /* Mocks */,
+				9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */,
 			);
 			path = MaliciousSiteProtection;
 			sourceTree = "<group>";
@@ -5248,6 +5256,15 @@
 				9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */,
 			);
 			path = UserPreferences;
+			sourceTree = "<group>";
+		};
+		9F0949AA2D3A08210079291B /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */,
+				9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		9F23B7FF2C2BABE000950875 /* OnboardingIntro */ = {
@@ -8720,6 +8737,7 @@
 				8590CB632684F10F0089F6BF /* ContentBlockerProtectionStoreTests.swift in Sources */,
 				83EDCC411F86B89C005CDFCD /* StatisticsLoaderTests.swift in Sources */,
 				564DE4572C4150E600D23241 /* NewTabPageControllerDaxDialogTests.swift in Sources */,
+				9F14C1DF2D3E366F00C12DB0 /* TimeTraveller.swift in Sources */,
 				C14882E327F20D9A00D59F0C /* BookmarksExporterTests.swift in Sources */,
 				85C29708247BDD060063A335 /* DaxDialogsBrowsingSpecTests.swift in Sources */,
 				9FE05CF12C36468A00D9046B /* OnboardingPixelReporterTests.swift in Sources */,
@@ -8774,6 +8792,7 @@
 				9FDEC7B62C8FDFD600C7A692 /* OnboardingManagerMock.swift in Sources */,
 				F198D78E1E39762C0088DA8A /* StringExtensionTests.swift in Sources */,
 				9FDEC7BA2C9006E000C7A692 /* BrowserComparisonModelTests.swift in Sources */,
+				9F0949A92D3A01D40079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */,
 				31B1FA87286EFC5C00CA3C1C /* XCTestCaseExtension.swift in Sources */,
 				D62EC3BC2C2470E000FC9D04 /* DuckPlayerTests.swift in Sources */,
 				1E8146AE28C8ABF400D1AF63 /* PrivacyIconLogicTests.swift in Sources */,
@@ -8789,6 +8808,7 @@
 				6F395BBB2CD2C87D00B92FC3 /* BoolFileMarkerTests.swift in Sources */,
 				8598F67B2405EB8D00FBC70C /* KeyboardSettingsTests.swift in Sources */,
 				98AAF8E4292EB46000DBDF06 /* BookmarksMigrationTests.swift in Sources */,
+				9F0949AC2D3A08300079291B /* MaliciousSiteProtectionMocks.swift in Sources */,
 				85D2187224BF24F2004373D2 /* NotFoundCachingDownloaderTests.swift in Sources */,
 				C1935A242C89CC6D001AD72D /* AutofillHeaderViewFactoryTests.swift in Sources */,
 				C111B26927F579EF006558B1 /* BookmarkOrFolderTests.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -824,6 +824,7 @@
 		9F254B052CF9FB890063B308 /* SpecialErrorPageContextHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B042CF9FB890063B308 /* SpecialErrorPageContextHandling.swift */; };
 		9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */; };
 		9F38A28C2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */; };
+		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
 		9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */; };
 		9F4CC5152C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */; };
 		9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */; };
@@ -2743,6 +2744,7 @@
 		9F254B042CF9FB890063B308 /* SpecialErrorPageContextHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageContextHandling.swift; sourceTree = "<group>"; };
 		9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorModel.swift; sourceTree = "<group>"; };
 		9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageThreatProvider.swift; sourceTree = "<group>"; };
+		9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+MaliciousSiteProtection.swift"; sourceTree = "<group>"; };
 		9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
 		9F4CC5142C47AD08006A96EB /* ContextualOnboardingPresenterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterMock.swift; sourceTree = "<group>"; };
 		9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerDaxDialogTests.swift; sourceTree = "<group>"; };
@@ -5247,6 +5249,7 @@
 		9F0949A22D3898C20079291B /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */,
 				9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */,
 				9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */,
 			);
@@ -8099,6 +8102,7 @@
 				7B1681022D106CCC005EAE24 /* UserTextShared.swift in Sources */,
 				3161D13227AC161B00285CF6 /* DownloadMetadata.swift in Sources */,
 				D664C7C72B289AA200CBFA76 /* PurchaseInProgressView.swift in Sources */,
+				9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */,
 				7BFD5FD72C9DB9D7000FF959 /* VPNGeoswitchingTip.swift in Sources */,
 				F1668BCE1E798081008CBA04 /* BookmarksViewController.swift in Sources */,
 				8590CB69268A4E190089F6BF /* DebugEtagStorage.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12161,7 +12161,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
 			requirement = {
-				branch = "alessandro/malicious-site-protection-update-changes";
+				branch = "alessandro/malicious-site-protection-ios";
 				kind = branch;
 			};
 		};

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -794,6 +794,7 @@
 		9F0949A92D3A01D40079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */; };
 		9F0949AC2D3A08300079291B /* MaliciousSiteProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */; };
 		9F14C1DF2D3E366F00C12DB0 /* TimeTraveller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */; };
+		9F14C1E12D3E374500C12DB0 /* MaliciousSiteProtectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F14C1E02D3E373A00C12DB0 /* MaliciousSiteProtectionManagerTests.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8002C2BC94400950875 /* OnboardingBackground.swift */; };
@@ -2718,6 +2719,7 @@
 		9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcherTests.swift; sourceTree = "<group>"; };
 		9F0949AB2D3A08290079291B /* MaliciousSiteProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionMocks.swift; sourceTree = "<group>"; };
 		9F14C1DE2D3E366C00C12DB0 /* TimeTraveller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveller.swift; sourceTree = "<group>"; };
+		9F14C1E02D3E373A00C12DB0 /* MaliciousSiteProtectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionManagerTests.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8002C2BC94400950875 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
@@ -5237,6 +5239,7 @@
 			children = (
 				9F0949AA2D3A08210079291B /* Mocks */,
 				9F0949A82D3A01CB0079291B /* MaliciousSiteProtectionDatasetsFetcherTests.swift */,
+				9F14C1E02D3E373A00C12DB0 /* MaliciousSiteProtectionManagerTests.swift */,
 			);
 			path = MaliciousSiteProtection;
 			sourceTree = "<group>";
@@ -8803,6 +8806,7 @@
 				310E79BD2949CAA5007C49E8 /* FireButtonReferenceTests.swift in Sources */,
 				4B62C4BA25B930DD008912C6 /* AppConfigurationFetchTests.swift in Sources */,
 				31C7D71C27515A6300A95D0A /* MockVoiceSearchHelper.swift in Sources */,
+				9F14C1E12D3E374500C12DB0 /* MaliciousSiteProtectionManagerTests.swift in Sources */,
 				9F254ACE2CF5D3540063B308 /* SpecialErrorPageNavigationHandlerIntegrationTests.swift in Sources */,
 				8519526C2CE256BC00578553 /* AutocompleteSuggestionsDataSourceTests.swift in Sources */,
 				6F395BBB2CD2C87D00B92FC3 /* BoolFileMarkerTests.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -788,7 +788,9 @@
 		98F3A1D8217B37010011A0D4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F3A1D7217B37010011A0D4 /* Theme.swift */; };
 		98F6EA472863124100720957 /* ContentBlockerRulesLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F6EA462863124100720957 /* ContentBlockerRulesLists.swift */; };
 		98F78B8E22419093007CACF4 /* ThemableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F78B8D22419093007CACF4 /* ThemableNavigationController.swift */; };
+		9F0949A02D372AE60079291B /* MaliciousSiteProtectionDatasetsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */; };
 		9F0949A52D3898FF0079291B /* MaliciousSiteProtectionPreferencesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */; };
+		9F0949A72D389F1E0079291B /* MaliciousSiteProtectionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
 		9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8002C2BC94400950875 /* OnboardingBackground.swift */; };
@@ -2707,7 +2709,9 @@
 		98F3A1D7217B37010011A0D4 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		98F6EA462863124100720957 /* ContentBlockerRulesLists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerRulesLists.swift; sourceTree = "<group>"; };
 		98F78B8D22419093007CACF4 /* ThemableNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemableNavigationController.swift; sourceTree = "<group>"; };
+		9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcher.swift; sourceTree = "<group>"; };
 		9F0949A42D3898F80079291B /* MaliciousSiteProtectionPreferencesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionPreferencesManager.swift; sourceTree = "<group>"; };
+		9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionAPI.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
 		9F23B8002C2BC94400950875 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
@@ -5229,6 +5233,15 @@
 			path = MaliciousSiteProtection;
 			sourceTree = "<group>";
 		};
+		9F0949A22D3898C20079291B /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */,
+				9F09499F2D372ADB0079291B /* MaliciousSiteProtectionDatasetsFetcher.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		9F0949A32D3898DD0079291B /* UserPreferences */ = {
 			isa = PBXGroup;
 			children = (
@@ -5292,6 +5305,7 @@
 			isa = PBXGroup;
 			children = (
 				9F0949A32D3898DD0079291B /* UserPreferences */,
+				9F0949A22D3898C20079291B /* Services */,
 				9F254AAA2CF47DD50063B308 /* MaliciousSiteProtectionManager.swift */,
 			);
 			path = MaliciousSiteProtection;
@@ -8220,6 +8234,7 @@
 				F4147354283BF834004AA7A5 /* AutofillContentScopeFeatureToggles.swift in Sources */,
 				6FE1273A2C204BD000EB5724 /* NewTabPageView.swift in Sources */,
 				986DA94A24884B18004A7E39 /* WebViewTransition.swift in Sources */,
+				9F0949A72D389F1E0079291B /* MaliciousSiteProtectionAPI.swift in Sources */,
 				31B524572715BB23002225AB /* WebJSAlert.swift in Sources */,
 				C1641EB32BC2F53C0012607A /* ImportPasswordsViewModel.swift in Sources */,
 				9FDEC7BF2C91264C00C7A692 /* OnboardingAddressBarPositionPicker.swift in Sources */,
@@ -8348,6 +8363,7 @@
 				4BD96E0B2C4DCE55003BC32C /* VPNSnoozeLiveActivityManager.swift in Sources */,
 				9F9A92312C86AAE9001D036D /* OnboardingDebugView.swift in Sources */,
 				1EFDCBC127D2393C00916BC5 /* DownloadsDeleteHelper.swift in Sources */,
+				9F0949A02D372AE60079291B /* MaliciousSiteProtectionDatasetsFetcher.swift in Sources */,
 				C1836CE12C359EC90016D057 /* AutofillBreakageReportCellContentView.swift in Sources */,
 				9FDEC7C12C9127F100C7A692 /* OnboardingAddressBarPositionPickerViewModel.swift in Sources */,
 				6F9FFE282C579DEA00A238BE /* NewTabPageSectionsSettingsStorage.swift in Sources */,

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "alessandro/malicious-site-protection-ios",
-        "revision" : "1a406300a68f8b63b1e21903b9ea19a02847044c"
+        "branch" : "alessandro/malicious-site-protection-update-changes",
+        "revision" : "a62462f74b69b8b15af939a661b599524625680e"
       }
     },
     {

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
-        "branch" : "alessandro/malicious-site-protection-update-changes",
-        "revision" : "a62462f74b69b8b15af939a661b599524625680e"
+        "branch" : "alessandro/malicious-site-protection-ios",
+        "revision" : "33c141b3e8a467dbc9fe95b5333d8f07631fe6c4"
       }
     },
     {

--- a/DuckDuckGo/AppDependencies.swift
+++ b/DuckDuckGo/AppDependencies.swift
@@ -52,6 +52,7 @@ struct AppDependencies {
     let widgetRefreshModel: NetworkProtectionWidgetRefreshModel
     let autofillPixelReporter: AutofillPixelReporter
     let crashReportUploaderOnboarding: CrashCollectionOnboarding
+    let maliciousSiteProtectionManager: MaliciousSiteProtectionManaging
 
     var syncDidFinishCancellable: AnyCancellable?
 

--- a/DuckDuckGo/AppDependencies.swift
+++ b/DuckDuckGo/AppDependencies.swift
@@ -52,7 +52,7 @@ struct AppDependencies {
     let widgetRefreshModel: NetworkProtectionWidgetRefreshModel
     let autofillPixelReporter: AutofillPixelReporter
     let crashReportUploaderOnboarding: CrashCollectionOnboarding
-    let maliciousSiteProtectionManager: MaliciousSiteProtectionManaging
+    let maliciousSiteProtectionService: MaliciousSiteProtectionService
 
     var syncDidFinishCancellable: AnyCancellable?
 

--- a/DuckDuckGo/AppDependencyProvider.swift
+++ b/DuckDuckGo/AppDependencyProvider.swift
@@ -52,7 +52,7 @@ protocol DependencyProvider {
     var serverInfoObserver: ConnectionServerInfoObserver { get }
     var vpnSettings: VPNSettings { get }
     var persistentPixel: PersistentPixelFiring { get }
-    
+
 }
 
 /// Provides dependencies for objects that are not directly instantiated

--- a/DuckDuckGo/AppDependencyProvider.swift
+++ b/DuckDuckGo/AppDependencyProvider.swift
@@ -29,6 +29,7 @@ import RemoteMessaging
 import PageRefreshMonitor
 import PixelKit
 import PixelExperimentKit
+import MaliciousSiteProtection
 
 protocol DependencyProvider {
 
@@ -53,6 +54,9 @@ protocol DependencyProvider {
     var vpnSettings: VPNSettings { get }
     var persistentPixel: PersistentPixelFiring { get }
 
+    // Malicious Site Protection
+    var maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging { get }
+    var maliciousSiteProtectionManager: MaliciousSiteProtectionManaging { get }
 }
 
 /// Provides dependencies for objects that are not directly instantiated
@@ -90,6 +94,10 @@ final class AppDependencyProvider: DependencyProvider {
     let serverInfoObserver: ConnectionServerInfoObserver = ConnectionServerInfoObserverThroughSession()
     let vpnSettings = VPNSettings(defaults: .networkProtectionGroupDefaults)
     let persistentPixel: PersistentPixelFiring = PersistentPixel()
+
+    // Malicious Site Protection
+    let maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging = MaliciousSiteProtectionPreferencesManager()
+    let maliciousSiteProtectionManager: MaliciousSiteProtectionManaging
 
     private init() {
         let featureFlaggerOverrides = FeatureFlagLocalOverrides(keyValueStore: UserDefaults(suiteName: FeatureFlag.localOverrideStoreName)!,
@@ -148,6 +156,50 @@ final class AppDependencyProvider: DependencyProvider {
                                                                               settings: vpnSettings)
         vpnFeatureVisibility = DefaultNetworkProtectionVisibility(userDefaults: .networkProtectionGroupDefaults,
                                                                   accountManager: accountManager)
+
+        // Malicious Site Protection
+        let maliciousSiteProtectionAPI = MaliciousSiteProtectionAPI()
+
+        let maliciousSiteProtectionDataManager = MaliciousSiteProtection.DataManager(
+            fileStore: MaliciousSiteProtection.FileStore(
+                dataStoreURL: FileManager.default.urls(
+                    for: .applicationSupportDirectory,
+                    in: .userDomainMask
+                )
+                .first!
+            ),
+            embeddedDataProvider: nil,
+            fileNameProvider: MaliciousSiteProtectionManager.fileName(for:)
+        )
+
+        let maliciousSiteProtectionFeatureFlagger = MaliciousSiteProtectionFeatureFlags(featureFlagger: featureFlagger)
+
+        let remoteIntervalProvider: (MaliciousSiteProtection.DataManager.StoredDataType) -> TimeInterval = { dataKind in
+            switch dataKind {
+            case .hashPrefixSet: .minutes(maliciousSiteProtectionFeatureFlagger.hashPrefixUpdateFrequency)
+            case .filterSet: .minutes(maliciousSiteProtectionFeatureFlagger.filterSetUpdateFrequency)
+            }
+        }
+
+        let updateManager = MaliciousSiteProtection.UpdateManager(
+            apiEnvironment: maliciousSiteProtectionAPI.environment,
+            service: maliciousSiteProtectionAPI.service,
+            dataManager: maliciousSiteProtectionDataManager,
+            updateIntervalProvider: remoteIntervalProvider
+        )
+
+        let maliciousSiteProtectionDatasetsFetcher = MaliciousSiteProtectionDatasetsFetcher(
+            updateManager: updateManager,
+            featureFlagger: maliciousSiteProtectionFeatureFlagger,
+            userPreferencesManager: maliciousSiteProtectionPreferencesManager
+        )
+
+        maliciousSiteProtectionManager = MaliciousSiteProtectionManager(
+            dataFetcher: maliciousSiteProtectionDatasetsFetcher,
+            api: maliciousSiteProtectionAPI,
+            preferencesManager: maliciousSiteProtectionPreferencesManager,
+            maliciousSiteProtectionFeatureFlagger: maliciousSiteProtectionFeatureFlagger
+        )
     }
 
 }

--- a/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -25,7 +25,6 @@ import WidgetKit
 import BackgroundTasks
 import Subscription
 import NetworkProtection
-import MaliciousSiteProtection
 
 /// Represents the state where the app is active and available for user interaction.
 /// - Usage:
@@ -209,7 +208,7 @@ struct Foreground: AppState {
         }
 
         // Fetch Malicious Site protection datasets
-        appDependencies.maliciousSiteProtectionManager.startFetching()
+        appDependencies.maliciousSiteProtectionService.onForeground()
 
         AppDependencyProvider.shared.persistentPixel.sendQueuedPixels { _ in }
     }

--- a/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -25,6 +25,7 @@ import WidgetKit
 import BackgroundTasks
 import Subscription
 import NetworkProtection
+import MaliciousSiteProtection
 
 /// Represents the state where the app is active and available for user interaction.
 /// - Usage:
@@ -206,6 +207,9 @@ struct Foreground: AppState {
         Task {
             await appDependencies.privacyProDataReporter.saveWidgetAdded()
         }
+
+        // Fetch Malicious Site protection datasets
+        appDependencies.maliciousSiteProtectionManager.startFetching()
 
         AppDependencyProvider.shared.persistentPixel.sendQueuedPixels { _ in }
     }

--- a/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -34,7 +34,6 @@ import Common
 import Combine
 import PixelKit
 import PixelExperimentKit
-import MaliciousSiteProtection
 
 /// Represents the transient state where the app is being prepared for user interaction after being launched by the system.
 /// - Usage:
@@ -77,10 +76,9 @@ struct Launching: AppState {
     private let isTesting = ProcessInfo().arguments.contains("testing")
     private let didFinishLaunchingStartTime = CFAbsoluteTimeGetCurrent()
     private let crashReportUploaderOnboarding: CrashCollectionOnboarding
-    private let maliciousSiteProtectionManager: MaliciousSiteProtectionManaging
-    private let maliciousSiteProtectionPreferencesManager = MaliciousSiteProtectionPreferencesManager()
 
     // These should ideally be let properties instead of force-unwrapped. However, due to various initialization paths, such as database completion blocks, setting them up in advance is currently not feasible. Refactoring will be done once this code is streamlined.
+    private let maliciousSiteProtectionService: MaliciousSiteProtectionService
     private let uiService: UIService
     private let unService: UNService
     private let syncDataProviders: SyncDataProviders
@@ -405,48 +403,7 @@ struct Launching: AppState {
         privacyProDataReporter.injectTabsModel(tabsModel)
 
         // Malicious Site Protection
-        let maliciousSiteProtectionAPI = MaliciousSiteProtectionAPI()
-
-        let maliciousSiteProtectionDataManager = MaliciousSiteProtection.DataManager(
-            fileStore: MaliciousSiteProtection.FileStore(
-                dataStoreURL: FileManager.default.urls(
-                    for: .applicationSupportDirectory,
-                    in: .userDomainMask
-                )
-                .first!
-            ),
-            embeddedDataProvider: nil,
-            fileNameProvider: MaliciousSiteProtectionManager.fileName(for:)
-        )
-
-        let maliciousSiteProtectionFeatureFlagger = MaliciousSiteProtectionFeatureFlags(featureFlagger: AppDependencyProvider.shared.featureFlagger)
-
-        let remoteIntervalProvider: (MaliciousSiteProtection.DataManager.StoredDataType) -> TimeInterval = { dataKind in
-            switch dataKind {
-            case .hashPrefixSet: .minutes(maliciousSiteProtectionFeatureFlagger.hashPrefixUpdateFrequency)
-            case .filterSet: .minutes(maliciousSiteProtectionFeatureFlagger.filterSetUpdateFrequency)
-            }
-        }
-
-        let updateManager = MaliciousSiteProtection.UpdateManager(
-            apiEnvironment: maliciousSiteProtectionAPI.environment,
-            service: maliciousSiteProtectionAPI.service,
-            dataManager: maliciousSiteProtectionDataManager,
-            updateIntervalProvider: remoteIntervalProvider
-        )
-
-        let maliciousSiteProtectionDatasetsFetcher = MaliciousSiteProtectionDatasetsFetcher(
-            updateManager: updateManager,
-            featureFlagger: maliciousSiteProtectionFeatureFlagger,
-            userPreferencesManager: maliciousSiteProtectionPreferencesManager
-        )
-
-        maliciousSiteProtectionManager = MaliciousSiteProtectionManager(
-            dataFetcher: maliciousSiteProtectionDatasetsFetcher,
-            api: maliciousSiteProtectionAPI,
-            preferencesManager: maliciousSiteProtectionPreferencesManager,
-            maliciousSiteProtectionFeatureFlagger: maliciousSiteProtectionFeatureFlagger
-        )
+        maliciousSiteProtectionService = MaliciousSiteProtectionService(featureFlagger: AppDependencyProvider.shared.featureFlagger)
 
         if shouldPresentInsufficientDiskSpaceAlertAndCrash {
             window = UIWindow(frame: UIScreen.main.bounds)
@@ -483,8 +440,8 @@ struct Launching: AppState {
                                                     textZoomCoordinator: Self.makeTextZoomCoordinator(),
                                                     websiteDataManager: Self.makeWebsiteDataManager(fireproofing: fireproofing),
                                                     appDidFinishLaunchingStartTime: didFinishLaunchingStartTime,
-                                                    maliciousSiteProtectionManager: maliciousSiteProtectionManager,
-                                                    maliciousSiteProtectionPreferencesManager: maliciousSiteProtectionPreferencesManager)
+                                                    maliciousSiteProtectionManager: maliciousSiteProtectionService.manager,
+                                                    maliciousSiteProtectionPreferencesManager: maliciousSiteProtectionService.preferencesManager)
 
             mainViewController!.loadViewIfNeeded()
             syncErrorHandler.alertPresenter = mainViewController
@@ -579,7 +536,7 @@ struct Launching: AppState {
         tipKitAppEventsHandler.appDidFinishLaunching()
 
         // Register Malicious Site Protection background tasks to fetch datasets
-        maliciousSiteProtectionManager.registerBackgroundRefreshTaskHandler()
+        maliciousSiteProtectionService.onLaunching()
     }
 
     private var appDependencies: AppDependencies {
@@ -606,7 +563,7 @@ struct Launching: AppState {
             widgetRefreshModel: widgetRefreshModel,
             autofillPixelReporter: autofillPixelReporter,
             crashReportUploaderOnboarding: crashReportUploaderOnboarding,
-            maliciousSiteProtectionManager: maliciousSiteProtectionManager
+            maliciousSiteProtectionService: maliciousSiteProtectionService
         )
     }
 

--- a/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -76,6 +76,7 @@ struct Launching: AppState {
     private let isTesting = ProcessInfo().arguments.contains("testing")
     private let didFinishLaunchingStartTime = CFAbsoluteTimeGetCurrent()
     private let crashReportUploaderOnboarding: CrashCollectionOnboarding
+    private let maliciousSiteProtectionManager = AppDependencyProvider.shared.maliciousSiteProtectionManager
 
     // These should ideally be let properties instead of force-unwrapped. However, due to various initialization paths, such as database completion blocks, setting them up in advance is currently not feasible. Refactoring will be done once this code is streamlined.
     private let uiService: UIService
@@ -528,6 +529,9 @@ struct Launching: AppState {
         }
 
         tipKitAppEventsHandler.appDidFinishLaunching()
+
+        // Register Malicious Site Protection background tasks to fetch datasets
+        maliciousSiteProtectionManager.registerBackgroundRefreshTaskHandler()
     }
 
     private var appDependencies: AppDependencies {
@@ -553,7 +557,8 @@ struct Launching: AppState {
             onboardingPixelReporter: onboardingPixelReporter,
             widgetRefreshModel: widgetRefreshModel,
             autofillPixelReporter: autofillPixelReporter,
-            crashReportUploaderOnboarding: crashReportUploaderOnboarding
+            crashReportUploaderOnboarding: crashReportUploaderOnboarding,
+            maliciousSiteProtectionManager: maliciousSiteProtectionManager
         )
     }
 

--- a/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -22,6 +22,7 @@ import BrowserServicesKit
 import MaliciousSiteProtection
 import Core
 
+// Container for Malicious Site Protection Feature.
 final class MaliciousSiteProtectionService {
 
     let preferencesManager = MaliciousSiteProtectionPreferencesManager()

--- a/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -18,8 +18,9 @@
 //
 
 import Foundation
+import BrowserServicesKit
 import MaliciousSiteProtection
-import protocol BrowserServicesKit.FeatureFlagger
+import Core
 
 final class MaliciousSiteProtectionService {
 
@@ -77,6 +78,24 @@ final class MaliciousSiteProtectionService {
 
     func onForeground() {
         manager.startFetching()
+    }
+
+}
+
+// MARK: Malicious Site Protection Feature Flagger
+
+extension MaliciousSiteProtectionFeatureFlags {
+
+    init(
+        featureFlagger: FeatureFlagger,
+        privacyConfigManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager
+    ) {
+        self.init(
+            privacyConfigManager: privacyConfigManager,
+            isMaliciousSiteProtectionEnabled: {
+                featureFlagger.isFeatureOn(.maliciousSiteProtection)
+            }
+        )
     }
 
 }

--- a/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -1,0 +1,82 @@
+//
+//  MaliciousSiteProtectionService.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import MaliciousSiteProtection
+import protocol BrowserServicesKit.FeatureFlagger
+
+final class MaliciousSiteProtectionService {
+
+    let preferencesManager = MaliciousSiteProtectionPreferencesManager()
+    let manager: MaliciousSiteProtectionManaging
+
+    init(featureFlagger: FeatureFlagger) {
+        let maliciousSiteProtectionAPI = MaliciousSiteProtectionAPI()
+
+        let maliciousSiteProtectionDataManager = MaliciousSiteProtection.DataManager(
+            fileStore: MaliciousSiteProtection.FileStore(
+                dataStoreURL: FileManager.default.urls(
+                    for: .applicationSupportDirectory,
+                    in: .userDomainMask
+                )
+                .first!
+            ),
+            embeddedDataProvider: nil,
+            fileNameProvider: MaliciousSiteProtectionManager.fileName(for:)
+        )
+
+        let maliciousSiteProtectionFeatureFlagger = MaliciousSiteProtectionFeatureFlags(featureFlagger: featureFlagger)
+
+        let remoteIntervalProvider: (MaliciousSiteProtection.DataManager.StoredDataType) -> TimeInterval = { dataKind in
+            switch dataKind {
+            case .hashPrefixSet: .minutes(maliciousSiteProtectionFeatureFlagger.hashPrefixUpdateFrequency)
+            case .filterSet: .minutes(maliciousSiteProtectionFeatureFlagger.filterSetUpdateFrequency)
+            }
+        }
+
+        let updateManager = MaliciousSiteProtection.UpdateManager(
+            apiEnvironment: maliciousSiteProtectionAPI.environment,
+            service: maliciousSiteProtectionAPI.service,
+            dataManager: maliciousSiteProtectionDataManager,
+            updateIntervalProvider: remoteIntervalProvider
+        )
+
+        let maliciousSiteProtectionDatasetsFetcher = MaliciousSiteProtectionDatasetsFetcher(
+            updateManager: updateManager,
+            featureFlagger: maliciousSiteProtectionFeatureFlagger,
+            userPreferencesManager: preferencesManager
+        )
+
+        manager = MaliciousSiteProtectionManager(
+            dataFetcher: maliciousSiteProtectionDatasetsFetcher,
+            api: maliciousSiteProtectionAPI,
+            preferencesManager: preferencesManager,
+            maliciousSiteProtectionFeatureFlagger: maliciousSiteProtectionFeatureFlagger
+        )
+    }
+
+    func onLaunching() {
+        manager.registerBackgroundRefreshTaskHandler()
+    }
+
+    func onForeground() {
+        manager.startFetching()
+    }
+
+}

--- a/DuckDuckGo/Info.plist
+++ b/DuckDuckGo/Info.plist
@@ -10,6 +10,8 @@
 	<array>
 		<string>com.duckduckgo.app.configurationRefresh</string>
 		<string>com.duckduckgo.app.remoteMessageRefresh</string>
+		<string>com.duckduckgo.app.maliciousSiteProtectionHashPrefixSetRefresh</string>
+		<string>com.duckduckgo.app.maliciousSiteProtectionFilterSetRefresh</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -226,7 +226,9 @@ class MainViewController: UIViewController {
         subscriptionCookieManager: SubscriptionCookieManaging,
         textZoomCoordinator: TextZoomCoordinating,
         websiteDataManager: WebsiteDataManaging,
-        appDidFinishLaunchingStartTime: CFAbsoluteTime?
+        appDidFinishLaunchingStartTime: CFAbsoluteTime?,
+        maliciousSiteProtectionManager: MaliciousSiteProtectionManaging,
+        maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.bookmarksDatabaseCleaner = bookmarksDatabaseCleaner
@@ -256,7 +258,9 @@ class MainViewController: UIViewController {
                                      appSettings: appSettings,
                                      textZoomCoordinator: textZoomCoordinator,
                                      websiteDataManager: websiteDataManager,
-                                     fireproofing: fireproofing)
+                                     fireproofing: fireproofing,
+                                     maliciousSiteProtectionManager: maliciousSiteProtectionManager,
+                                     maliciousSiteProtectionPreferencesManager: maliciousSiteProtectionPreferencesManager)
         self.syncPausedStateManager = syncPausedStateManager
         self.privacyProDataReporter = privacyProDataReporter
         self.homeTabManager = NewTabPageManager()

--- a/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -35,7 +35,47 @@ extension MaliciousSiteProtectionFeatureFlags {
 
 }
 
-final class MaliciousSiteProtectionManager: MaliciousSiteDetecting {
+typealias MaliciousSiteProtectionManaging = MaliciousSiteDetecting & MaliciousSiteProtectionDatasetsFetching
+
+final class MaliciousSiteProtectionManager {
+
+    private let dataFetcher: MaliciousSiteProtectionDatasetsFetching
+    private let api: MaliciousSiteProtectionAPI
+    private let preferencesManager: MaliciousSiteProtectionPreferencesReading
+    private let maliciousSiteProtectionFeatureFlagger: MaliciousSiteProtectionFeatureFlagger
+
+    init(
+        dataFetcher: MaliciousSiteProtectionDatasetsFetching,
+        api: MaliciousSiteProtectionAPI,
+        dataManager: MaliciousSiteProtection.DataManager? = nil,
+        detector: MaliciousSiteProtection.MaliciousSiteDetecting? = nil,
+        preferencesManager: MaliciousSiteProtectionPreferencesReading,
+        maliciousSiteProtectionFeatureFlagger: MaliciousSiteProtectionFeatureFlagger
+    ) {
+        self.dataFetcher = dataFetcher
+        self.api = api
+        self.preferencesManager = preferencesManager
+        self.maliciousSiteProtectionFeatureFlagger = maliciousSiteProtectionFeatureFlagger
+    }
+}
+
+// MARK: - MaliciousSiteProtectionDatasetsFetching
+
+extension MaliciousSiteProtectionManager: MaliciousSiteProtectionDatasetsFetching {
+
+    func startFetching() {
+        dataFetcher.startFetching()
+    }
+    
+    func registerBackgroundRefreshTaskHandler() {
+        dataFetcher.registerBackgroundRefreshTaskHandler()
+    }
+    
+}
+
+// MARK: - MaliciousSiteDetecting
+
+extension MaliciousSiteProtectionManager: MaliciousSiteDetecting {
 
     func evaluate(_ url: URL) async -> ThreatKind? {
         try? await Task.sleep(interval: 0.3)
@@ -50,4 +90,19 @@ final class MaliciousSiteProtectionManager: MaliciousSiteDetecting {
         }
     }
 
+}
+
+// MARK: - Configuration
+
+extension MaliciousSiteProtectionManager {
+    
+    static func fileName(for dataType: MaliciousSiteProtection.DataManager.StoredDataType) -> String {
+        switch (dataType, dataType.threatKind) {
+        case (.hashPrefixSet, .phishing): "phishingHashPrefixes.json"
+        case (.filterSet, .phishing): "phishingFilterSet.json"
+        case (.hashPrefixSet, .malware): "malwareHashPrefixes.json"
+        case (.filterSet, .malware): "malwareFilterSet.json"
+        }
+    }
+    
 }

--- a/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -17,23 +17,8 @@
 //  limitations under the License.
 //
 
-import BrowserServicesKit
-import Core
 import Foundation
 import MaliciousSiteProtection
-
-extension MaliciousSiteProtectionFeatureFlags {
-
-    init(
-        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-        privacyConfigManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager
-    ) {
-        self.init(privacyConfigManager: privacyConfigManager, isMaliciousSiteProtectionEnabled: {
-            featureFlagger.isFeatureOn(.maliciousSiteProtection)
-        })
-    }
-
-}
 
 typealias MaliciousSiteProtectionManaging = MaliciousSiteDetecting & MaliciousSiteProtectionDatasetsFetching
 

--- a/DuckDuckGo/MaliciousSiteProtection/Services/Logger+MaliciousSiteProtection.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/Logger+MaliciousSiteProtection.swift
@@ -1,0 +1,27 @@
+//
+//  Logger+MaliciousSiteProtection.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+
+extension Logger {
+    enum MaliciousSiteProtection {
+        static let datasetsFetcher = Logger(subsystem: "MSP", category: "DatasetsFetcher")
+    }
+}

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionAPI.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionAPI.swift
@@ -1,0 +1,26 @@
+//
+//  MaliciousSiteProtectionAPI.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import MaliciousSiteProtection
+import Networking
+
+struct MaliciousSiteProtectionAPI {
+    var environment: MaliciousSiteDetector.APIEnvironment = .production
+    var service: APIService = DefaultAPIService(urlSession: .shared)
+}

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -39,11 +39,13 @@ final class MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDatas
     private var preferencesManagerCancellable: AnyCancellable?
 
     private var shouldUpdateHashPrefixSets: Bool {
-        dateProvider().timeIntervalSince(updateManager.lastHashPrefixSetUpdateDate) > .minutes(featureFlagger.hashPrefixUpdateFrequency)
+        // Absolute interval to avoid never updating the dataset if the `lastHashPrefixSetUpdateDate` is mistakenly set in the far future
+        abs(dateProvider().timeIntervalSince(updateManager.lastHashPrefixSetUpdateDate)) > .minutes(featureFlagger.hashPrefixUpdateFrequency)
     }
 
     private var shouldUpdateFilterSets: Bool {
-        dateProvider().timeIntervalSince(updateManager.lastFilterSetUpdateDate) > .minutes(featureFlagger.filterSetUpdateFrequency)
+        // Absolute interval to avoid never updating the dataset if the `lastFilterSetUpdateDate` is mistakenly set in the far future
+        abs(dateProvider().timeIntervalSince(updateManager.lastFilterSetUpdateDate)) > .minutes(featureFlagger.filterSetUpdateFrequency)
     }
 
     private var canFetchDatasets: Bool {

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -61,8 +61,6 @@ final class MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDatas
         self.userPreferencesManager = userPreferencesManager
         self.dateProvider = dateProvider
         self.backgroundTaskScheduler = backgroundTaskScheduler
-
-        setupBindings()
     }
 }
 
@@ -212,6 +210,8 @@ extension MaliciousSiteProtectionDatasetsFetcher {
                 backgroundRefreshTaskHandler(backgroundTask: backgroundTask, datasetType: datasetType)
             }
         }
+
+        setupBindings()
     }
 
     private func scheduleBackgroundRefreshTask(datasetType: DataManager.StoredDataType.Kind) {

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -35,9 +35,6 @@ final class MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDatas
     private let updateManager: MaliciousSiteUpdateManaging
     private let backgroundTaskScheduler: BGTaskScheduling
 
-    private var hashPrefixSetsUpdateTask: Task<Void, any Error>?
-    private var filterSetsUpdateTask: Task<Void, any Error>?
-
     private var preferencesManagerCancellable: AnyCancellable?
 
     private var shouldUpdateHashPrefixSets: Bool {
@@ -50,16 +47,6 @@ final class MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDatas
 
     private var canFetchDatasets: Bool {
         featureFlagger.isMaliciousSiteProtectionEnabled && userPreferencesManager.isMaliciousSiteProtectionOn
-    }
-
-    // Used for testing pursposes
-    var isUpdatingHashPrefixSets: Bool {
-        hashPrefixSetsUpdateTask != nil
-    }
-
-    // Used for testing pursposes
-    var isUpdatingFilterSets: Bool {
-        filterSetsUpdateTask != nil
     }
 
     init(
@@ -88,12 +75,12 @@ extension MaliciousSiteProtectionDatasetsFetcher {
 
         // If hashPrefix Sets need to be updated fetch them
         if shouldUpdateHashPrefixSets {
-            hashPrefixSetsUpdateTask = updateManager.updateData(datasetType: .hashPrefixSet)
+            _ = updateManager.updateData(datasetType: .hashPrefixSet)
         }
 
         // If hashPrefix Sets need to be updated fetch them
         if shouldUpdateFilterSets {
-            filterSetsUpdateTask = updateManager.updateData(datasetType: .filterSet)
+            _ = updateManager.updateData(datasetType: .filterSet)
         }
     }
 
@@ -159,13 +146,6 @@ private extension MaliciousSiteProtectionDatasetsFetcher {
     }
 
     func stopUpdateTasks() {
-        // Cancel any in-flight tasks
-        hashPrefixSetsUpdateTask?.cancel()
-        hashPrefixSetsUpdateTask = nil
-
-        filterSetsUpdateTask?.cancel()
-        filterSetsUpdateTask = nil
-
         // Cancel scheduled background tasks
         DataManager.StoredDataType.Kind.allCases.forEach {
             backgroundTaskScheduler.cancel(taskRequestWithIdentifier: $0.backgroundTaskIdentifier)

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -1,0 +1,300 @@
+//
+//  MaliciousSiteProtectionDatasetsFetcher.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import MaliciousSiteProtection
+import BackgroundTasks
+import Core
+import Combine
+
+protocol MaliciousSiteProtectionDatasetsFetching {
+    func startFetching()
+    func registerBackgroundRefreshTaskHandler()
+}
+
+final class MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDatasetsFetching {
+    private let featureFlagger: MaliciousSiteProtectionFeatureFlagger & MaliciousSiteProtectionFeatureFlagsSettingsProvider
+    private let userPreferencesManager: MaliciousSiteProtectionPreferencesProvider
+    private let dateProvider: () -> Date
+    private let updateManager: MaliciousSiteUpdateManaging
+    private let backgroundTaskScheduler: BGTaskScheduling
+
+    private var hashPrefixSetsUpdateTask: Task<Void, any Error>?
+    private var filterSetsUpdateTask: Task<Void, any Error>?
+
+    private var preferencesManagerCancellable: AnyCancellable?
+
+    private var shouldUpdateHashPrefixSets: Bool {
+        dateProvider().timeIntervalSince(updateManager.lastHashPrefixSetUpdateDate) > .minutes(featureFlagger.hashPrefixUpdateFrequency)
+    }
+
+    private var shouldUpdateFilterSets: Bool {
+        dateProvider().timeIntervalSince(updateManager.lastFilterSetUpdateDate) > .minutes(featureFlagger.filterSetUpdateFrequency)
+    }
+
+    private var canFetchDatasets: Bool {
+        featureFlagger.isMaliciousSiteProtectionEnabled && userPreferencesManager.isMaliciousSiteProtectionOn
+    }
+
+    // Used for testing pursposes
+    var isUpdatingHashPrefixSets: Bool {
+        hashPrefixSetsUpdateTask != nil
+    }
+
+    // Used for testing pursposes
+    var isUpdatingFilterSets: Bool {
+        filterSetsUpdateTask != nil
+    }
+
+    init(
+        updateManager: MaliciousSiteUpdateManaging,
+        featureFlagger: MaliciousSiteProtectionFeatureFlagger & MaliciousSiteProtectionFeatureFlagsSettingsProvider,
+        userPreferencesManager: MaliciousSiteProtectionPreferencesProvider,
+        dateProvider: @escaping () -> Date = Date.init,
+        backgroundTaskScheduler: BGTaskScheduling = BGTaskScheduler.shared
+    ) {
+        self.updateManager = updateManager
+        self.featureFlagger = featureFlagger
+        self.userPreferencesManager = userPreferencesManager
+        self.dateProvider = dateProvider
+        self.backgroundTaskScheduler = backgroundTaskScheduler
+
+        setupBindings()
+    }
+}
+
+// MARK: - Public
+
+extension MaliciousSiteProtectionDatasetsFetcher {
+
+    func startFetching() {
+        guard canFetchDatasets else { return }
+
+        // If hashPrefix Sets need to be updated fetch them
+        if shouldUpdateHashPrefixSets {
+            hashPrefixSetsUpdateTask = updateManager.updateData(datasetType: .hashPrefixSet)
+        }
+
+        // If hashPrefix Sets need to be updated fetch them
+        if shouldUpdateFilterSets {
+            filterSetsUpdateTask = updateManager.updateData(datasetType: .filterSet)
+        }
+    }
+
+}
+
+// MARK: - Private
+
+private extension MaliciousSiteProtectionDatasetsFetcher {
+
+    func setupBindings() {
+        guard featureFlagger.isMaliciousSiteProtectionEnabled else { return }
+        subscribeToDetectionPreferences()
+    }
+
+    func subscribeToDetectionPreferences() {
+        let isMaliciousSiteProtectionOn = userPreferencesManager.isMaliciousSiteProtectionOn
+
+        preferencesManagerCancellable = userPreferencesManager
+            .isMaliciousSiteProtectionOnPublisher
+            .scan((previous: isMaliciousSiteProtectionOn, current: isMaliciousSiteProtectionOn)) { accumulated, newValue in // Get the previous value of the publisher
+                (accumulated.current, newValue)
+            }
+            .sink { [weak self] isOnInfo in
+                self?.handleUserPreferencesChange(wasOn: isOnInfo.previous, isOn: isOnInfo.current)
+            }
+    }
+
+    func handleUserPreferencesChange(wasOn: Bool, isOn: Bool) {
+        // If the feature is turned off in the user Preferences when we launch the App we don't need to stop background tasks.
+        // If the feature was turned off and the user turns it on we want to download the datasets and schedule the background tasks.
+        // If the feature is turned on when in the user Preferences when we launch the App we want to schedule the background tasks as we already started fetching the datasets on App launch.
+        // If the feature was turned on and the user turns it off we want to cancel the background tasks.
+        switch (wasOn, isOn) {
+        case (false, false):
+            break
+        case (true, true):
+            // Start only background tasks
+            scheduleBackgroundTasksIfNeeded()
+        case (false, true):
+            // Start downloading and initiate background tasks
+            startUpdateTasks()
+        case (true, false):
+            stopUpdateTasks()
+        }
+    }
+
+    func startUpdateTasks() {
+        startFetching()
+        scheduleBackgroundTasksIfNeeded()
+    }
+
+    func scheduleBackgroundTasksIfNeeded() {
+        backgroundTaskScheduler.getPendingTaskRequests { [weak self] tasks in
+            guard let self else { return }
+
+            DataManager.StoredDataType.Kind.allCases.forEach { datasetType in
+                // BackgroundTasks will automatically replace an existing task in the queue if one with the same identifier is queued, so we should only
+                // schedule a task if there are none pending in order to avoid the config task getting perpetually replaced.
+                guard !tasks.contains(where: { $0.identifier == datasetType.backgroundTaskIdentifier }) else { return }
+                self.scheduleBackgroundRefreshTask(datasetType: datasetType)
+            }
+        }
+    }
+
+    func stopUpdateTasks() {
+        // Cancel any in-flight tasks
+        hashPrefixSetsUpdateTask?.cancel()
+        hashPrefixSetsUpdateTask = nil
+
+        filterSetsUpdateTask?.cancel()
+        filterSetsUpdateTask = nil
+
+        // Cancel scheduled background tasks
+        DataManager.StoredDataType.Kind.allCases.forEach {
+            backgroundTaskScheduler.cancel(taskRequestWithIdentifier: $0.backgroundTaskIdentifier)
+        }
+    }
+
+    func refreshInterval(for datasetsType: DataManager.StoredDataType.Kind) -> TimeInterval {
+        switch datasetsType {
+        case .hashPrefixSet:
+            return .minutes(featureFlagger.hashPrefixUpdateFrequency)
+        case .filterSet:
+            return .minutes(featureFlagger.filterSetUpdateFrequency)
+        }
+    }
+
+    func shouldRefresh(datasetType: DataManager.StoredDataType.Kind) -> Bool {
+        switch datasetType {
+        case .hashPrefixSet:
+            shouldUpdateHashPrefixSets
+        case .filterSet:
+            shouldUpdateFilterSets
+        }
+    }
+
+    func backgroundRefreshTaskHandler(backgroundTask: BGTaskInterface, datasetType: DataManager.StoredDataType.Kind) {
+        let fetchAndProcessDatasetTask = Task {
+            if canFetchDatasets {
+                _ = updateManager.updateData(datasetType: datasetType)
+            }
+            scheduleBackgroundRefreshTask(datasetType: datasetType)
+            backgroundTask.setTaskCompleted(success: true)
+        }
+
+        backgroundTask.expirationHandler = {
+            fetchAndProcessDatasetTask.cancel()
+            backgroundTask.setTaskCompleted(success: false)
+        }
+    }
+
+}
+
+// MARK: - Background Tasks
+
+extension MaliciousSiteProtectionDatasetsFetcher {
+
+    func registerBackgroundRefreshTaskHandler() {
+        DataManager.StoredDataType.Kind.allCases.forEach { datasetType in
+            backgroundTaskScheduler.register(forTaskWithIdentifier: datasetType.backgroundTaskIdentifier) { [weak self] backgroundTask in
+                guard let self else { return }
+
+                guard shouldRefresh(datasetType: datasetType) else {
+                    backgroundTask.setTaskCompleted(success: true)
+                    scheduleBackgroundRefreshTask(datasetType: datasetType)
+                    return
+                }
+
+                backgroundRefreshTaskHandler(backgroundTask: backgroundTask, datasetType: datasetType)
+            }
+        }
+    }
+
+    private func scheduleBackgroundRefreshTask(datasetType: DataManager.StoredDataType.Kind) {
+        func performScheduleTasks() {
+            do {
+                try backgroundTaskScheduler.submit(task)
+            } catch {
+                Pixel.fire(pixel: .backgroundTaskSubmissionFailed, error: error)
+            }
+        }
+
+        guard canFetchDatasets else { return }
+
+        let task = BGProcessingTaskRequest(identifier: datasetType.backgroundTaskIdentifier)
+        task.requiresNetworkConnectivity = true
+        task.earliestBeginDate = Date(timeIntervalSinceNow: refreshInterval(for: datasetType))
+
+        // Background tasks can be debugged by breaking on the `submit` call, stepping over, then running the following LLDB command, before resuming:
+        //
+        // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]
+        //
+        // Task expiration can be simulated similarly:
+        //
+        // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateExpirationForTaskWithIdentifier:@"com.duckduckgo.app.configurationRefresh"]
+
+        #if targetEnvironment(simulator)
+        guard ProcessInfo().arguments.contains("testing") else { return }
+        performScheduleTasks()
+        #else
+        performScheduleTasks()
+        #endif
+    }
+
+}
+
+// MARK: - DataManager.StoredDataType.Kind + Background Tasks
+
+extension DataManager.StoredDataType.Kind {
+
+    var backgroundTaskIdentifier: String {
+        switch self {
+        case .hashPrefixSet: return "com.duckduckgo.app.maliciousSiteProtectionHashPrefixSetRefresh"
+        case .filterSet: return "com.duckduckgo.app.maliciousSiteProtectionFilterSetRefresh"
+        }
+    }
+
+}
+
+// MARK: - Background Tasks + Testing
+
+protocol BGTaskInterface: AnyObject {
+    var identifier: String { get }
+    var expirationHandler: (() -> Void)? { get set }
+
+    func setTaskCompleted(success: Bool)
+}
+
+extension BGTask: BGTaskInterface {}
+
+protocol BGTaskScheduling: AnyObject {
+    @discardableResult
+    func register(forTaskWithIdentifier identifier: String, launchHandler: @escaping (BGTaskInterface) -> Void) -> Bool
+    func submit(_ taskRequest: BGTaskRequest) throws
+    func cancel(taskRequestWithIdentifier identifier: String)
+    func getPendingTaskRequests(completionHandler: @escaping ([BGTaskRequest]) -> Void)
+    func pendingTaskRequests() async -> [BGTaskRequest]
+}
+
+extension BGTaskScheduler: BGTaskScheduling {
+    func register(forTaskWithIdentifier identifier: String, launchHandler: @escaping (any BGTaskInterface) -> Void) -> Bool {
+        register(forTaskWithIdentifier: identifier, using: nil, launchHandler: launchHandler)
+    }
+}

--- a/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -138,7 +138,10 @@ private extension MaliciousSiteProtectionDatasetsFetcher {
     }
 
     func scheduleBackgroundTasksIfNeeded() {
-        guard application.backgroundRefreshStatus == .available else { return }
+        guard application.backgroundRefreshStatus == .available else {
+            Logger.MaliciousSiteProtection.datasetsFetcher.debug("Skipping scheduling background tasks as App does not support background refresh.")
+            return
+        }
 
         backgroundTaskScheduler.getPendingTaskRequests { [weak self] tasks in
             guard let self else { return }

--- a/DuckDuckGo/MaliciousSiteProtection/UserPreferences/MaliciousSiteProtectionPreferencesManager.swift
+++ b/DuckDuckGo/MaliciousSiteProtection/UserPreferences/MaliciousSiteProtectionPreferencesManager.swift
@@ -1,0 +1,48 @@
+//
+//  MaliciousSiteProtectionPreferencesManager.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Combine
+
+protocol MaliciousSiteProtectionPreferencesPublishing {
+    var isMaliciousSiteProtectionOnPublisher: AnyPublisher<Bool, Never> { get }
+}
+
+protocol MaliciousSiteProtectionPreferencesReading {
+    var isMaliciousSiteProtectionOn: Bool { get }
+}
+
+typealias MaliciousSiteProtectionPreferencesProvider = MaliciousSiteProtectionPreferencesReading & MaliciousSiteProtectionPreferencesPublishing
+
+protocol MaliciousSiteProtectionPreferencesWriting {
+    var isMaliciousSiteProtectionOn: Bool { get set }
+}
+
+typealias MaliciousSiteProtectionPreferencesManaging = MaliciousSiteProtectionPreferencesWriting & MaliciousSiteProtectionPreferencesProvider
+
+final class MaliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging {
+    @Published var isMaliciousSiteProtectionOn: Bool
+
+    var isMaliciousSiteProtectionOnPublisher: AnyPublisher<Bool, Never> { $isMaliciousSiteProtectionOn.eraseToAnyPublisher() }
+
+    // TODO: Inject Store
+    init() {
+        isMaliciousSiteProtectionOn = true
+    }
+}

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
@@ -66,7 +66,7 @@ final class MaliciousSiteProtectionNavigationHandler {
     @MainActor private(set) var maliciousSiteDetectionTasks: [URL: Task<MaliciousSiteProtectionNavigationResult, Never>] = [:]
 
     init(
-        maliciousSiteProtectionManager: MaliciousSiteDetecting = AppDependencyProvider.shared.maliciousSiteProtectionManager,
+        maliciousSiteProtectionManager: MaliciousSiteDetecting,
         storageCache: StorageCache = AppDependencyProvider.shared.storageCache
     ) {
         self.maliciousSiteProtectionManager = maliciousSiteProtectionManager

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler+MaliciousSite.swift
@@ -66,7 +66,7 @@ final class MaliciousSiteProtectionNavigationHandler {
     @MainActor private(set) var maliciousSiteDetectionTasks: [URL: Task<MaliciousSiteProtectionNavigationResult, Never>] = [:]
 
     init(
-        maliciousSiteProtectionManager: MaliciousSiteDetecting = MaliciousSiteProtectionManager(),
+        maliciousSiteProtectionManager: MaliciousSiteDetecting = AppDependencyProvider.shared.maliciousSiteProtectionManager,
         storageCache: StorageCache = AppDependencyProvider.shared.storageCache
     ) {
         self.maliciousSiteProtectionManager = maliciousSiteProtectionManager

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -44,7 +44,7 @@ final class SpecialErrorPageNavigationHandler: SpecialErrorPageContextHandling {
 
     init(
         sslErrorPageNavigationHandler: SSLSpecialErrorPageNavigationHandling & SpecialErrorPageActionHandler = SSLErrorPageNavigationHandler(),
-        maliciousSiteProtectionNavigationHandler: MaliciousSiteProtectionNavigationHandling & SpecialErrorPageActionHandler = MaliciousSiteProtectionNavigationHandler()
+        maliciousSiteProtectionNavigationHandler: MaliciousSiteProtectionNavigationHandling & SpecialErrorPageActionHandler
     ) {
         self.sslErrorPageNavigationHandler = sslErrorPageNavigationHandler
         self.maliciousSiteProtectionNavigationHandler = maliciousSiteProtectionNavigationHandler

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -49,6 +49,8 @@ class TabManager {
     private let websiteDataManager: WebsiteDataManaging
     private let subscriptionCookieManager: SubscriptionCookieManaging
     private let appSettings: AppSettings
+    private let maliciousSiteProtectionManager: MaliciousSiteProtectionManaging
+    private let maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging
 
     weak var delegate: TabDelegate?
 
@@ -72,7 +74,10 @@ class TabManager {
          appSettings: AppSettings,
          textZoomCoordinator: TextZoomCoordinating,
          websiteDataManager: WebsiteDataManaging,
-         fireproofing: Fireproofing) {
+         fireproofing: Fireproofing,
+         maliciousSiteProtectionManager: MaliciousSiteProtectionManaging,
+         maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging
+    ) {
         self.model = model
         self.previewsSource = previewsSource
         self.interactionStateSource = interactionStateSource
@@ -90,6 +95,8 @@ class TabManager {
         self.textZoomCoordinator = textZoomCoordinator
         self.websiteDataManager = websiteDataManager
         self.fireproofing = fireproofing
+        self.maliciousSiteProtectionManager = maliciousSiteProtectionManager
+        self.maliciousSiteProtectionPreferencesManager = maliciousSiteProtectionPreferencesManager
         registerForNotifications()
     }
 
@@ -106,6 +113,12 @@ class TabManager {
                                  interactionState: Data?) -> TabViewController {
         let configuration =  WKWebViewConfiguration.persistent()
 
+        let specialErrorPageNavigationHandler = SpecialErrorPageNavigationHandler(
+            maliciousSiteProtectionNavigationHandler: MaliciousSiteProtectionNavigationHandler(
+                maliciousSiteProtectionManager: maliciousSiteProtectionManager
+            )
+        )
+
         let controller = TabViewController.loadFromStoryboard(model: tab,
                                                               bookmarksDatabase: bookmarksDatabase,
                                                               historyManager: historyManager,
@@ -120,7 +133,8 @@ class TabManager {
                                                               textZoomCoordinator: textZoomCoordinator,
                                                               websiteDataManager: websiteDataManager,
                                                               fireproofing: fireproofing,
-                                                              tabInteractionStateSource: interactionStateSource)
+                                                              tabInteractionStateSource: interactionStateSource,
+                                                              specialErrorPageNavigationHandler: specialErrorPageNavigationHandler)
         controller.applyInheritedAttribution(inheritedAttribution)
         controller.attachWebView(configuration: configuration,
                                  interactionStateData: interactionState,
@@ -190,6 +204,12 @@ class TabManager {
         model.insert(tab: tab, at: model.currentIndex + 1)
         model.select(tabAt: model.currentIndex + 1)
 
+        let specialErrorPageNavigationHandler = SpecialErrorPageNavigationHandler(
+            maliciousSiteProtectionNavigationHandler: MaliciousSiteProtectionNavigationHandler(
+                maliciousSiteProtectionManager: maliciousSiteProtectionManager
+            )
+        )
+
         let controller = TabViewController.loadFromStoryboard(model: tab,
                                                               bookmarksDatabase: bookmarksDatabase,
                                                               historyManager: historyManager,
@@ -204,7 +224,8 @@ class TabManager {
                                                               textZoomCoordinator: textZoomCoordinator,
                                                               websiteDataManager: websiteDataManager,
                                                               fireproofing: fireproofing,
-                                                              tabInteractionStateSource: interactionStateSource)
+                                                              tabInteractionStateSource: interactionStateSource,
+                                                              specialErrorPageNavigationHandler: specialErrorPageNavigationHandler)
         controller.attachWebView(configuration: configCopy,
                                  andLoadRequest: request,
                                  consumeCookies: !model.hasActiveTabs,

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -334,8 +334,8 @@ class TabViewController: UIViewController {
                                    textZoomCoordinator: TextZoomCoordinating,
                                    websiteDataManager: WebsiteDataManaging,
                                    fireproofing: Fireproofing,
-                                   tabInteractionStateSource: TabInteractionStateSource?) -> TabViewController {
-
+                                   tabInteractionStateSource: TabInteractionStateSource?,
+                                   specialErrorPageNavigationHandler: SpecialErrorPageManaging) -> TabViewController {
         let storyboard = UIStoryboard(name: "Tab", bundle: nil)
         let controller = storyboard.instantiateViewController(identifier: "TabViewController", creator: { coder in
             TabViewController(coder: coder,
@@ -354,7 +354,8 @@ class TabViewController: UIViewController {
                               textZoomCoordinator: textZoomCoordinator,
                               fireproofing: fireproofing,
                               websiteDataManager: websiteDataManager,
-                              tabInteractionStateSource: tabInteractionStateSource
+                              tabInteractionStateSource: tabInteractionStateSource,
+                              specialErrorPageNavigationHandler: specialErrorPageNavigationHandler
             )
         })
         return controller
@@ -397,7 +398,7 @@ class TabViewController: UIViewController {
                    fireproofing: Fireproofing,
                    websiteDataManager: WebsiteDataManaging,
                    tabInteractionStateSource: TabInteractionStateSource?,
-                   specialErrorPageNavigationHandler: SpecialErrorPageManaging = SpecialErrorPageNavigationHandler()) {
+                   specialErrorPageNavigationHandler: SpecialErrorPageManaging) {
         self.tabModel = tabModel
         self.appSettings = appSettings
         self.bookmarksDatabase = bookmarksDatabase

--- a/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -117,7 +117,8 @@ extension TabViewController {
             textZoomCoordinator: textZoomCoordinator,
             websiteDataManager: websiteDataManager,
             fireproofing: fireproofing,
-            tabInteractionStateSource: tabInteractionStateSource)
+            tabInteractionStateSource: tabInteractionStateSource,
+            specialErrorPageNavigationHandler: specialErrorPageNavigationHandler)
 
         tabController.isLinkPreview = true
         let configuration = WKWebViewConfiguration.nonPersistent()

--- a/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -1,0 +1,412 @@
+//
+//  MaliciousSiteProtectionDatasetsFetcherTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+import MaliciousSiteProtection
+@testable import DuckDuckGo
+
+@Suite("Malicious Site Protection - Feature Flags", .serialized)
+final class MaliciousSiteProtectionDatasetsFetcherTests {
+    private var sut: MaliciousSiteProtectionDatasetsFetcher!
+    private var updateManagerMock: MockMaliciousSiteProtectionUpdateManager!
+    private var featureFlaggerMock: MockMaliciousSiteProtectionFeatureFlags!
+    private var userPreferencesManagerMock: MockMaliciousSiteProtectionPreferencesManager!
+    private var backgroundSchedulerMock: MockBackgroundScheduler!
+    private var timeTraveller: TimeTraveller!
+
+    init() {
+        setupSUT()
+    }
+
+    func setupSUT(
+        updateManagerMock: MockMaliciousSiteProtectionUpdateManager = .init(),
+        featureFlaggerMock: MockMaliciousSiteProtectionFeatureFlags = .init(),
+        userPreferencesManagerMock: MockMaliciousSiteProtectionPreferencesManager = .init(),
+        dateProvider: @escaping () -> Date = Date.init,
+        backgroundSchedulerMock: MockBackgroundScheduler = .init()
+    ) {
+        self.updateManagerMock = updateManagerMock
+        self.featureFlaggerMock = featureFlaggerMock
+        self.userPreferencesManagerMock = userPreferencesManagerMock
+        self.backgroundSchedulerMock = backgroundSchedulerMock
+        self.timeTraveller = TimeTraveller()
+
+        sut = MaliciousSiteProtectionDatasetsFetcher(
+            updateManager: updateManagerMock,
+            featureFlagger: featureFlaggerMock,
+            userPreferencesManager: userPreferencesManagerMock,
+            dateProvider: timeTraveller.getDate,
+            backgroundTaskScheduler: backgroundSchedulerMock
+        )
+    }
+
+    // MARK: - Explicitely Fetch Datasets
+
+    @Test("Fetch Datasets When Feature Is Enabled and User Turned On the Feature")
+    func whenStartFetchingCalled_AndFeatureEnabled_AndPreferencesEnabled_ThenStartUpdateTask() {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // WHEN
+        sut.startFetching()
+
+        // THEN
+        #expect(sut.isUpdatingHashPrefixSets)
+        #expect(sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == true)
+    }
+
+    @Test("Do not Fetch Datasets When Feature is Disabled")
+    func whenStartFetchingCalled_AndFeatureDisabled_ThenDoNotStartUpdateTask() {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = false
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // WHEN
+        sut.startFetching()
+
+        // THEN
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+    }
+
+    @Test("Do not Fetch Datasets When User Turned Off the Feature")
+    func whentartFetchingCalled_AndFeatureEnabled_AndPreferencesDisabled_ThenDoNotStartUpdateTask() {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+
+        // WHEN
+        sut.startFetching()
+
+        // THEN
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+    }
+
+    @Test("Fetch Hash Prefix Dataset When Start Fetching Is Called And Last Update Date Is Greater Than Update Interval")
+    func whenStartFetchingCalled_AndLastHashPrefixSetUpdateDateIsGreaterThanUpdateInterval_ThenFetchHashPrefixSet() {
+        // GIVEN
+        let timeTraveller = TimeTraveller()
+        timeTraveller.advanceBy(-.minutes(6))
+        updateManagerMock.lastHashPrefixSetUpdateDate = timeTraveller.getDate()
+        updateManagerMock.lastFilterSetUpdateDate = timeTraveller.getDate()
+        featureFlaggerMock.hashPrefixUpdateFrequency = 5 // Value expressed in minutes
+        featureFlaggerMock.filterSetUpdateFrequency = 10 // Value expressed in minutes
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // WHEN
+        sut.startFetching()
+
+        // THEN
+        #expect(sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+    }
+
+    @Test("Fetch Filter Dataset When Start Fetching Is Called And Last Update Date Is Greater Than Update Interval")
+    func whenStartFetchingCalled_AndLastFilterSetUpdateDateIsGreaterThanUpdateInterval_ThenFetchHashPrefixSet() {
+        // GIVEN
+        let timeTraveller = TimeTraveller()
+        timeTraveller.advanceBy(-.minutes(11))
+        updateManagerMock.lastHashPrefixSetUpdateDate = timeTraveller.getDate()
+        updateManagerMock.lastFilterSetUpdateDate = timeTraveller.getDate()
+        featureFlaggerMock.hashPrefixUpdateFrequency = 15 // Value expressed in minutes
+        featureFlaggerMock.filterSetUpdateFrequency = 10 // Value expressed in minutes
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // WHEN
+        sut.startFetching()
+
+        // THEN
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(sut.isUpdatingFilterSets)
+    }
+
+    @Test("Fetch Datasets When Update Interval Becomes Grather Than Last Update Interval")
+    func whenStartFetchingCalled_AndUpdateIntervalBecomesGraterThanLastUpdateDate_ThenFetchDatasets() {
+        // GIVEN
+        updateManagerMock.lastHashPrefixSetUpdateDate = timeTraveller.getDate()
+        updateManagerMock.lastFilterSetUpdateDate = timeTraveller.getDate()
+        featureFlaggerMock.hashPrefixUpdateFrequency = 15 // Value expressed in minutes
+        featureFlaggerMock.filterSetUpdateFrequency = 10 // Value expressed in minutes
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        sut.startFetching()
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+
+        // WHEN
+        timeTraveller.advanceBy(.minutes(16))
+        sut.startFetching()
+
+        // THEN
+        #expect(sut.isUpdatingHashPrefixSets)
+        #expect(sut.isUpdatingFilterSets)
+    }
+
+    // MARK: - Events Upon User Preference Subscription
+
+    @Test("Do Not Fetch Datasets on Init when Feature Is Enabled and User Turned On the Feature")
+    func whenInitialized_AndFeatureEnabled_AndPreferencesEnabled_ThenStartUpdateTask() {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // WHEN
+        setupSUT(featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
+
+        // THEN
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+    }
+
+    @Test("Start Fetching Datasets When User Turns On the Feature And Last Update Is Greater Than Update Interval")
+    func whenPreferencesEnabled_AndLastUpdateDateIsGreaterThanUpdateInterval_ThenStartUpdateTask() {
+        // GIVEN
+        updateManagerMock.lastHashPrefixSetUpdateDate = .distantPast
+        updateManagerMock.lastFilterSetUpdateDate = .distantPast
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+        setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+
+        // WHEN
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // TRUE
+        #expect(sut.isUpdatingHashPrefixSets)
+        #expect(sut.isUpdatingFilterSets)
+    }
+
+    @Test("Do Not Start Fetching Datasets When User Turns On the Feature and Last Update Is Smaller Than Update Interval")
+    func whenPreferencesEnabled_AndLastUpdateDateIsSmallerThanUpdateInterval_ThenDoNotStartUpdateTask() {
+        // GIVEN
+        let now = Date()
+        updateManagerMock.lastHashPrefixSetUpdateDate = now
+        updateManagerMock.lastFilterSetUpdateDate = now
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+        setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+
+        // WHEN
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // TRUE
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+    }
+
+    @Test("Stop Fetching Datasets When User Turns Off the Feature")
+    func whenPreferencesDisabledThenStopUpdateTask() async throws {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        setupSUT(featureFlaggerMock: featureFlaggerMock)
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        #expect(sut.isUpdatingHashPrefixSets)
+        #expect(sut.isUpdatingFilterSets)
+
+        // WHEN
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+
+        // TRUE
+        #expect(!sut.isUpdatingHashPrefixSets)
+        #expect(!sut.isUpdatingFilterSets)
+    }
+
+    // MARK: - Background Tasks
+
+    @Test("Schedule Background Tasks When Init And Feature Preference Is On")
+    func whenInitAndFeaturePreferenceIsOnThenScheduleBackgroundTasks() async {
+        // GIVEN
+        let expectedBackgroundTasksIdentifiers = [
+            "com.duckduckgo.app.maliciousSiteProtectionHashPrefixSetRefresh",
+            "com.duckduckgo.app.maliciousSiteProtectionFilterSetRefresh",
+        ]
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        await confirmation(expectedCount: 2) { submittedBackgroundTask in
+            backgroundSchedulerMock.scheduleBackgroundTaskConfirmation = submittedBackgroundTask
+
+            // WHEN
+            setupSUT(featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock, backgroundSchedulerMock: backgroundSchedulerMock)
+
+            // THEN
+            #expect(backgroundSchedulerMock.submittedTaskRequests.map(\.identifier) == expectedBackgroundTasksIdentifiers)
+        }
+    }
+
+    @Test("Register Background Tasks")
+    func whenRegisterBackgroundRefreshTaskHandlerIsCalledThenRegisterBackgroundTasks() {
+        // GIVEN
+        let expectedBackgroundTasksIdentifiers = [
+            "com.duckduckgo.app.maliciousSiteProtectionHashPrefixSetRefresh",
+            "com.duckduckgo.app.maliciousSiteProtectionFilterSetRefresh",
+        ]
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers.isEmpty)
+
+        // WHEN
+        sut.registerBackgroundRefreshTaskHandler()
+
+        // THEN
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers == expectedBackgroundTasksIdentifiers)
+    }
+
+    @Test(
+        "Do Not Execute Background Task When Dataset Does Not Need To Update",
+        arguments: [
+            (type: DataManager.StoredDataType.Kind.hashPrefixSet, updateFrequency: 1),
+            (type: .filterSet, updateFrequency: 5),
+        ]
+    )
+    func whenRegisterBackgroundRefreshTaskHandlerIsExecuted_AndShouldNotRefreshDataset_ThenSetTaskCompletedTrueAndScheduleRefreshTask(datasetInfo: (type: DataManager.StoredDataType.Kind, updateFrequency: Int)) throws {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        featureFlaggerMock.hashPrefixUpdateFrequency = 1
+        featureFlaggerMock.filterSetUpdateFrequency = 5
+        let date = Date()
+        updateManagerMock.lastHashPrefixSetUpdateDate = date
+        updateManagerMock.lastFilterSetUpdateDate = date
+        let identifier = datasetInfo.type.backgroundTaskIdentifier
+        let backgroundTask = MockBGTask(identifier: identifier)
+        sut.registerBackgroundRefreshTaskHandler()
+        #expect(!backgroundTask.didCallSetTaskCompleted)
+        #expect(backgroundTask.capturedTaskCompletedSuccess == nil)
+        #expect(!backgroundSchedulerMock.didCallSubmitTaskRequest)
+        #expect(backgroundSchedulerMock.capturedSubmittedTaskRequest == nil)
+        let launchHandler = try #require(backgroundSchedulerMock.launchHandlers[identifier])
+
+        // WHEN
+        launchHandler?(backgroundTask)
+
+        // THEN
+        let tolerance: TimeInterval = 5
+        #expect(backgroundTask.didCallSetTaskCompleted)
+        #expect(backgroundTask.capturedTaskCompletedSuccess == true)
+        #expect(backgroundTask.expirationHandler == nil)
+        #expect(backgroundSchedulerMock.didCallSubmitTaskRequest)
+        let capturedSubmittedTaskRequest = try #require(backgroundSchedulerMock.capturedSubmittedTaskRequest)
+        let earliestBeginDate = try #require(capturedSubmittedTaskRequest.earliestBeginDate)
+        #expect(capturedSubmittedTaskRequest.identifier == identifier)
+        #expect(abs(earliestBeginDate.timeIntervalSince1970 - Date(timeIntervalSinceNow: .minutes(datasetInfo.updateFrequency)).timeIntervalSince1970) < tolerance)
+    }
+
+    @Test(
+        "Execute Background Task When Dataset Needs To Update",
+        arguments: [
+            DataManager.StoredDataType.Kind.hashPrefixSet,
+            .filterSet,
+        ]
+    )
+    func whenRegisterBackgroundRefreshTaskHandlerIsExecuted_AndShouldRefreshDataset_ThenRunTask(datasetType: DataManager.StoredDataType.Kind) throws {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        updateManagerMock.lastFilterSetUpdateDate = .distantPast
+        updateManagerMock.lastFilterSetUpdateDate = .distantPast
+        let identifier = datasetType.backgroundTaskIdentifier
+        let backgroundTask = MockBGTask(identifier: identifier)
+        sut.registerBackgroundRefreshTaskHandler()
+        let launchHandler = try #require(backgroundSchedulerMock.launchHandlers[identifier])
+        #expect(backgroundTask.expirationHandler == nil)
+
+        // WHEN
+        launchHandler?(backgroundTask)
+
+        // THEN
+        #expect(backgroundTask.expirationHandler != nil)
+    }
+
+    @Test(
+        "Check Expiration Handler Cancel Task",
+        arguments: [
+            DataManager.StoredDataType.Kind.hashPrefixSet,
+            .filterSet,
+        ]
+    )
+    func whenExpirationHandlerIsCalledThenCancelTask(datasetType: DataManager.StoredDataType.Kind) throws {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        updateManagerMock.lastFilterSetUpdateDate = .distantPast
+        updateManagerMock.lastFilterSetUpdateDate = .distantPast
+        let identifier = datasetType.backgroundTaskIdentifier
+        let backgroundTask = MockBGTask(identifier: identifier)
+        sut.registerBackgroundRefreshTaskHandler()
+        let launchHandler = try #require(backgroundSchedulerMock.launchHandlers[identifier])
+        #expect(!backgroundTask.didCallSetTaskCompleted)
+        #expect(backgroundTask.capturedTaskCompletedSuccess == nil)
+        launchHandler?(backgroundTask)
+
+        // WHEN
+        backgroundTask.expirationHandler?()
+
+        // THEN
+        #expect(backgroundTask.didCallSetTaskCompleted)
+        #expect(backgroundTask.capturedTaskCompletedSuccess == false)
+    }
+
+    @Test("Start Background Update Task When User Turns On the Feature")
+    func whenUserTurnsOnProtectionThenStartBackgroundUpdateTask() {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+        setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
+        #expect(!backgroundSchedulerMock.didCallSubmitTaskRequest)
+        #expect(backgroundSchedulerMock.capturedSubmittedTaskRequest == nil)
+
+        // WHEN
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+
+        // TRUE
+        #expect(backgroundSchedulerMock.didCallSubmitTaskRequest)
+        #expect(backgroundSchedulerMock.capturedSubmittedTaskRequest != nil)
+    }
+
+    @Test("Stop Background Update Task When User Turns Off the Feature")
+    func whenUserTurnsOffProtectionThenStopBackgroundUpdateTask() {
+        // GIVEN
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        setupSUT(featureFlaggerMock: featureFlaggerMock)
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        #expect(!backgroundSchedulerMock.didCallCancelTaskRequestWithIdentifier)
+
+        // WHEN
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+
+        // TRUE
+        #expect(backgroundSchedulerMock.didCallCancelTaskRequestWithIdentifier)
+    }
+
+}

--- a/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -197,6 +197,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
         setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
+        sut.registerBackgroundRefreshTaskHandler()
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
@@ -239,12 +240,13 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         ]
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        setupSUT(featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock, backgroundSchedulerMock: backgroundSchedulerMock)
 
         await confirmation(expectedCount: 2) { submittedBackgroundTask in
             backgroundSchedulerMock.scheduleBackgroundTaskConfirmation = submittedBackgroundTask
 
             // WHEN
-            setupSUT(featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock, backgroundSchedulerMock: backgroundSchedulerMock)
+            sut.registerBackgroundRefreshTaskHandler()
 
             // THEN
             #expect(backgroundSchedulerMock.submittedTaskRequests.map(\.identifier) == expectedBackgroundTasksIdentifiers)
@@ -288,8 +290,6 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         sut.registerBackgroundRefreshTaskHandler()
         #expect(!backgroundTask.didCallSetTaskCompleted)
         #expect(backgroundTask.capturedTaskCompletedSuccess == nil)
-        #expect(!backgroundSchedulerMock.didCallSubmitTaskRequest)
-        #expect(backgroundSchedulerMock.capturedSubmittedTaskRequest == nil)
         let launchHandler = try #require(backgroundSchedulerMock.launchHandlers[identifier])
 
         // WHEN
@@ -368,6 +368,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
         setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
+        sut.registerBackgroundRefreshTaskHandler()
         #expect(!backgroundSchedulerMock.didCallSubmitTaskRequest)
         #expect(backgroundSchedulerMock.capturedSubmittedTaskRequest == nil)
 
@@ -384,6 +385,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         // GIVEN
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         setupSUT(featureFlaggerMock: featureFlaggerMock)
+        sut.registerBackgroundRefreshTaskHandler()
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
         #expect(!backgroundSchedulerMock.didCallCancelTaskRequestWithIdentifier)
 

--- a/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -64,13 +64,13 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         // GIVEN
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         sut.startFetching()
 
         // THEN
-        #expect(sut.isUpdatingHashPrefixSets)
-        #expect(sut.isUpdatingFilterSets)
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
         #expect(updateManagerMock.updateDatasets[.filterSet] == true)
     }
@@ -80,13 +80,13 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         // GIVEN
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = false
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         sut.startFetching()
 
         // THEN
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
     }
@@ -96,13 +96,13 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         // GIVEN
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         sut.startFetching()
 
         // THEN
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
     }
@@ -118,13 +118,15 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.filterSetUpdateFrequency = 10 // Value expressed in minutes
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         sut.startFetching()
 
         // THEN
-        #expect(sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
     }
 
     @Test("Fetch Filter Dataset When Start Fetching Is Called And Last Update Date Is Greater Than Update Interval")
@@ -138,13 +140,15 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.filterSetUpdateFrequency = 10 // Value expressed in minutes
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         sut.startFetching()
 
         // THEN
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == true)
     }
 
     @Test("Fetch Datasets When Update Interval Becomes Grather Than Last Update Interval")
@@ -157,16 +161,16 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
         sut.startFetching()
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         timeTraveller.advanceBy(.minutes(16))
         sut.startFetching()
 
         // THEN
-        #expect(sut.isUpdatingHashPrefixSets)
-        #expect(sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == true)
     }
 
     // MARK: - Events Upon User Preference Subscription
@@ -181,8 +185,6 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         setupSUT(featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
 
         // THEN
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
     }
@@ -195,15 +197,15 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
         setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
 
         // TRUE
-        #expect(sut.isUpdatingHashPrefixSets)
-        #expect(sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == true)
     }
 
     @Test("Do Not Start Fetching Datasets When User Turns On the Feature and Last Update Is Smaller Than Update Interval")
@@ -215,32 +217,15 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
         setupSUT(updateManagerMock: updateManagerMock, featureFlaggerMock: featureFlaggerMock, userPreferencesManagerMock: userPreferencesManagerMock)
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
 
         // TRUE
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
-    }
-
-    @Test("Stop Fetching Datasets When User Turns Off the Feature")
-    func whenPreferencesDisabledThenStopUpdateTask() async throws {
-        // GIVEN
-        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
-        setupSUT(featureFlaggerMock: featureFlaggerMock)
-        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
-        #expect(sut.isUpdatingHashPrefixSets)
-        #expect(sut.isUpdatingFilterSets)
-
-        // WHEN
-        userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
-
-        // TRUE
-        #expect(!sut.isUpdatingHashPrefixSets)
-        #expect(!sut.isUpdatingFilterSets)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
     }
 
     // MARK: - Background Tasks

--- a/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionManagerTests.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionManagerTests.swift
@@ -1,0 +1,65 @@
+//
+//  MaliciousSiteProtectionManagerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+@testable import DuckDuckGo
+
+@Suite("Malicious Site Protection - Manager", .serialized)
+final class MaliciousSiteProtectionManagerTests {
+    private var sut: MaliciousSiteProtectionManager!
+    private var dataFetcherMock: MockMaliciousSiteProtectionDataFetcher!
+    private var preferencesManagerMock: MockMaliciousSiteProtectionPreferencesManager!
+    private var featureFlaggerMock: MockMaliciousSiteProtectionFeatureFlags!
+
+    init() {
+        dataFetcherMock = MockMaliciousSiteProtectionDataFetcher()
+        preferencesManagerMock = MockMaliciousSiteProtectionPreferencesManager()
+        featureFlaggerMock = MockMaliciousSiteProtectionFeatureFlags()
+        sut = MaliciousSiteProtectionManager(
+            dataFetcher: dataFetcherMock,
+            api: MaliciousSiteProtectionAPI(),
+            preferencesManager: preferencesManagerMock,
+            maliciousSiteProtectionFeatureFlagger: featureFlaggerMock
+        )
+    }
+
+    @Test("Start Fetching Datasets Asks DatasetsFetcher To Fetch Data")
+    func whenStartFetchingDatasetsIsCalledThenItAsksDataFetcherToFetchData() {
+        // GIVEN
+        #expect(!dataFetcherMock.didCallStartFetching)
+
+        // WHEN
+        sut.startFetching()
+
+        // THEN
+        #expect(dataFetcherMock.didCallStartFetching)
+    }
+
+    @Test("Register Background Tasks Asks DatasetsFetcher to Register Background Tasks")
+    func whenRegisterBackgroundTasksIsCalledThenItAsksDataFetcherToRegisterBackgroundTasks() {
+        // GIVEN
+        #expect(!dataFetcherMock.didCallRegisterBackgroundRefreshTaskHandler)
+
+        // WHEN
+        sut.registerBackgroundRefreshTaskHandler()
+
+        // THEN
+        #expect(dataFetcherMock.didCallRegisterBackgroundRefreshTaskHandler)
+    }
+}

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -22,6 +22,7 @@ import Combine
 import MaliciousSiteProtection
 import BackgroundTasks
 import Testing
+import enum UIKit.UIBackgroundRefreshStatus
 @testable import DuckDuckGo
 
 final class MockMaliciousSiteProtectionUpdateManager: MaliciousSiteUpdateManaging {
@@ -140,4 +141,8 @@ final class MockMaliciousSiteProtectionDataFetcher: MaliciousSiteProtectionDatas
     func registerBackgroundRefreshTaskHandler() {
         didCallRegisterBackgroundRefreshTaskHandler = true
     }
+}
+
+final class MockBackgroundRefreshApplication: BackgroundRefreshCapable {
+    var backgroundRefreshStatus: UIBackgroundRefreshStatus = .available
 }

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -128,3 +128,16 @@ final class MockBGTask: BGTaskInterface {
         capturedTaskCompletedSuccess = success
     }
 }
+
+final class MockMaliciousSiteProtectionDataFetcher: MaliciousSiteProtectionDatasetsFetching {
+    private(set) var didCallStartFetching = false
+    private(set) var didCallRegisterBackgroundRefreshTaskHandler = false
+
+    func startFetching() {
+        didCallStartFetching = true
+    }
+    
+    func registerBackgroundRefreshTaskHandler() {
+        didCallRegisterBackgroundRefreshTaskHandler = true
+    }
+}

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -1,0 +1,130 @@
+//
+//  MaliciousSiteProtectionMocks.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Combine
+import MaliciousSiteProtection
+import BackgroundTasks
+import Testing
+@testable import DuckDuckGo
+
+final class MockMaliciousSiteProtectionUpdateManager: MaliciousSiteUpdateManaging {
+    private(set) var updateDatasets: [MaliciousSiteProtection.DataManager.StoredDataType.Kind: Bool] = [
+        .hashPrefixSet: false,
+        .filterSet: false
+    ]
+
+    var lastHashPrefixSetUpdateDate: Date = .distantPast
+    var lastFilterSetUpdateDate: Date = .distantPast
+
+    func startPeriodicUpdates() -> Task<Void, any Error> {
+        Task { }
+    }
+    
+    func updateData(datasetType: MaliciousSiteProtection.DataManager.StoredDataType.Kind) -> Task<Void, any Error> {
+        updateDatasets[datasetType] = true
+        return Task { }
+    }
+}
+
+final class MockMaliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging {
+    var isMaliciousSiteProtectionOn: Bool = false {
+        didSet {
+            subject.send(isMaliciousSiteProtectionOn)
+        }
+    }
+
+    private lazy var subject = CurrentValueSubject<Bool, Never>(isMaliciousSiteProtectionOn)
+
+    var isMaliciousSiteProtectionOnPublisher: AnyPublisher<Bool, Never> {
+        subject.eraseToAnyPublisher()
+    }
+}
+
+final class MockMaliciousSiteProtectionFeatureFlags: MaliciousSiteProtectionFeatureFlagger, MaliciousSiteProtectionFeatureFlagsSettingsProvider {
+    var shouldDetectMaliciousThreatForDomainResult = false
+
+    var isMaliciousSiteProtectionEnabled = false
+
+    var hashPrefixUpdateFrequency: Int = 10
+
+    var filterSetUpdateFrequency: Int = 20
+
+    func shouldDetectMaliciousThreat(forDomain domain: String?) -> Bool {
+        shouldDetectMaliciousThreatForDomainResult
+    }
+}
+
+final class MockBackgroundScheduler: BGTaskScheduling {
+    private(set) var capturedRegisteredTaskIdentifiers: [String] = []
+
+    private(set) var didCallSubmitTaskRequest = false
+    private(set) var capturedSubmittedTaskRequest: BGTaskRequest?
+    private(set) var submittedTaskRequests: [BGTaskRequest] = []
+
+    private(set) var didCallCancelTaskRequestWithIdentifier = false
+    private(set) var capturedCanceledTaskRequestIdentifier: String?
+
+    var scheduleBackgroundTaskConfirmation: Confirmation?
+
+    var launchHandlers: [String: ((BGTaskInterface) -> Void)?] = [:]
+
+    func register(forTaskWithIdentifier identifier: String, launchHandler: @escaping (BGTaskInterface) -> Void) -> Bool {
+        capturedRegisteredTaskIdentifiers.append(identifier)
+        self.launchHandlers[identifier] = launchHandler
+        return true
+    }
+    
+    func submit(_ taskRequest: BGTaskRequest) throws {
+        didCallSubmitTaskRequest = true
+        capturedSubmittedTaskRequest = taskRequest
+        submittedTaskRequests.append(taskRequest)
+        scheduleBackgroundTaskConfirmation?()
+    }
+    
+    func cancel(taskRequestWithIdentifier identifier: String) {
+        didCallCancelTaskRequestWithIdentifier = true
+        capturedCanceledTaskRequestIdentifier = identifier
+    }
+    
+    func pendingTaskRequests() async -> [BGTaskRequest] {
+        []
+    }
+
+    func getPendingTaskRequests(completionHandler: @escaping ([BGTaskRequest]) -> Void) {
+        completionHandler([])
+    }
+}
+
+final class MockBGTask: BGTaskInterface {
+    private(set) var didCallSetTaskCompleted = false
+    private(set) var capturedTaskCompletedSuccess: Bool?
+
+    let identifier: String
+    var expirationHandler: (() -> Void)?
+
+    init(identifier: String) {
+        self.identifier = identifier
+    }
+
+    func setTaskCompleted(success: Bool) {
+        didCallSetTaskCompleted = true
+        capturedTaskCompletedSuccess = success
+    }
+}

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -146,3 +146,27 @@ final class MockMaliciousSiteProtectionDataFetcher: MaliciousSiteProtectionDatas
 final class MockBackgroundRefreshApplication: BackgroundRefreshCapable {
     var backgroundRefreshStatus: UIBackgroundRefreshStatus = .available
 }
+
+final class MockMaliciousSiteDetector: MaliciousSiteProtection.MaliciousSiteDetecting {
+
+    var isMalicious: (URL) -> MaliciousSiteProtection.ThreatKind? = { url in
+        if url.absoluteString.contains("phishing") {
+            .phishing
+        } else if url.absoluteString.contains("malware") {
+            .malware
+        } else {
+            nil
+        }
+    }
+
+    init(isMalicious: ((URL) -> MaliciousSiteProtection.ThreatKind?)? = nil) {
+        if let isMalicious {
+            self.isMalicious = isMalicious
+        }
+    }
+
+    func evaluate(_ url: URL) async -> MaliciousSiteProtection.ThreatKind? {
+        return isMalicious(url)
+    }
+
+}

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/TimeTraveller.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/TimeTraveller.swift
@@ -1,0 +1,36 @@
+//
+//  TimeTraveller.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+final class TimeTraveller {
+    private var date: Date
+
+    init(date: Date = Date()) {
+        self.date = date
+    }
+
+    func advanceBy(_ timeInterval: TimeInterval) {
+        date.addTimeInterval(timeInterval)
+    }
+
+    func getDate() -> Date {
+        date
+    }
+}

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -26,6 +26,8 @@ import Core
 import Persistence
 import Subscription
 import SubscriptionTestingUtilities
+import SpecialErrorPages
+import MaliciousSiteProtection
 @testable import DuckDuckGo
 
 final class MockTabDelegate: TabDelegate {
@@ -142,10 +144,50 @@ extension TabViewController {
             textZoomCoordinator: MockTextZoomCoordinator(),
             websiteDataManager: MockWebsiteDataManager(),
             fireproofing: MockFireproofing(),
-            tabInteractionStateSource: MockTabInteractionStateSource()
+            tabInteractionStateSource: MockTabInteractionStateSource(),
+            specialErrorPageNavigationHandler: DummySpecialErrorPageNavigationHandler()
         )
         tab.attachWebView(configuration: .nonPersistent(), andLoadRequest: nil, consumeCookies: false, customWebView: customWebView)
         return tab
     }
+
+}
+
+class DummySpecialErrorPageNavigationHandler: SpecialErrorPageManaging {
+    var delegate: (any DuckDuckGo.SpecialErrorPageNavigationDelegate)?
+    
+    var isSpecialErrorPageVisible: Bool = false
+
+    var failedURL: URL?
+    
+    var isSpecialErrorPageRequest: Bool = false
+
+    var currentThreatKind: MaliciousSiteProtection.ThreatKind?
+
+    func attachWebView(_ webView: WKWebView) {}
+    
+    func setUserScript(_ userScript: SpecialErrorPages.SpecialErrorPageUserScript?) {}
+    
+    func handleDecidePolicy(for navigationAction: WKNavigationAction, webView: WKWebView) {}
+    
+    func handleDecidePolicy(for navigationResponse: WKNavigationResponse, webView: WKWebView) async -> Bool {
+        true
+    }
+    
+    func handleWebView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+
+    }
+    
+    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: any DuckDuckGo.WebViewNavigation, withError error: NSError) {}
+    
+    func handleWebView(_ webView: WKWebView, didFinish navigation: any DuckDuckGo.WebViewNavigation) {}
+    
+    var errorData: SpecialErrorPages.SpecialErrorData?
+    
+    func leaveSiteAction() {}
+    
+    func visitSiteAction() {}
+    
+    func advancedInfoPresented() {}
 
 }

--- a/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
+++ b/DuckDuckGoTests/OnboardingDaxFavouritesTests.swift
@@ -90,7 +90,9 @@ final class OnboardingDaxFavouritesTests: XCTestCase {
             subscriptionCookieManager: SubscriptionCookieManagerMock(),
             textZoomCoordinator: MockTextZoomCoordinator(),
             websiteDataManager: mockWebsiteDataManager,
-            appDidFinishLaunchingStartTime: nil
+            appDidFinishLaunchingStartTime: nil,
+            maliciousSiteProtectionManager: MockMaliciousSiteProtectionManager(),
+            maliciousSiteProtectionPreferencesManager: MockMaliciousSiteProtectionPreferencesManager()
         )
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()

--- a/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -88,7 +88,10 @@ final class OnboardingNavigationDelegateTests: XCTestCase {
             subscriptionCookieManager: SubscriptionCookieManagerMock(),
             textZoomCoordinator: MockTextZoomCoordinator(),
             websiteDataManager: MockWebsiteDataManager(),
-            appDidFinishLaunchingStartTime: nil)
+            appDidFinishLaunchingStartTime: nil,
+            maliciousSiteProtectionManager: MockMaliciousSiteProtectionManager(),
+            maliciousSiteProtectionPreferencesManager: MockMaliciousSiteProtectionPreferencesManager()
+        )
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()

--- a/DuckDuckGoTests/SpecialErrorPage/TestDoubles/MockMaliciousSiteProtectionManager.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/TestDoubles/MockMaliciousSiteProtectionManager.swift
@@ -21,9 +21,19 @@ import Foundation
 import MaliciousSiteProtection
 @testable import DuckDuckGo
 
-final class MockMaliciousSiteProtectionManager: MaliciousSiteDetecting {
+final class MockMaliciousSiteProtectionManager: MaliciousSiteDetecting, MaliciousSiteProtectionDatasetsFetching {
+    private(set) var didCallStartFetching = false
+    private(set) var didCallRegisterBackgroundRefreshTaskHandler = false
 
     var threatKind: ThreatKind?
+
+    func startFetching() {
+        didCallStartFetching = true
+    }
+
+    func registerBackgroundRefreshTaskHandler() {
+        didCallRegisterBackgroundRefreshTaskHandler = true
+    }
 
     func evaluate(_ url: URL) async -> MaliciousSiteProtection.ThreatKind? {
         threatKind


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1209158005098852/f
Tech Design URL: https://app.asana.com/0/481882893211075/1209133564224796/f
CC: @jaceklyp 

**Description**:

This PR adds a Datasets Fetcher for Malicious Site Protection to download the datasets needed for the feature to work.

The datasets are fetched in two ways:

1. When the App state changes to `Foreground` we trigger the datasets fetch. This follows the pattern of `AppConfigurationFetch`.
   - To avoid keep fetching the datasets when the app state change to background <-> foreground we check that the interval update interval is not due.
   
2. Via background fetches:
-   I added two new background task types, one for the `hashPrefixSet` and one for the `filterSet` since they have a different update interval time.

**Steps to test this PR**:

**Scenario 1: When the app launches ensure that the datasets are fetched if feature is enabled**
Prerequisites: Ensure that `isMaliciousSiteProtectionEnabled` returns `true` in `MaliciousSiteProtectionFeatureFlags`.
1. Launch the App
2. Ensure that the following files are created in the Application Support folder.
 - "phishingHashPrefixes.json"
 - "phishingFilterSet.json"
 - "malwareHashPrefixes.json"
 - “malwareFilterSet.json
 
  If using simulator go to: ~/Library/Developer/CoreSimulator/Devices/<simulator_id>/Data/Containers/Data/Application/<app_id>/Library/Application\ Support/
 
 **Scenario 2: When the app launches ensure that the datasets are fetched if feature is disabled**
 Prerequisites: Ensure that `isMaliciousSiteProtectionEnabled` returns `false` in `MaliciousSiteProtectionFeatureFlags`.
 1. Launch the App
 2. Ensure that the following files are not created in the Application Support folder.
  - "phishingHashPrefixes.json"
  - "phishingFilterSet.json"
  - "malwareHashPrefixes.json"
  - “malwareFilterSet.json
 
 Repeat the test by changing `isMaliciousSiteProtectionEnabled` to `true` and change `isMaliciousSiteProtectionOn` to `false` in `MaliciousSiteProtectionPreferencesManager`.

**Scenario 3: Moving the app to the background and then to the foreground should not trigger another fetch if the update interval is not passed**
 1. Launch the App.
 2. Ensure the datasets are fetched.
 3. Send the app to the background.
 4. Bring the app to the foreground.
 5. Ensure Datasets are not fetched again.

**Scenario 4: Moving the app to the background and then to the foreground should trigger another fetch if the update interval is passed** 
Prerequisites: Change `hashPrefixUpdateFrequency` and `filterSetUpdateFrequency` to `1` in `MaliciousSiteProtectionFeatureFlags`. 
 1. Launch the App.
 2. Ensure the datasets are fetched.
 3. Send the app to the background.
 4. Wait a minute.
 4. Bring the app to the foreground.
 5. Ensure Datasets are fetched again.

**Scenario 5: Ensure Background Tasks schedule and cancellation are called**
Prerequisites: Run the app on the device.
Follow [Apple Documentation](https://developer.apple.com/documentation/backgroundtasks/starting-and-terminating-tasks-during-development)

PS: To simulate background task cancellation it could be helpful to comment the below snippet in `registerBackgroundRefreshTaskHandler`

```
guard shouldRefresh(datasetType: datasetType) else {
   backgroundTask.setTaskCompleted(success: true)
   scheduleBackgroundRefreshTask(datasetType: datasetType)
   return
}
```

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
