### PR TITLE
Strip patch component from the OS version in Pixel requests User Agent

### DIFF
--- a/Core/Pixel.swift
+++ b/Core/Pixel.swift
@@ -187,6 +187,13 @@ public class Pixel {
         DefaultInternalUserDecider(store: InternalUserStore()).isInternalUser
     }
 
+    public static let defaultPixelUserAgent: String = {
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        // Strip patch version component as per https://app.asana.com/0/69071770703008/1209176655620013/f
+        let trimmedOSVersion = "\(osVersion.majorVersion).\(osVersion.minorVersion)"
+        return DefaultUserAgentManager.duckduckGoUserAgent(for: AppVersion.shared, osVersion: trimmedOSVersion)
+    }()
+
     public enum QueryParameters: Codable {
         case atb
         case appVersion
@@ -236,7 +243,7 @@ public class Pixel {
                             forDeviceType deviceType: UIUserInterfaceIdiom? = UIDevice.current.userInterfaceIdiom,
                             withAdditionalParameters params: [String: String] = [:],
                             allowedQueryReservedCharacters: CharacterSet? = nil,
-                            withHeaders headers: APIRequest.Headers = APIRequest.Headers(),
+                            withHeaders headers: APIRequest.Headers = APIRequest.Headers(userAgent: defaultPixelUserAgent),
                             includedParameters: [QueryParameters] = [.appVersion],
                             onComplete: @escaping (Error?) -> Void = { _ in }) {
         var newParams = params

--- a/Core/UserAgentManager.swift
+++ b/Core/UserAgentManager.swift
@@ -82,8 +82,7 @@ public class DefaultUserAgentManager: UserAgentManager {
 
     public static var duckDuckGoUserAgent: String { duckduckGoUserAgent(for: AppVersion.shared) }
 
-    public static func duckduckGoUserAgent(for appVersion: AppVersion) -> String {
-        let osVersion = UIDevice.current.systemVersion
+    public static func duckduckGoUserAgent(for appVersion: AppVersion, osVersion: String = UIDevice.current.systemVersion) -> String {
         return "ddg_ios/\(appVersion.versionAndBuildNumber) (\(appVersion.identifier); iOS \(osVersion))"
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1209268316380789/f

**Description**:
This change updates how we pass OS version in Pixel requests, as agreed in the [Privacy Triage](https://app.asana.com/0/69071770703008/1209176655620013).

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Update Launching.swift:128 (`Pixel.isDryRun`) and set `dryRun` to `false`.
2. Set a breakpoint in Pixel.swift:285 (request.fetch) and run the app.
3. When stopped at the breakpoint, inspect request and verify that the User Agent header only contains OS version without the patch component.

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
