### PR TITLE
Support multiple bangs

### DIFF
--- a/LocalPackages/AIChat/Sources/AIChat/URL+Extension.swift
+++ b/LocalPackages/AIChat/Sources/AIChat/URL+Extension.swift
@@ -26,7 +26,7 @@ extension URL {
         static let chatQueryValue = "chat"
 
         static let bangQueryName = "q"
-        static let bangQueryPrefix = "!ai"
+        static let supportedBangs: Set<String> = ["ai", "aichat", "chat", "duckai"]
     }
 
     func addingOrReplacingQueryItem(_ queryItem: URLQueryItem) -> URL {
@@ -65,7 +65,19 @@ extension URL {
             return false
         }
 
-        return queryItems.contains { $0.name == Constants.bangQueryName && $0.value?.hasPrefix(Constants.bangQueryPrefix) == true }
+        return queryItems.contains { $0.name == Constants.bangQueryName && hasSupportedBangPrefix($0.value) }
+    }
+
+    private func hasSupportedBangPrefix(_ input: String?) -> Bool {
+        guard let input = input else {
+            return false
+        }
+
+        /// Bangs can be used either at the beginning or at the end of a query.
+        let bangValues = Constants.supportedBangs.flatMap { bang in
+            return ["!\(bang)", "\(bang)!"]
+        }
+        return bangValues.contains { input.hasPrefix($0) }
     }
 
 }

--- a/LocalPackages/AIChat/Tests/URLExtensionTests.swift
+++ b/LocalPackages/AIChat/Tests/URLExtensionTests.swift
@@ -145,8 +145,35 @@ final class URLExtensionTests: XCTestCase {
     }
 
     /// Duck AI Bang
-    func testIsDuckAIBangWithValidBangQuery() {
+    func testIsDuckAIBangWithValidAIBangQuery() {
         let urlString = "https://duckduckgo.com/?q=!ai+some+query"
+        if let url = URL(string: urlString) {
+            XCTAssertTrue(url.isDuckAIBang, "The URL should be identified as a DuckDuckGo AI Bang URL.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithValidAIEndingBangQuery() {
+        let urlString = "https://duckduckgo.com/?q=ai!+some+query"
+        if let url = URL(string: urlString) {
+            XCTAssertTrue(url.isDuckAIBang, "The URL should be identified as a DuckDuckGo AI Bang URL.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithValidChatBangQuery() {
+        let urlString = "https://duckduckgo.com/?q=!chat+some+query"
+        if let url = URL(string: urlString) {
+            XCTAssertTrue(url.isDuckAIBang, "The URL should be identified as a DuckDuckGo AI Bang URL.")
+        } else {
+            XCTFail("Failed to create URL from string.")
+        }
+    }
+
+    func testIsDuckAIBangWithValidChatEndingBangQuery() {
+        let urlString = "https://duckduckgo.com/?q=chat!+some+query"
         if let url = URL(string: urlString) {
             XCTAssertTrue(url.isDuckAIBang, "The URL should be identified as a DuckDuckGo AI Bang URL.")
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209237779934842/f

**Description**:
Add support for more bangs combinations

**Steps to test this PR**:
1. Use this config file http://jsonblob.com/api/1332301684340350976
2. Open the app and type !ai test, it should open the custom duck.ai
3. Test the same with other bangs like aichat, and chat (duck.ai is not yet supported in the FE)

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

