### PR TITLE
Makes a small fix to UserDefaultsWrapper

### DIFF
--- a/Core/UserDefaultsPropertyWrapper.swift
+++ b/Core/UserDefaultsPropertyWrapper.swift
@@ -214,7 +214,7 @@ public struct UserDefaultsWrapper<T> {
             if let optional = newValue as? AnyOptional, optional.isNil {
                 container.removeObject(forKey: key.rawValue)
             } else {
-                container.setValue(newValue, forKey: key.rawValue)
+                container.set(newValue, forKey: key.rawValue)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1209395955778891

## Description:

We're calling [setValue(_, forKey: )](https://developer.apple.com/documentation/objectivec/nsobject/1415969-setvalue) for UserDefaults instead of [set(_, forKey: )](https://developer.apple.com/documentation/foundation/userdefaults/1414067-set).

This is a long-shot attempt to resolve https://app.asana.com/0/1203108348835387/1209057191598801.

## Testing:

Just make `UserDefaults` still work fine.  The best option is to set a breakpoint in [this line](https://github.com/duckduckgo/iOS/blob/1cc6e9156427a0ae84a4d94b0bd159f42067ad6e/Core/UserDefaultsPropertyWrapper.swift#L217) and make sure it's hit and nothing breaks.

**Definition of Done (Internal Only)**:

* [ ] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
