### PR TITLE
Fix webview retain cycle in special error pages handler and Expired certificate UI Test

### DIFF
--- a/.maestro/privacy_tests/10_expired_certificate.yaml
+++ b/.maestro/privacy_tests/10_expired_certificate.yaml
@@ -17,8 +17,8 @@ tags:
 - inputText: "https://expired.badssl.com"
 - pressKey: Enter
 - assertVisible: "Warning: This site may be insecure"
-- assertNotVisible: 
-    id: "LogoIcon"
+- assertVisible:
+    id: "Globe-24"
 - tapOn: "Leave This Site"
 - assertNotVisible: "Warning: This site may be insecure"
 
@@ -27,11 +27,13 @@ tags:
     id: "searchEntry"
 - inputText: "https://expired.badssl.com"
 - pressKey: Enter
+- assertVisible:
+    id: "Globe-24"
 - tapOn: "Advanced"
 - scroll
 - tapOn: "Accept Risk and Visit Site"
 - assertVisible: 
-    id: "LogoIcon"
+    id: "privacy-icon-shield.button"
 - assertVisible: "expired.badssl.com"
 
 

--- a/DuckDuckGo/PrivacyIconView.swift
+++ b/DuckDuckGo/PrivacyIconView.swift
@@ -122,6 +122,7 @@ class PrivacyIconView: UIView {
             accessibilityHint = nil
             accessibilityTraits = .image
         case .shield, .shieldWithDot:
+            accessibilityIdentifier = "privacy-icon-shield.button"
             accessibilityLabel = UserText.privacyIconShield
             accessibilityHint = UserText.privacyIconOpenDashboardHint
             accessibilityTraits = .button

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -26,7 +26,7 @@ import MaliciousSiteProtection
 typealias SpecialErrorPageManaging = SpecialErrorPageContextHandling & WebViewNavigationHandling & SpecialErrorPageUserScriptDelegate
 
 final class SpecialErrorPageNavigationHandler: SpecialErrorPageContextHandling {
-    private var webView: WKWebView?
+    private weak var webView: WKWebView?
     private weak var userScript: SpecialErrorPageUserScript?
     weak var delegate: SpecialErrorPageNavigationDelegate?
 

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
@@ -463,7 +463,7 @@ final class SpecialErrorPageNavigationHandlerTests {
             webView = nil
         }
         // THEN
-        RunLoop.current.run(until: Date().addingTimeInterval(0.1)) // Gives the run loop time to process deinit event
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2)) // Gives the run loop time to process deinit event
         #expect(weakWebView == nil)
     }
 }

--- a/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
+++ b/DuckDuckGoTests/SpecialErrorPage/SpecialErrorPageNavigationHandlerTests.swift
@@ -447,6 +447,25 @@ final class SpecialErrorPageNavigationHandlerTests {
         // THEN
         #expect(maliciousSiteProtectionNavigationHandler.didCallCurrentThreatKind)
     }
+
+    @MainActor
+    @Test("Web View is not strongly retained")
+    func whenWebViewIsNilled_ThenWebViewIsDeallocated() {
+        weak var weakWebView: MockWebView?
+
+        autoreleasepool {
+            // GIVEN
+            var webView: MockWebView! = MockWebView()
+            weakWebView = webView
+            sut.attachWebView(webView)
+
+            // WHEN
+            webView = nil
+        }
+        // THEN
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1)) // Gives the run loop time to process deinit event
+        #expect(weakWebView == nil)
+    }
 }
 
 private extension NSError {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209348984855251

**Description**:

This PR addresses:
- Fix web view retain cycle in SpecialErrorPageNavigationHandler by weakly retaining the webView.
- Fix [Expired Certificate UI test](https://github.com/duckduckgo/iOS/blob/main/.maestro/privacy_tests/10_expired_certificate.yaml) broken due to icon logic changes for Malicious Site Protection 

**Steps to test this PR**:

**Retain Cycle**
1. Launch debug version.
2. Open SERP.
3. Long press on any result.
4. Select "Open in background”.
5. Ensure deallocation assertion is not fired.

**UI Test**
1. Ensure [Expired Certificate UI test](https://github.com/duckduckgo/iOS/blob/main/.maestro/privacy_tests/10_expired_certificate.yaml) pass. 

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
