### PR TITLE
Privacy Pro Free Trials - Settings Page Copy Updates

### DIFF
--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -842,14 +842,14 @@
 		9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */; };
 		9F4CC5242C4A4F0D006A96EB /* SwiftUITestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */; };
 		9F4CC5272C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */; };
+		9F5179D82D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */; };
+		9F5179DA2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
+		9F5179DB2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
 		9F5BEA7C2D4382430045E484 /* MaliciousSiteProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA762D4382430045E484 /* MaliciousSiteProtectionMocks.swift */; };
 		9F5BEA7D2D4382430045E484 /* TimeTraveller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA772D4382430045E484 /* TimeTraveller.swift */; };
 		9F5BEA7E2D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */; };
 		9F5BEA7F2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */; };
 		9F5BEA832D438B880045E484 /* MockMaliciousSiteProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA822D438B880045E484 /* MockMaliciousSiteProtectionManager.swift */; };
-		9F5179D82D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */; };
-		9F5179DA2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
-		9F5179DB2D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */; };
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
@@ -2785,13 +2785,13 @@
 		9F4CC51E2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactoryTests.swift; sourceTree = "<group>"; };
 		9F4CC5232C4A4F0D006A96EB /* SwiftUITestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUITestUtilities.swift; sourceTree = "<group>"; };
 		9F4CC5262C4E230C006A96EB /* PrivacyIconContextualOnboardingAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyIconContextualOnboardingAnimator.swift; sourceTree = "<group>"; };
+		9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogsOnboardingMigrator.swift; sourceTree = "<group>"; };
+		9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogsOnboardingMigratorTests.swift; sourceTree = "<group>"; };
 		9F5BEA762D4382430045E484 /* MaliciousSiteProtectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionMocks.swift; sourceTree = "<group>"; };
 		9F5BEA772D4382430045E484 /* TimeTraveller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTraveller.swift; sourceTree = "<group>"; };
 		9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcherTests.swift; sourceTree = "<group>"; };
 		9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionManagerTests.swift; sourceTree = "<group>"; };
 		9F5BEA822D438B880045E484 /* MockMaliciousSiteProtectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMaliciousSiteProtectionManager.swift; sourceTree = "<group>"; };
-		9F5179D72D54598800E40B40 /* DaxDialogsOnboardingMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogsOnboardingMigrator.swift; sourceTree = "<group>"; };
-		9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogsOnboardingMigratorTests.swift; sourceTree = "<group>"; };
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
@@ -12279,8 +12279,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit.git";
 			requirement = {
-				kind = exactVersion;
-				version = 236.0.2;
+				kind = revision;
+				revision = 01039fa178fa95b9f26491a30ecce1a3e26c1889;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12279,8 +12279,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit.git";
 			requirement = {
-				kind = revision;
-				revision = 01039fa178fa95b9f26491a30ecce1a3e26c1889;
+				kind = exactVersion;
+				version = 236.0.4;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit.git",
       "state" : {
-        "revision" : "01039fa178fa95b9f26491a30ecce1a3e26c1889"
+        "revision" : "f0db9978000e0e469c25186d2a68785b05c8a812",
+        "version" : "236.0.4"
       }
     },
     {

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit.git",
       "state" : {
-        "revision" : "8b7cb167b94dea66313175c88234fdc3cd2db306",
-        "version" : "236.0.2"
+        "revision" : "01039fa178fa95b9f26491a30ecce1a3e26c1889"
       }
     },
     {

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "ff0f781cf7c6a22d52957e50b104f5768b50c779",
-        "version" : "3.10.0"
+        "revision" : "f2f3774fd116a305136b6866e5e7cb7dff39d8f2",
+        "version" : "3.10.1"
       }
     },
     {

--- a/DuckDuckGo/SettingsState.swift
+++ b/DuckDuckGo/SettingsState.swift
@@ -47,6 +47,7 @@ struct SettingsState {
         var entitlements: [Entitlement.ProductName]
         var platform: PrivacyProSubscription.Platform
         var isShowingStripeView: Bool
+        var isActiveTrialOffer: Bool
     }
 
     struct AIChat: Codable {
@@ -147,7 +148,8 @@ struct SettingsState {
                                        subscriptionFeatures: [],
                                        entitlements: [],
                                        platform: .unknown,
-                                       isShowingStripeView: false),
+                                       isShowingStripeView: false,
+                                       isActiveTrialOffer: false),
             sync: SyncSettings(enabled: false, title: ""),
             syncSource: nil,
             duckPlayerEnabled: false,

--- a/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/DuckDuckGo/SettingsSubscriptionView.swift
@@ -220,8 +220,11 @@ struct SettingsSubscriptionView: View {
             }
             .disabled(!hasITREntitlement)
         }
-        
-        NavigationLink(destination: LazyView(SubscriptionSettingsView(configuration: .subscribed, settingsViewModel: settingsViewModel))
+
+        let isActiveTrialOffer = settingsViewModel.state.subscription.isActiveTrialOffer
+        let configuration: SubscriptionSettingsView.Configuration = isActiveTrialOffer ? .trial : .subscribed
+
+        NavigationLink(destination: LazyView(SubscriptionSettingsView(configuration: configuration, settingsViewModel: settingsViewModel))
             .environmentObject(subscriptionNavigationCoordinator)
         ) {
             SettingsCustomCell(content: { manageSubscriptionView })

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -808,7 +808,7 @@ extension SettingsViewModel {
             state.subscription.platform = subscription.platform
             state.subscription.hasSubscription = true
             state.subscription.hasActiveSubscription = subscription.isActive
-            state.subscription.isActiveTrialOffer = subscription.activeOffers.contains(where: { $0.type == .trial })
+            state.subscription.isActiveTrialOffer = subscription.hasActiveTrialOffer
 
             // Check entitlements and update state
             var currentEntitlements: [Entitlement.ProductName] = []

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -808,7 +808,7 @@ extension SettingsViewModel {
             state.subscription.platform = subscription.platform
             state.subscription.hasSubscription = true
             state.subscription.hasActiveSubscription = subscription.isActive
-            state.subscription.isActiveTrialOffer = subscription.activeOffers.contains(where: { $0.type == .trial } )
+            state.subscription.isActiveTrialOffer = subscription.activeOffers.contains(where: { $0.type == .trial })
 
             // Check entitlements and update state
             var currentEntitlements: [Entitlement.ProductName] = []

--- a/DuckDuckGo/SettingsViewModel.swift
+++ b/DuckDuckGo/SettingsViewModel.swift
@@ -795,6 +795,7 @@ extension SettingsViewModel {
             state.subscription.hasActiveSubscription = false
             state.subscription.entitlements = []
             state.subscription.platform = .unknown
+            state.subscription.isActiveTrialOffer = false
 
             subscriptionStateCache.set(state.subscription) // Sync cache
             return
@@ -807,6 +808,7 @@ extension SettingsViewModel {
             state.subscription.platform = subscription.platform
             state.subscription.hasSubscription = true
             state.subscription.hasActiveSubscription = subscription.isActive
+            state.subscription.isActiveTrialOffer = subscription.activeOffers.contains(where: { $0.type == .trial } )
 
             // Check entitlements and update state
             var currentEntitlements: [Entitlement.ProductName] = []
@@ -829,6 +831,7 @@ extension SettingsViewModel {
                     state.subscription.hasActiveSubscription = false
                     state.subscription.entitlements = []
                     state.subscription.platform = .unknown
+                    state.subscription.isActiveTrialOffer = false
 
                     DailyPixel.fireDailyAndCount(pixel: .settingsPrivacyProAccountWithNoSubscriptionFound)
                 }

--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -547,7 +547,7 @@ private extension SubscriptionPagesUseSubscriptionFeature {
     ///
     /// - Parameter freeTrialsCohort: The cohort the user belongs to (`control` or `treatment`).
     /// - Returns: A `SubscriptionOptions` object containing the relevant subscription options.
-    func freeTrialSubscriptionOptions(for freeTrialsCohort: PrivacyProFreeTrialExperimentCohort) async -> SubscriptionOptions? {
+    func se async -> SubscriptionOptions? {
         var subscriptionOptions: SubscriptionOptions?
 
         switch freeTrialsCohort {

--- a/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -547,7 +547,7 @@ private extension SubscriptionPagesUseSubscriptionFeature {
     ///
     /// - Parameter freeTrialsCohort: The cohort the user belongs to (`control` or `treatment`).
     /// - Returns: A `SubscriptionOptions` object containing the relevant subscription options.
-    func se async -> SubscriptionOptions? {
+    func freeTrialSubscriptionOptions(for freeTrialsCohort: PrivacyProFreeTrialExperimentCohort) async -> SubscriptionOptions? {
         var subscriptionOptions: SubscriptionOptions?
 
         switch freeTrialsCohort {

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -117,8 +117,7 @@ final class SubscriptionSettingsViewModel: ObservableObject {
                 self.state.subscriptionInfo = subscription
                 if loadingIndicator { self.displaySubscriptionLoader(false) }
             }
-            await updateSubscriptionsStatusMessage(status: subscription.status,
-                                                   activeOffers: subscription.activeOffers,
+            await updateSubscriptionsStatusMessage(subscription: subscription,
                                                    date: subscription.expiresOrRenewsAt,
                                                    product: subscription.productId,
                                                    billingPeriod: subscription.billingPeriod)
@@ -207,12 +206,12 @@ final class SubscriptionSettingsViewModel: ObservableObject {
     }
     
     @MainActor
-    private func updateSubscriptionsStatusMessage(status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.Offer], date: Date, product: String, billingPeriod: PrivacyProSubscription.BillingPeriod) {
+    private func updateSubscriptionsStatusMessage(subscription: PrivacyProSubscription, date: Date, product: String, billingPeriod: PrivacyProSubscription.BillingPeriod) {
         let date = dateFormatter.string(from: date)
 
-        let hasActiveTrialOffer = activeOffers.contains(where: { $0.type == .trial })
+        let hasActiveTrialOffer = subscription.hasActiveTrialOffer
 
-        switch status {
+        switch subscription.status {
         case .autoRenewable:
             if hasActiveTrialOffer {
                 state.subscriptionDetails = UserText.renewingTrialSubscriptionInfo(billingPeriod: billingPeriod, renewalDate: date)

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -207,10 +207,10 @@ final class SubscriptionSettingsViewModel: ObservableObject {
     }
     
     @MainActor
-    private func updateSubscriptionsStatusMessage(status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.OfferType], date: Date, product: String, billingPeriod: PrivacyProSubscription.BillingPeriod) {
+    private func updateSubscriptionsStatusMessage(status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.Offer], date: Date, product: String, billingPeriod: PrivacyProSubscription.BillingPeriod) {
         let date = dateFormatter.string(from: date)
 
-        let hasActiveTrialOffer = activeOffers.contains(.trial)
+        let hasActiveTrialOffer = activeOffers.contains(where: { $0.type == .trial })
 
         switch status {
         case .autoRenewable:

--- a/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -207,7 +207,7 @@ final class SubscriptionSettingsViewModel: ObservableObject {
     }
     
     @MainActor
-    private func updateSubscriptionsStatusMessage(status: Subscription.Status, activeOffers: [Subscription.OfferType], date: Date, product: String, billingPeriod: Subscription.BillingPeriod) {
+    private func updateSubscriptionsStatusMessage(status: PrivacyProSubscription.Status, activeOffers: [PrivacyProSubscription.OfferType], date: Date, product: String, billingPeriod: PrivacyProSubscription.BillingPeriod) {
         let date = dateFormatter.string(from: date)
 
         let hasActiveTrialOffer = activeOffers.contains(.trial)

--- a/DuckDuckGo/Subscription/Views/SubscriptionSettingsHeaderView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionSettingsHeaderView.swift
@@ -21,10 +21,11 @@ import SwiftUI
 
 struct SubscriptionSettingsHeaderView: View {
 
-    enum HeaderState {
+    enum HeaderState: Equatable {
         case subscribed
         case expired(_ details: String)
         case activating
+        case trial
     }
 
     let state: HeaderState
@@ -42,12 +43,12 @@ struct SubscriptionSettingsHeaderView: View {
                 .foregroundColor(Color(designSystemColor: .textPrimary))
 
             switch state {
-            case .subscribed:
+            case .subscribed, .trial:
                 HStack(spacing: 4) {
                     Circle()
                         .fill(Color(designSystemColor: .alertGreen))
                         .frame(width: 8, height: 8)
-                    Text(UserText.subscriptionSubscribed)
+                    Text(state == .subscribed ? UserText.subscriptionSubscribed : UserText.trialSubscription)
                         .daxBodyRegular()
                         .foregroundColor(Color(designSystemColor: .textSecondary))
                 }

--- a/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -286,7 +286,7 @@ struct SubscriptionSettingsView: View {
             headerSection
                 .padding(.horizontal, -20)
                 .padding(.vertical, -10)
-            if configuration == .subscribed || configuration == .expired {
+            if configuration == .subscribed || configuration == .expired || configuration == .trial {
                 devicesSection
             }
             manageSection

--- a/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -29,6 +29,7 @@ struct SubscriptionSettingsView: View {
         case subscribed
         case expired
         case activating
+        case trial
     }
     @State var configuration: Configuration
     @Environment(\.dismiss) var dismiss
@@ -70,6 +71,8 @@ struct SubscriptionSettingsView: View {
                 SubscriptionSettingsHeaderView(state: .expired(viewModel.state.subscriptionDetails))
             case .activating:
                 SubscriptionSettingsHeaderView(state: .activating)
+            case .trial:
+                SubscriptionSettingsHeaderView(state: .trial)
             }
         }
         .listRowBackground(Color.clear)
@@ -121,7 +124,7 @@ struct SubscriptionSettingsView: View {
                 footer: manageSectionFooter) {
 
             switch configuration {
-            case .subscribed, .expired:
+            case .subscribed, .expired, .trial:
                 let active = viewModel.state.subscriptionInfo?.isActive ?? false
                 SettingsCustomCell(content: {
                     if !viewModel.state.isLoadingSubscriptionInfo {

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -1322,7 +1322,7 @@ But if you *do* want a peek under the hood, you can find more information about 
         return String(format: localized, expiration)
     }
 
-    static func renewingTrialSubscriptionInfo(billingPeriod: Subscription.BillingPeriod, renewalDate: String) -> String {
+    static func renewingTrialSubscriptionInfo(billingPeriod: PrivacyProSubscription.BillingPeriod, renewalDate: String) -> String {
         let localized: String
 
         switch billingPeriod {

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -1328,12 +1328,12 @@ But if you *do* want a peek under the hood, you can find more information about 
         switch billingPeriod {
         case .monthly:
             localized = NSLocalizedString("subscription.subscription.renewing.trial.monthly.caption",
-                                          value: "Your free trial ends on %@, and will convert to a monthly paid subscription.",
-                                          comment: "Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a monthly paid subscription.'")
+                                          value: "Your free trial ends on %@ & automatically converts to a monthly paid subscription on that day.",
+                                          comment: "Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date) & automatically converts to a monthly paid subscription on that day.'")
         case .yearly:
             localized = NSLocalizedString("subscription.subscription.renewing.trial.yearly.caption",
-                                          value: "Your free trial ends on %@, and will convert to an annual paid subscription.",
-                                          comment: "Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a annual paid subscription.'")
+                                          value: "Your free trial ends on %@ & automatically converts to an annual paid subscription on that day.",
+                                          comment: "Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date) & automatically converts to an annual paid subscription on that day.'")
         case .unknown:
             localized = NSLocalizedString("subscription.subscription.renewing.unknown.caption",
                                           value: "Your subscription renews on %@.",
@@ -1345,8 +1345,8 @@ But if you *do* want a peek under the hood, you can find more information about 
 
     static func expiringTrialSubscriptionInfo(expiryDate: String) -> String {
         let localized = NSLocalizedString("subscription.subscription.expiring.trial.monthly.caption",
-                                          value: "Your free trial ends on %@, and will not convert to a paid subscription.",
-                                          comment: "Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) and will not convert to a paid subscription.'")
+                                          value: "Your free trial ends on %@ & will not convert to a paid subscription.",
+                                          comment: "Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) & will not convert to a paid subscription.'")
         return String(format: localized, expiryDate)
     }
 

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -1270,6 +1270,8 @@ But if you *do* want a peek under the hood, you can find more information about 
     public static let subscriptionTitle = NSLocalizedString("subscription.title", value: "Privacy Pro", comment: "Navigation bar Title for subscriptions")
     public static let subscriptionSubscribed = NSLocalizedString("subscription.subscribed", value: "Subscribed", comment: "Subtitle in header when subscribed")
     public static let subscriptionCloseButton = NSLocalizedString("subscription.close", value: "Close", comment: "Navigation Button for closing subscription view")
+    public static let trialSubscription = NSLocalizedString("subscription.trial", value: "Free Trial", comment: "Subtitle in header when on a free trial subscription")
+
 
     static func renewingSubscriptionInfo(billingPeriod: PrivacyProSubscription.BillingPeriod, renewalDate: String) -> String {
         let localized: String
@@ -1318,6 +1320,34 @@ But if you *do* want a peek under the hood, you can find more information about 
                                           value: "Your subscription expired on %@",
                                           comment: "Subscription Expired Data. This reads as 'Your subscription expired on (date)'")
         return String(format: localized, expiration)
+    }
+
+    static func renewingTrialSubscriptionInfo(billingPeriod: Subscription.BillingPeriod, renewalDate: String) -> String {
+        let localized: String
+
+        switch billingPeriod {
+        case .monthly:
+            localized = NSLocalizedString("subscription.subscription.renewing.trial.monthly.caption",
+                                          value: "Your free trial renews into a paid monthly subscription on %@.",
+                                          comment: "Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid monthly subscription on (date)'")
+        case .yearly:
+            localized = NSLocalizedString("subscription.subscription.renewing.trial.yearly.caption",
+                                          value: "Your free trial renews into a paid yearly subscription on %@.",
+                                          comment: "Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid yearly subscription on (date)'")
+        case .unknown:
+            localized = NSLocalizedString("subscription.subscription.renewing.unknown.caption",
+                                          value: "Your subscription renews on %@.",
+                                          comment: "Unknown period subscription renewal info where parameter is renewal date. This reads as 'Your subscription renews on (date)'")
+        }
+
+        return String(format: localized, renewalDate)
+    }
+
+    static func expiringTrialSubscriptionInfo(expiryDate: String) -> String {
+        let localized = NSLocalizedString("subscription.subscription.expiring.trial.monthly.caption",
+                                          value: "Your free trial ends on %@.",
+                                          comment: "Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date)'")
+        return String(format: localized, expiryDate)
     }
 
     public static let subscriptionDevicesSectionHeader = NSLocalizedString("subscription.devices.header", value: "Activate on Other Devices", comment: "Header for section for activating subscription on other devices")

--- a/DuckDuckGo/UserText.swift
+++ b/DuckDuckGo/UserText.swift
@@ -1270,7 +1270,7 @@ But if you *do* want a peek under the hood, you can find more information about 
     public static let subscriptionTitle = NSLocalizedString("subscription.title", value: "Privacy Pro", comment: "Navigation bar Title for subscriptions")
     public static let subscriptionSubscribed = NSLocalizedString("subscription.subscribed", value: "Subscribed", comment: "Subtitle in header when subscribed")
     public static let subscriptionCloseButton = NSLocalizedString("subscription.close", value: "Close", comment: "Navigation Button for closing subscription view")
-    public static let trialSubscription = NSLocalizedString("subscription.trial", value: "Free Trial", comment: "Subtitle in header when on a free trial subscription")
+    public static let trialSubscription = NSLocalizedString("subscription.trial", value: "Free Trial Active", comment: "Subtitle in header when on a free trial subscription")
 
 
     static func renewingSubscriptionInfo(billingPeriod: PrivacyProSubscription.BillingPeriod, renewalDate: String) -> String {
@@ -1328,12 +1328,12 @@ But if you *do* want a peek under the hood, you can find more information about 
         switch billingPeriod {
         case .monthly:
             localized = NSLocalizedString("subscription.subscription.renewing.trial.monthly.caption",
-                                          value: "Your free trial renews into a paid monthly subscription on %@.",
-                                          comment: "Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid monthly subscription on (date)'")
+                                          value: "Your free trial ends on %@, and will convert to a monthly paid subscription.",
+                                          comment: "Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a monthly paid subscription.'")
         case .yearly:
             localized = NSLocalizedString("subscription.subscription.renewing.trial.yearly.caption",
-                                          value: "Your free trial renews into a paid yearly subscription on %@.",
-                                          comment: "Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid yearly subscription on (date)'")
+                                          value: "Your free trial ends on %@, and will convert to an annual paid subscription.",
+                                          comment: "Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a annual paid subscription.'")
         case .unknown:
             localized = NSLocalizedString("subscription.subscription.renewing.unknown.caption",
                                           value: "Your subscription renews on %@.",
@@ -1345,8 +1345,8 @@ But if you *do* want a peek under the hood, you can find more information about 
 
     static func expiringTrialSubscriptionInfo(expiryDate: String) -> String {
         let localized = NSLocalizedString("subscription.subscription.expiring.trial.monthly.caption",
-                                          value: "Your free trial ends on %@.",
-                                          comment: "Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date)'")
+                                          value: "Your free trial ends on %@, and will not convert to a paid subscription.",
+                                          comment: "Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) and will not convert to a paid subscription.'")
         return String(format: localized, expiryDate)
     }
 

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -2707,8 +2707,8 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Monthly subscription expiration info where parameter is expiration date. This reads as 'Your monthly subscription expires on (date)' */
 "subscription.subscription.expiring.monthly.caption" = "Your monthly subscription expires on %@.";
 
