### PR TITLE
Malicious site protection detection integration

### DIFF
--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -803,15 +803,10 @@
 		9F254AB32CF4A1F10063B308 /* SpecialErrorPageNavigationHandler+MaliciousSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AB22CF4A1E10063B308 /* SpecialErrorPageNavigationHandler+MaliciousSite.swift */; };
 		9F254ACB2CF5CDC60063B308 /* SpecialErrorPageNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254ACA2CF5CDC60063B308 /* SpecialErrorPageNavigationHandlerTests.swift */; };
 		9F254ACE2CF5D3540063B308 /* SpecialErrorPageNavigationHandlerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254ACD2CF5D3540063B308 /* SpecialErrorPageNavigationHandlerIntegrationTests.swift */; };
-		9F254AD22CF5D3A80063B308 /* MockSpecialErrorWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AD12CF5D3A20063B308 /* MockSpecialErrorWebView.swift */; };
 		9F254AD32CF5D3A80063B308 /* MockSpecialErrorWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AD12CF5D3A20063B308 /* MockSpecialErrorWebView.swift */; };
 		9F254AD52CF5E5B10063B308 /* MockMaliciousSiteProtectionNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AD42CF5E5B10063B308 /* MockMaliciousSiteProtectionNavigationHandler.swift */; };
-		9F254AD62CF5E5B10063B308 /* MockMaliciousSiteProtectionNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AD42CF5E5B10063B308 /* MockMaliciousSiteProtectionNavigationHandler.swift */; };
-		9F254AD82CF605310063B308 /* MockSSLErrorPageNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AD72CF605310063B308 /* MockSSLErrorPageNavigationHandler.swift */; };
 		9F254AD92CF605310063B308 /* MockSSLErrorPageNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AD72CF605310063B308 /* MockSSLErrorPageNavigationHandler.swift */; };
-		9F254ADB2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254ADA2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift */; };
 		9F254ADC2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254ADA2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift */; };
-		9F254ADE2CF636CF0063B308 /* DummyWKNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254ADD2CF636CF0063B308 /* DummyWKNavigation.swift */; };
 		9F254ADF2CF636CF0063B308 /* DummyWKNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254ADD2CF636CF0063B308 /* DummyWKNavigation.swift */; };
 		9F254AF12CF8D5250063B308 /* MaliciousSiteProtection in Frameworks */ = {isa = PBXBuildFile; productRef = 9F254AF02CF8D5250063B308 /* MaliciousSiteProtection */; };
 		9F254AFF2CF9FA1B0063B308 /* WebViewNavigationHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254AFE2CF9FA1B0063B308 /* WebViewNavigationHandling.swift */; };
@@ -873,7 +868,6 @@
 		9FB0271D2C293619009EA190 /* OnboardingIntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB0271C2C293619009EA190 /* OnboardingIntroViewModel.swift */; };
 		9FBC76672CFE33B5008B21E7 /* MaliciousSiteProtectionNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC76662CFE33B5008B21E7 /* MaliciousSiteProtectionNavigationHandlerTests.swift */; };
 		9FBC766A2CFE3802008B21E7 /* MockMaliciousSiteProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC76692CFE3802008B21E7 /* MockMaliciousSiteProtectionManager.swift */; };
-		9FBC766B2CFE3802008B21E7 /* MockMaliciousSiteProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC76692CFE3802008B21E7 /* MockMaliciousSiteProtectionManager.swift */; };
 		9FCFCD802C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */; };
 		9FCFCD812C6B020D006EB7A0 /* LaunchOptionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */; };
 		9FCFCD852C75C91A006EB7A0 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD842C75C91A006EB7A0 /* ProgressBarView.swift */; };
@@ -9019,14 +9013,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F254AD62CF5E5B10063B308 /* MockMaliciousSiteProtectionNavigationHandler.swift in Sources */,
 				85F21DB0210F5E32002631A6 /* AtbIntegrationTests.swift in Sources */,
-				9FBC766B2CFE3802008B21E7 /* MockMaliciousSiteProtectionManager.swift in Sources */,
-				9F254AD22CF5D3A80063B308 /* MockSpecialErrorWebView.swift in Sources */,
-				9F254ADE2CF636CF0063B308 /* DummyWKNavigation.swift in Sources */,
 				8551912724746EDC0010FDD0 /* SnapshotHelper.swift in Sources */,
