### PR TITLE
Fix broken state on failed purchase

### DIFF
--- a/Core/PixelEvent.swift
+++ b/Core/PixelEvent.swift
@@ -810,6 +810,15 @@ extension Pixel {
         case privacyProSubscriptionCookieRefreshedWithEmptyValue
         case privacyProSubscriptionCookieFailedToSetSubscriptionCookie
 
+        case settingsPrivacyProAccountWithNoSubscriptionFound
+
+        case privacyProActivatingRestoreErrorMissingAccountOrTransactions
+        case privacyProActivatingRestoreErrorPastTransactionAuthenticationError
+        case privacyProActivatingRestoreErrorFailedToObtainAccessToken
+        case privacyProActivatingRestoreErrorFailedToFetchAccountDetails
+        case privacyProActivatingRestoreErrorFailedToFetchSubscriptionDetails
+        case privacyProActivatingRestoreErrorSubscriptionExpired
+
         // MARK: Pixel Experiment
         case pixelExperimentEnrollment
 
@@ -1770,6 +1779,15 @@ extension Pixel.Event {
         case .privacyProSubscriptionCookieRefreshedWithAccessToken: return "m_privacy-pro_subscription-cookie-refreshed_with_access_token"
         case .privacyProSubscriptionCookieRefreshedWithEmptyValue: return "m_privacy-pro_subscription-cookie-refreshed_with_empty_value"
         case .privacyProSubscriptionCookieFailedToSetSubscriptionCookie: return "m_privacy-pro_subscription-cookie-failed_to_set_subscription_cookie"
+
+        case .settingsPrivacyProAccountWithNoSubscriptionFound: return "m_settings_privacy-pro_account_with_no_subscription_found"
+
+        case .privacyProActivatingRestoreErrorMissingAccountOrTransactions: return "m_privacy-pro_activating_restore_error_missing_account_or_transactions"
+        case .privacyProActivatingRestoreErrorPastTransactionAuthenticationError: return "m_privacy-pro_activating_restore_error_past_transaction_authentication_error"
+        case .privacyProActivatingRestoreErrorFailedToObtainAccessToken: return "m_privacy-pro_activating_restore_error_failed_to_obtain_access_token"
+        case .privacyProActivatingRestoreErrorFailedToFetchAccountDetails: return "m_privacy-pro_activating_restore_error_failed_to_fetch_account_details"
+        case .privacyProActivatingRestoreErrorFailedToFetchSubscriptionDetails: return "m_privacy-pro_activating_restore_error_failed_to_fetch_subscription_details"
+        case .privacyProActivatingRestoreErrorSubscriptionExpired: return "m_privacy-pro_activating_restore_error_subscription_expired"
 
         // MARK: Pixel Experiment
         case .pixelExperimentEnrollment: return "pixel_experiment_enrollment"

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -39,6 +39,7 @@ struct SettingsState {
     struct Subscription: Codable {
         var canPurchase: Bool
         var isSignedIn: Bool
+        var hasSubscription: Bool
         var hasActiveSubscription: Bool
         var isRestoring: Bool
         var shouldDisplayRestoreSubscriptionError: Bool
@@ -137,6 +138,7 @@ struct SettingsState {
             networkProtectionConnected: false,
             subscription: Subscription(canPurchase: false,
                                        isSignedIn: false,
+                                       hasSubscription: false,
                                        hasActiveSubscription: false,
                                        isRestoring: false,
                                        shouldDisplayRestoreSubscriptionError: false,

--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -154,7 +154,7 @@ struct SettingsSubscriptionView: View {
     }
 
     @ViewBuilder
-    private var noEntitlementsAvailableView: some View {
+    private var missingSubscriptionOrEntitlementsView: some View {
         disabledFeaturesView
         
         // Renew Subscription (Expired)
@@ -233,8 +233,9 @@ struct SettingsSubscriptionView: View {
             if isShowingPrivacyPro {
 
                 let isSignedIn = settingsViewModel.state.subscription.isSignedIn
+                let hasSubscription = settingsViewModel.state.subscription.hasSubscription
                 let hasActiveSubscription = settingsViewModel.state.subscription.hasActiveSubscription
-                let hasNoEntitlements = settingsViewModel.state.subscription.entitlements.isEmpty
+                let hasAnyEntitlements = !settingsViewModel.state.subscription.entitlements.isEmpty
 
                 let footerLink = Link(UserText.settingsPProSectionFooter,
                                       destination: ViewConstants.privacyPolicyURL)
@@ -244,23 +245,27 @@ struct SettingsSubscriptionView: View {
                         footer: !isSignedIn ? footerLink : nil
                 ) {
 
-                    switch (isSignedIn, hasActiveSubscription, hasNoEntitlements) {
+                    switch (isSignedIn, hasSubscription, hasActiveSubscription, hasAnyEntitlements) {
 
-                        // Signed In, Subscription Expired
-                    case (true, false, _):
+                    // Signed out
+                    case (false, _, _, _):
+                        purchaseSubscriptionView
+
+                    // Signed In, Subscription Missing
+                    case (true, false, _, _):
+                        missingSubscriptionOrEntitlementsView
+
+                    // Signed In, Subscription Present & Not Active
+                    case (true, true, false, _):
                         subscriptionExpiredView
-                        
-                        // Signed in, Subscription Active, Valid entitlements
-                    case (true, true, false):
-                        subscriptionDetailsView  // View for valid subscription details
-                        
-                        // Signed in, Subscription Active, Empty Entitlements
-                    case (true, true, true):
-                        noEntitlementsAvailableView  // View for no entitlements
-                        
-                        // Signed out
-                    case (false, _, _):
-                        purchaseSubscriptionView  // View for signing up or purchasing a subscription
+
+                    // Signed in, Subscription Present & Active, Missing Entitlements
+                    case (true, true, true, false):
+                        missingSubscriptionOrEntitlementsView
+
+                    // Signed in, Subscription Present & Active, Valid entitlements
+                    case (true, true, true, true):
+                        subscriptionDetailsView
                     }
                 }
                 .onReceive(subscriptionNavigationCoordinator.$shouldPopToAppSettings) { shouldDismiss in

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -780,7 +780,7 @@ extension SettingsViewModel {
             
         case .success(let subscription):
             state.subscription.platform = subscription.platform
-            state.subscription.hasActiveSubscription = true
+            state.subscription.hasSubscription = true
             state.subscription.hasActiveSubscription = subscription.isActive
 
             // Check entitlements and update state

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -865,7 +865,20 @@ extension SettingsViewModel {
                 }
             }
 
-            // TODO: Fire pixel for restoreFlowError
+            switch restoreFlowError {
+            case .missingAccountOrTransactions:
+                DailyPixel.fireDailyAndCount(pixel: .privacyProActivatingRestoreErrorMissingAccountOrTransactions)
+            case .pastTransactionAuthenticationError:
+                DailyPixel.fireDailyAndCount(pixel: .privacyProActivatingRestoreErrorPastTransactionAuthenticationError)
+            case .failedToObtainAccessToken:
+                DailyPixel.fireDailyAndCount(pixel: .privacyProActivatingRestoreErrorFailedToObtainAccessToken)
+            case .failedToFetchAccountDetails:
+                DailyPixel.fireDailyAndCount(pixel: .privacyProActivatingRestoreErrorFailedToFetchAccountDetails)
+            case .failedToFetchSubscriptionDetails:
+                DailyPixel.fireDailyAndCount(pixel: .privacyProActivatingRestoreErrorFailedToFetchSubscriptionDetails)
+            case .subscriptionExpired:
+                DailyPixel.fireDailyAndCount(pixel: .privacyProActivatingRestoreErrorSubscriptionExpired)
+            }
         }
     }
     

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -805,7 +805,7 @@ extension SettingsViewModel {
                     state.subscription.entitlements = []
                     state.subscription.platform = .unknown
 
-                    // TOOD: Fire pixel
+                    // TODO: Fire pixel for "No subscription found"
                 }
             }
         }
@@ -855,13 +855,17 @@ extension SettingsViewModel {
             }
             await self.setupSubscriptionEnvironment()
             
-        case .failure:
+        case .failure(let restoreFlowError):
             DispatchQueue.main.async {
                 self.state.subscription.isRestoring = false
                 self.state.subscription.shouldDisplayRestoreSubscriptionError = true
-                self.state.subscription.shouldDisplayRestoreSubscriptionError = false
                 
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self.state.subscription.shouldDisplayRestoreSubscriptionError = false
+                }
             }
+
+            // TODO: Fire pixel for restoreFlowError
         }
     }
     

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -805,7 +805,7 @@ extension SettingsViewModel {
                     state.subscription.entitlements = []
                     state.subscription.platform = .unknown
 
-                    // TODO: Fire pixel for "No subscription found"
+                    DailyPixel.fireDailyAndCount(pixel: .settingsPrivacyProAccountWithNoSubscriptionFound)
                 }
             }
         }

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -101,11 +101,6 @@ final class SubscriptionSettingsViewModel: ObservableObject {
             async let reloadedSubscription = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .reloadIgnoringLocalCacheData,
                                                                                           loadingIndicator: !hasLoadedSubscriptionFromCache)
             let (hasReloadedEmail, hasReloadedSubscription) = await (reloadedEmail, reloadedSubscription)
-
-            // In case any fetch fails show an error
-            if !hasReloadedEmail || !hasReloadedSubscription {
-                self.showConnectionError(true)
-            }
         }
     }
 

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -266,7 +266,8 @@ final class SubscriptionSettingsViewModel: ObservableObject {
 
     @MainActor
     func showTermsOfService() {
-        self.openURL(SettingsSubscriptionView.ViewConstants.privacyPolicyURL)
+        let privacyPolicyQuickLinkURL = URL(string: AppDeepLinkSchemes.quickLink.appending(SettingsSubscriptionView.ViewConstants.privacyPolicyURL.absoluteString))!
+        openURL(privacyPolicyQuickLinkURL)
     }
 
     // MARK: -

--- a/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -157,37 +157,56 @@ struct SubscriptionSettingsView: View {
                     }
                 }
 
-                SettingsCustomCell(content: {
-                    Text(UserText.subscriptionRemoveFromDevice)
-                        .daxBodyRegular()
-                    .foregroundColor(Color.init(designSystemColor: .accent))},
-                                   action: { viewModel.displayRemovalNotice(true) },
-                                   isButton: true)
+                removeFromDeviceView
+                
             case .activating:
                 restorePurchaseView
+                removeFromDeviceView
             }