-/* Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date)' */
-"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@.";
+/* Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) and will not convert to a paid subscription.' */
+"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@ and will not convert to a paid subscription.";
 
 /* Unknown period subscription expiration info where parameter is expiration date. This reads as 'Your subscription expires on (date)' */
 "subscription.subscription.expiring.unknown.caption" = "Your subscription expires on %@.";
@@ -2719,11 +2719,11 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Monthly subscription renewal info where parameter is renewal date. This reads as 'Your monthly subscription renews on (date)' */
 "subscription.subscription.renewing.monthly.caption" = "Your monthly subscription renews on %@.";
 
-/* Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid monthly subscription on (date)' */
-"subscription.subscription.renewing.trial.monthly.caption" = "Your free trial renews into a paid monthly subscription on %@.";
+/* Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a monthly paid subscription.' */
+"subscription.subscription.renewing.trial.monthly.caption" = "Your free trial ends on %@, and will convert to a monthly paid subscription.";
 
-/* Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid yearly subscription on (date)' */
-"subscription.subscription.renewing.trial.yearly.caption" = "Your free trial renews into a paid yearly subscription on %@.";
+/* Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a annual paid subscription.' */
+"subscription.subscription.renewing.trial.yearly.caption" = "Your free trial ends on %@, and will convert to an annual paid subscription.";
 
 /* Unknown period subscription renewal info where parameter is renewal date. This reads as 'Your subscription renews on (date)' */
 "subscription.subscription.renewing.unknown.caption" = "Your subscription renews on %@.";
