### PR TITLE
Fix password menu edit actions in iOS 18

### DIFF
--- a/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -569,6 +569,11 @@ private struct Copyable: ViewModifier {
     
     public func body(content: Content) -> some View {
         ZStack {
+            content
+                .allowsHitTesting(false)
+                .contentShape(Rectangle())
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: Constants.minRowHeight)
             Rectangle()
                 .foregroundColor(.clear)
                 .menuController(menuTitle,
@@ -577,12 +582,6 @@ private struct Copyable: ViewModifier {
                                 secondaryAction: menuSecondaryAction,
                                 onOpen: menuOpenedAction,
                                 onClose: menuClosedAction)
-
-            content
-                .allowsHitTesting(false)
-                .contentShape(Rectangle())
-                .frame(maxWidth: .infinity)
-                .frame(minHeight: Constants.minRowHeight)
 
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202926619870900/1209132360844274

**Description**:

The menu actions on the username / password / website URL form entries are no longer appearing as of iOS 18. This fixes that by using the `UIEditMenuInteraction` to replace the deprecated `UIMenuController`

**Steps to test this PR**:
1. Go to the password management screen
2. Ensure you have at least one password saved with all fields populated (username, password, website URL, Notes)
3. Press each of the fields

You should see Copy (Username|Password|Website URL|Notes) and, for the Password field, also Show Password

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `'`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [x] iOS 15
* [x] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
