### PR TITLE
Fix toggle report not showing after user decides to send a report

### DIFF
--- a/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -12253,8 +12253,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit.git";
 			requirement = {
-				kind = exactVersion;
-				version = 236.0.0;
+				branch = "jacek/fix-toggle-report-prompting";
+				kind = branch;
 			};
 		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {

--- a/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DuckDuckGo/BrowserServicesKit.git",
       "state" : {
-        "revision" : "1169c5565a1d6e3091e93448a28485a736dfa6d4",
-        "version" : "236.0.0"
+        "branch" : "jacek/fix-toggle-report-prompting",
+        "revision" : "b7afc621500a41d030d89a2afd56f8343fc7115e"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209117117981111

**Description**:
On macOS we were incorrectly recording user's choice to send a breakage report as dismissal.

**Steps to test this PR**:
See: https://github.com/duckduckgo/BrowserServicesKit/pull/1220