+        }
+    }
+
+    @ViewBuilder
+    var removeFromDeviceView: some View {
+        SettingsCustomCell(content: {
+            Text(UserText.subscriptionRemoveFromDevice)
+                .daxBodyRegular()
+            .foregroundColor(Color.init(designSystemColor: .accent))},
+                           action: { viewModel.displayRemovalNotice(true) },
+                           isButton: true)
+        .alert(isPresented: $isShowingRemovalNotice) {
+            Alert(
+                title: Text(UserText.subscriptionRemoveFromDeviceConfirmTitle),
+                message: Text(UserText.subscriptionRemoveFromDeviceConfirmText),
+                primaryButton: .cancel(Text(UserText.subscriptionRemoveCancel)) {},
+                secondaryButton: .destructive(Text(UserText.subscriptionRemove)) {
+                    Pixel.fire(pixel: .privacyProSubscriptionManagementRemoval)
+                    viewModel.removeSubscription()
+                    dismiss()
+                }
+            )
         }
     }
 
     @ViewBuilder
     var restorePurchaseView: some View {
          let text = !settingsViewModel.state.subscription.isRestoring ? UserText.subscriptionActivateAppleIDButton : UserText.subscriptionRestoringTitle
-         SettingsCustomCell(content: {
-             Text(text)
-                 .daxBodyRegular()
-                 .foregroundColor(Color.init(designSystemColor: .accent)) },
-                            action: {
-                                 Task { await settingsViewModel.restoreAccountPurchase() }
-                             },
-                            isButton: !settingsViewModel.state.subscription.isRestoring )
-         .alert(isPresented: $isShowingSubscriptionError) {
-             Alert(
-                 title: Text(UserText.subscriptionAppStoreErrorTitle),
-                 message: Text(UserText.subscriptionAppStoreErrorMessage),
-                 dismissButton: .default(Text(UserText.actionOK)) {}
-             )
-         }
-     }
+        SettingsCustomCell(content: {
+            Text(text)
+                .daxBodyRegular()
+            .foregroundColor(Color.init(designSystemColor: .accent)) },
+                           action: {
+            Task { await settingsViewModel.restoreAccountPurchase() }
+        },
+                           isButton: !settingsViewModel.state.subscription.isRestoring )
+        .alert(isPresented: $isShowingSubscriptionError) {
+            Alert(
+                title: Text(UserText.subscriptionAppStoreErrorTitle),
+                message: Text(UserText.subscriptionAppStoreErrorMessage),
+                dismissButton: .default(Text(UserText.actionOK)) {}
+            )
+        }
+    }
 
     private var manageSectionFooter: some View {
         let isExpired = !(viewModel.state.subscriptionInfo?.isActive ?? false)
@@ -266,18 +285,6 @@ struct SubscriptionSettingsView: View {
                 .padding(.vertical, -10)
             if configuration == .subscribed || configuration == .expired {
                 devicesSection
-                    .alert(isPresented: $isShowingRemovalNotice) {
-                        Alert(
-                            title: Text(UserText.subscriptionRemoveFromDeviceConfirmTitle),
-                            message: Text(UserText.subscriptionRemoveFromDeviceConfirmText),
-                            primaryButton: .cancel(Text(UserText.subscriptionRemoveCancel)) {},
-                            secondaryButton: .destructive(Text(UserText.subscriptionRemove)) {
-                                Pixel.fire(pixel: .privacyProSubscriptionManagementRemoval)
-                                viewModel.removeSubscription()
-                                dismiss()
-                            }
-                        )
-                    }
             }
             manageSection
             helpSection


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209139424950325/f
CC:

**Description**:
See https://app.asana.com/0/414709148257752/1209139424950325/f

**How to test this PR**:
To simulate the "broken state" (being authenticated with a valid account but lacking subscription object in the BE) easiest way is to break when purchasing a new subscription:
- on simulator when purchasing and App Store sign in alert is shown kill the simulator (account will be created and not removed)
- on the device do as above but when the App Store sign in alert is shown you cannot leave the app (to achieve that type in something into the fields, tap ok to dismiss it and quickly minimise and kill the app), if you do it sufficiently quickly you will replicate the state

**Steps to test this PR**:
Replicate "broken state" as described above
1. Open main app settings and confirm that the state is "Activating" (and not "Expired")
2. Confirm that `m_settings_privacy-pro_account_with_no_subscription_found` pixel is sent
3. You can open "Subscription settings" (no alert with "Back to Settings" button)
4. "Restore Purchase" button is present
5. Tapping "Restore Purchase" will fail for the above scenario but appropriate alert is shown and the matching pixel is sent (see https://app.asana.com/0/414709148257752/1209270336314430/f for the list)
6. "Remove from this device" button is present.
7. Tapping "Remove from this device" button will show a confirmation prompt.
8. By confirming user successfully signs out and resets the state of the account/subscription and is able to re-try the purchase again

Check successful purchase scenario (Alpha target on a real device) and the subscription settings for no regression .


**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