@@ -2735,7 +2735,7 @@ But if you *do* want a peek under the hood, you can find more information about 
 "subscription.title" = "Privacy Pro";
 
 /* Subtitle in header when on a free trial subscription */
-"subscription.trial" = "Free Trial";
+"subscription.trial" = "Free Trial Active";
 
 /* Message confirming that recovery code was copied to clipboard */
 "sync.code.copied" = "Recovery code copied to clipboard";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -2707,8 +2707,8 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Monthly subscription expiration info where parameter is expiration date. This reads as 'Your monthly subscription expires on (date)' */
 "subscription.subscription.expiring.monthly.caption" = "Your monthly subscription expires on %@.";
 
-/* Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) and will not convert to a paid subscription.' */
-"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@, and will not convert to a paid subscription.";
+/* Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) & will not convert to a paid subscription.' */
+"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@ & will not convert to a paid subscription.";
 
 /* Unknown period subscription expiration info where parameter is expiration date. This reads as 'Your subscription expires on (date)' */
 "subscription.subscription.expiring.unknown.caption" = "Your subscription expires on %@.";
@@ -2719,11 +2719,11 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Monthly subscription renewal info where parameter is renewal date. This reads as 'Your monthly subscription renews on (date)' */
 "subscription.subscription.renewing.monthly.caption" = "Your monthly subscription renews on %@.";
 
