### PR TITLE
Fix frequent feedback view model instantiation

### DIFF
--- a/DuckDuckGo/NetworkProtectionRootView.swift
+++ b/DuckDuckGo/NetworkProtectionRootView.swift
@@ -21,10 +21,12 @@ import SwiftUI
 import NetworkProtection
 import Subscription
 import Core
+import Networking
 
 struct NetworkProtectionRootView: View {
 
     let statusViewModel: NetworkProtectionStatusViewModel
+    let feedbackFormModel: UnifiedFeedbackFormViewModel
 
     init() {
         let subscriptionManager = AppDependencyProvider.shared.subscriptionManager
@@ -38,10 +40,15 @@ struct NetworkProtectionRootView: View {
                                                            locationListRepository: locationListRepository,
                                                            usesUnifiedFeedbackForm: usesUnifiedFeedbackForm,
                                                            subscriptionManager: subscriptionManager)
+
+        feedbackFormModel = UnifiedFeedbackFormViewModel(subscriptionManager: subscriptionManager,
+                                                         apiService: DefaultAPIService(),
+                                                         vpnMetadataCollector: DefaultVPNMetadataCollector(),
+                                                         source: .vpn)
     }
 
     var body: some View {
-        NetworkProtectionStatusView(statusModel: statusViewModel)
+        NetworkProtectionStatusView(statusModel: statusViewModel, feedbackFormModel: feedbackFormModel)
             .navigationTitle(UserText.netPNavTitle)
             .onFirstAppear {
                 Pixel.fire(pixel: .privacyProVPNSettings)

--- a/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -31,6 +31,9 @@ struct NetworkProtectionStatusView: View {
     @ObservedObject
     public var statusModel: NetworkProtectionStatusViewModel
 
+    @StateObject
+    public var feedbackFormModel: UnifiedFeedbackFormViewModel
+
     var tipsModel: VPNTipsModel {
         statusModel.tipsModel
     }
@@ -283,22 +286,20 @@ struct NetworkProtectionStatusView: View {
 
     @ViewBuilder
     private func about() -> some View {
-        let viewModel = UnifiedFeedbackFormViewModel(subscriptionManager: statusModel.subscriptionManager,
-                                                     apiService: DefaultAPIService(),
-                                                     vpnMetadataCollector: DefaultVPNMetadataCollector(),
-                                                     source: .vpn)
-
         Section {
             NavigationLink(UserText.netPVPNSettingsFAQ, destination: LazyView(NetworkProtectionFAQView()))
                 .daxBodyRegular()
                 .foregroundColor(.init(designSystemColor: .textPrimary))
 
             if statusModel.usesUnifiedFeedbackForm {
-                NavigationLink(UserText.subscriptionFeedback, destination: UnifiedFeedbackRootView(viewModel: viewModel))
+                NavigationLink(
+                    UserText.subscriptionFeedback,
+                    destination: LazyView(UnifiedFeedbackRootView(viewModel: feedbackFormModel))
+                )
                     .daxBodyRegular()
                     .foregroundColor(.init(designSystemColor: .textPrimary))
             } else {
-                NavigationLink(UserText.netPVPNSettingsShareFeedback, destination: VPNFeedbackFormCategoryView())
+                NavigationLink(UserText.netPVPNSettingsShareFeedback, destination: LazyView(VPNFeedbackFormCategoryView()))
                     .daxBodyRegular()
                     .foregroundColor(.init(designSystemColor: .textPrimary))
             }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414235014887631/1209301003276843/f
Tech Design URL:
CC:

**Description**:

This PR updates the feedback form view model to no longer get created any time the view is recreated. Instead, it gets created at the same time as the regular view model and passed in the same way.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Run this branch and start the VPN
2. Check that you do not see frequent subscription cache hits every couple seconds
3. Next, in the VPN UI, tap the `Send Feedback` button and go through the flow to the point of submitting an issue (in debug mode, pixels won't send, so feel free to submit)
4. Check that the feedback pixel shows up in the logs with the correct data

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
