### PR TITLE
add tds experiment metrics

### DIFF
--- a/DuckDuckGo/AppPageRefreshMonitor.swift
+++ b/DuckDuckGo/AppPageRefreshMonitor.swift
@@ -21,6 +21,8 @@ import Core
 import Common
 import PageRefreshMonitor
 import PixelExperimentKit
+import Configuration
+import PixelKit
 
 extension PageRefreshMonitor {
 
@@ -31,14 +33,30 @@ extension PageRefreshMonitor {
             TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .refresh2X, etag: tdsEtag, fireDebugExperiment: { parameters in
                 UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
             })
+            TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .refresh2X)
         case 3:
             Pixel.fire(pixel: .pageRefreshThreeTimesWithin20Seconds)
             TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .refresh3X, etag: tdsEtag, fireDebugExperiment: { parameters in
                 UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
             })
+            TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .refresh3X)
         default:
             return
         }
     }
 
+}
+
+public extension TDSOverrideExperimentMetrics {
+    static func fireTDSExperimentMetricUpdated( metricType: TDSExperimentMetricType) {
+        for experiment in TDSExperimentType.allCases {
+            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...0, value: "1")
+            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...1, value: "1")
+            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...2, value: "1")
+            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...3, value: "1")
+            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...4, value: "1")
+            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...5, value: "1")
+
+        }
+    }
 }

--- a/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -141,6 +141,7 @@ final class PrivacyDashboardViewController: UIViewController {
             TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .privacyToggleUsed, etag: tdsEtag) { parameters in
                 UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
             }
+            TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .privacyToggleUsed)
         }
         
         contentBlockingManager.scheduleCompilation()

--- a/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -535,6 +535,7 @@ extension TabViewController {
         TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .privacyToggleUsed, etag: tdsEtag) { parameters in
             UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
         }
+        TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .privacyToggleUsed)
     }
 
     private func togglePrivacyProtection(domain: String, didSendReport: Bool = false) {

--- a/DuckDuckGoTests/PageRefreshMonitor/PageRefreshMonitorExtensionTests.swift
+++ b/DuckDuckGoTests/PageRefreshMonitor/PageRefreshMonitorExtensionTests.swift
@@ -22,12 +22,14 @@ import XCTest
 @testable import PixelExperimentKit
 import PageRefreshMonitor
 import BrowserServicesKit
+import PixelKit
 
 final class PageRefreshMonitorExtensionTests: XCTestCase {
 
     var captureMetric: String?
 
     override func setUpWithError() throws {
+        PixelKit.configureExperimentKit(featureFlagger: MockFeatureFlagger(), eventTracker: ExperimentEventTracker(), fire: { _, _, _ in })
         TDSOverrideExperimentMetrics.configureTDSOverrideExperimentMetrics { _, metric, _, _ in
             self.captureMetric = metric
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1209153206410268

**Description**: Add more conversion window for tds experiment (later I’ll make the changes in BSK but it needs to go in this release)

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Start with a fresh app
2. refresh a page 3 times and check you see pixels like 👾[Unique By Name And Parameters-Fired] experiment_metrics_tdsNextExperimentBaseline_treatment_ios_phone ["conversionWindowDays": "0-4", "pixelSource": "phone", "metric": "3XRefresh", "value": "1", "enrollmentDate": "2025-02-14”] with metric": “3XRefresh” and “2XRefresh” with conversion windows (0, 0-1, 0-2, 0-3, 0-4, 0-5)
3. Same if you toggle protection off

<!—
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
—>

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

**Copy Testing**:

* [ ] Use of correct apostrophes in new copy, ie `’` rather than `’`

**Orientation Testing**:

* [ ] Portrait
* [ ] Landscape

**Device Testing**:

* [ ] iPhone SE (1st Gen)
* [ ] iPhone 8
* [ ] iPhone X
* [ ] iPhone 14 Pro
* [ ] iPad

**OS Testing**:

* [ ] iOS 15
* [ ] iOS 16
* [ ] iOS 17

**Theme Testing**:

* [ ] Light theme
* [ ] Dark theme

—
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