-/* Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a monthly paid subscription.' */
-"subscription.subscription.renewing.trial.monthly.caption" = "Your free trial ends on %@, and will convert to a monthly paid subscription.";
+/* Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date) & automatically converts to a monthly paid subscription on that day.' */
+"subscription.subscription.renewing.trial.monthly.caption" = "Your free trial ends on %@ & automatically converts to a monthly paid subscription on that day.";
 
-/* Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date), and will convert to a annual paid subscription.' */
-"subscription.subscription.renewing.trial.yearly.caption" = "Your free trial ends on %@, and will convert to an annual paid subscription.";
+/* Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial ends on (date) & automatically converts to an annual paid subscription on that day.' */
+"subscription.subscription.renewing.trial.yearly.caption" = "Your free trial ends on %@ & automatically converts to an annual paid subscription on that day.";
 
 /* Unknown period subscription renewal info where parameter is renewal date. This reads as 'Your subscription renews on (date)' */
 "subscription.subscription.renewing.unknown.caption" = "Your subscription renews on %@.";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -2707,6 +2707,9 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Monthly subscription expiration info where parameter is expiration date. This reads as 'Your monthly subscription expires on (date)' */
 "subscription.subscription.expiring.monthly.caption" = "Your monthly subscription expires on %@.";
 
+/* Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date)' */
+"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@.";
+
 /* Unknown period subscription expiration info where parameter is expiration date. This reads as 'Your subscription expires on (date)' */
 "subscription.subscription.expiring.unknown.caption" = "Your subscription expires on %@.";
 
