### PR TITLE
Malicious Site Protection - Optional clientSideHit parameter

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -2096,7 +2096,7 @@ extension Pixel.Event {
 public extension Pixel.Event {
 
     enum MaliciousSiteProtectionEvent: Equatable {
-        case errorPageShown(category: ThreatKind, clientSideHit: Bool)
+        case errorPageShown(category: ThreatKind, clientSideHit: Bool?)
         case visitSite(category: ThreatKind)
         case iframeLoaded(category: ThreatKind)
         case settingToggled(to: Bool)

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit",
       "state" : {
         "branch" : "alessandro/malicious-site-protection-ios",
-        "revision" : "e3520f7f4c1957524d76ac658b60d3e61d216cbb"
+        "revision" : "02091eab94333f26836602407a6aa40b78572f5e"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1209242004458518/f

**Description**:

Update BSK Ref to version where clientSideHit pixel parameter is optional

**Steps to test this PR**:
1. Ensure CI is green.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
