### PR TITLE
Fix Sync E2E tests failing on missing Settings

### DIFF
--- a/.maestro/release_tests/backgrounding.yaml
+++ b/.maestro/release_tests/backgrounding.yaml
@@ -33,8 +33,7 @@ tags:
 - tapOn: "Browsing menu"
 - assertVisible: "Add Bookmark"
 - tapOn: "Add Bookmark"
-- tapOn: 
-    id: PrivacyIcon
+- tapOn: "Privacy Icon"
 - assertVisible: "Protections are ON for this site"
 - tapOn: "Done"
 
@@ -55,6 +54,7 @@ tags:
 
 # Check menus
 - tapOn: "Cancel"
+- tapOn: "Browsing menu"
 - tapOn: "Settings"
 - assertVisible: "Default Browser"
 - tapOn: "Done"

--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -23,8 +23,7 @@ tags:
 - pressKey: Enter
 
 - assertVisible: "1 major tracker loaded via script src"
-- tapOn: 
-    id: PrivacyIcon
+- tapOn: "Privacy Icon"
 - assertVisible: "Protections are ON for this site"
 
 - assertVisible: "We blocked Google Ads (Google) from loading tracking requests on this page."
@@ -47,7 +46,6 @@ tags:
 
 - assertVisible: "1 major tracker loaded via script src"
 
-- tapOn: 
-    id: PrivacyIcon
+- tapOn: "Privacy Icon"
 - assertVisible: "Protections are OFF for this site"
 

--- a/.maestro/sync_tests/01_create_account.yaml
+++ b/.maestro/sync_tests/01_create_account.yaml
@@ -10,6 +10,7 @@ name: 01_create_account
     file: ../shared/setup.yaml
 
 # Set Internal User
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/set_internal_user_from_settings.yaml

--- a/.maestro/sync_tests/02_login_account.yaml
+++ b/.maestro/sync_tests/02_login_account.yaml
@@ -10,6 +10,7 @@ name: 02_login_account
     file: ../shared/setup.yaml
 
 #  Copy Recovery Code
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/copy_recovery_code_from_settings.yaml

--- a/.maestro/sync_tests/03_recover_account.yaml
+++ b/.maestro/sync_tests/03_recover_account.yaml
@@ -10,7 +10,8 @@ name: 03_recover_account
     file: ../shared/setup.yaml
 
 # Set Internal User
-- tapOn: Settings
+- tapOn: "Browsing menu"
+- tapOn: "Settings"
 - runFlow:
     file: ../shared/set_internal_user_from_settings.yaml
 

--- a/.maestro/sync_tests/04_sync_data_setup.yaml
+++ b/.maestro/sync_tests/04_sync_data_setup.yaml
@@ -22,6 +22,7 @@ name: 04_sync_data_setup
         text: "Cancel"
     commands:
       - tapOn: Cancel
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/add_login_from_settings.yaml

--- a/.maestro/sync_tests/05_sync_data_check.yaml
+++ b/.maestro/sync_tests/05_sync_data_check.yaml
@@ -14,6 +14,7 @@ name: 05_sync_data_check
     file: ../shared/setup.yaml
 
 #  Copy Recovery Code
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/copy_recovery_code_from_settings.yaml
@@ -32,17 +33,20 @@ name: 05_sync_data_check
 - assertVisible: Sync & Backup
 
 # Verify bookmarks have been merged
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/sync_verify_bookmarks.yaml
 
 # Verify favorites are unified
 - tapOn: Done
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/sync_verify_unified_favorites.yaml
 
 # Verify logins
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/sync_verify_logins.yaml

--- a/.maestro/sync_tests/06_delete_account.yaml
+++ b/.maestro/sync_tests/06_delete_account.yaml
@@ -9,6 +9,7 @@ name: 06_delete_account
     file: ../shared/setup.yaml
 
 # Set Internal User
+- tapOn: Browsing menu
 - tapOn: Settings
 - runFlow:
     file: ../shared/set_internal_user_from_settings.yaml


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.

⚠️ If you're an external contributor, please file an issue first before working on a PR, as we can't guarantee that we will accept your changes if they haven't been discussed ahead of time. Thanks!
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1209404321699252
Tech Design URL:
CC: @loremattei 

**Description**:

Fixes Sync E2E tests failing on missing Settings button (Duck.ai button is there instead). I'm using browsing menu to open settings instead.

<!--
If at any point it isn't actively being worked on/ready for review/otherwise moving forward strongly consider closing it (or not opening it in the first place). If you decide not to close it, use Draft PR while work is still in progress or use `DO NOT MERGE` label to clarify the PRs state and comment with more information.
-->

**Steps to test this PR**:
1. Make sure Sync E2E tests pass (https://github.com/duckduckgo/iOS/actions/runs/13332111301)

<!--
Before submitting a PR, please ensure you have tested the combinations you expect the reviewer to test, then delete configurations you *know* do not need explicit testing.

Using a simulator where a physical device is unavailable is acceptable.
-->

**Definition of Done (Internal Only)**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