@@ -2716,6 +2719,12 @@ But if you *do* want a peek under the hood, you can find more information about 
 /* Monthly subscription renewal info where parameter is renewal date. This reads as 'Your monthly subscription renews on (date)' */
 "subscription.subscription.renewing.monthly.caption" = "Your monthly subscription renews on %@.";
 
+/* Monthly trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid monthly subscription on (date)' */
+"subscription.subscription.renewing.trial.monthly.caption" = "Your free trial renews into a paid monthly subscription on %@.";
+
+/* Annual trial subscription renewal info where parameter is renewal date. This reads as 'Your free trial renews into a paid yearly subscription on (date)' */
+"subscription.subscription.renewing.trial.yearly.caption" = "Your free trial renews into a paid yearly subscription on %@.";
+
 /* Unknown period subscription renewal info where parameter is renewal date. This reads as 'Your subscription renews on (date)' */
 "subscription.subscription.renewing.unknown.caption" = "Your subscription renews on %@.";
 
@@ -2724,6 +2733,9 @@ But if you *do* want a peek under the hood, you can find more information about 
 
 /* Navigation bar Title for subscriptions */
 "subscription.title" = "Privacy Pro";
+
+/* Subtitle in header when on a free trial subscription */
+"subscription.trial" = "Free Trial";
 
 /* Message confirming that recovery code was copied to clipboard */
 "sync.code.copied" = "Recovery code copied to clipboard";

