### PR TITLE
Fix crash on sites that open about:blank and so WKNavigation object is nil

### DIFF
--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/WebViewNavigationHandling.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageInterfaces/WebViewNavigationHandling.swift
@@ -69,7 +69,7 @@ protocol WebViewNavigationHandling: AnyObject {
     ///   - navigation: The navigation object for the operation.
     ///   - error: The error that occurred.
     @MainActor
-    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WebViewNavigation, withError error: NSError)
+    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WebViewNavigation?, withError error: NSError)
 
     /// Handles the successful completion of a navigation in the web view.
     ///
@@ -77,5 +77,5 @@ protocol WebViewNavigationHandling: AnyObject {
     ///   - webView: The web view that loaded the content.
     ///   - navigation: The navigation object that finished.
     @MainActor
-    func handleWebView(_ webView: WKWebView, didFinish navigation: WebViewNavigation)
+    func handleWebView(_ webView: WKWebView, didFinish navigation: WebViewNavigation?)
 }

--- a/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
+++ b/DuckDuckGo/SpecialErrorPage/SpecialErrorPageNavigationHandler.swift
@@ -110,7 +110,7 @@ extension SpecialErrorPageNavigationHandler: WebViewNavigationHandling {
     }
 
     @MainActor
-    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WebViewNavigation, withError error: NSError) {
+    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WebViewNavigation?, withError error: NSError) {
         guard let sslSpecialError = sslErrorPageNavigationHandler.makeNewRequestURLAndSpecialErrorDataIfEnabled(error: error) else { return }
         failedURL = sslSpecialError.error.url
         sslErrorPageNavigationHandler.errorPageVisited(errorType: sslSpecialError.type)
@@ -119,7 +119,7 @@ extension SpecialErrorPageNavigationHandler: WebViewNavigationHandling {
     }
 
     @MainActor
-    func handleWebView(_ webView: WKWebView, didFinish navigation: WebViewNavigation) {
+    func handleWebView(_ webView: WKWebView, didFinish navigation: WebViewNavigation?) {
         isSpecialErrorPageRequest = false
         userScript?.isEnabled = webView.url == failedURL
         if webView.url != failedURL {

--- a/DuckDuckGoTests/MockTabDelegate.swift
+++ b/DuckDuckGoTests/MockTabDelegate.swift
@@ -178,10 +178,10 @@ class DummySpecialErrorPageNavigationHandler: SpecialErrorPageManaging {
 
     }
     
-    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: any DuckDuckGo.WebViewNavigation, withError error: NSError) {}
+    func handleWebView(_ webView: WKWebView, didFailProvisionalNavigation navigation: (any WebViewNavigation)?, withError error: NSError) {}
     
-    func handleWebView(_ webView: WKWebView, didFinish navigation: any DuckDuckGo.WebViewNavigation) {}
-    
+    func handleWebView(_ webView: WKWebView, didFinish navigation: (any WebViewNavigation)?) {}
+
     var errorData: SpecialErrorPages.SpecialErrorData?
     
     func leaveSiteAction() {}


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/414709148257752/1209372383528747

**Description**: Do not crash on about:blank when site is redirection.

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
