### PR TITLE
Old to new onboarding migration fix

### DIFF
--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -806,6 +806,9 @@
 		9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */; };
 		9F4CC5242C4A4F0D006A96EB /* SwiftUITestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */; };
 		9F4CC5272C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */; };
+		9F5179D82D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */; };
+		9F5179DA2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
+		9F5179DB2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
@@ -2701,6 +2704,8 @@
 		9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactoryTests.swift; sourceTree = "<group>"; };
 		9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITestUtilities.swift; sourceTree = "<group>"; };
 		9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyIconContextualOnboardingAnimator.swift; sourceTree = "<group>"; };
+		9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogsOnboardingMigrator.swift; sourceTree = "<group>"; };
+		9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogsOnboardingMigratorTests.swift; sourceTree = "<group>"; };
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
@@ -5212,6 +5217,7 @@
 				9FDEC7B92C9006E000C7A692 /* BrowserComparisonModelTests.swift */,
 				9F8E0F322CCA642D001EA7C5 /* VideoPlayerViewModelTests.swift */,
 				9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */,
+				9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -6696,6 +6702,7 @@
 				851B128B2220483A004781BC /* OnboardingViewController.swift */,
 				F47E53DA250A9A1C0037C686 /* Onboarding.xcassets */,
 				6F8496402BC3D8EE00ADA54E /* OnboardingButtonsView.swift */,
+				9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */,
 			);
 			name = Onboarding;
 			sourceTree = "<group>";
@@ -8299,6 +8306,7 @@
 				98F0FC2021FF18E700CE77AB /* AutoClearSettingsViewController.swift in Sources */,
 				D67969112BC84CE700BA8B34 /* SubscriptionContainerViewModel.swift in Sources */,
 				85DB12ED2A1FED0C000A4A72 /* AppDelegate+AppDeepLinks.swift in Sources */,
+				9F5179D82D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift in Sources */,
 				98DA6ECA2181E41F00E65433 /* ThemeManager.swift in Sources */,
 				F1D43AFC2B99C56000BAB743 /* RootDebugViewController+VanillaBrowser.swift in Sources */,
 				C159DF072A430B60007834BB /* EmailSignupViewController.swift in Sources */,
@@ -8727,6 +8735,7 @@
 				CBC88EE12C7F834300F0F8C5 /* SpecialErrorPageUserScriptTests.swift in Sources */,
 				56D0602D2C383FD2003BAEB5 /* OnboardingSuggestedSearchesProviderTests.swift in Sources */,
 				31E77B272D038BBC006F1C9F /* OmnibarAccessoryHandlerTests.swift in Sources */,
+				9F5179DA2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */,
 				569437242BDD405400C0881B /* SyncBookmarksAdapterTests.swift in Sources */,
 				858479CD2B87964500D156C1 /* HistoryManagerTests.swift in Sources */,
 				CBCCF96828885DEE006F4A71 /* AppPrivacyConfigurationTests.swift in Sources */,
@@ -8832,6 +8841,7 @@
 			files = (
 				85F21DB0210F5E32002631A6 /* AtbIntegrationTests.swift in Sources */,
 				8551912724746EDC0010FDD0 /* SnapshotHelper.swift in Sources */,
+				9F5179DB2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -295,6 +295,9 @@ struct Launching: AppState {
             }
         }
 
+        // Hide Dax Dialogs if users already completed old onboarding.
+        DaxDialogsOnboardingMigrator().migrateFromOldToNewOboarding()
+
         // MARK: Sync initialisation
 #if DEBUG
         let defaultEnvironment = ServerEnvironment.development

--- a/DuckDuckGo/DaxDialogsOnboardingMigrator.swift
+++ b/DuckDuckGo/DaxDialogsOnboardingMigrator.swift
@@ -1,0 +1,38 @@
+//
+//  DaxDialogsOnboardingMigrator.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+// This class is used to avoid showing in-context Dax Dialogs to users who already completed the old onboarding flow.
+// https://app.asana.com/0/414709148257752/1209317131414536
+final class DaxDialogsOnboardingMigrator {
+    private let daxDialogsSettings: DaxDialogsSettings
+
+    init(daxDialogsSettings: DaxDialogsSettings = DefaultDaxDialogsSettings()) {
+        self.daxDialogsSettings = daxDialogsSettings
+    }
+
+    func migrateFromOldToNewOboarding() {
+        // Check if `homeScreenMessagesSeen` is not 0.
+        // In that case we consider the old onboarding flow completed and hide the dax dialogs.
+        if daxDialogsSettings.homeScreenMessagesSeen > 0 {
+            daxDialogsSettings.isDismissed = true
+        }
+    }
+}