--- a/DuckDuckGo/en.lproj/Localizable.strings
+++ b/DuckDuckGo/en.lproj/Localizable.strings
@@ -2708,7 +2708,7 @@ But if you *do* want a peek under the hood, you can find more information about 
 "subscription.subscription.expiring.monthly.caption" = "Your monthly subscription expires on %@.";
 
 /* Trial subscription expiration info where parameter is expiration date. This reads as 'Your free trial ends on (date) and will not convert to a paid subscription.' */
-"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@ and will not convert to a paid subscription.";
+"subscription.subscription.expiring.trial.monthly.caption" = "Your free trial ends on %@, and will not convert to a paid subscription.";
 
 /* Unknown period subscription expiration info where parameter is expiration date. This reads as 'Your subscription expires on (date)' */
 "subscription.subscription.expiring.unknown.caption" = "Your subscription expires on %@.";


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206488453854252/1209235370800483

**Description**: Utilizes Subscription trial data to display trial-related copy on the settings page in two scenarios:
1. User has stated a trial and has not cancelled
2. User has stated a trial and has  cancelled

**Steps to test this PR**:
1. Sign into an Apple Sandbox Account with a user who does not have any active purchases
2. Enroll in the experiment via Debug Menu - Subscription - `privacyProFreeTrialJan25` (at the bottom)
3. Open the Privacy Pro paywall and purchase a monthly free trial
4. Open the Subscription settings screen and ensure the subtitle is "Free Trial Active" and the text below the "Remove..." cell is "Your free trial ends on (DATE) & automatically converts to a monthly paid subscription on that day."
5. Cancel your subscription
6. Reload the Subscription settings screen and ensure that subtitle is "Free Trial Active" and the text below the "Remove..." cell is "Your free trial ends on (DATE) & will not convert to a paid subscription."

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [x] Use of correct apostrophes in new copy, ie `’` rather than `'`

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
