### PR TITLE
Fix crash when rotating

### DIFF
--- a/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -111,8 +111,7 @@ class SwipeTabsCoordinator: NSObject {
         updateLayout()
         scrollToCurrent()
 
-        let indexPath = IndexPath(row: self.tabsModel.currentIndex, section: 0)
-        collectionView.reloadItems(at: [indexPath])
+        collectionView.reloadData()
     }
 
     private func updateLayout() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209376796676971/f
Tech Design URL:
CC:

**Description**:
Fixes crash introduced on https://github.com/duckduckgo/iOS/pull/3881
<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->
Recreated from [already accepted PR](https://github.com/duckduckgo/iOS/pull/3956).

**Steps to test this PR**:
1.Test rotation to / from landscape with and without the keyboard. Confirm that the UI updates as expected and that the keyboard remains visible if it was visible before rotation.
2.Validate iPad behaviour remains the same.


**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