--- a/DuckDuckGo/DaxDialogsSettings.swift
+++ b/DuckDuckGo/DaxDialogsSettings.swift
@@ -19,10 +19,12 @@
 
 import Core
 
-protocol DaxDialogsSettings {
-    
+protocol DaxDialogsSettings: AnyObject {
+
     var isDismissed: Bool { get set }
-    
+
+    var homeScreenMessagesSeen: Int { get }
+
     var browsingAfterSearchShown: Bool { get set }
     
     var browsingWithTrackersShown: Bool { get set }
@@ -93,7 +95,9 @@ class DefaultDaxDialogsSettings: DaxDialogsSettings {
 class InMemoryDaxDialogsSettings: DaxDialogsSettings {
     
     var isDismissed: Bool = false
-    
+
+    var homeScreenMessagesSeen: Int = 0
+
     var browsingAfterSearchShown: Bool = false
     
     var browsingWithTrackersShown: Bool = false

--- a/DuckDuckGo/DaxDialogsSettings.swift
+++ b/DuckDuckGo/DaxDialogsSettings.swift
@@ -23,6 +23,7 @@ protocol DaxDialogsSettings: AnyObject {
 
     var isDismissed: Bool { get set }
 
+    // Used to understand if users completed the old onboarding flow and should not be prompted in-context dax dialogs.
     var homeScreenMessagesSeen: Int { get }
 
     var browsingAfterSearchShown: Bool { get set }
@@ -88,36 +89,6 @@ class DefaultDaxDialogsSettings: DaxDialogsSettings {
     var lastVisitedOnboardingWebsiteURLPath: String?
 
     @UserDefaultsWrapper(key: .daxLastShownContextualOnboardingDialogType, defaultValue: nil)
-    var lastShownContextualOnboardingDialogType: String?
-
-}
-
-class InMemoryDaxDialogsSettings: DaxDialogsSettings {
-    
-    var isDismissed: Bool = false
-
-    var homeScreenMessagesSeen: Int = 0
-
-    var browsingAfterSearchShown: Bool = false
-    
-    var browsingWithTrackersShown: Bool = false
-    
-    var browsingWithoutTrackersShown: Bool = false
-    
-    var browsingMajorTrackingSiteShown: Bool = false
-    
-    var fireButtonEducationShownOrExpired: Bool = false
-
-    var fireMessageExperimentShown: Bool = false
-
-    var fireButtonPulseDateShown: Date?
-
-    var privacyButtonPulseShown: Bool = false
-
-    var browsingFinalDialogShown = false
-
-    var lastVisitedOnboardingWebsiteURLPath: String?
-
     var lastShownContextualOnboardingDialogType: String?
 
 }

--- a/DuckDuckGoTests/DaxDialogTests.swift
+++ b/DuckDuckGoTests/DaxDialogTests.swift
@@ -59,7 +59,7 @@ final class DaxDialog: XCTestCase {
 
     }
 
-    let settings: InMemoryDaxDialogsSettings = InMemoryDaxDialogsSettings()
+    let settings: MockDaxDialogsSettings = MockDaxDialogsSettings()
     lazy var mockVariantManager = MockVariantManager(isSupportedReturns: false)
     lazy var onboarding = DaxDialogs(settings: settings,
                                      entityProviding: MockEntityProvider(),
@@ -93,7 +93,7 @@ final class DaxDialog: XCTestCase {
 
         testCases.forEach { testCase in
             
-            let onboarding = DaxDialogs(settings: InMemoryDaxDialogsSettings(),
+            let onboarding = DaxDialogs(settings: MockDaxDialogsSettings(),
                                         entityProviding: MockEntityProvider(),
                                         variantManager: mockVariantManager)
             let privacyInfo = makePrivacyInfo(url: URLs.example)
@@ -112,7 +112,7 @@ final class DaxDialog: XCTestCase {
     }
     
     func testWhenPrimingDaxDialogForUseThenDismissedIsFalse() {
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.isDismissed = true
         
         let onboarding = DaxDialogs(settings: settings, entityProviding: entityProvider)
@@ -126,7 +126,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBrowsingSpecIsWithOneTrackerThenHighlightAddressBarIsFalse() throws {
         // GIVEN
-        let sut = makeSUT(settings: InMemoryDaxDialogsSettings())
+        let sut = makeSUT(settings: MockDaxDialogsSettings())
         let privacyInfo = makePrivacyInfo(url: URLs.example)
         let detectedTracker = detectedTrackerFrom(URLs.google, pageUrl: URLs.example.absoluteString)
         privacyInfo.trackerInfo.addDetectedTracker(detectedTracker, onPageWithURL: URLs.example)
@@ -141,7 +141,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBrowsingSpecIsWithMultipleTrackerThenHighlightAddressBarIsFalse() throws {
         // GIVEN
-        let sut = makeSUT(settings: InMemoryDaxDialogsSettings())
+        let sut = makeSUT(settings: MockDaxDialogsSettings())
         let privacyInfo = makePrivacyInfo(url: URLs.example)
         [URLs.google, URLs.amazon].forEach { tracker in
             let detectedTracker = detectedTrackerFrom(tracker, pageUrl: URLs.example.absoluteString)
@@ -158,7 +158,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenURLIsDuckDuckGoSearchAndSearchDialogHasNotBeenSeenThenReturnSpecTypeAfterSearch() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingAfterSearchShown = false
         let sut = makeSUT(settings: settings)
 
@@ -171,7 +171,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenURLIsMajorTrackerWebsiteAndMajorTrackerDialogHasNotBeenSeenThenReturnSpecTypeSiteIsMajorTracker() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingMajorTrackingSiteShown = false
         let sut = makeSUT(settings: settings)
         let privacyInfo = makePrivacyInfo(url: URLs.facebook)
@@ -185,7 +185,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenURLIsOwnedByMajorTrackerAndMajorTrackerDialogHasNotBeenSeenThenReturnSpecTypeSiteOwnedByMajorTracker() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingMajorTrackingSiteShown = false
         let sut = makeSUT(settings: settings)
         let privacyInfo = makePrivacyInfo(url: URLs.ownedByFacebook)
@@ -199,7 +199,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenURLHasTrackersAndMultipleTrackersDialogHasNotBeenSeenThenReturnSpecTypeWithMultipleTrackers() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = false
         let sut = makeSUT(settings: settings)
         let privacyInfo = makePrivacyInfo(url: URLs.example)
@@ -217,7 +217,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenURLHasNoTrackersAndIsNotSERPAndNoTrakcersDialogHasNotBeenSeenThenReturnSpecTypeWithoutTrackers() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithoutTrackersShown = false
         let sut = makeSUT(settings: settings)
 
@@ -231,7 +231,7 @@ final class DaxDialog: XCTestCase {
     func testWhenURLIsDuckDuckGoSearchAndHasVisitedWebsiteThenSpecTypeSearchIsReturned() throws {
         try [DaxDialogs.BrowsingSpec.withoutTrackers, .siteIsMajorTracker, .siteOwnedByMajorTracker, .withOneTracker, .withMultipleTrackers].forEach { spec in
             // GIVEN
-            let settings = InMemoryDaxDialogsSettings()
+            let settings = MockDaxDialogsSettings()
             let sut = DaxDialogs(settings: settings, entityProviding: entityProvider)
             sut.overrideShownFlagFor(spec, flag: true)
 
@@ -245,7 +245,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogNotSeen_AndSearchDone_ThenFinalBrowsingSpecIsReturned() throws {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingAfterSearchShown = true
         settings.fireMessageExperimentShown = true
         let sut = makeSUT(settings: settings)
@@ -259,7 +259,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogNotSeen_AndWebsiteWithoutTracker_ThenFinalBrowsingSpecIsReturned() throws {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithoutTrackersShown = true
         settings.fireMessageExperimentShown = true
         let sut = makeSUT(settings: settings)
@@ -273,7 +273,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogNotSeen_AndWebsiteWithTracker_ThenFinalBrowsingSpecIsReturned() throws {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.fireMessageExperimentShown = true
         let sut = makeSUT(settings: settings)
@@ -290,7 +290,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogNotSeen_AndWebsiteMajorTracker_ThenFinalBrowsingSpecIsReturned() throws {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingMajorTrackingSiteShown = true
         settings.fireMessageExperimentShown = true
         let sut = makeSUT(settings: settings)
@@ -305,7 +305,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogSeen_AndSearchDone_ThenBrowsingSpecIsNil() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingAfterSearchShown = true
         settings.fireMessageExperimentShown = true
         settings.browsingFinalDialogShown = true
@@ -320,7 +320,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogSeen_AndWebsiteWithoutTracker_ThenBrowsingSpecIsNotFinal() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithoutTrackersShown = true
         settings.fireMessageExperimentShown = true
         settings.browsingFinalDialogShown = true
@@ -335,7 +335,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogSeen_AndWebsiteWithTracker_ThenBrowsingSpecIsNil() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.fireMessageExperimentShown = true
         settings.browsingFinalDialogShown = true
@@ -353,7 +353,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogSeen_AndWebsiteMajorTracker_ThenFinalBrowsingSpecIsReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingMajorTrackingSiteShown = true
         settings.fireMessageExperimentShown = true
         settings.browsingFinalDialogShown = true
@@ -369,7 +369,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonSeen_AndFinalDialogSeen_AndSearchNotSeen_ThenAfterSearchSpecIsReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithoutTrackersShown = true
         settings.browsingWithTrackersShown = true
         settings.browsingMajorTrackingSiteShown = true
@@ -386,7 +386,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenSearchDialogSeen_OnReload_SearchDialogReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -400,7 +400,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenSearchDialogSeen_OnLoadingAnotherSearch_NilReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -414,7 +414,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenMajorTrackerDialogSeen_OnReload_MajorTrackerDialogReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -428,7 +428,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenMajorTrackerDialogSeen_OnLoadingAnotherSearch_NilReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -442,7 +442,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenMajorTrackerOwnerMessageSeen_OnReload_MajorTrackerOwnerDialogReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -456,7 +456,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenMajorTrackerOwnerMessageSeen_OnLoadingAnotherSearch_NilReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -470,7 +470,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenWithoutTrackersMessageSeen_OnReload_WithoutTrackersDialogReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -484,7 +484,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenWithoutTrackersMessageSeen_OnLoadingAnotherSearch_NilReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
 
         // WHEN
@@ -498,7 +498,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFinalMessageSeen_OnReload_NilReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithoutTrackersShown = true
         settings.fireMessageExperimentShown = true
         let sut = makeSUT(settings: settings)
@@ -514,7 +514,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenVisitWebsiteSeen_OnReload_VisitWebsiteReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         sut.setSearchMessageSeen()
 
@@ -532,7 +532,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenVisitWebsiteSeen_OnLoadingAnotherSearch_NilIseturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         sut.setSearchMessageSeen()
 
@@ -550,7 +550,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireMessageSeen_OnReload_FireMessageReturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         sut.setSearchMessageSeen()
 
@@ -568,7 +568,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenSearchNotSeen_AndFireMessageSeen_OnLoadingAnotherSearch_ExpectedDialogIseturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         sut.setSearchMessageSeen()
 
@@ -586,7 +586,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenSearchSeen_AndFireMessageSeen_OnLoadingAnotherSearch_ExpectedDialogIseturned() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         sut.setSearchMessageSeen()
 
@@ -607,7 +607,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBrowserWithTrackersShown_AndPrivacyAnimationNotShown_ThenShowPrivacyAnimationPulse() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.privacyButtonPulseShown = false
         let sut = makeSUT(settings: settings)
@@ -621,7 +621,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBrowserWithTrackersShown_AndPrivacyAnimationShown_ThenDoNotShowPrivacyAnimationPulse() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.privacyButtonPulseShown = true
         let sut = makeSUT(settings: settings)
@@ -635,7 +635,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBrowserWithTrackersShown_AndFireButtonPulseActive_ThenDoNotShowPrivacyAnimationPulse() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.privacyButtonPulseShown = false
         let sut = makeSUT(settings: settings)
@@ -650,7 +650,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenCallSetPrivacyButtonPulseSeen_ThenSetPrivacyButtonPulseShownFlagToTrue() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         XCTAssertFalse(settings.privacyButtonPulseShown)
 
@@ -663,7 +663,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenSetFireEducationMessageSeenIsCalled_ThenSetPrivacyButtonPulseShownToTrue() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
         XCTAssertFalse(settings.privacyButtonPulseShown)
 
@@ -676,7 +676,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonAnimationPulseNotShown__AndShouldShowFireButtonPulseIsCalled_ThenReturnTrue() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.privacyButtonPulseShown = true
         settings.browsingWithTrackersShown = true
         settings.fireButtonPulseDateShown = nil
@@ -691,7 +691,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireButtonAnimationPulseShown_AndShouldShowFireButtonPulseIsCalled_ThenReturnFalse() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.privacyButtonPulseShown = true
         settings.browsingWithTrackersShown = true
         settings.fireButtonPulseDateShown = Date()
@@ -706,7 +706,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenFireEducationMessageSeen_AndFinalMessageNotSeen_ThenShowFinalMessage() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.fireMessageExperimentShown = true
         settings.browsingFinalDialogShown = false
         let sut = makeSUT(settings: settings)
@@ -720,7 +720,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenNextHomeScreenMessageNewIsCalled_ThenLastVisitedOnboardingWebsiteAndLastShownDaxDialogAreSetToNil() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
         settings.lastVisitedOnboardingWebsiteURLPath = "https://www.example.com"
         let sut = makeSUT(settings: settings)
@@ -737,7 +737,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenEnableAddFavoritesFlowIsCalled_ThenIsAddFavoriteFlowIsTrue() {
         // GIVEN
-        let sut = makeSUT(settings: InMemoryDaxDialogsSettings())
+        let sut = makeSUT(settings: MockDaxDialogsSettings())
         XCTAssertFalse(sut.isAddFavoriteFlow)
 
         // WHEN
@@ -749,7 +749,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBlockedTrackersDialogSeen_AndMajorTrackerNotSeen_ThenReturnNilSpec() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.browsingMajorTrackingSiteShown = false
         let sut = makeSUT(settings: settings)
@@ -763,7 +763,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBlockedTrackersDialogNotSeen_AndMajorTrackerNotSeen_ThenReturnMajorNetworkSpec() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = false
         settings.browsingMajorTrackingSiteShown = false
         let sut = makeSUT(settings: settings)
@@ -777,7 +777,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBlockedTrackersDialogSeen_AndOwnedByMajorTrackerNotSeen_ThenReturnNilSpec() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
         settings.browsingMajorTrackingSiteShown = false
         let sut = makeSUT(settings: settings)
@@ -791,7 +791,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenBlockedTrackersDialogNotSeen_AndOwnedByMajorTrackerNotSeen_ThenReturnOwnedByMajorNetworkSpec() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = false
         settings.browsingMajorTrackingSiteShown = false
         let sut = makeSUT(settings: settings)
@@ -805,7 +805,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenDismissIsCalled_ThenLastVisitedOnboardingWebsiteAndLastShownDaxDialogAreSetToNil() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
         settings.lastVisitedOnboardingWebsiteURLPath = "https://www.example.com"
         let sut = makeSUT(settings: settings)
@@ -822,7 +822,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenSetDaxDialogDismiss_ThenLastVisitedOnboardingWebsiteAndLastShownDaxDialogAreSetToNil() {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
         settings.lastVisitedOnboardingWebsiteURLPath = "https://www.example.com"
         let sut = makeSUT(settings: settings)
@@ -839,7 +839,7 @@ final class DaxDialog: XCTestCase {
 
     func testWhenClearedBrowserDataIsCalled_ThenLastVisitedOnboardingWebsiteAndLastShownDaxDialogAreSetToNil() throws {
         // GIVEN
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
         settings.lastVisitedOnboardingWebsiteURLPath = "https://www.example.com"
         let sut = makeSUT(settings: settings)
@@ -858,7 +858,7 @@ final class DaxDialog: XCTestCase {
         // GIVEN
         let lastVisitedWebsitePath = "https://www.example.com"
         let lastVisitedWebsiteURL = try XCTUnwrap(URL(string: lastVisitedWebsitePath))
-        let settings = InMemoryDaxDialogsSettings()
+        let settings = MockDaxDialogsSettings()
         settings.lastShownContextualOnboardingDialogType = DaxDialogs.BrowsingSpec.fire.type.rawValue
         settings.lastVisitedOnboardingWebsiteURLPath = lastVisitedWebsitePath
         let sut = makeSUT(settings: settings)

--- a/DuckDuckGoTests/DaxDialogsOnboardingMigratorTests.swift
+++ b/DuckDuckGoTests/DaxDialogsOnboardingMigratorTests.swift
@@ -1,0 +1,62 @@
+//
+//  DaxDialogsOnboardingMigratorTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class DaxDialogsOnboardingMigratorTests: XCTestCase {
+    private var sut: DaxDialogsOnboardingMigrator!
+    private var daxDialogsSettingsMock: MockDaxDialogsSettings!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        daxDialogsSettingsMock = MockDaxDialogsSettings()
+        sut = DaxDialogsOnboardingMigrator(daxDialogsSettings: daxDialogsSettingsMock)
+    }
+
+    override func tearDownWithError() throws {
+        daxDialogsSettingsMock = nil
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testWhenDaxDialogsHomeScreenMessagesSeenSettingIsNotZero_ThenSetIsDismissedToTrue() throws {
+        // GIVEN
+        daxDialogsSettingsMock.homeScreenMessagesSeen = 1
+        XCTAssertFalse(daxDialogsSettingsMock.isDismissed)
+
+        // WHEN
+        sut.migrateFromOldToNewOboarding()
+
+        // THEN
+        XCTAssertTrue(daxDialogsSettingsMock.isDismissed)
+    }
+
+    func testWhenDaxDialogsHomeScreenMessagesSeenSettingIsZero_ThenDoNotSetIsDismissedToTrue() throws {
+        // GIVEN
+        daxDialogsSettingsMock.homeScreenMessagesSeen = 0
+        XCTAssertFalse(daxDialogsSettingsMock.isDismissed)
+
+        // WHEN
+        sut.migrateFromOldToNewOboarding()
+
+        // THEN
+        XCTAssertFalse(daxDialogsSettingsMock.isDismissed)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209336232176393/f 

**Description**:

This PR add a fix to set the onboarding Dax Dialogs hidden when the user updates the App if the saw the old onboarding and they haven’t seen some of the dialogs. More info in [Asana Task](https://app.asana.com/0/414709148257752/1209317131414536)

🎥 Video of the Fix

Old onboarding fresh install:

https://github.com/user-attachments/assets/af0208c8-bbbc-429f-86c5-46fc94d3ea2c
 
Updating the App does not show any dax dialog:

https://github.com/user-attachments/assets/548c9370-7a4a-4c05-9a5a-61adf21ced66

**Steps to test this PR**:

1. Remove the DDG App from the simulator.
2. Checkout branch `origin/alessandro/old-onboarding`. This is branched off tag `7.130.-2` and include a fix to make it compile with Xcode 16.2.
3. Launch the App.
4. Wait for Onboarding to Appear.
5. Tap the “Let’s Do It” button on the first screen..
6. When Make DuckDuckGo your default Browser Appear tap the “Skip” button.
7. When Dax Dialog appear on screen asking to navigate to one of your favourite sites, navigate to duckduckgo.com
8. When the ’no blocked tracker’ dialog appears on screen, tap the “Got It” button.
9. Tap the Fire button.
10.Tap the “Close Tabs and Clear Data” button.
11. Wait for the “end of journey” (You Got this!) dialogs to appear on screen.
12. Kill the App.
13. Switch to `origin/alessandro/old-to-new-onboarding-migration-fix` branch.
14. Launch the App.
15. Ensure that no new dax dialogs are shown in the new tab page.
16. Navigate to bbc.com
17. Ensure no dax dialogs are shown.
18. Navigate to facebook.com
19. Ensure no dax dialogs are shown.
20. Navigate to duckduckgo.com
21. Ensure no dax dialogs are shown.
22. Clear data using the fire button.
23. Ensure no end of journey dialog is shown in the new tab page appearing.

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