-				9F254ADB2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift in Sources */,
-				9F254AD82CF605310063B308 /* MockSSLErrorPageNavigationHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -68,6 +68,7 @@ final class MaliciousSiteProtectionService {
         manager = MaliciousSiteProtectionManager(
             dataFetcher: maliciousSiteProtectionDatasetsFetcher,
             api: maliciousSiteProtectionAPI,
+            dataManager: maliciousSiteProtectionDataManager,
             preferencesManager: preferencesManager,
             maliciousSiteProtectionFeatureFlagger: maliciousSiteProtectionFeatureFlagger
         )

--- a/DuckDuckGo/MainViewController.swift
+++ b/DuckDuckGo/MainViewController.swift
@@ -2334,8 +2334,8 @@ extension MainViewController: TabDelegate {
         return newTab.webView
     }
 
-    func tabDidRequestClose(_ tab: TabViewController) {
-        closeTab(tab.tabModel)
+    func tabDidRequestClose(_ tab: TabViewController, shouldCreateEmptyTabAtSamePosition: Bool) {
+        closeTab(tab.tabModel, andOpenEmptyOneAtSamePosition: shouldCreateEmptyTabAtSamePosition)
     }
 
     func tabLoadingStateDidChange(tab: TabViewController) {
@@ -2585,12 +2585,20 @@ extension MainViewController: TabSwitcherDelegate {
             showFireButtonPulse()
         }
     }
-    
-    func closeTab(_ tab: Tab) {
+
+    func closeTab(_ tab: Tab, andOpenEmptyOneAtSamePosition shouldOpen: Bool = false) {
         guard let index = tabManager.model.indexOf(tab: tab) else { return }
         hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
-        tabManager.remove(at: index)
+
+        if shouldOpen {
+            let newTab = Tab()
+            tabManager.replaceTab(at: index, withNewTab: newTab)
+            tabManager.selectTab(newTab)
+        } else {
+            tabManager.remove(at: index)
+        }
+
         updateCurrentTab()
         tabsBarController?.refresh(tabsModel: tabManager.model)
     }

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/SpecialErrorPageContextHandling.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/SpecialErrorPageContextHandling.swift
@@ -29,9 +29,6 @@ protocol SpecialErrorPageContextHandling: SpecialErrorPageThreatProvider {
     /// A Boolean value indicating whether the special error page is currently visible.
     var isSpecialErrorPageVisible: Bool { get }
 
-    /// The URL that failed to load, if any.
-    var failedURL: URL? { get }
-
     /// A boolean value indicating whether the WebView request requires showing a special error page.
     var isSpecialErrorPageRequest: Bool { get }
 

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/SpecialErrorPageNavigationDelegate.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/SpecialErrorPageNavigationDelegate.swift
@@ -22,5 +22,5 @@ import Foundation
 /// A delegate for handling navigation actions related to special error pages.
 protocol SpecialErrorPageNavigationDelegate: AnyObject {
     /// Asks the delegate to close the special error page tab when the web view can't navigate back.
-    func closeSpecialErrorPageTab()
+    func closeSpecialErrorPageTab(shouldCreateNewEmptyTab: Bool)
 }

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -70,6 +70,7 @@ extension SpecialErrorPageNavigationHandler: WebViewNavigationHandling {
         if navigationAction.isTargetingMainFrame() {
             errorData = nil
             failedURL = nil
+            isSpecialErrorPageVisible = false
         }
         maliciousSiteProtectionNavigationHandler.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
     }

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -143,12 +143,12 @@ extension SpecialErrorPageNavigationHandler: SpecialErrorPageUserScriptDelegate 
             if webView?.canGoBack == true {
                 _ = webView?.goBack()
             } else {
-                closeTab()
+                closeTab(shouldCreateNewTab: false)
             }
         }
 
-        func closeTab() {
-            delegate?.closeSpecialErrorPageTab()
+        func closeTab(shouldCreateNewTab: Bool) {
+            delegate?.closeSpecialErrorPageTab(shouldCreateNewEmptyTab: shouldCreateNewTab)
         }
 
         guard let errorData else { return }
@@ -159,7 +159,7 @@ extension SpecialErrorPageNavigationHandler: SpecialErrorPageUserScriptDelegate 
             navigateBackIfPossible()
         case .maliciousSite:
             maliciousSiteProtectionNavigationHandler.leaveSite()
-            closeTab()
+            closeTab(shouldCreateNewTab: true)
         }
     }
 

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -66,12 +66,7 @@ extension SpecialErrorPageNavigationHandler: WebViewNavigationHandling {
 
     @MainActor
     func handleDecidePolicy(for navigationAction: WKNavigationAction, webView: WKWebView) {
-        // A new main navigation is starting reset the error
-        if navigationAction.isTargetingMainFrame() {
-            errorData = nil
-            failedURL = nil
-            isSpecialErrorPageVisible = false
-        }
+        guard navigationAction.isTargetingMainFrame() else { return }
         maliciousSiteProtectionNavigationHandler.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
     }
 
@@ -102,6 +97,7 @@ extension SpecialErrorPageNavigationHandler: WebViewNavigationHandling {
             return true
         case .navigationNotHandled:
             isSpecialErrorPageRequest = false
+            isSpecialErrorPageVisible = false
             return false
         }
     }

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -66,6 +66,11 @@ extension SpecialErrorPageNavigationHandler: WebViewNavigationHandling {
 
     @MainActor
     func handleDecidePolicy(for navigationAction: WKNavigationAction, webView: WKWebView) {
+        // A new main navigation is starting reset the error
+        if navigationAction.isTargetingMainFrame() {
+            errorData = nil
+            failedURL = nil
+        }
         maliciousSiteProtectionNavigationHandler.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
     }
 

--- a/DuckDuckGo/TabDelegate.swift
+++ b/DuckDuckGo/TabDelegate.swift
@@ -33,7 +33,7 @@ protocol TabDelegate: AnyObject {
              for navigationAction: WKNavigationAction,
              inheritingAttribution: AdClickAttributionLogic.State?) -> WKWebView?
 
-    func tabDidRequestClose(_ tab: TabViewController)
+    func tabDidRequestClose(_ tab: TabViewController, shouldCreateEmptyTabAtSamePosition: Bool)
 
     func tab(_ tab: TabViewController,
              didRequestNewTabForUrl url: URL,
@@ -96,4 +96,12 @@ protocol TabDelegate: AnyObject {
 
     func tabDidRequestRefresh(tab: TabViewController)
     func tabDidRequestNavigationToDifferentSite(tab: TabViewController)
+}
+
+extension TabDelegate {
+
+    func tabDidRequestClose(_ tab: TabViewController) {
+        tabDidRequestClose(tab, shouldCreateEmptyTabAtSamePosition: false)
+    }
+    
 }

--- a/DuckDuckGo/TabManager.swift
+++ b/DuckDuckGo/TabManager.swift
@@ -307,6 +307,12 @@ class TabManager {
         save()
     }
 
+    func replaceTab(at index: Int, withNewTab newTab: Tab) {
+        model.remove(at: index)
+        model.insert(tab: newTab, at: index)
+        save()
+    }
+
     private func removeFromCache(_ controller: TabViewController) {
         if let index = tabControllerCache.firstIndex(of: controller) {
             tabControllerCache.remove(at: index)

--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -3164,8 +3164,8 @@ extension UserContentController {
 
 extension TabViewController: SpecialErrorPageNavigationDelegate {
 
-    func closeSpecialErrorPageTab() {
-        delegate?.tabDidRequestClose(self)
+    func closeSpecialErrorPageTab(shouldCreateNewEmptyTab: Bool) {
+        delegate?.tabDidRequestClose(self, shouldCreateEmptyTabAtSamePosition: shouldCreateNewEmptyTab)
     }
 
 }

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -152,10 +152,9 @@ final class MockMaliciousSiteFileStore: MaliciousSiteProtection.FileStoring {
     var didWriteToDisk: Bool = false
     var didReadFromDisk: Bool = false
 
-    func write(data: Data, to filename: String) -> Bool {
+    func write(data: Data, to filename: String) throws {
         didWriteToDisk = true
         storage[filename] = data
-        return true
     }
 
     func read(from filename: String) -> Data? {

--- a/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -147,6 +147,23 @@ final class MockBackgroundRefreshApplication: BackgroundRefreshCapable {
     var backgroundRefreshStatus: UIBackgroundRefreshStatus = .available
 }
 
+final class MockMaliciousSiteFileStore: MaliciousSiteProtection.FileStoring {
+    private var storage: [String: Data] = [:]
+    var didWriteToDisk: Bool = false
+    var didReadFromDisk: Bool = false
+
+    func write(data: Data, to filename: String) -> Bool {
+        didWriteToDisk = true
+        storage[filename] = data
+        return true
+    }
+
+    func read(from filename: String) -> Data? {
+        didReadFromDisk = true
+        return storage[filename]
+    }
+}
+
 final class MockMaliciousSiteDetector: MaliciousSiteProtection.MaliciousSiteDetecting {
 
     var isMalicious: (URL) -> MaliciousSiteProtection.ThreatKind? = { url in

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -46,7 +46,7 @@ final class MockTabDelegate: TabDelegate {
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewWebViewWithConfiguration configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) -> WKWebView? { nil }
 
-    func tabDidRequestClose(_ tab: DuckDuckGo.TabViewController) {}
+    func tabDidRequestClose(_ tab: DuckDuckGo.TabViewController, shouldCreateEmptyTabAtSamePosition: Bool) {}
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewTabForUrl url: URL, openedByPage: Bool, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}
 

--- a/DuckDuckGoTests/SpecialErrorPage/MaliciousSiteProtectionNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/MaliciousSiteProtectionNavigationHandlerTests.swift
@@ -133,7 +133,7 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
         "Handle known threat in Main Frame",
         arguments: [
             ThreatKind.phishing,
-                .malware
+            .malware
         ]
     )
     func whenThreatKindIsNotNil_AndNavigationIsMainFrame_ThenReturnNavigationHandledMainFrame(threat: ThreatKind) async throws {
@@ -156,7 +156,7 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
         "Handle known threat in IFrame",
         arguments: [
             ThreatKind.phishing,
-                .malware
+            .malware
         ]
     )
     func whenThreatKindIsNotNil_AndNavigationIsIFrame_ThenReturnNavigationHandledIFrame(threat: ThreatKind) async throws {
@@ -178,7 +178,8 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
     @Test(
         "Visit Site sets Exemption URL and Threat Kind",
         arguments: [
-            ThreatKind.phishing, .malware
+            ThreatKind.phishing,
+            .malware
         ]
     )
     func whenVisitSiteActionThenSetExemptionURLAndThreatKind(threat: ThreatKind) throws {

--- a/DuckDuckGoTests/SpecialErrorPage/MaliciousSiteProtectionNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/MaliciousSiteProtectionNavigationHandlerTests.swift
@@ -48,7 +48,7 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
     func unhandledURLTypes(path: String) async throws {
         // GIVEN
         let url = try #require(URL(string: path))
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
 
         // WHEN
         sut.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
@@ -85,7 +85,7 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
         let url = try #require(URL(string: "https://www.example.com"))
         mockMaliciousSiteProtectionManager.threatKind = threat
         sut.visitSite(url: url, errorData: .maliciousSite(kind: threat, url: url))
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
 
         // WHEN
         sut.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
@@ -99,7 +99,7 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
     func whenHandleDecidePolicyForNavigationResponse_AndTaskIsNotNil_ReturnTaskAndRemoveItFromTheDictionary() throws {
         // GIVEN
         let url = try #require(URL(string: "https://www.example.com"))
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
         let navigationResponse = MockNavigationResponse.with(url: url)
         #expect(sut.maliciousSiteDetectionTasks[url] != nil)
@@ -116,7 +116,7 @@ struct MaliciousSiteProtectionNavigationHandlerTests {
     func whenThreatKindIsNilThenReturnNavigationNotHandled() async throws {
         // GIVEN
         let url = try #require(URL(string: "https://www.example.com"))
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
         mockMaliciousSiteProtectionManager.threatKind = nil
         sut.makeMaliciousSiteDetectionTask(for: navigationAction, webView: webView)
         let navigationResponse = MockNavigationResponse.with(url: url)

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerIntegrationTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerIntegrationTests.swift
@@ -40,10 +40,10 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         sslErrorPageNavigationHandler = SSLErrorPageNavigationHandler(featureFlagger: featureFlagger)
         let preferencesManager = MockMaliciousSiteProtectionPreferencesManager()
         preferencesManager.isMaliciousSiteProtectionOn = true
-        let maliciousSiteProtectionFeatureFlags = MockMaliciousSiteProtectionFeatureFlags()
+        maliciousSiteProtectionFeatureFlags = MockMaliciousSiteProtectionFeatureFlags()
         maliciousSiteProtectionFeatureFlags.isMaliciousSiteProtectionEnabled = true
         maliciousSiteProtectionFeatureFlags.shouldDetectMaliciousThreatForDomainResult = true
-        let maliciousSiteProtectionManager = MaliciousSiteProtectionManager(
+        maliciousSiteProtectionManager = MaliciousSiteProtectionManager(
             dataFetcher: MockMaliciousSiteProtectionDataFetcher(),
             api: MaliciousSiteProtectionAPI(),
             dataManager: MaliciousSiteProtection.DataManager(

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerIntegrationTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerIntegrationTests.swift
@@ -291,7 +291,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         let url = try #require(URL(string: threatInfo.path))
         webView.setCurrentURL(url)
         sut.attachWebView(webView)
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: navigationAction, webView: webView)
         let response = MockNavigationResponse.with(url: url)
         _ = await sut.handleDecidePolicy(for: response, webView: webView)
@@ -311,7 +311,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         let url = try #require(URL(string: "http://privacy-test-pages.site/"))
         webView.setCurrentURL(url)
         sut.attachWebView(webView)
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: navigationAction, webView: webView)
         let response = MockNavigationResponse.with(url: url)
 
@@ -335,7 +335,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         let url = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
         webView.setCurrentURL(url)
         sut.attachWebView(webView)
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: navigationAction, webView: webView)
         let response = MockNavigationResponse.with(url: url)
 
@@ -370,7 +370,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         let url = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
         webView.setCurrentURL(url)
         sut.attachWebView(webView)
-        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: navigationAction, webView: webView)
         let response = MockNavigationResponse.with(url: url)
 
@@ -396,7 +396,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         sut.attachWebView(webView)
         let maliciousURL = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
         webView.setCurrentURL(maliciousURL)
-        let maliciousSiteNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL))
+        let maliciousSiteNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: maliciousSiteNavigationAction, webView: webView)
         let maliciousSiteResponse = MockNavigationResponse.with(url: maliciousURL)
 
@@ -421,7 +421,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         // GIVEN
         let safeURL = try #require(URL(string: "http://broken.third-party.site/"))
         webView.setCurrentURL(safeURL)
-        let safeSiteNavigationAction = MockNavigationAction(request: URLRequest(url: safeURL))
+        let safeSiteNavigationAction = MockNavigationAction(request: URLRequest(url: safeURL), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: safeSiteNavigationAction, webView: webView)
         let safeSiteResponse = MockNavigationResponse.with(url: safeURL)
 
@@ -447,7 +447,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         sut.attachWebView(webView)
         let maliciousURL = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
         webView.setCurrentURL(maliciousURL)
-        let maliciousSiteNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL))
+        let maliciousSiteNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: maliciousSiteNavigationAction, webView: webView)
         let maliciousSiteResponse = MockNavigationResponse.with(url: maliciousURL)
 
@@ -472,7 +472,7 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         // GIVEN
         let safeURL = try #require(URL(string: "http://duckduckgo.com/"))
         webView.setCurrentURL(safeURL)
-        let safeSiteNavigationAction = MockNavigationAction(request: URLRequest(url: safeURL))
+        let safeSiteNavigationAction = MockNavigationAction(request: URLRequest(url: safeURL), targetFrame: MockFrameInfo(isMainFrame: true))
         sut.handleDecidePolicy(for: safeSiteNavigationAction, webView: webView)
         let safeSiteResponse = MockNavigationResponse.with(url: safeURL)
 

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerIntegrationTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerIntegrationTests.swift
@@ -28,12 +28,14 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
     private var sut: SpecialErrorPageNavigationHandler!
     private var webView: MockSpecialErrorWebView!
     private var sslErrorPageNavigationHandler: SSLErrorPageNavigationHandler!
+    private var maliciousSiteProtectionManager: MaliciousSiteProtectionManager!
+    private var maliciousSiteProtectionFeatureFlags: MockMaliciousSiteProtectionFeatureFlags!
     private var maliciousSiteProtectionNavigationHandler: MaliciousSiteProtectionNavigationHandler!
 
     @MainActor
     init() {
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.sslCertificatesBypass]
+        featureFlagger.enabledFeatureFlags = [.sslCertificatesBypass, .maliciousSiteProtection]
         webView = MockSpecialErrorWebView(frame: CGRect(), configuration: .nonPersistent())
         sslErrorPageNavigationHandler = SSLErrorPageNavigationHandler(featureFlagger: featureFlagger)
         let preferencesManager = MockMaliciousSiteProtectionPreferencesManager()
@@ -60,18 +62,14 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
             maliciousSiteProtectionFeatureFlagger: maliciousSiteProtectionFeatureFlags
         )
         maliciousSiteProtectionNavigationHandler = MaliciousSiteProtectionNavigationHandler(maliciousSiteProtectionManager: maliciousSiteProtectionManager)
+        
         sut = SpecialErrorPageNavigationHandler(
             sslErrorPageNavigationHandler: sslErrorPageNavigationHandler,
             maliciousSiteProtectionNavigationHandler: maliciousSiteProtectionNavigationHandler
         )
     }
 
-    deinit {
-        sslErrorPageNavigationHandler = nil
-        maliciousSiteProtectionNavigationHandler = nil
-        sut = nil
-        webView = nil
-    }
+    // MARK: - SSL
 
     @MainActor
     @Test
@@ -277,6 +275,8 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         #expect(script.isEnabled)
     }
 
+    // MARK: - Malicious Site Protection
+
     @MainActor
     @Test(
         "Test Current Threat Kind Returns Threat Kind",
@@ -303,4 +303,190 @@ final class SpecialErrorPageNavigationHandlerIntegrationTests {
         // THEN
         #expect(result == threatInfo.threat)
     }
+
+    @MainActor
+    @Test
+    func whenNoMaliciousThreatIsDetectedThenSpecialErrorPageIsNotLoaded() async throws {
+        // GIVEN
+        let url = try #require(URL(string: "http://privacy-test-pages.site/"))
+        webView.setCurrentURL(url)
+        sut.attachWebView(webView)
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        sut.handleDecidePolicy(for: navigationAction, webView: webView)
+        let response = MockNavigationResponse.with(url: url)
+
+        await confirmation(expectedCount: 0) { receivedHTML in
+            webView.loadRequestHandler = { _, _ in
+                receivedHTML()
+            }
+
+            // WHEN
+            let result = await sut.handleDecidePolicy(for: response, webView: webView)
+
+            // THEN
+            #expect(!result)
+        }
+    }
+
+    @MainActor
+    @Test
+    func whenPhishingThreatIsDetectedThenSpecialErrorPageIsLoaded() async throws {
+        // GIVEN
+        let url = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
+        webView.setCurrentURL(url)
+        sut.attachWebView(webView)
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        sut.handleDecidePolicy(for: navigationAction, webView: webView)
+        let response = MockNavigationResponse.with(url: url)
+
+        var expectedHTML: String?
+
+        try await confirmation { receivedHTML in
+            webView.loadRequestHandler = { _, html in
+                expectedHTML = html
+                receivedHTML()
+            }
+
+            // WHEN
+            let result = await sut.handleDecidePolicy(for: response, webView: webView)
+
+            // THEN
+            #expect(result)
+            #expect(sut.failedURL == url)
+            #expect(sut.errorData == .maliciousSite(kind: .phishing, url: url))
+            #expect(sut.isSpecialErrorPageRequest)
+            #expect(sut.isSpecialErrorPageVisible)
+            let html = try #require(expectedHTML)
+            #expect(html.contains("Warning: This site may put your personal information at risk"))
+            #expect(html.contains("This website may be impersonating a legitimate site in order to trick you into providing personal information, such as passwords or credit card numbers."))
+        }
+    }
+
+    @MainActor
+    @Test
+    func wheanMaliciousSiteProtectionDisabledThenSpecialErrorPageIsNotLoaded() async throws {
+        // GIVEN
+        maliciousSiteProtectionFeatureFlags.shouldDetectMaliciousThreatForDomainResult = false
+        let url = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
+        webView.setCurrentURL(url)
+        sut.attachWebView(webView)
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url))
+        sut.handleDecidePolicy(for: navigationAction, webView: webView)
+        let response = MockNavigationResponse.with(url: url)
+
+        await confirmation(expectedCount: 0) { receivedHTML in
+            webView.loadRequestHandler = { _, _ in
+                receivedHTML()
+            }
+
+            // WHEN
+            let result = await sut.handleDecidePolicy(for: response, webView: webView)
+
+            // THEN
+            #expect(!result)
+        }
+    }
+
+    @MainActor
+    @Test
+    func whenLoadingASafeWebsiteAfterDetectingAThreat_ThenSpecialErrorPageIsNotLoaded() async throws {
+        // LOAD MALICIOUS WEBSITE
+
+        // GIVEN
+        sut.attachWebView(webView)
+        let maliciousURL = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
+        webView.setCurrentURL(maliciousURL)
+        let maliciousSiteNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL))
+        sut.handleDecidePolicy(for: maliciousSiteNavigationAction, webView: webView)
+        let maliciousSiteResponse = MockNavigationResponse.with(url: maliciousURL)
+
+        await confirmation { receivedHTML in
+            webView.loadRequestHandler = { _, _ in
+                receivedHTML()
+            }
+
+            // WHEN
+            let maliciousResult = await sut.handleDecidePolicy(for: maliciousSiteResponse, webView: webView)
+
+            // THEN
+            #expect(maliciousResult)
+            #expect(sut.failedURL == maliciousURL)
+            #expect(sut.errorData == .maliciousSite(kind: .phishing, url: maliciousURL))
+            #expect(sut.isSpecialErrorPageRequest)
+            #expect(sut.isSpecialErrorPageVisible)
+        }
+
+        // LOAD SAFE WEBSITE
+
+        // GIVEN
+        let safeURL = try #require(URL(string: "http://broken.third-party.site/"))
+        webView.setCurrentURL(safeURL)
+        let safeSiteNavigationAction = MockNavigationAction(request: URLRequest(url: safeURL))
+        sut.handleDecidePolicy(for: safeSiteNavigationAction, webView: webView)
+        let safeSiteResponse = MockNavigationResponse.with(url: safeURL)
+
+        await confirmation(expectedCount: 0) { receivedHTML in
+            webView.loadRequestHandler = { _, _ in
+                receivedHTML()
+            }
+
+            // WHEN
+            let result = await sut.handleDecidePolicy(for: safeSiteResponse, webView: webView)
+
+            // THEN
+            #expect(!result)
+        }
+    }
+
+    @MainActor
+    @Test
+    func whenLoadingDDGWebsiteAfterDetectingAThreat_ThenSpecialErrorPageIsNotLoaded() async throws {
+        // LOAD MALICIOUS WEBSITE
+
+        // GIVEN
+        sut.attachWebView(webView)
+        let maliciousURL = try #require(URL(string: "http://privacy-test-pages.site/security/badware/phishing.html"))
+        webView.setCurrentURL(maliciousURL)
+        let maliciousSiteNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL))
+        sut.handleDecidePolicy(for: maliciousSiteNavigationAction, webView: webView)
+        let maliciousSiteResponse = MockNavigationResponse.with(url: maliciousURL)
+
+        await confirmation { receivedHTML in
+            webView.loadRequestHandler = { _, _ in
+                receivedHTML()
+            }
+
+            // WHEN
+            let maliciousResult = await sut.handleDecidePolicy(for: maliciousSiteResponse, webView: webView)
+
+            // THEN
+            #expect(maliciousResult)
+            #expect(sut.failedURL == maliciousURL)
+            #expect(sut.errorData == .maliciousSite(kind: .phishing, url: maliciousURL))
+            #expect(sut.isSpecialErrorPageRequest)
+            #expect(sut.isSpecialErrorPageVisible)
+        }
+
+        // LOAD DDG WEBSITE
+
+        // GIVEN
+        let safeURL = try #require(URL(string: "http://duckduckgo.com/"))
+        webView.setCurrentURL(safeURL)
+        let safeSiteNavigationAction = MockNavigationAction(request: URLRequest(url: safeURL))
+        sut.handleDecidePolicy(for: safeSiteNavigationAction, webView: webView)
+        let safeSiteResponse = MockNavigationResponse.with(url: safeURL)
+
+        await confirmation(expectedCount: 0) { receivedHTML in
+            webView.loadRequestHandler = { _, _ in
+                receivedHTML()
+            }
+
+            // WHEN
+            let result = await sut.handleDecidePolicy(for: safeSiteResponse, webView: webView)
+
+            // THEN
+            #expect(!result)
+        }
+    }
+
 }

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
@@ -297,7 +297,7 @@ final class SpecialErrorPageNavigationHandlerTests {
     }
 
     @MainActor
-    @Test("Lave Site closes Tab when SSL Error")
+    @Test("Leave Site closes Tab when SSL Error")
     func whenLeaveSite_AndSSLError_AndWebViewCannotNavigateBack_ThenAskDelegateToCloseTab() {
         // GIVEN
         webView.setCanGoBack(false)
@@ -306,12 +306,14 @@ final class SpecialErrorPageNavigationHandlerTests {
         sut.attachWebView(webView)
         sut.handleWebView(webView, didFailProvisionalNavigation: DummyWKNavigation(), withError: .genericSSL)
         #expect(!delegate.didCallCloseSpecialErrorPageTab)
+        #expect(!delegate.capturedShouldCreateNewEmptyTab)
 
         // WHEN
         sut.leaveSiteAction()
 
         // THEN
         #expect(delegate.didCallCloseSpecialErrorPageTab)
+        #expect(!delegate.capturedShouldCreateNewEmptyTab)
     }
 
     @MainActor
@@ -337,13 +339,15 @@ final class SpecialErrorPageNavigationHandlerTests {
         let delegate = SpySpecialErrorPageNavigationDelegate()
         sut.delegate = delegate
         #expect(!delegate.didCallCloseSpecialErrorPageTab)
-        
+        #expect(!delegate.capturedShouldCreateNewEmptyTab)
+
 
         // WHEN
         sut.leaveSiteAction()
 
         // THEN
         #expect(delegate.didCallCloseSpecialErrorPageTab)
+        #expect(delegate.capturedShouldCreateNewEmptyTab)
     }
 
     @MainActor

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
@@ -66,6 +66,34 @@ final class SpecialErrorPageNavigationHandlerTests {
     }
 
     @MainActor
+    @Test
+    func whenHandleDecidePolicyForNavigationActionIsCalled_AndNavigationIsMainFrame_ThenResetErrorData() async throws {
+        // GIVEN
+        let maliciousURL = try #require(URL(string: "https://www.phishing.com"))
+        webView.setCurrentURL(maliciousURL)
+        let errorData = SpecialErrorData.maliciousSite(kind: .phishing, url: maliciousURL)
+        let maliciousNavigationAction = MockNavigationAction(request: URLRequest(url: maliciousURL), targetFrame: MockFrameInfo(isMainFrame: true))
+        let maliciousNavigationResponse = MockNavigationResponse.with(url: maliciousURL)
+        maliciousSiteProtectionNavigationHandler.task = Task {
+            .navigationHandled(.mainFrame(MaliciousSiteDetectionNavigationResponse(navigationAction: maliciousNavigationAction, errorData: errorData)))
+        }
+        _ = await sut.handleDecidePolicy(for: maliciousNavigationResponse, webView: webView)
+        #expect(sut.errorData == errorData)
+        #expect(sut.failedURL == maliciousURL)
+
+        let url = try #require(URL(string: "https://www.example.com"))
+        webView.setCurrentURL(url)
+        let navigationAction = MockNavigationAction(request: URLRequest(url: url), targetFrame: MockFrameInfo(isMainFrame: true))
+
+        // WHEN
+        sut.handleDecidePolicy(for: navigationAction, webView: webView)
+
+        // THEN
+        #expect(sut.errorData == nil)
+        #expect(sut.failedURL == nil)
+    }
+
+    @MainActor
     @Test("Decide Policy For Navigation Response forwards event to Malicious Site Protection Handler")
     func whenHandleDecidePolicyforNavigationResponseThenAskMaliciousSiteProtectionNavigationHandlerToHandleTheDecision() async throws {
         // GIVEN

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
@@ -190,6 +190,7 @@ final class SpecialErrorPageNavigationHandlerTests {
 
         // THEN
         #expect(sut.isSpecialErrorPageRequest == false)
+        #expect(sut.isSpecialErrorPageVisible == false)
         #expect(sut.failedURL == nil)
         #expect(didCallLoadSimulatedRequest == false)
         #expect(result == false)

--- a/DuckDuckGoTests/SpecialErrorPage/TestDoubles/MockSpecialErrorPageNavigationDelegate.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/TestDoubles/MockSpecialErrorPageNavigationDelegate.swift
@@ -22,8 +22,10 @@ import Foundation
 
 final class SpySpecialErrorPageNavigationDelegate: SpecialErrorPageNavigationDelegate {
     private(set) var didCallCloseSpecialErrorPageTab: Bool = false
+    private(set) var capturedShouldCreateNewEmptyTab: Bool = false
 
-    func closeSpecialErrorPageTab() {
+    func closeSpecialErrorPageTab(shouldCreateNewEmptyTab: Bool) {
         didCallCloseSpecialErrorPageTab = true
+        capturedShouldCreateNewEmptyTab = shouldCreateNewEmptyTab
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208758247571054/f
CC: @not-a-rootkit

Description:

Integrate BSK library for malicious threat detection.

Steps to test this PR:

Prerequisites: Return true in MaliciousSiteProtectionFeatureFlags.swift -> isMaliciousSiteProtectionEnabled and shouldDetectMaliciousThreat(forDomain domain: String?) -> Bool

**Scenario 1 - Phishing**

1. Navigate to http://privacy-test-pages.site/security/badware/phishing.html
2. Ensure special error pages is shown.

**Scenario 2 - Malware**

1. Navigate to http://privacy-test-pages.site/security/badware/malware.html
2. Ensure special error pages is shown.

**Scenario 3 - Leave Site Creates an Empty Tab at same index of the tab closed**

1. Open multiple tabs and load some random websites
2. Open a tab and load a malicious website.
3. When the special error page is shown, tap the “Leave Site” Button.
4. Ensure that when the Tab is closed a new empty one is created at the same index.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
