### PR TITLE
Fix an issue that caused  the TunnelVision-fix not to be publicly available

### DIFF
--- a/Core/FeatureFlag.swift
+++ b/Core/FeatureFlag.swift
@@ -139,7 +139,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .textZoom:
             return .remoteReleasable(.feature(.textZoom))
         case .networkProtectionEnforceRoutes:
-            return .remoteDevelopment(.subfeature(NetworkProtectionSubfeature.enforceRoutes))
+            return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.enforceRoutes))
         case .adAttributionReporting:
             return .remoteReleasable(.feature(.adAttributionReporting))
         case .crashReportOptInStatusResetting:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1209262365365751/f

## Description

Our TunnelVision exploit fix was not released publicly due to a mistake that's being addressed here.

## Testing

1. Connect to a network with TunnelVision enabled.
2. Run our app and make sure you're not an internal user.
3. Start the VPN
4. Check that TunnelVision is guarded against.
5. Check with another VPN that it fails to address TunnelVision.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
