### PR TITLE
Handle duck.ai bang

### DIFF
--- a/DuckDuckGo/TabViewController.swift
+++ b/DuckDuckGo/TabViewController.swift
@@ -1763,9 +1763,7 @@ extension TabViewController: WKNavigationDelegate {
             if !tabURLInterceptor.allowsNavigatingTo(url: url) {
                 decisionHandler(.cancel)
                 // If there is history or a page loaded keep the tab open
-                if self.currentlyLoadedURL != nil {
-                    refresh()
-                } else {
+                if self.currentlyLoadedURL == nil {
                     delegate?.tabDidRequestClose(self)
                 }
                 return

--- a/LocalPackages/AIChat/Sources/AIChat/URL+Extension.swift
+++ b/LocalPackages/AIChat/Sources/AIChat/URL+Extension.swift
@@ -24,6 +24,9 @@ extension URL {
         static let duckDuckGoHost = "duckduckgo.com"
         static let chatQueryName = "ia"
         static let chatQueryValue = "chat"
+
+        static let bangQueryName = "q"
+        static let bangQueryPrefix = "!ai"
     }
 
     func addingOrReplacingQueryItem(_ queryItem: URLQueryItem) -> URL {
@@ -49,6 +52,20 @@ extension URL {
             return false
         }
 
-        return queryItems.contains { $0.name == Constants.chatQueryName && $0.value == Constants.chatQueryValue }
+        return queryItems.contains { $0.name == Constants.chatQueryName && $0.value == Constants.chatQueryValue } || self.isDuckAIBang
     }
+
+    public var isDuckAIBang: Bool {
+        guard let host = self.host, host == Constants.duckDuckGoHost else {
+            return false
+        }
+
+        guard let urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let queryItems = urlComponents.queryItems else {
+            return false
+        }
+
+        return queryItems.contains { $0.name == Constants.bangQueryName && $0.value?.hasPrefix(Constants.bangQueryPrefix) == true }
+    }
+
 }

--- a/LocalPackages/AIChat/Tests/URLExtensionTests.swift
+++ b/LocalPackages/AIChat/Tests/URLExtensionTests.swift
@@ -143,6 +143,62 @@ final class URLExtensionTests: XCTestCase {
             XCTFail("Failed to create URL from string.")
         }
     }
+
+    /// Duck AI Bang
+    func testIsDuckAIBangWithValidBangQuery() {
+        let urlString = "https://duckduckgo.com/?q=!ai+some+query"
+        if let url = URL(string: urlString) {
+            XCTAssertTrue(url.isDuckAIBang, "The URL should be identified as a DuckDuckGo AI Bang URL.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithInvalidBangQuery() {
+        let urlString = "https://duckduckgo.com/?q=some+query"
+        if let url = URL(string: urlString) {
+            XCTAssertFalse(url.isDuckAIBang, "The URL should not be identified as a DuckDuckGo AI Bang URL due to missing bang prefix.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithDifferentBangPrefix() {
+        let urlString = "https://duckduckgo.com/?q=!other+query"
+        if let url = URL(string: urlString) {
+            XCTAssertFalse(url.isDuckAIBang, "The URL should not be identified as a DuckDuckGo AI Bang URL due to different bang prefix.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithMultipleQueryItems() {
+        let urlString = "https://duckduckgo.com/?q=!ai+some+query&other=param"
+        if let url = URL(string: urlString) {
+            XCTAssertTrue(url.isDuckAIBang, "The URL should be identified as a DuckDuckGo AI Bang URL even with additional query items.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithMissingQueryItem() {
+        let urlString = "https://duckduckgo.com/"
+        if let url = URL(string: urlString) {
+            XCTAssertFalse(url.isDuckAIBang, "The URL should not be identified as a DuckDuckGo AI Bang URL due to missing query item.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithNilQueryValue() {
+        let urlString = "https://duckduckgo.com/?q="
+        if let url = URL(string: urlString) {
+            XCTAssertFalse(url.isDuckAIBang, "The URL should not be identified as a DuckDuckGo AI Bang URL due to nil query value.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
 }
 
 extension URL {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209233138534045/f
Tech Design URL:
CC:

**Description**:
Fix loop when opening duck.ai bang

**Steps to test this PR**:
1. Host [this](https://gist.github.com/Bunn/af1edcf2dd4e1160e6e38862c052fcbf) site locally to test duck.ai and privacy pro
2. Use this config file http://jsonblob.com/api/1332301684340350976
3. Test if privacy pro links are working with both the hosted page above or directly opening duckduckgo.com/pro
4. Check if using the bang “!ai test” opens duck.ai


**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

